### PR TITLE
docs: Add migration documentation for テリスケ assigned agents

### DIFF
--- a/docs/migration/agents/business-info-agent/MIGRATION-GUIDE.md
+++ b/docs/migration/agents/business-info-agent/MIGRATION-GUIDE.md
@@ -1,0 +1,563 @@
+# Business Info Agent - 移行ガイド
+
+> Mastra (TypeScript) → LangGraph (Python) 移行手順
+
+## 移行概要
+
+### 現在の実装（Mastra/TypeScript）
+
+```
+frontend/src/
+├── mastra/agents/business-info-agent.ts    # 401行
+├── mastra/tools/enhanced-rag-search.ts     # Enhanced RAG
+├── mastra/tools/context-filter.ts          # コンテキストフィルタ
+└── lib/simplified-memory.ts                # メモリシステム
+```
+
+### 移行先（LangGraph/Python）
+
+```
+backend/
+├── agents/
+│   └── business_info_agent.py              # 新規作成
+├── tools/
+│   ├── enhanced_rag_search.py              # 新規作成
+│   └── context_filter.py                   # 新規作成
+├── utils/
+│   └── memory_system.py                    # 新規作成
+└── workflows/
+    └── main_workflow.py                    # 既存（修正）
+```
+
+## 移行ステップ
+
+### Step 1: 依存モジュールの移行
+
+#### 1.1 Enhanced RAG Search の移行
+
+**元ファイル**: `frontend/src/mastra/tools/enhanced-rag-search.ts`
+
+```python
+# backend/tools/enhanced_rag_search.py
+
+from typing import TypedDict, Literal
+from supabase import create_client
+import openai
+
+class EnhancedRAGResult(TypedDict):
+    success: bool
+    data: dict | None
+    error: str | None
+
+class EnhancedRAGSearch:
+    def __init__(self, supabase_client, openai_client):
+        self.supabase = supabase_client
+        self.openai = openai_client
+
+    async def execute(
+        self,
+        query: str,
+        category: str,
+        language: str,
+        include_advice: bool = True,
+        max_results: int = 10
+    ) -> EnhancedRAGResult:
+        """Enhanced RAG検索を実行"""
+        try:
+            # クエリをエンベディングに変換
+            embedding = await self._get_embedding(query)
+
+            # ベクトル検索実行
+            results = await self._vector_search(embedding, max_results)
+
+            # エンティティ認識とスコアリング
+            scored_results = self._score_results(results, query, category)
+
+            # コンテキスト構築
+            context = self._build_context(scored_results, include_advice)
+
+            return {
+                "success": True,
+                "data": {"context": context, "results": scored_results},
+                "error": None
+            }
+        except Exception as e:
+            return {"success": False, "data": None, "error": str(e)}
+
+    async def _get_embedding(self, text: str) -> list[float]:
+        """OpenAI embeddings APIを使用"""
+        response = await self.openai.embeddings.create(
+            model="text-embedding-3-small",
+            input=text
+        )
+        return response.data[0].embedding
+
+    async def _vector_search(self, embedding: list[float], limit: int) -> list[dict]:
+        """Supabaseでベクトル検索"""
+        result = self.supabase.rpc(
+            'match_knowledge_base',
+            {
+                'query_embedding': embedding,
+                'match_count': limit,
+                'match_threshold': 0.7
+            }
+        ).execute()
+        return result.data
+
+    def _score_results(self, results: list[dict], query: str, category: str) -> list[dict]:
+        """エンティティ認識とスコアリング"""
+        scored = []
+        for r in results:
+            score = r.get('similarity', 0)
+
+            # エンティティ認識
+            if 'saino' in query.lower() and 'saino' in r.get('content', '').lower():
+                score += 0.1
+            elif 'エンジニアカフェ' in query and 'エンジニアカフェ' in r.get('content', ''):
+                score += 0.1
+
+            # カテゴリマッチング
+            if category and r.get('category') == category:
+                score += 0.05
+
+            scored.append({**r, 'final_score': score})
+
+        return sorted(scored, key=lambda x: x['final_score'], reverse=True)
+
+    def _build_context(self, results: list[dict], include_advice: bool) -> str:
+        """コンテキスト文字列を構築"""
+        context_parts = [r.get('content', '') for r in results[:5]]
+        return '\n\n'.join(context_parts)
+```
+
+#### 1.2 Context Filter の移行
+
+**元ファイル**: `frontend/src/mastra/tools/context-filter.ts`
+
+```python
+# backend/tools/context_filter.py
+
+from typing import TypedDict
+
+class FilterResult(TypedDict):
+    success: bool
+    data: dict | None
+
+class ContextFilter:
+    def execute(
+        self,
+        context: str,
+        request_type: str,
+        language: str,
+        query: str
+    ) -> FilterResult:
+        """requestTypeに基づいてコンテキストをフィルタ"""
+        if not request_type:
+            return {"success": True, "data": {"filteredContext": context}}
+
+        # リクエストタイプに応じたキーワード
+        keywords = self._get_keywords(request_type, language)
+
+        # 関連する文を抽出
+        sentences = context.split('。')
+        filtered_sentences = []
+
+        for sentence in sentences:
+            if any(kw in sentence for kw in keywords):
+                filtered_sentences.append(sentence)
+
+        filtered_context = '。'.join(filtered_sentences)
+        if not filtered_context:
+            filtered_context = context  # フォールバック
+
+        return {
+            "success": True,
+            "data": {"filteredContext": filtered_context}
+        }
+
+    def _get_keywords(self, request_type: str, language: str) -> list[str]:
+        """リクエストタイプに応じたキーワードリスト"""
+        keywords_map = {
+            'hours': {
+                'ja': ['営業時間', '時間', '開館', '閉館', '開い', '閉ま'],
+                'en': ['hours', 'open', 'close', 'time']
+            },
+            'price': {
+                'ja': ['料金', '価格', '無料', '有料', '円'],
+                'en': ['price', 'cost', 'free', 'fee', 'yen']
+            },
+            'location': {
+                'ja': ['場所', '住所', 'アクセス', '行き方', '駅'],
+                'en': ['location', 'address', 'access', 'station', 'direction']
+            }
+        }
+        return keywords_map.get(request_type, {}).get(language, [])
+```
+
+### Step 2: Business Info Agent 本体の移行
+
+**元ファイル**: `frontend/src/mastra/agents/business-info-agent.ts`
+
+```python
+# backend/agents/business_info_agent.py
+
+from typing import TypedDict, Literal
+import re
+from backend.tools.enhanced_rag_search import EnhancedRAGSearch
+from backend.tools.context_filter import ContextFilter
+from backend.utils.memory_system import SimplifiedMemorySystem
+
+SupportedLanguage = Literal["ja", "en"]
+
+class BusinessInfoResponse(TypedDict):
+    text: str
+    emotion: str
+    agent_name: str
+    language: str
+    metadata: dict
+
+class BusinessInfoAgent:
+    def __init__(self, llm, supabase_client, openai_client):
+        self.llm = llm
+        self.memory = SimplifiedMemorySystem('shared', supabase_client)
+        self.enhanced_rag = EnhancedRAGSearch(supabase_client, openai_client)
+        self.context_filter = ContextFilter()
+
+    async def answer_business_query(
+        self,
+        query: str,
+        category: str,
+        request_type: str | None,
+        language: SupportedLanguage,
+        session_id: str | None = None
+    ) -> BusinessInfoResponse:
+        """ビジネス情報クエリに回答"""
+        print(f"[BusinessInfoAgent] Processing: {query}")
+
+        # 文脈継承チェック
+        effective_request_type = request_type
+        context_entity = None
+
+        if session_id and self._is_short_context_query(query):
+            memory_context = await self.memory.get_context(
+                query,
+                include_knowledge_base=False,
+                language=language,
+                inherit_context=True
+            )
+
+            if memory_context.get('inherited_request_type'):
+                effective_request_type = memory_context['inherited_request_type']
+                print(f"[BusinessInfoAgent] Inherited: {effective_request_type}")
+
+            # エンティティ検出
+            context_string = memory_context.get('context_string', '')
+            if 'サイノカフェ' in context_string or 'saino' in context_string.lower():
+                context_entity = 'saino'
+            elif 'エンジニアカフェ' in context_string:
+                context_entity = 'engineer'
+
+        # クエリ拡張
+        search_query = query
+        if self._is_short_context_query(query) or context_entity:
+            search_query = self._enhance_context_query(
+                query, effective_request_type, language, context_entity
+            )
+            print(f"[BusinessInfoAgent] Enhanced query: {search_query}")
+
+        # Enhanced RAG検索
+        rag_category = self._map_request_type_to_category(effective_request_type)
+        search_result = await self.enhanced_rag.execute(
+            query=search_query,
+            category=rag_category,
+            language=language,
+            include_advice=True,
+            max_results=10
+        )
+
+        if not search_result['success']:
+            return self._get_default_response(language, category, request_type)
+
+        context = search_result['data'].get('context', '')
+        if not context:
+            return self._get_default_response(language, category, request_type)
+
+        # コンテキストフィルタリング
+        if effective_request_type:
+            filter_result = self.context_filter.execute(
+                context=context,
+                request_type=effective_request_type,
+                language=language,
+                query=query
+            )
+            if filter_result['success']:
+                context = filter_result['data']['filteredContext']
+
+        # プロンプト構築とLLM応答
+        prompt = self._build_prompt(query, context, effective_request_type, language)
+        response = await self.llm.generate(prompt)
+
+        # レスポンス構築
+        emotion = self._determine_emotion(effective_request_type)
+        sources = ['enhanced_rag']
+
+        return {
+            "text": response,
+            "emotion": emotion,
+            "agent_name": "BusinessInfoAgent",
+            "language": language,
+            "metadata": {
+                "confidence": 0.85,
+                "category": category,
+                "request_type": effective_request_type,
+                "sources": sources,
+                "processing_info": {
+                    "filtered": effective_request_type is not None,
+                    "context_inherited": effective_request_type != request_type,
+                    "enhanced_rag": True
+                }
+            }
+        }
+
+    def _is_short_context_query(self, query: str) -> bool:
+        """文脈依存クエリかどうか判定"""
+        trimmed = query.strip()
+
+        context_patterns = [
+            r'^土曜[日]?は.*',
+            r'^日曜[日]?は.*',
+            r'^平日は.*',
+            r'^saino[のは方]?.*',
+            r'^そっち[のは]?.*',
+            r'^あっち[のは]?.*',
+        ]
+
+        for pattern in context_patterns:
+            if re.match(pattern, trimmed):
+                return True
+
+        return len(trimmed) < 10
+
+    def _enhance_context_query(
+        self,
+        query: str,
+        request_type: str | None,
+        language: SupportedLanguage,
+        context_entity: str | None
+    ) -> str:
+        """文脈に基づいてクエリを拡張"""
+        lower_query = query.lower()
+
+        # エンティティ優先
+        if context_entity == 'saino':
+            if request_type == 'hours':
+                return 'sainoカフェの営業時間' if language == 'ja' else 'saino cafe operating hours'
+            if request_type == 'price':
+                return 'sainoカフェの料金 メニュー' if language == 'ja' else 'saino cafe prices menu'
+            return 'sainoカフェ 情報' if language == 'ja' else 'saino cafe information'
+
+        # 曜日関連
+        if '土曜' in lower_query or '日曜' in lower_query or '平日' in lower_query:
+            return 'エンジニアカフェ 営業時間 曜日' if language == 'ja' else 'engineer cafe operating hours days'
+
+        # requestTypeベース
+        if request_type == 'hours':
+            return f'{query} 営業時間' if language == 'ja' else f'{query} operating hours'
+        if request_type == 'price':
+            return f'{query} 料金 価格' if language == 'ja' else f'{query} price cost'
+        if request_type == 'location':
+            return f'{query} 場所 アクセス' if language == 'ja' else f'{query} location access'
+
+        return query
+
+    def _map_request_type_to_category(self, request_type: str | None) -> str:
+        """requestTypeをEnhanced RAGカテゴリにマッピング"""
+        mapping = {
+            'hours': 'hours',
+            'price': 'pricing',
+            'location': 'location',
+            'access': 'location',
+        }
+        return mapping.get(request_type or '', 'general')
+
+    def _build_prompt(
+        self,
+        query: str,
+        context: str,
+        request_type: str | None,
+        language: SupportedLanguage
+    ) -> str:
+        """LLM用プロンプトを構築"""
+        if request_type:
+            type_prompt = self._get_request_type_prompt(request_type, language)
+            if language == 'en':
+                return f"""Extract ONLY the {type_prompt} from the following information to answer the question.
+
+Question: {query}
+Information: {context}
+
+Answer with ONLY the {type_prompt}. Maximum 1-2 sentences.
+IMPORTANT: Start your response with [relaxed] for information or [happy] for positive news."""
+            else:
+                return f"""次の情報から{type_prompt}のみを抽出して質問に答えてください。
+
+質問: {query}
+情報: {context}
+
+{type_prompt}のみを答えてください。最大1-2文。
+重要: 情報提供の場合は[relaxed]、良いニュースの場合は[happy]で回答を始めてください。"""
+        else:
+            if language == 'en':
+                return f"""Answer the question using the provided information. Be concise and direct.
+
+Question: {query}
+Information: {context}
+
+Answer briefly (1-2 sentences) with only the relevant information.
+IMPORTANT: Start with an emotion tag: [relaxed] for info, [happy] for positive news, [sad] for unavailable."""
+            else:
+                return f"""提供された情報を使って質問に答えてください。簡潔で直接的に答えてください。
+
+質問: {query}
+情報: {context}
+
+関連する情報のみを簡潔に（1-2文）答えてください。
+重要: 感情タグで回答を始めてください: [relaxed]/[happy]/[sad]。"""
+
+    def _get_request_type_prompt(self, request_type: str, language: SupportedLanguage) -> str:
+        """requestTypeに対応するプロンプト文字列"""
+        prompts = {
+            'hours': {'en': 'operating hours', 'ja': '営業時間'},
+            'price': {'en': 'pricing information', 'ja': '料金情報'},
+            'location': {'en': 'location information', 'ja': '場所情報'},
+        }
+        return prompts.get(request_type, {}).get(language, 'requested information' if language == 'en' else '要求された情報')
+
+    def _determine_emotion(self, request_type: str | None) -> str:
+        """レスポンスの感情を決定"""
+        emotions = {
+            'hours': 'informative',
+            'price': 'informative',
+            'location': 'guiding',
+        }
+        return emotions.get(request_type or '', 'helpful')
+
+    def _get_default_response(
+        self,
+        language: SupportedLanguage,
+        category: str | None,
+        request_type: str | None
+    ) -> BusinessInfoResponse:
+        """デフォルトレスポンス（情報なし時）"""
+        text = (
+            "[sad]申し訳ございません。お探しの情報が見つかりませんでした。"
+            if language == 'ja' else
+            "[sad]I'm sorry, I couldn't find the specific information you're looking for."
+        )
+
+        return {
+            "text": text,
+            "emotion": "apologetic",
+            "agent_name": "BusinessInfoAgent",
+            "language": language,
+            "metadata": {
+                "confidence": 0.3,
+                "category": category,
+                "request_type": request_type,
+                "sources": ["fallback"],
+                "processing_info": {
+                    "filtered": False,
+                    "context_inherited": False,
+                    "enhanced_rag": False
+                }
+            }
+        }
+```
+
+### Step 3: ワークフローへの統合
+
+**修正ファイル**: `backend/workflows/main_workflow.py`
+
+```python
+from backend.agents.business_info_agent import BusinessInfoAgent
+
+class MainWorkflow:
+    def __init__(self, llm, supabase_client, openai_client):
+        self.business_info_agent = BusinessInfoAgent(llm, supabase_client, openai_client)
+        self.graph = self._build_graph()
+
+    async def _business_info_node(self, state: WorkflowState) -> dict:
+        """ビジネス情報ノード"""
+        query = state["query"]
+        language = state["language"]
+        session_id = state.get("session_id")
+        routing_metadata = state.get("metadata", {}).get("routing", {})
+
+        result = await self.business_info_agent.answer_business_query(
+            query=query,
+            category=routing_metadata.get("category", "facility-info"),
+            request_type=routing_metadata.get("request_type"),
+            language=language,
+            session_id=session_id
+        )
+
+        return {
+            "response": result["text"],
+            "metadata": {
+                **state.get("metadata", {}),
+                "business_info": result["metadata"]
+            }
+        }
+```
+
+## 移行チェックリスト
+
+### Phase 1: 準備
+
+- [ ] 既存のTypeScriptコードを完全に理解した
+- [ ] Pythonの依存パッケージを確認した（langchain, langgraph, supabase, openai）
+- [ ] テスト環境を準備した
+
+### Phase 2: ツール移行
+
+- [ ] `enhanced_rag_search.py` を作成した
+- [ ] `context_filter.py` を作成した
+- [ ] 単体テストを作成・通過した
+
+### Phase 3: Agent本体
+
+- [ ] `business_info_agent.py` を作成した
+- [ ] 文脈継承ロジックを移行した
+- [ ] クエリ拡張ロジックを移行した
+- [ ] 単体テストを作成・通過した
+
+### Phase 4: ワークフロー統合
+
+- [ ] `main_workflow.py` にBusinessInfoAgentを統合した
+- [ ] エンドツーエンドテストを通過した
+
+### Phase 5: 検証
+
+- [ ] 営業時間クエリをテストした
+- [ ] 料金クエリをテストした
+- [ ] 場所クエリをテストした
+- [ ] 文脈継承（「土曜日は？」等）をテストした
+- [ ] Sainoカフェクエリをテストした
+- [ ] パフォーマンスを計測した
+
+## トラブルシューティング
+
+### よくある問題
+
+| 問題 | 原因 | 解決策 |
+|-----|------|-------|
+| Enhanced RAG結果が空 | エンベディング次元不一致 | 1536次元を確認 |
+| 文脈継承が動作しない | sessionIdが未設定 | sessionIdの伝播を確認 |
+| フィルタで情報が消える | キーワード不足 | キーワードリストを拡充 |
+| 感情タグが欠落 | プロンプト不備 | プロンプトテンプレートを確認 |
+
+## 参考リンク
+
+- [LangGraph ドキュメント](https://langchain-ai.github.io/langgraph/)
+- [Supabase Python](https://supabase.com/docs/reference/python)
+- [OpenAI Embeddings](https://platform.openai.com/docs/guides/embeddings)

--- a/docs/migration/agents/business-info-agent/SPEC.md
+++ b/docs/migration/agents/business-info-agent/SPEC.md
@@ -1,0 +1,990 @@
+# Business Info Agent - 技術仕様書
+
+> 入出力仕様・API定義・データ構造
+
+## 概要
+
+BusinessInfoAgentは、エンジニアカフェおよびSainoカフェの営業情報、料金、場所、アクセス情報を提供する専門エージェントです。Enhanced RAGシステムとの統合により、エンティティ認識と優先度スコアリングを活用した高精度な情報検索を実現します。
+
+## 入力仕様
+
+### メイン入力: `answerBusinessQuery()`
+
+```typescript
+interface BusinessQueryInput {
+  query: string;              // ユーザーからの入力テキスト
+  category: string;           // クエリカテゴリ (RouterAgentから継承)
+  requestType: string | null; // 具体的なリクエストタイプ (RouterAgentから継承)
+  language: SupportedLanguage; // 'ja' | 'en'
+  sessionId?: string;         // セッション識別子 (オプション)
+}
+```
+
+#### 入力例
+
+```typescript
+// 営業時間の質問
+{
+  query: "エンジニアカフェの営業時間を教えてください",
+  category: "facility-info",
+  requestType: "hours",
+  language: "ja",
+  sessionId: "session_abc123"
+}
+
+// 文脈依存の短いクエリ (前の会話で営業時間を聞いた後)
+{
+  query: "土曜日は？",
+  category: "facility-info",
+  requestType: null,  // ← メモリから "hours" を継承
+  language: "ja",
+  sessionId: "session_abc123"
+}
+
+// Sainoカフェの料金
+{
+  query: "sainoの料金は？",
+  category: "saino-cafe",
+  requestType: "price",
+  language: "ja",
+  sessionId: "session_xyz456"
+}
+
+// 場所の質問
+{
+  query: "Where is Engineer Cafe located?",
+  category: "facility-info",
+  requestType: "location",
+  language: "en",
+  sessionId: "session_def789"
+}
+```
+
+## 出力仕様
+
+### メイン出力: `UnifiedAgentResponse`
+
+```typescript
+interface UnifiedAgentResponse {
+  text: string;      // 実際の応答テキスト (感情タグ付き)
+  emotion: string;   // 感情 (helpful, informative, guiding, apologetic)
+  metadata: {
+    agentName: string;          // "BusinessInfoAgent"
+    confidence: number;         // 信頼度 (0.0 - 1.0)
+    language: SupportedLanguage; // 'ja' | 'en'
+    category?: string;          // クエリカテゴリ
+    requestType?: string | null; // リクエストタイプ
+    sources?: string[];         // 情報源 ['enhanced_rag', 'knowledge_base', 'fallback']
+    processingInfo?: {
+      filtered: boolean;        // コンテキストフィルタリングの有無
+      contextInherited: boolean; // 文脈継承の有無
+      enhancedRag: boolean;     // Enhanced RAG使用の有無
+    };
+  };
+}
+```
+
+#### 出力例
+
+```typescript
+// 営業時間の応答
+{
+  text: "[relaxed]エンジニアカフェの営業時間は9:00〜22:00です。",
+  emotion: "informative",
+  metadata: {
+    agentName: "BusinessInfoAgent",
+    confidence: 0.85,
+    language: "ja",
+    category: "facility-info",
+    requestType: "hours",
+    sources: ["enhanced_rag"],
+    processingInfo: {
+      filtered: true,
+      contextInherited: false,
+      enhancedRag: true
+    }
+  }
+}
+
+// 文脈継承後の応答
+{
+  text: "[relaxed]土曜日も同じ9:00〜22:00です。",
+  emotion: "informative",
+  metadata: {
+    agentName: "BusinessInfoAgent",
+    confidence: 0.85,
+    language: "ja",
+    category: "facility-info",
+    requestType: "hours",
+    sources: ["enhanced_rag"],
+    processingInfo: {
+      filtered: true,
+      contextInherited: true,  // ← 前の会話から継承
+      enhancedRag: true
+    }
+  }
+}
+
+// 情報が見つからない場合
+{
+  text: "[sad]申し訳ございません。お探しの情報が見つかりませんでした。質問を言い換えていただくか、スタッフにお問い合わせください。",
+  emotion: "apologetic",
+  metadata: {
+    agentName: "BusinessInfoAgent",
+    confidence: 0.3,
+    language: "ja",
+    category: "facility-info",
+    requestType: "hours",
+    sources: ["fallback"]
+  }
+}
+```
+
+## requestType マッピングテーブル
+
+### requestType → Enhanced RAG Category
+
+BusinessInfoAgentは、RouterAgentから受け取った`requestType`をEnhanced RAGのカテゴリにマッピングします。
+
+| requestType | Enhanced RAG Category | 説明 | キーワード例 |
+|-------------|----------------------|------|------------|
+| `hours` | `hours` | 営業時間 | 営業時間, 何時まで, 何時から, open, close, 時間 |
+| `price` | `pricing` | 料金情報 | 料金, いくら, 値段, price, cost, fee, メニュー |
+| `location` | `location` | 場所情報 | 場所, どこ, where, 住所, address |
+| `access` | `location` | アクセス情報 | アクセス, access, 行き方, 駅, station, 交通 |
+| `basement` | `facility-info` | 地下施設 | 地下, basement, B1, MTGスペース |
+| `facility` | `facility-info` | 一般施設 | 設備, 電源, プリンター, equipment |
+| `wifi` | `facility-info` | Wi-Fi情報 | wi-fi, wifi, インターネット, ネット |
+| `null` または未定義 | `general` | 一般情報 | その他 |
+
+### emotion マッピング
+
+応答内容に応じて適切な感情を選択します。
+
+| requestType | 推奨 emotion | 説明 |
+|-------------|--------------|------|
+| `hours`, `price` | `informative` | 事実情報の提供 |
+| `location`, `access` | `guiding` | 案内・ガイダンス |
+| 情報見つからず | `apologetic` | 謝罪 |
+| その他 | `helpful` | 一般的な支援 |
+
+## 内部処理フロー
+
+### 処理シーケンス
+
+```
+1. answerBusinessQuery(query, category, requestType, language, sessionId)
+   │
+   ├─2. 文脈依存チェック
+   │    ├─ isShortContextQuery(query)
+   │    │    → /^土曜[日]?は.*/, /^saino[のは方]?.*/ などパターンマッチ
+   │    │    → query.length < 10 もチェック
+   │    │
+   │    └─ sessionId && isShortContextQuery → メモリから文脈取得
+   │         └─ memory.getContext(query, { inheritContext: true })
+   │              ├─ inheritedRequestType (前回のrequestType)
+   │              └─ contextEntity (saino / engineer)
+   │
+   ├─3. requestType 確定
+   │    └─ effectiveRequestType = requestType || inheritedRequestType
+   │
+   ├─4. クエリ拡張 (文脈依存の場合)
+   │    └─ enhanceContextQuery(query, effectiveRequestType, language, contextEntity)
+   │         ├─ contextEntity === 'saino' → "sainoカフェの営業時間"
+   │         ├─ contextEntity === 'engineer' → "エンジニアカフェの営業時間"
+   │         ├─ 土曜/日曜/平日 → "エンジニアカフェ 営業時間 曜日"
+   │         └─ requestType based → "〜の料金", "〜の場所" など
+   │
+   ├─5. RAG検索
+   │    ├─ Enhanced RAG優先
+   │    │    └─ enhancedRagSearch.execute({
+   │    │         query: searchQuery,
+   │    │         category: mapRequestTypeToCategory(effectiveRequestType),
+   │    │         language,
+   │    │         includeAdvice: true,
+   │    │         maxResults: 10
+   │    │       })
+   │    │
+   │    └─ フォールバック: 標準RAG
+   │         └─ ragSearch.execute({ query, language, limit: 10 })
+   │
+   ├─6. コンテキスト抽出
+   │    ├─ Enhanced RAG → searchResult.data.context
+   │    └─ 標準RAG → searchResult.results[].content.join('\n\n')
+   │
+   ├─7. コンテキストフィルタリング (requestTypeが存在する場合)
+   │    └─ contextFilter.execute({ context, requestType, language, query })
+   │         → 営業時間のみ、料金のみなど特定情報のみ抽出
+   │
+   ├─8. プロンプト構築
+   │    └─ buildPrompt(query, filteredContext, requestType, language)
+   │         ├─ requestType あり → 特定情報のみ抽出プロンプト (1-2文)
+   │         └─ requestType なし → 簡潔な一般回答プロンプト
+   │
+   ├─9. LLM応答生成
+   │    └─ this.generate([{ role: 'user', content: prompt }])
+   │
+   └─10. UnifiedAgentResponse作成
+        └─ createUnifiedResponse(
+             response.text,
+             emotion,
+             'BusinessInfoAgent',
+             language,
+             { confidence, category, requestType, sources, processingInfo }
+           )
+```
+
+### フローチャート
+
+```
+┌────────────────────────────────────┐
+│ answerBusinessQuery()              │
+│ (query, category, requestType,     │
+│  language, sessionId)              │
+└──────────────┬─────────────────────┘
+               │
+               ▼
+    ┌──────────────────────┐
+    │ 短いクエリ？          │ Yes  ┌─────────────────────┐
+    │ isShortContextQuery() │─────→│ メモリから文脈取得   │
+    └──────────┬───────────┘      │ - inheritedRequestType│
+               │ No                │ - contextEntity       │
+               │                   └──────────┬────────────┘
+               │                              │
+               ▼                              │
+    ┌──────────────────────┐                │
+    │ requestType 確定      │←───────────────┘
+    │ effectiveRequestType  │
+    └──────────┬───────────┘
+               │
+               ▼
+    ┌──────────────────────┐
+    │ クエリ拡張            │
+    │ enhanceContextQuery() │
+    │ - saino → "sainoの〜"│
+    │ - 土曜 → "〜曜日"    │
+    └──────────┬───────────┘
+               │
+               ▼
+    ┌──────────────────────────┐
+    │ Enhanced RAG 検索         │
+    │ category: hours/pricing/  │
+    │           location/etc    │
+    └──────────┬───────────────┘
+               │
+               ▼
+    ┌──────────────────────────┐
+    │ コンテキスト抽出          │
+    │ - Enhanced: data.context  │
+    │ - Standard: results[]     │
+    └──────────┬───────────────┘
+               │
+               ▼
+    ┌──────────────────────────┐
+    │ コンテキストフィルタ      │ (requestType存在時)
+    │ → 営業時間のみ抽出        │
+    │ → 料金のみ抽出            │
+    └──────────┬───────────────┘
+               │
+               ▼
+    ┌──────────────────────────┐
+    │ プロンプト構築            │
+    │ - 特定情報抽出 (1-2文)    │
+    │ - 感情タグ指定            │
+    └──────────┬───────────────┘
+               │
+               ▼
+    ┌──────────────────────────┐
+    │ Gemini LLM 応答生成       │
+    │ this.generate()           │
+    └──────────┬───────────────┘
+               │
+               ▼
+    ┌──────────────────────────┐
+    │ UnifiedAgentResponse 作成 │
+    │ - text (感情タグ付き)     │
+    │ - emotion                 │
+    │ - metadata                │
+    └────────────────────────────┘
+```
+
+## 文脈依存クエリパターン
+
+### 短いクエリの判定パターン (正規表現)
+
+BusinessInfoAgentは、以下のパターンに一致するクエリを「文脈依存クエリ」として認識します。
+
+```typescript
+// 曜日パターン
+/^土曜[日]?は.*/          // 土曜日は... 土曜は...
+/^日曜[日]?は.*/          // 日曜日は... 日曜は...
+/^平日は.*/               // 平日は...
+
+// Sainoカフェ参照パターン
+/^saino[のは方]?.*/       // sainoの方は... sainoは...
+
+// 指示代名詞パターン
+/^そっち[のは]?.*/        // そっちの方は... そっちは...
+/^あっち[のは]?.*/        // あっちの方は... あっちは...
+/^それ[のは]?.*/          // それの方は... それは...
+/^そこ[のは]?.*/          // そこの方は... そこは...
+
+// 長さベース判定
+query.length < 10         // 10文字未満のクエリ
+```
+
+### 文脈エンティティ検出
+
+メモリから取得した会話履歴を分析し、文脈エンティティを特定します。
+
+```typescript
+if (memoryContext.contextString.includes('サイノカフェ') ||
+    memoryContext.contextString.includes('saino')) {
+  contextEntity = 'saino';
+} else if (memoryContext.contextString.includes('エンジニアカフェ')) {
+  contextEntity = 'engineer';
+}
+```
+
+### クエリ拡張ロジック
+
+#### Sainoカフェ拡張
+
+| 元のクエリ | requestType | 拡張後のクエリ (日本語) | 拡張後のクエリ (英語) |
+|-----------|-------------|------------------------|---------------------|
+| "saino" | hours | "sainoカフェの営業時間" | "saino cafe operating hours" |
+| "saino" | price | "sainoカフェの料金 メニュー" | "saino cafe prices menu" |
+| "saino" | null | "sainoカフェ 情報" | "saino cafe information" |
+
+#### 曜日クエリ拡張
+
+| 元のクエリ | requestType | 拡張後のクエリ (日本語) | 拡張後のクエリ (英語) |
+|-----------|-------------|------------------------|---------------------|
+| "土曜日は？" | (inherited: hours) | "エンジニアカフェ 営業時間 曜日" | "engineer cafe operating hours days" |
+| "日曜は？" | (inherited: hours) | "エンジニアカフェ 営業時間 曜日" | "engineer cafe operating hours days" |
+| "平日は？" | (inherited: price) | "エンジニアカフェ 料金 価格" | "engineer cafe price cost" |
+
+#### エンティティ + requestType拡張
+
+| contextEntity | requestType | query.length < 10 | 拡張後のクエリ (日本語) |
+|---------------|-------------|-------------------|------------------------|
+| saino | hours | Yes | "sainoカフェの営業時間" |
+| engineer | price | Yes | "エンジニアカフェの料金 価格" |
+| saino | location | Yes | "sainoカフェの場所 アクセス" |
+
+## ツール依存関係
+
+### 必須ツール
+
+#### 1. Enhanced RAG Search Tool
+
+**ツール名**: `enhancedRagSearch`
+
+**機能**: エンティティ認識と優先度スコアリングを活用した高精度検索
+
+**実行インターフェース**:
+```typescript
+await enhancedRagSearch.execute({
+  query: string,          // 検索クエリ
+  category: string,       // hours, pricing, location, facility-info, general
+  language: SupportedLanguage,
+  includeAdvice: boolean, // 実用的なアドバイス生成
+  maxResults: number      // 最大結果数 (通常10)
+})
+```
+
+**返却データ**:
+```typescript
+{
+  success: boolean,
+  data: {
+    context: string,      // 統合されたコンテキスト文字列
+    results: Array<{
+      content: string,
+      category: string,
+      subcategory: string,
+      score: number,
+      priority: number    // エンティティ認識による優先度
+    }>,
+    advice?: string       // 実用的なアドバイス (オプション)
+  }
+}
+```
+
+#### 2. Standard RAG Search Tool (フォールバック)
+
+**ツール名**: `ragSearch`
+
+**機能**: 標準的なベクトル検索
+
+**実行インターフェース**:
+```typescript
+await ragSearch.execute({
+  query: string,
+  language: SupportedLanguage,
+  limit: number  // 最大結果数 (通常10)
+})
+```
+
+**返却データ**:
+```typescript
+{
+  success: boolean,
+  results: Array<{
+    content: string,
+    metadata: {
+      category: string,
+      subcategory: string,
+      language: string
+    }
+  }>
+}
+```
+
+#### 3. Context Filter Tool
+
+**ツール名**: `contextFilter`
+
+**機能**: requestTypeに基づいた特定情報のみの抽出
+
+**実行インターフェース**:
+```typescript
+await contextFilter.execute({
+  context: string,        // フィルタ対象のコンテキスト
+  requestType: string,    // hours, price, location, etc.
+  language: SupportedLanguage,
+  query: string          // 元のユーザークエリ
+})
+```
+
+**返却データ**:
+```typescript
+{
+  success: boolean,
+  data: {
+    filteredContext: string  // フィルタリング後のコンテキスト
+  }
+}
+```
+
+**フィルタリング例**:
+
+```typescript
+// 入力コンテキスト (複数情報が含まれる)
+`エンジニアカフェは東京都千代田区にあります。
+営業時間は9:00〜22:00です。
+料金は1時間500円、1日2000円です。`
+
+// requestType: "hours" でフィルタ
+↓
+`営業時間は9:00〜22:00です。`
+
+// requestType: "price" でフィルタ
+↓
+`料金は1時間500円、1日2000円です。`
+```
+
+### オプショナルツール
+
+#### SimplifiedMemorySystem
+
+**機能**: 会話履歴とrequestType継承
+
+**使用メソッド**:
+```typescript
+// 文脈とrequestType継承を取得
+const memoryContext = await memory.getContext(query, {
+  includeKnowledgeBase: false,
+  language,
+  inheritContext: true
+});
+
+// 返却値
+{
+  recentMessages: Message[],
+  knowledgeResults: [],
+  contextString: string,          // 会話履歴文字列
+  inheritedRequestType: string | null  // 前回のrequestType
+}
+```
+
+## プロンプトテンプレート
+
+### requestType指定時 (特定情報抽出)
+
+#### 日本語プロンプト
+
+```
+次の情報から{requestTypePrompt}のみを抽出して質問に答えてください。
+
+質問: {query}
+情報: {context}
+
+{requestTypePrompt}のみを答えてください。最大1-2文。他の情報は含めないでください。
+重要: 情報提供の場合は[relaxed]、良いニュースの場合は[happy]で回答を始めてください。
+```
+
+**requestTypePrompt マッピング**:
+- `hours` → "営業時間"
+- `price` → "料金情報"
+- `location` → "場所情報"
+- `access` → "アクセス情報"
+- `basement` → "地下施設情報"
+
+#### 英語プロンプト
+
+```
+Extract ONLY the {requestTypePrompt} from the following information to answer the question.
+
+Question: {query}
+Information: {context}
+
+Answer with ONLY the {requestTypePrompt}. Maximum 1-2 sentences. Do not include any other information.
+IMPORTANT: Start your response with [relaxed] for information or [happy] for positive news.
+```
+
+**requestTypePrompt マッピング**:
+- `hours` → "operating hours"
+- `price` → "pricing information"
+- `location` → "location information"
+- `access` → "access information"
+- `basement` → "basement facility information"
+
+### requestType未指定時 (一般回答)
+
+#### 日本語プロンプト
+
+```
+提供された情報を使って質問に答えてください。簡潔で直接的に答えてください。
+
+質問: {query}
+情報: {context}
+
+関連する情報のみを簡潔に（1-2文）答えてください。
+重要: 感情タグで回答を始めてください: 情報提供は[relaxed]、良いニュースは[happy]、利用できないサービスは[sad]。
+```
+
+#### 英語プロンプト
+
+```
+Answer the question using the provided information. Be concise and direct.
+
+Question: {query}
+Information: {context}
+
+Answer briefly (1-2 sentences) with only the relevant information.
+IMPORTANT: Start your response with an emotion tag: [relaxed] for information, [happy] for positive news, [sad] for unavailable services.
+```
+
+## エラーハンドリング
+
+### エラーケース
+
+| エラーケース | 対応 | confidence | emotion |
+|------------|------|-----------|---------|
+| RAG検索失敗 | getDefaultResponse() | 0.3 | apologetic |
+| RAG結果が空 | getDefaultResponse() | 0.3 | apologetic |
+| コンテキストが空 | getDefaultResponse() | 0.3 | apologetic |
+| コンテキストフィルタ失敗 | フィルタなしで継続 | 0.85 | 元のemotion |
+| メモリアクセス失敗 | inheritedRequestType = null で継続 | 0.85 | 元のemotion |
+
+### デフォルトレスポンス
+
+```typescript
+// 日本語
+{
+  text: "[sad]申し訳ございません。お探しの情報が見つかりませんでした。質問を言い換えていただくか、スタッフにお問い合わせください。",
+  emotion: "apologetic",
+  metadata: {
+    agentName: "BusinessInfoAgent",
+    confidence: 0.3,
+    language: "ja",
+    category: category,
+    requestType: requestType,
+    sources: ["fallback"]
+  }
+}
+
+// 英語
+{
+  text: "[sad]I'm sorry, I couldn't find the specific information you're looking for. Please try rephrasing your question or contact the staff for assistance.",
+  emotion: "apologetic",
+  metadata: {
+    agentName: "BusinessInfoAgent",
+    confidence: 0.3,
+    language: "en",
+    category: category,
+    requestType: requestType,
+    sources: ["fallback"]
+  }
+}
+```
+
+### ログ出力
+
+#### デバッグログ
+
+```typescript
+// クエリ処理開始
+console.log('[BusinessInfoAgent] Processing query:', {
+  query,
+  category,
+  requestType,
+  language,
+  sessionId
+});
+
+// 文脈継承
+console.log('[BusinessInfoAgent] Inherited request type:', effectiveRequestType);
+
+// 文脈エンティティ検出
+console.log('[BusinessInfoAgent] Context entity detected:', contextEntity);
+
+// クエリ拡張
+console.log('[BusinessInfoAgent] Enhanced context query:', searchQuery);
+
+// RAG検索
+console.log('[BusinessInfoAgent] Using Enhanced RAG with category:', category);
+
+// コンテキストフィルタリング
+console.log('[BusinessInfoAgent] Filtered context:', {
+  originalLength,
+  filteredLength
+});
+
+// プロンプト構築
+console.log('[BusinessInfoAgent] Building prompt with:', {
+  queryLength,
+  contextLength,
+  requestType,
+  language
+});
+```
+
+#### エラーログ
+
+```typescript
+// RAG検索エラー
+console.error('[BusinessInfoAgent] RAG search error:', error);
+
+// コンテキストフィルタエラー
+console.error('[BusinessInfoAgent] Context filter error:', error);
+
+// RAGツールが見つからない
+console.error('[BusinessInfoAgent] No RAG search tool available');
+```
+
+## LangGraph版の仕様
+
+### Python型定義
+
+```python
+from typing import TypedDict, Literal, Optional
+from pydantic import BaseModel
+
+class BusinessQueryInput(BaseModel):
+    """ビジネス情報クエリの入力"""
+    query: str
+    category: str
+    request_type: Optional[str]
+    language: Literal["ja", "en"]
+    session_id: Optional[str] = None
+
+class UnifiedAgentResponse(TypedDict):
+    """統一エージェント応答"""
+    text: str
+    emotion: str
+    metadata: dict
+
+class ProcessingInfo(TypedDict):
+    """処理情報"""
+    filtered: bool
+    context_inherited: bool
+    enhanced_rag: bool
+
+class ResponseMetadata(TypedDict):
+    """応答メタデータ"""
+    agent_name: Literal["BusinessInfoAgent"]
+    confidence: float
+    language: Literal["ja", "en"]
+    category: Optional[str]
+    request_type: Optional[str]
+    sources: list[str]
+    processing_info: ProcessingInfo
+```
+
+### ノード関数シグネチャ
+
+```python
+from langgraph.graph import StateGraph
+from typing import Annotated
+
+def business_info_node(state: WorkflowState) -> dict:
+    """
+    ビジネス情報エージェントノード
+
+    Args:
+        state: ワークフロー状態
+            - query: ユーザークエリ
+            - category: クエリカテゴリ
+            - request_type: リクエストタイプ
+            - language: 言語
+            - session_id: セッションID
+
+    Returns:
+        dict: response, emotion, metadata を含む辞書
+    """
+    # 1. 文脈依存チェック
+    if is_short_context_query(state["query"]) and state.get("session_id"):
+        memory_context = get_memory_context(
+            state["query"],
+            session_id=state["session_id"],
+            language=state["language"]
+        )
+        effective_request_type = (
+            state["request_type"] or memory_context.get("inherited_request_type")
+        )
+        context_entity = detect_context_entity(memory_context)
+    else:
+        effective_request_type = state["request_type"]
+        context_entity = None
+
+    # 2. クエリ拡張
+    search_query = enhance_context_query(
+        state["query"],
+        effective_request_type,
+        state["language"],
+        context_entity
+    )
+
+    # 3. Enhanced RAG検索
+    rag_category = map_request_type_to_category(effective_request_type)
+    search_result = enhanced_rag_search(
+        query=search_query,
+        category=rag_category,
+        language=state["language"],
+        include_advice=True,
+        max_results=10
+    )
+
+    # 4. コンテキスト抽出 & フィルタリング
+    context = extract_context(search_result)
+    if effective_request_type:
+        context = filter_context_by_request_type(
+            context,
+            effective_request_type,
+            state["language"],
+            state["query"]
+        )
+
+    # 5. プロンプト構築 & LLM応答
+    prompt = build_prompt(
+        state["query"],
+        context,
+        effective_request_type,
+        state["language"]
+    )
+    response = llm_generate(prompt)
+
+    # 6. 統一応答作成
+    return create_unified_response(
+        text=response.text,
+        emotion=determine_emotion(effective_request_type),
+        agent_name="BusinessInfoAgent",
+        language=state["language"],
+        metadata={
+            "confidence": 0.85,
+            "category": state["category"],
+            "request_type": effective_request_type,
+            "sources": ["enhanced_rag"],
+            "processing_info": {
+                "filtered": bool(effective_request_type),
+                "context_inherited": effective_request_type != state["request_type"],
+                "enhanced_rag": True
+            }
+        }
+    )
+```
+
+### LangGraphグラフ定義
+
+```python
+from langgraph.graph import StateGraph, END
+
+# ワークフローグラフ構築
+workflow = StateGraph(WorkflowState)
+
+# ビジネス情報ノード追加
+workflow.add_node("business_info", business_info_node)
+
+# エッジ定義
+workflow.add_edge("router", "business_info")
+workflow.add_edge("business_info", "voice_output")
+workflow.add_edge("business_info", "character_control")
+
+# コンパイル
+app = workflow.compile()
+```
+
+## パフォーマンス指標
+
+### 目標値
+
+| 指標 | 目標値 | 測定方法 |
+|------|--------|---------|
+| 応答精度 | 85%+ | RAG検索のconfidence |
+| 応答時間 | < 3秒 | クエリ受信から応答生成まで |
+| 文脈継承率 | 90%+ | 短いクエリでの継承成功率 |
+| Enhanced RAG使用率 | 95%+ | enhancedRagTool使用比率 |
+| コンテキストフィルタ適用率 | 80%+ | requestType存在時のフィルタ適用率 |
+
+### モニタリングメトリクス
+
+```typescript
+// 応答メタデータに含まれるメトリクス
+{
+  processingInfo: {
+    filtered: boolean,           // フィルタ適用の有無
+    contextInherited: boolean,   // 文脈継承の有無
+    enhancedRag: boolean         // Enhanced RAG使用の有無
+  }
+}
+```
+
+## バージョン履歴
+
+| バージョン | 日付 | 変更内容 |
+|-----------|------|---------|
+| 1.0 | 2024-01 | 初期実装（Mastra） |
+| 1.1 | 2024-07 | 文脈依存クエリ処理追加 |
+| 1.2 | 2024-07 | Enhanced RAG統合 |
+| 1.3 | 2024-12 | コンテキストフィルタリング強化 |
+| 1.4 | 2025-01 | エンティティ認識と優先度スコアリング追加 |
+| 2.0 | 予定 | LangGraph移行 |
+
+## 関連ドキュメント
+
+- [RouterAgent SPEC.md](../router-agent/SPEC.md) - クエリルーティング仕様
+- [Enhanced RAG System](../../../mastra/tools/enhanced-rag-search.ts) - RAG検索実装
+- [SimplifiedMemorySystem](../../../lib/simplified-memory.ts) - メモリシステム実装
+- [UnifiedAgentResponse](../../../mastra/types/unified-response.ts) - 応答型定義
+
+## 付録: テストケース例
+
+### 基本営業時間クエリ
+
+```typescript
+// 入力
+{
+  query: "営業時間は？",
+  category: "facility-info",
+  requestType: "hours",
+  language: "ja"
+}
+
+// 期待出力
+{
+  text: "[relaxed]エンジニアカフェの営業時間は9:00〜22:00です。",
+  emotion: "informative",
+  metadata: {
+    agentName: "BusinessInfoAgent",
+    confidence: 0.85,
+    language: "ja",
+    requestType: "hours",
+    sources: ["enhanced_rag"],
+    processingInfo: {
+      filtered: true,
+      contextInherited: false,
+      enhancedRag: true
+    }
+  }
+}
+```
+
+### 文脈継承クエリ
+
+```typescript
+// 前提: 直前に "エンジニアカフェの営業時間は？" を質問済み
+
+// 入力
+{
+  query: "土曜日は？",
+  category: "facility-info",
+  requestType: null,
+  language: "ja",
+  sessionId: "session_123"
+}
+
+// 期待出力
+{
+  text: "[relaxed]土曜日も同じ9:00〜22:00です。",
+  emotion: "informative",
+  metadata: {
+    agentName: "BusinessInfoAgent",
+    confidence: 0.85,
+    language: "ja",
+    requestType: "hours",  // ← 継承された
+    sources: ["enhanced_rag"],
+    processingInfo: {
+      filtered: true,
+      contextInherited: true,  // ← 継承フラグ
+      enhancedRag: true
+    }
+  }
+}
+```
+
+### Sainoカフェクエリ
+
+```typescript
+// 入力
+{
+  query: "sainoの料金は？",
+  category: "saino-cafe",
+  requestType: "price",
+  language: "ja"
+}
+
+// 期待出力
+{
+  text: "[relaxed]Sainoカフェの料金は、コーヒー1杯500円からです。",
+  emotion: "informative",
+  metadata: {
+    agentName: "BusinessInfoAgent",
+    confidence: 0.85,
+    language: "ja",
+    requestType: "price",
+    sources: ["enhanced_rag"],
+    processingInfo: {
+      filtered: true,
+      contextInherited: false,
+      enhancedRag: true
+    }
+  }
+}
+```
+
+### エラーケース
+
+```typescript
+// 入力 (情報が見つからない場合)
+{
+  query: "深夜営業はしていますか？",
+  category: "facility-info",
+  requestType: "hours",
+  language: "ja"
+}
+
+// 期待出力
+{
+  text: "[sad]申し訳ございません。お探しの情報が見つかりませんでした。質問を言い換えていただくか、スタッフにお問い合わせください。",
+  emotion: "apologetic",
+  metadata: {
+    agentName: "BusinessInfoAgent",
+    confidence: 0.3,
+    language: "ja",
+    requestType: "hours",
+    sources: ["fallback"]
+  }
+}
+```

--- a/docs/migration/agents/business-info-agent/TESTING.md
+++ b/docs/migration/agents/business-info-agent/TESTING.md
@@ -1,0 +1,518 @@
+# Business Info Agent - テスト戦略
+
+> テストケース・検証方法・品質基準
+
+## テスト概要
+
+Business Info Agentは営業情報の正確性が重要なため、高いテストカバレッジが必要です。
+
+### テストレベル
+
+| レベル | 対象 | 目的 |
+|-------|------|------|
+| 単体テスト | 各メソッド | 個別機能の検証 |
+| 統合テスト | RAG・メモリ連携 | エンドツーエンド検証 |
+| 回帰テスト | 全情報カテゴリ | 既存機能の維持確認 |
+
+## 単体テストケース
+
+### 1. 営業時間クエリテスト
+
+```python
+# tests/test_business_info_agent.py
+
+import pytest
+from backend.agents.business_info_agent import BusinessInfoAgent
+
+class TestBusinessHoursQueries:
+    """営業時間クエリのテスト"""
+
+    @pytest.fixture
+    def agent(self, mock_llm, mock_supabase, mock_openai):
+        return BusinessInfoAgent(mock_llm, mock_supabase, mock_openai)
+
+    @pytest.mark.parametrize("query,expected_type", [
+        # 日本語
+        ("エンジニアカフェの営業時間は？", "hours"),
+        ("何時まで開いてますか？", "hours"),
+        ("何時から利用できますか？", "hours"),
+        ("開館時間を教えて", "hours"),
+
+        # 英語
+        ("What are the opening hours?", "hours"),
+        ("When does it close?", "hours"),
+        ("What time does it open?", "hours"),
+    ])
+    async def test_hours_query_detection(self, agent, query, expected_type):
+        # requestTypeがhoursとして処理されることを確認
+        result = await agent.answer_business_query(
+            query=query,
+            category="facility-info",
+            request_type="hours",
+            language="ja" if any(c > '\u3000' for c in query) else "en"
+        )
+        assert result["metadata"]["request_type"] == expected_type
+
+    @pytest.mark.parametrize("query,lang,expected_keywords", [
+        ("エンジニアカフェの営業時間は？", "ja", ["9:00", "22:00"]),
+        ("What are the opening hours?", "en", ["9:00", "22:00"]),
+    ])
+    async def test_hours_response_content(self, agent, query, lang, expected_keywords):
+        result = await agent.answer_business_query(
+            query=query,
+            category="facility-info",
+            request_type="hours",
+            language=lang
+        )
+        for keyword in expected_keywords:
+            assert keyword in result["text"]
+```
+
+### 2. 料金クエリテスト
+
+```python
+class TestPricingQueries:
+    """料金クエリのテスト"""
+
+    @pytest.fixture
+    def agent(self, mock_llm, mock_supabase, mock_openai):
+        return BusinessInfoAgent(mock_llm, mock_supabase, mock_openai)
+
+    @pytest.mark.parametrize("query,expected_type", [
+        # 日本語
+        ("利用料金はいくらですか？", "price"),
+        ("料金を教えてください", "price"),
+        ("いくらかかりますか？", "price"),
+
+        # 英語
+        ("How much does it cost?", "price"),
+        ("What are the fees?", "price"),
+        ("Is it free?", "price"),
+    ])
+    async def test_price_query_detection(self, agent, query, expected_type):
+        result = await agent.answer_business_query(
+            query=query,
+            category="facility-info",
+            request_type="price",
+            language="ja" if any(c > '\u3000' for c in query) else "en"
+        )
+        assert result["metadata"]["request_type"] == expected_type
+
+    async def test_engineer_cafe_free_response(self, agent):
+        """エンジニアカフェ基本エリアが無料であることを確認"""
+        result = await agent.answer_business_query(
+            query="エンジニアカフェの利用料金は？",
+            category="facility-info",
+            request_type="price",
+            language="ja"
+        )
+        assert "無料" in result["text"] or "free" in result["text"].lower()
+```
+
+### 3. 場所クエリテスト
+
+```python
+class TestLocationQueries:
+    """場所・アクセスクエリのテスト"""
+
+    @pytest.fixture
+    def agent(self, mock_llm, mock_supabase, mock_openai):
+        return BusinessInfoAgent(mock_llm, mock_supabase, mock_openai)
+
+    @pytest.mark.parametrize("query,expected_type", [
+        # 日本語
+        ("場所はどこですか？", "location"),
+        ("アクセス方法を教えて", "location"),
+        ("住所を教えてください", "location"),
+
+        # 英語
+        ("Where is it located?", "location"),
+        ("How do I get there?", "location"),
+        ("What is the address?", "location"),
+    ])
+    async def test_location_query_detection(self, agent, query, expected_type):
+        result = await agent.answer_business_query(
+            query=query,
+            category="facility-info",
+            request_type="location",
+            language="ja" if any(c > '\u3000' for c in query) else "en"
+        )
+        assert result["metadata"]["request_type"] == expected_type
+```
+
+### 4. Sainoカフェクエリテスト
+
+```python
+class TestSainoCafeQueries:
+    """Sainoカフェ関連クエリのテスト"""
+
+    @pytest.fixture
+    def agent(self, mock_llm, mock_supabase, mock_openai):
+        return BusinessInfoAgent(mock_llm, mock_supabase, mock_openai)
+
+    @pytest.mark.parametrize("query,expected_entity", [
+        ("Sainoカフェの営業時間は？", "saino"),
+        ("サイノカフェの料金は？", "saino"),
+        ("sainoの方は何時まで？", "saino"),
+    ])
+    async def test_saino_entity_detection(self, agent, query, expected_entity):
+        result = await agent.answer_business_query(
+            query=query,
+            category="saino-cafe",
+            request_type="hours",
+            language="ja"
+        )
+        # Sainoカフェの情報が含まれることを確認
+        assert "saino" in result["text"].lower() or "サイノ" in result["text"]
+
+    async def test_saino_hours_different_from_engineer_cafe(self, agent):
+        """SainoカフェとEngineer Cafeの営業時間が異なることを確認"""
+        saino_result = await agent.answer_business_query(
+            query="Sainoカフェの営業時間は？",
+            category="saino-cafe",
+            request_type="hours",
+            language="ja"
+        )
+        # Sainoカフェは11:00-20:30（エンジニアカフェと異なる）
+        assert "11:00" in saino_result["text"] or "20:30" in saino_result["text"]
+```
+
+### 5. 文脈継承テスト
+
+```python
+class TestContextInheritance:
+    """文脈継承機能のテスト"""
+
+    @pytest.fixture
+    def agent(self, mock_llm, mock_supabase, mock_openai):
+        return BusinessInfoAgent(mock_llm, mock_supabase, mock_openai)
+
+    @pytest.mark.parametrize("query,expected_inherited", [
+        ("土曜日は？", True),
+        ("日曜日も同じ？", True),
+        ("平日はどう？", True),
+        ("sainoの方は？", True),
+        ("そっちは？", True),
+        ("エンジニアカフェの営業時間は？", False),  # 明示的なクエリ
+    ])
+    async def test_context_dependent_detection(self, agent, query, expected_inherited):
+        is_context_dependent = agent._is_short_context_query(query)
+        assert is_context_dependent == expected_inherited
+
+    async def test_request_type_inheritance(self, agent, mock_memory_with_hours_context):
+        """前回のhoursクエリからrequestTypeを継承"""
+        # メモリに前回の「営業時間」クエリを設定
+        agent.memory = mock_memory_with_hours_context
+
+        result = await agent.answer_business_query(
+            query="土曜日は？",
+            category="facility-info",
+            request_type=None,  # 明示的には指定しない
+            language="ja",
+            session_id="test_session"
+        )
+
+        # hoursが継承されていることを確認
+        assert result["metadata"]["processing_info"]["context_inherited"] == True
+        assert result["metadata"]["request_type"] == "hours"
+
+    async def test_entity_inheritance_from_context(self, agent, mock_memory_with_saino_context):
+        """前回のSainoカフェクエリからエンティティを継承"""
+        agent.memory = mock_memory_with_saino_context
+
+        result = await agent.answer_business_query(
+            query="土曜日は？",
+            category="facility-info",
+            request_type=None,
+            language="ja",
+            session_id="test_session"
+        )
+
+        # Sainoカフェの情報が返されることを確認
+        assert "saino" in result["text"].lower() or "サイノ" in result["text"]
+```
+
+### 6. クエリ拡張テスト
+
+```python
+class TestQueryEnhancement:
+    """クエリ拡張機能のテスト"""
+
+    @pytest.fixture
+    def agent(self, mock_llm, mock_supabase, mock_openai):
+        return BusinessInfoAgent(mock_llm, mock_supabase, mock_openai)
+
+    @pytest.mark.parametrize("query,request_type,context_entity,expected_contains", [
+        # エンティティ優先
+        ("土曜日は？", "hours", "saino", "sainoカフェ"),
+        ("いくら？", "price", "saino", "sainoカフェ"),
+
+        # 曜日関連
+        ("土曜日は？", "hours", None, "営業時間"),
+        ("日曜は？", "hours", None, "営業時間"),
+
+        # requestTypeベース
+        ("エンジニアカフェ", "hours", None, "営業時間"),
+        ("エンジニアカフェ", "price", None, "料金"),
+    ])
+    def test_query_enhancement(self, agent, query, request_type, context_entity, expected_contains):
+        enhanced = agent._enhance_context_query(query, request_type, "ja", context_entity)
+        assert expected_contains in enhanced
+```
+
+## 統合テストケース
+
+### Enhanced RAG統合テスト
+
+```python
+class TestEnhancedRAGIntegration:
+    """Enhanced RAGとの統合テスト"""
+
+    @pytest.fixture
+    def agent_with_real_rag(self, llm, supabase_client, openai_client):
+        return BusinessInfoAgent(llm, supabase_client, openai_client)
+
+    async def test_rag_search_for_hours(self, agent_with_real_rag):
+        """営業時間のRAG検索が正しく動作することを確認"""
+        result = await agent_with_real_rag.answer_business_query(
+            query="エンジニアカフェの営業時間は？",
+            category="facility-info",
+            request_type="hours",
+            language="ja"
+        )
+
+        assert result["metadata"]["sources"] == ["enhanced_rag"]
+        assert result["metadata"]["processing_info"]["enhanced_rag"] == True
+        assert "9:00" in result["text"] or "22:00" in result["text"]
+
+    async def test_entity_aware_scoring(self, agent_with_real_rag):
+        """エンティティ認識がスコアリングに影響することを確認"""
+        # Sainoカフェのクエリ
+        saino_result = await agent_with_real_rag.answer_business_query(
+            query="Sainoカフェの営業時間は？",
+            category="saino-cafe",
+            request_type="hours",
+            language="ja"
+        )
+
+        # エンジニアカフェのクエリ
+        ec_result = await agent_with_real_rag.answer_business_query(
+            query="エンジニアカフェの営業時間は？",
+            category="facility-info",
+            request_type="hours",
+            language="ja"
+        )
+
+        # それぞれ異なる営業時間が返されることを確認
+        assert saino_result["text"] != ec_result["text"]
+```
+
+### メモリシステム統合テスト
+
+```python
+class TestMemoryIntegration:
+    """メモリシステムとの統合テスト"""
+
+    async def test_conversation_continuity(self, agent_with_real_memory):
+        """会話の連続性が維持されることを確認"""
+        session_id = "test_session_123"
+
+        # 1. 最初の質問
+        first_result = await agent_with_real_memory.answer_business_query(
+            query="エンジニアカフェの営業時間は？",
+            category="facility-info",
+            request_type="hours",
+            language="ja",
+            session_id=session_id
+        )
+
+        # 2. フォローアップ質問
+        followup_result = await agent_with_real_memory.answer_business_query(
+            query="土曜日は？",
+            category="facility-info",
+            request_type=None,  # 継承させる
+            language="ja",
+            session_id=session_id
+        )
+
+        # 文脈が継承されていることを確認
+        assert followup_result["metadata"]["processing_info"]["context_inherited"] == True
+```
+
+## パフォーマンステスト
+
+### レスポンスタイム計測
+
+```python
+import time
+import asyncio
+
+class TestPerformance:
+    """パフォーマンステスト"""
+
+    async def test_response_time(self, agent):
+        """レスポンス時間のテスト"""
+        queries = [
+            ("エンジニアカフェの営業時間は？", "hours"),
+            ("料金はいくらですか？", "price"),
+            ("場所はどこですか？", "location"),
+            ("Sainoカフェの営業時間は？", "hours"),
+        ]
+
+        times = []
+        for query, request_type in queries:
+            start = time.perf_counter()
+            await agent.answer_business_query(
+                query=query,
+                category="facility-info",
+                request_type=request_type,
+                language="ja"
+            )
+            elapsed = (time.perf_counter() - start) * 1000
+            times.append(elapsed)
+
+        avg_time = sum(times) / len(times)
+        max_time = max(times)
+
+        # 目標: 平均3秒以下、最大5秒以下
+        assert avg_time < 3000, f"Average time {avg_time:.2f}ms exceeds 3000ms"
+        assert max_time < 5000, f"Max time {max_time:.2f}ms exceeds 5000ms"
+
+    async def test_concurrent_queries(self, agent):
+        """同時クエリのテスト"""
+        queries = [("エンジニアカフェの営業時間は？", "hours")] * 5
+
+        start = time.perf_counter()
+        results = await asyncio.gather(*[
+            agent.answer_business_query(
+                query=q,
+                category="facility-info",
+                request_type=rt,
+                language="ja"
+            )
+            for q, rt in queries
+        ])
+        elapsed = (time.perf_counter() - start) * 1000
+
+        assert len(results) == 5
+        assert all(r["metadata"]["confidence"] > 0.5 for r in results)
+        # 5件の同時処理が10秒以内
+        assert elapsed < 10000
+```
+
+## 回帰テストマトリクス
+
+### 情報正確性テスト
+
+| カテゴリ | テストケース数 | 目標精度 |
+|---------|--------------|---------|
+| 営業時間 | 10 | 100% |
+| 料金 | 8 | 100% |
+| 場所 | 8 | 100% |
+| Sainoカフェ | 8 | 95% |
+| 文脈継承 | 10 | 90% |
+| **合計** | **44** | **95%以上** |
+
+### 期待値テストケース
+
+```python
+class TestExpectedResponses:
+    """期待される回答のテスト"""
+
+    @pytest.mark.parametrize("query,expected_response_contains", [
+        # 営業時間
+        ("エンジニアカフェの営業時間は？", ["9:00", "22:00"]),
+        ("Sainoカフェの営業時間は？", ["11:00", "20:30"]),
+
+        # 料金
+        ("エンジニアカフェの利用料金は？", ["無料"]),
+
+        # 場所
+        ("エンジニアカフェの場所は？", ["福岡", "天神"]),
+    ])
+    async def test_expected_response_content(self, agent, query, expected_response_contains):
+        result = await agent.answer_business_query(
+            query=query,
+            category="facility-info",
+            request_type=None,
+            language="ja"
+        )
+
+        for expected in expected_response_contains:
+            assert expected in result["text"], f"Expected '{expected}' in response"
+```
+
+## テスト実行方法
+
+### ローカル実行
+
+```bash
+# 全テスト実行
+pytest tests/test_business_info_agent.py -v
+
+# 特定のテストクラスのみ
+pytest tests/test_business_info_agent.py::TestBusinessHoursQueries -v
+
+# パフォーマンステストのみ
+pytest tests/test_business_info_agent.py::TestPerformance -v
+
+# カバレッジレポート付き
+pytest tests/test_business_info_agent.py --cov=backend/agents/business_info_agent --cov-report=html
+```
+
+### CI/CD連携
+
+```yaml
+# .github/workflows/test-business-info-agent.yml
+
+name: Business Info Agent Tests
+
+on:
+  push:
+    paths:
+      - 'backend/agents/business_info_agent.py'
+      - 'backend/tools/enhanced_rag_search.py'
+      - 'backend/tools/context_filter.py'
+      - 'tests/test_business_info_agent.py'
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+      - name: Install dependencies
+        run: |
+          pip install -r backend/requirements.txt
+          pip install pytest pytest-asyncio pytest-cov
+      - name: Run tests
+        run: |
+          pytest tests/test_business_info_agent.py -v --cov=backend/agents/business_info_agent
+```
+
+## 品質基準
+
+### 合格基準
+
+| 項目 | 基準 |
+|-----|------|
+| 単体テストカバレッジ | 85%以上 |
+| 情報正確性 | 95%以上 |
+| 平均レスポンス時間 | 3秒以下 |
+| 文脈継承成功率 | 90%以上 |
+| 回帰テスト | 全パス |
+
+### リリース前チェックリスト
+
+- [ ] 全単体テストがパス
+- [ ] 統合テストがパス
+- [ ] パフォーマンステストが基準を満たす
+- [ ] 営業時間の情報が正確
+- [ ] 料金の情報が正確
+- [ ] Sainoカフェの情報が正確
+- [ ] 文脈継承が正しく動作
+- [ ] コードレビュー完了
+- [ ] ドキュメント更新完了

--- a/docs/migration/agents/event-agent/MIGRATION-GUIDE.md
+++ b/docs/migration/agents/event-agent/MIGRATION-GUIDE.md
@@ -1,0 +1,769 @@
+# Event Agent - 移行ガイド
+
+> Mastra (TypeScript) → LangGraph (Python) 移行手順
+
+## 移行概要
+
+### 現在の実装（Mastra/TypeScript）
+
+```
+frontend/src/mastra/agents/
+└── event-agent.ts                   # 250行
+```
+
+### 移行先（LangGraph/Python）
+
+```
+backend/
+├── agents/
+│   └── event_agent.py              # 新規作成
+├── tools/
+│   ├── calendar_service.py         # 既存（修正）
+│   └── rag_search.py               # 既存（利用）
+└── workflows/
+    └── main_workflow.py            # 既存（修正）
+```
+
+## 移行ステップ
+
+### Step 1: Event Agent 本体の移行
+
+**元ファイル**: `frontend/src/mastra/agents/event-agent.ts`
+
+```python
+# backend/agents/event_agent.py
+
+from typing import TypedDict, Literal
+from datetime import datetime
+import logging
+
+logger = logging.getLogger(__name__)
+
+TimeRange = Literal["today", "thisWeek", "nextWeek", "thisMonth"]
+SupportedLanguage = Literal["ja", "en"]
+
+class CalendarEvent(TypedDict):
+    title: str
+    start: str
+    end: str | None
+    description: str | None
+
+class UnifiedAgentResponse(TypedDict):
+    text: str
+    emotion: str
+    agent_name: str
+    language: SupportedLanguage
+    metadata: dict
+
+class EventAgent:
+    def __init__(self, llm_client, tools: dict):
+        """
+        イベントエージェントの初期化
+
+        Args:
+            llm_client: LLMクライアント（Gemini等）
+            tools: ツール辞書 {'calendarService': ..., 'ragSearch': ...}
+        """
+        self.llm = llm_client
+        self.tools = tools
+        self.name = "EventAgent"
+
+    async def answer_event_query(
+        self,
+        query: str,
+        language: SupportedLanguage
+    ) -> UnifiedAgentResponse:
+        """
+        イベントクエリへの応答生成
+
+        Args:
+            query: ユーザーからのイベント関連クエリ
+            language: 応答言語 ('ja' | 'en')
+
+        Returns:
+            UnifiedAgentResponse: エージェント応答
+        """
+        logger.info(f"[EventAgent] Processing event query: {query}")
+
+        # 時間範囲抽出
+        time_range = self._extract_time_range(query)
+
+        # カレンダーイベント取得
+        calendar_result = await self._get_calendar_events(time_range, query)
+
+        # RAG検索でイベント情報を取得
+        knowledge_result = await self._search_event_knowledge(query, language)
+
+        # 結果を統合
+        has_calendar_events = (
+            calendar_result.get("success", False) and
+            calendar_result.get("data", {}).get("events", [])
+        )
+        has_knowledge_events = knowledge_result.get("success", False)
+
+        if not has_calendar_events and not has_knowledge_events:
+            return self._get_no_events_response(time_range, language)
+
+        # プロンプト構築
+        prompt = self._build_event_prompt(
+            query=query,
+            calendar_events=calendar_result.get("data", {}).get("events", []),
+            knowledge_context=self._extract_knowledge_context(knowledge_result),
+            time_range=time_range,
+            language=language
+        )
+
+        # LLM生成
+        response_text = await self.llm.generate(prompt)
+
+        # ソース情報を記録
+        sources = []
+        if has_calendar_events:
+            sources.append("calendar")
+        if has_knowledge_events:
+            sources.append("knowledge_base")
+
+        # エモーション決定
+        emotion = self._determine_emotion(has_calendar_events, has_knowledge_events)
+
+        return self._create_unified_response(
+            text=response_text,
+            emotion=emotion,
+            language=language,
+            sources=sources
+        )
+
+    def _extract_time_range(self, query: str) -> TimeRange:
+        """
+        クエリから時間範囲を抽出
+
+        Args:
+            query: ユーザークエリ
+
+        Returns:
+            TimeRange: 'today' | 'thisWeek' | 'nextWeek' | 'thisMonth'
+        """
+        lower_query = query.lower()
+
+        # 今日
+        if any(kw in lower_query for kw in ['今日', 'today', '本日']):
+            return 'today'
+
+        # 今週
+        if any(kw in lower_query for kw in ['今週', 'this week']):
+            return 'thisWeek'
+
+        # 来週
+        if any(kw in lower_query for kw in ['来週', 'next week']):
+            return 'nextWeek'
+
+        # 今月
+        if any(kw in lower_query for kw in ['今月', 'this month']):
+            return 'thisMonth'
+
+        # デフォルト: 今週
+        return 'thisWeek'
+
+    async def _get_calendar_events(
+        self,
+        time_range: TimeRange,
+        query: str
+    ) -> dict:
+        """
+        カレンダーからイベントを取得
+
+        Args:
+            time_range: 時間範囲
+            query: 元のクエリ
+
+        Returns:
+            dict: {'success': bool, 'data': {'events': [...]}}
+        """
+        calendar_tool = self.tools.get("calendarService")
+        if not calendar_tool:
+            logger.warning("[EventAgent] Calendar tool not available")
+            return {"success": False, "data": None}
+
+        try:
+            result = await calendar_tool.execute({
+                "action": "searchEvents",
+                "timeRange": time_range,
+                "query": query
+            })
+            return result
+        except Exception as e:
+            logger.error(f"[EventAgent] Calendar tool error: {e}")
+            return {"success": False, "data": None}
+
+    async def _search_event_knowledge(
+        self,
+        query: str,
+        language: SupportedLanguage
+    ) -> dict:
+        """
+        RAG検索でイベント関連知識を取得
+
+        Args:
+            query: 検索クエリ
+            language: 言語
+
+        Returns:
+            dict: RAG検索結果
+        """
+        rag_tool = self.tools.get("ragSearch")
+        if not rag_tool:
+            logger.warning("[EventAgent] RAG search tool not available")
+            return {"success": False, "data": None}
+
+        try:
+            result = await rag_tool.execute({
+                "query": query,
+                "language": language,
+                "limit": 10
+            })
+            return result
+        except Exception as e:
+            logger.error(f"[EventAgent] RAG search error: {e}")
+            return {"success": False, "data": None}
+
+    def _extract_knowledge_context(self, knowledge_result: dict) -> str:
+        """
+        RAG検索結果からコンテキストを抽出
+
+        Args:
+            knowledge_result: RAG検索結果
+
+        Returns:
+            str: コンテキスト文字列
+        """
+        if not knowledge_result.get("success"):
+            return ""
+
+        # results形式
+        if "results" in knowledge_result and isinstance(knowledge_result["results"], list):
+            return "\n\n".join(r.get("content", "") for r in knowledge_result["results"])
+
+        # data.context形式
+        if "data" in knowledge_result and "context" in knowledge_result["data"]:
+            return knowledge_result["data"]["context"]
+
+        return ""
+
+    def _build_event_prompt(
+        self,
+        query: str,
+        calendar_events: list[CalendarEvent],
+        knowledge_context: str,
+        time_range: TimeRange,
+        language: SupportedLanguage
+    ) -> str:
+        """
+        イベント情報応答のプロンプトを構築
+
+        Args:
+            query: ユーザークエリ
+            calendar_events: カレンダーイベントリスト
+            knowledge_context: RAG検索結果のコンテキスト
+            time_range: 時間範囲
+            language: 応答言語
+
+        Returns:
+            str: LLM用プロンプト
+        """
+        calendar_info = self._format_calendar_events(calendar_events, language)
+
+        if language == "en":
+            return f"""Provide information about events at Engineer Cafe based on the following data.
+
+Question: {query}
+Time Range: {time_range}
+
+Calendar Events:
+{calendar_info or 'No events found in calendar'}
+
+Additional Event Information:
+{knowledge_context or 'No additional information available'}
+
+Format the response with clear dates, times, and event descriptions. If there are multiple events, list them chronologically."""
+
+        else:  # ja
+            time_range_ja = self._translate_time_range(time_range)
+            return f"""以下のデータに基づいて、エンジニアカフェのイベントについて情報を提供してください。
+
+質問: {query}
+期間: {time_range_ja}
+
+カレンダーイベント:
+{calendar_info or 'カレンダーにイベントが見つかりません'}
+
+追加のイベント情報:
+{knowledge_context or '追加情報はありません'}
+
+日付、時間、イベントの説明を明確にフォーマットして応答してください。複数のイベントがある場合は、時系列順に一覧表示してください。"""
+
+    def _format_calendar_events(
+        self,
+        events: list[CalendarEvent],
+        language: SupportedLanguage
+    ) -> str:
+        """
+        カレンダーイベントをフォーマット
+
+        Args:
+            events: イベントリスト
+            language: 言語
+
+        Returns:
+            str: フォーマット済みイベント情報
+        """
+        if not events:
+            return ""
+
+        formatted_events = []
+        locale = "ja_JP" if language == "ja" else "en_US"
+
+        for event in events:
+            try:
+                start_time = datetime.fromisoformat(event["start"]).strftime("%Y/%m/%d %H:%M:%S")
+                end_time = ""
+                if event.get("end"):
+                    end_time = datetime.fromisoformat(event["end"]).strftime("%Y/%m/%d %H:%M:%S")
+
+                if language == "en":
+                    formatted = f"- {event['title']}\n  Time: {start_time}"
+                    if end_time:
+                        formatted += f" - {end_time}"
+                    formatted += f"\n  {event.get('description', 'No description')}"
+                else:
+                    formatted = f"- {event['title']}\n  時間: {start_time}"
+                    if end_time:
+                        formatted += f" - {end_time}"
+                    formatted += f"\n  {event.get('description', '説明なし')}"
+
+                formatted_events.append(formatted)
+            except Exception as e:
+                logger.error(f"[EventAgent] Error formatting event: {e}")
+                continue
+
+        return "\n\n".join(formatted_events)
+
+    def _translate_time_range(self, time_range: TimeRange) -> str:
+        """
+        時間範囲を日本語に翻訳
+
+        Args:
+            time_range: 時間範囲
+
+        Returns:
+            str: 日本語訳
+        """
+        translations = {
+            "today": "今日",
+            "thisWeek": "今週",
+            "nextWeek": "来週",
+            "thisMonth": "今月"
+        }
+        return translations.get(time_range, time_range)
+
+    def _determine_emotion(
+        self,
+        has_calendar_events: bool,
+        has_knowledge_events: bool
+    ) -> str:
+        """
+        エモーションを決定
+
+        Args:
+            has_calendar_events: カレンダーイベントの有無
+            has_knowledge_events: 知識ベースイベントの有無
+
+        Returns:
+            str: emotion値
+        """
+        if has_calendar_events:
+            return "excited"
+        elif not has_calendar_events and not has_knowledge_events:
+            return "apologetic"
+        else:
+            return "helpful"
+
+    def _get_no_events_response(
+        self,
+        time_range: TimeRange,
+        language: SupportedLanguage
+    ) -> UnifiedAgentResponse:
+        """
+        イベント不在時の応答を生成
+
+        Args:
+            time_range: 時間範囲
+            language: 言語
+
+        Returns:
+            UnifiedAgentResponse: イベント不在応答
+        """
+        time_range_text = (
+            self._translate_time_range(time_range) if language == "ja"
+            else time_range
+        )
+
+        if language == "en":
+            text = f"[sad]I couldn't find any scheduled events for {time_range} at Engineer Cafe. Please check the official website or contact the staff for the most up-to-date event information."
+        else:
+            text = f"[sad]{time_range_text}のエンジニアカフェでの予定されたイベントが見つかりませんでした。最新のイベント情報については、公式ウェブサイトをご確認いただくか、スタッフにお問い合わせください。"
+
+        return self._create_unified_response(
+            text=text,
+            emotion="apologetic",
+            language=language,
+            sources=["calendar", "knowledge_base"],
+            confidence=0.7
+        )
+
+    def _create_unified_response(
+        self,
+        text: str,
+        emotion: str,
+        language: SupportedLanguage,
+        sources: list[str],
+        confidence: float = 0.8
+    ) -> UnifiedAgentResponse:
+        """
+        統一応答オブジェクトを生成
+
+        Args:
+            text: 応答テキスト
+            emotion: エモーション
+            language: 言語
+            sources: データソースリスト
+            confidence: 信頼度
+
+        Returns:
+            UnifiedAgentResponse: 統一応答
+        """
+        return {
+            "text": text,
+            "emotion": emotion,
+            "agent_name": self.name,
+            "language": language,
+            "metadata": {
+                "confidence": confidence,
+                "category": "events",
+                "sources": sources,
+                "processing_info": {
+                    "enhanced_rag": False
+                }
+            }
+        }
+```
+
+### Step 2: ワークフローへの統合
+
+**修正ファイル**: `backend/workflows/main_workflow.py`
+
+```python
+# backend/workflows/main_workflow.py
+
+from backend.agents.event_agent import EventAgent
+
+class MainWorkflow:
+    def __init__(self):
+        # エージェント初期化
+        self.event_agent = EventAgent(
+            llm_client=self.llm,
+            tools={
+                "calendarService": self.calendar_tool,
+                "ragSearch": self.rag_tool
+            }
+        )
+        self.graph = self._build_graph()
+
+    async def _event_agent_node(self, state: WorkflowState) -> dict:
+        """
+        イベントエージェントノード
+
+        Args:
+            state: ワークフロー状態
+
+        Returns:
+            dict: 更新状態
+        """
+        query = state.get("query", "")
+        language = state.get("language", "ja")
+
+        # EventAgentを使用
+        response = await self.event_agent.answer_event_query(query, language)
+
+        return {
+            "response": response["text"],
+            "emotion": response["emotion"],
+            "metadata": {
+                **state.get("metadata", {}),
+                "agent": "EventAgent",
+                "sources": response["metadata"]["sources"],
+                "confidence": response["metadata"]["confidence"]
+            }
+        }
+
+    def _build_graph(self):
+        """ワークフローグラフの構築"""
+        from langgraph.graph import StateGraph
+
+        graph = StateGraph(WorkflowState)
+
+        # ノード追加
+        graph.add_node("router", self._router_node)
+        graph.add_node("event", self._event_agent_node)  # イベントノード追加
+        # ... 他のノード
+
+        # エッジ追加
+        graph.add_conditional_edges(
+            "router",
+            self._route_decision,
+            {
+                "event": "event",  # EventAgentへのルーティング
+                # ... 他のルーティング
+            }
+        )
+
+        return graph.compile()
+```
+
+### Step 3: ツールインターフェースの調整
+
+#### Calendar Service Tool
+
+```python
+# backend/tools/calendar_service.py
+
+from typing import TypedDict, Literal
+from datetime import datetime, timedelta
+import logging
+
+logger = logging.getLogger(__name__)
+
+TimeRange = Literal["today", "thisWeek", "nextWeek", "thisMonth"]
+
+class CalendarServiceTool:
+    def __init__(self, google_calendar_client):
+        self.calendar_client = google_calendar_client
+
+    async def execute(self, params: dict) -> dict:
+        """
+        カレンダーツール実行
+
+        Args:
+            params: {
+                'action': 'searchEvents',
+                'timeRange': TimeRange,
+                'query': str
+            }
+
+        Returns:
+            dict: {'success': bool, 'data': {'events': [...]}}
+        """
+        action = params.get("action")
+        if action != "searchEvents":
+            return {"success": False, "error": "Unknown action"}
+
+        time_range = params.get("timeRange", "thisWeek")
+        query = params.get("query", "")
+
+        try:
+            # 時間範囲を日付範囲に変換
+            start_date, end_date = self._get_date_range(time_range)
+
+            # Google Calendar APIで検索
+            events = await self.calendar_client.search_events(
+                start_date=start_date,
+                end_date=end_date,
+                query=query
+            )
+
+            return {
+                "success": True,
+                "data": {
+                    "events": events
+                }
+            }
+        except Exception as e:
+            logger.error(f"[CalendarServiceTool] Error: {e}")
+            return {"success": False, "error": str(e)}
+
+    def _get_date_range(self, time_range: TimeRange) -> tuple[datetime, datetime]:
+        """
+        時間範囲を日付範囲に変換
+
+        Args:
+            time_range: 時間範囲
+
+        Returns:
+            tuple: (start_date, end_date)
+        """
+        now = datetime.now()
+
+        if time_range == "today":
+            start = now.replace(hour=0, minute=0, second=0)
+            end = now.replace(hour=23, minute=59, second=59)
+        elif time_range == "thisWeek":
+            start = now - timedelta(days=now.weekday())
+            end = start + timedelta(days=6)
+        elif time_range == "nextWeek":
+            start = now + timedelta(days=(7 - now.weekday()))
+            end = start + timedelta(days=6)
+        elif time_range == "thisMonth":
+            start = now.replace(day=1, hour=0, minute=0, second=0)
+            next_month = start.replace(month=start.month + 1) if start.month < 12 else start.replace(year=start.year + 1, month=1)
+            end = next_month - timedelta(seconds=1)
+        else:
+            start = now
+            end = now + timedelta(days=7)
+
+        return start, end
+```
+
+## 移行チェックリスト
+
+### Phase 1: 準備
+
+- [ ] 既存のTypeScriptコードを完全に理解した
+- [ ] Python依存パッケージを確認した（langchain, google-calendar等）
+- [ ] テスト環境を準備した
+
+### Phase 2: EventAgent本体
+
+- [ ] `event_agent.py` を作成した
+- [ ] `answer_event_query()` メソッドを実装した
+- [ ] `_extract_time_range()` を実装した
+- [ ] `_format_calendar_events()` を実装した
+- [ ] 単体テストを作成・通過した
+
+### Phase 3: ツール統合
+
+- [ ] `calendar_service.py` を修正/作成した
+- [ ] `rag_search.py` との統合を確認した
+- [ ] ツールエラーハンドリングを実装した
+
+### Phase 4: ワークフロー統合
+
+- [ ] `main_workflow.py` にEventAgentノードを追加した
+- [ ] ルーティング条件を設定した
+- [ ] エンドツーエンドテストを通過した
+
+### Phase 5: 検証
+
+- [ ] 全時間範囲パターンをテストした（today, thisWeek, nextWeek, thisMonth）
+- [ ] マルチソース統合を検証した（calendar + RAG）
+- [ ] エモーション生成を確認した
+- [ ] 日英両言語での動作確認を完了した
+
+## データ型変換ガイド
+
+### TypeScript → Python
+
+| TypeScript | Python | 備考 |
+|-----------|--------|------|
+| `string` | `str` | |
+| `number` | `int` / `float` | |
+| `boolean` | `bool` | |
+| `any` | `Any` | typing.Anyをimport |
+| `Array<T>` | `list[T]` | Python 3.9+ |
+| `Record<K, V>` | `dict[K, V]` | |
+| `T \| null` | `T \| None` | |
+| `interface` | `TypedDict` | typing.TypedDict |
+| `type` | `TypeAlias` | typing.TypeAlias |
+
+### 非同期処理
+
+```typescript
+// TypeScript
+async answerEventQuery(query: string): Promise<Response> {
+  const result = await this.tool.execute(params);
+  return result;
+}
+```
+
+```python
+# Python
+async def answer_event_query(self, query: str) -> dict:
+    result = await self.tool.execute(params)
+    return result
+```
+
+### 日付処理
+
+```typescript
+// TypeScript
+const startTime = new Date(event.start).toLocaleString('ja-JP');
+```
+
+```python
+# Python
+from datetime import datetime
+start_time = datetime.fromisoformat(event["start"]).strftime("%Y/%m/%d %H:%M:%S")
+```
+
+## トラブルシューティング
+
+### よくある問題
+
+| 問題 | 原因 | 解決策 |
+|-----|------|-------|
+| タイムゾーンのずれ | 日付処理でUTC/JSTの混在 | datetimeにtzinfo設定 |
+| カレンダーAPI認証エラー | Google Calendar認証設定不足 | OAuth2設定確認 |
+| イベント0件で例外発生 | Noneチェック不足 | `events or []` でデフォルト設定 |
+| 日本語フォーマット崩れ | ロケール設定ミス | strftimeで明示的にフォーマット指定 |
+
+### デバッグ方法
+
+```python
+# ログレベル設定
+import logging
+logging.basicConfig(level=logging.DEBUG)
+
+# デバッグログ追加
+logger.debug(f"[EventAgent] Calendar result: {calendar_result}")
+logger.debug(f"[EventAgent] Knowledge context: {knowledge_context}")
+logger.debug(f"[EventAgent] Time range: {time_range}")
+```
+
+## パフォーマンス最適化
+
+### 並列処理
+
+```python
+# カレンダーとRAG検索を並列実行
+import asyncio
+
+calendar_task = self._get_calendar_events(time_range, query)
+knowledge_task = self._search_event_knowledge(query, language)
+
+calendar_result, knowledge_result = await asyncio.gather(
+    calendar_task,
+    knowledge_task,
+    return_exceptions=True
+)
+```
+
+### キャッシング
+
+```python
+from functools import lru_cache
+
+@lru_cache(maxsize=100)
+def _translate_time_range(self, time_range: TimeRange) -> str:
+    """時間範囲翻訳（キャッシュ付き）"""
+    translations = {
+        "today": "今日",
+        "thisWeek": "今週",
+        "nextWeek": "来週",
+        "thisMonth": "今月"
+    }
+    return translations.get(time_range, time_range)
+```
+
+## 参考リンク
+
+- [LangGraph ドキュメント](https://langchain-ai.github.io/langgraph/)
+- [Google Calendar API](https://developers.google.com/calendar)
+- [元実装: event-agent.ts](/Users/teradakousuke/Developer/engineer-cafe-navigator2025/frontend/src/mastra/agents/event-agent.ts)

--- a/docs/migration/agents/event-agent/SPEC.md
+++ b/docs/migration/agents/event-agent/SPEC.md
@@ -1,0 +1,484 @@
+# Event Agent - 技術仕様書
+
+> 入出力仕様・API定義・データ構造
+
+## 入力仕様
+
+### メイン入力: `answerEventQuery()`
+
+```typescript
+interface EventQueryInput {
+  query: string;              // ユーザーからのイベント関連クエリ
+  language: SupportedLanguage; // 'ja' | 'en'
+}
+```
+
+#### 入力例
+
+```typescript
+// 今日のイベント
+{
+  query: "今日のイベントは？",
+  language: "ja"
+}
+
+// 今週のスケジュール
+{
+  query: "What events are scheduled this week?",
+  language: "en"
+}
+
+// 来週のワークショップ
+{
+  query: "来週の勉強会を教えて",
+  language: "ja"
+}
+
+// 今月のイベント
+{
+  query: "今月のイベントはありますか？",
+  language: "ja"
+}
+```
+
+## 出力仕様
+
+### メイン出力: `UnifiedAgentResponse`
+
+```typescript
+interface UnifiedAgentResponse {
+  text: string;                    // イベント情報を含む応答テキスト
+  emotion: string;                 // 'excited' | 'helpful' | 'apologetic'
+  agentName: string;              // 'EventAgent' (固定)
+  language: SupportedLanguage;    // 'ja' | 'en'
+  metadata: {
+    confidence: number;           // 信頼度 (通常 0.7-0.8)
+    category: string;             // 'events' (固定)
+    sources: string[];            // ['calendar', 'knowledge_base']
+    processingInfo: {
+      enhancedRag: boolean;       // false (現在未使用)
+    };
+  };
+}
+```
+
+#### 出力例
+
+```typescript
+// イベントが見つかった場合
+{
+  text: "[happy]今週は以下のイベントがあります：\n\n- TypeScript勉強会\n  時間: 2025年1月15日 19:00 - 21:00\n  参加者30名募集中です。",
+  emotion: "excited",
+  agentName: "EventAgent",
+  language: "ja",
+  metadata: {
+    confidence: 0.8,
+    category: "events",
+    sources: ["calendar", "knowledge_base"],
+    processingInfo: {
+      enhancedRag: false
+    }
+  }
+}
+
+// イベントが見つからない場合
+{
+  text: "[sad]今週のエンジニアカフェでの予定されたイベントが見つかりませんでした。最新のイベント情報については、公式ウェブサイトをご確認いただくか、スタッフにお問い合わせください。",
+  emotion: "apologetic",
+  agentName: "EventAgent",
+  language: "ja",
+  metadata: {
+    confidence: 0.7,
+    category: "events",
+    sources: ["calendar", "knowledge_base"]
+  }
+}
+```
+
+## 時間範囲抽出
+
+### extractTimeRange()
+
+クエリから時間範囲を自動検出します。
+
+```typescript
+type TimeRange = 'today' | 'thisWeek' | 'nextWeek' | 'thisMonth';
+```
+
+#### 検出パターン
+
+| TimeRange | 日本語キーワード | 英語キーワード |
+|-----------|----------------|---------------|
+| `today` | 今日, 本日 | today |
+| `thisWeek` | 今週 | this week |
+| `nextWeek` | 来週 | next week |
+| `thisMonth` | 今月 | this month |
+
+#### デフォルト値
+
+明示的な時間指定がない場合は `thisWeek` を使用。
+
+#### 実装例
+
+```typescript
+private extractTimeRange(query: string): TimeRange {
+  const lowerQuery = query.toLowerCase();
+
+  if (lowerQuery.includes('今日') || lowerQuery.includes('today') || lowerQuery.includes('本日')) {
+    return 'today';
+  }
+  if (lowerQuery.includes('今週') || lowerQuery.includes('this week')) {
+    return 'thisWeek';
+  }
+  if (lowerQuery.includes('来週') || lowerQuery.includes('next week')) {
+    return 'nextWeek';
+  }
+  if (lowerQuery.includes('今月') || lowerQuery.includes('this month')) {
+    return 'thisMonth';
+  }
+
+  // Default to this week
+  return 'thisWeek';
+}
+```
+
+## データソース統合
+
+### 1. カレンダーサービス (calendarService)
+
+```typescript
+interface CalendarToolInput {
+  action: 'searchEvents';
+  timeRange: TimeRange;
+  query: string;
+}
+
+interface CalendarToolResult {
+  success: boolean;
+  data: {
+    events: CalendarEvent[];
+  } | null;
+}
+
+interface CalendarEvent {
+  title: string;
+  start: string;        // ISO 8601 timestamp
+  end?: string;         // ISO 8601 timestamp (オプション)
+  description?: string; // イベント説明 (オプション)
+}
+```
+
+### 2. RAG検索 (ragSearch)
+
+```typescript
+interface RAGSearchInput {
+  query: string;
+  language: SupportedLanguage;
+  limit: number;        // デフォルト: 10
+}
+
+interface RAGSearchResult {
+  success: boolean;
+  results?: Array<{
+    content: string;
+  }>;
+  data?: {
+    context: string;
+  };
+}
+```
+
+### マルチソース統合ロジック
+
+```typescript
+// カレンダーイベントとRAG結果を組み合わせる
+const hasCalendarEvents = calendarResult.success && calendarResult.data?.events?.length > 0;
+const hasKnowledgeEvents = knowledgeResult.success && knowledgeContext;
+
+if (!hasCalendarEvents && !hasKnowledgeEvents) {
+  return this.getNoEventsResponse(timeRange, language);
+}
+
+// ソース情報を記録
+const sources = [];
+if (hasCalendarEvents) sources.push('calendar');
+if (hasKnowledgeEvents) sources.push('knowledge_base');
+```
+
+## イベント情報フォーマット
+
+### formatCalendarEvents()
+
+```typescript
+private formatCalendarEvents(events: CalendarEvent[], language: SupportedLanguage): string {
+  if (!events || events.length === 0) {
+    return '';
+  }
+
+  return events.map(event => {
+    const startTime = new Date(event.start).toLocaleString(
+      language === 'ja' ? 'ja-JP' : 'en-US'
+    );
+    const endTime = event.end
+      ? new Date(event.end).toLocaleString(language === 'ja' ? 'ja-JP' : 'en-US')
+      : '';
+
+    return language === 'en'
+      ? `- ${event.title}\n  Time: ${startTime}${endTime ? ` - ${endTime}` : ''}\n  ${event.description || 'No description'}`
+      : `- ${event.title}\n  時間: ${startTime}${endTime ? ` - ${endTime}` : ''}\n  ${event.description || '説明なし'}`;
+  }).join('\n\n');
+}
+```
+
+#### フォーマット例
+
+```
+- TypeScript勉強会
+  時間: 2025/01/15 19:00:00 - 2025/01/15 21:00:00
+  TypeScriptの基礎から応用まで学びます
+
+- Reactハンズオン
+  時間: 2025/01/17 18:30:00 - 2025/01/17 20:30:00
+  説明なし
+```
+
+## エモーションマッピング
+
+### emotion値の選択ロジック
+
+| 条件 | emotion | エモーションタグ |
+|------|---------|----------------|
+| カレンダーイベント > 0 | excited | [happy] |
+| イベント0件 | apologetic | [sad] |
+| 通常ケース | helpful | [relaxed] |
+
+### エモーションタグ仕様
+
+応答テキストの先頭に必ず含める：
+
+- `[happy]`: イベントが複数見つかった場合
+- `[sad]`: イベントが見つからない場合
+- `[relaxed]`: 一般的な情報提供時
+- `[surprised]`: 特別なアナウンス時
+
+```typescript
+// Determine emotion based on events found
+let emotion = 'helpful';
+if (hasCalendarEvents && calendarResult.data?.events?.length > 0) {
+  emotion = 'excited';
+} else if (!hasCalendarEvents && !hasKnowledgeEvents) {
+  emotion = 'apologetic';
+}
+```
+
+## プロンプト構築
+
+### buildEventPrompt()
+
+```typescript
+private buildEventPrompt(
+  query: string,
+  calendarEvents: CalendarEvent[],
+  knowledgeContext: string,
+  timeRange: TimeRange,
+  language: SupportedLanguage
+): string
+```
+
+#### 日本語プロンプトテンプレート
+
+```
+以下のデータに基づいて、エンジニアカフェのイベントについて情報を提供してください。
+
+質問: ${query}
+期間: ${this.translateTimeRange(timeRange)}
+
+カレンダーイベント:
+${calendarInfo || 'カレンダーにイベントが見つかりません'}
+
+追加のイベント情報:
+${knowledgeContext || '追加情報はありません'}
+
+日付、時間、イベントの説明を明確にフォーマットして応答してください。複数のイベントがある場合は、時系列順に一覧表示してください。
+```
+
+#### 英語プロンプトテンプレート
+
+```
+Provide information about events at Engineer Cafe based on the following data.
+
+Question: ${query}
+Time Range: ${timeRange}
+
+Calendar Events:
+${calendarInfo || 'No events found in calendar'}
+
+Additional Event Information:
+${knowledgeContext || 'No additional information available'}
+
+Format the response with clear dates, times, and event descriptions. If there are multiple events, list them chronologically.
+```
+
+## イベント不在時の応答
+
+### getNoEventsResponse()
+
+```typescript
+private getNoEventsResponse(timeRange: TimeRange, language: SupportedLanguage): UnifiedAgentResponse {
+  const timeRangeText = language === 'ja'
+    ? this.translateTimeRange(timeRange)
+    : timeRange;
+
+  const text = language === 'en'
+    ? `[sad]I couldn't find any scheduled events for ${timeRange} at Engineer Cafe. Please check the official website or contact the staff for the most up-to-date event information.`
+    : `[sad]${timeRangeText}のエンジニアカフェでの予定されたイベントが見つかりませんでした。最新のイベント情報については、公式ウェブサイトをご確認いただくか、スタッフにお問い合わせください。`;
+
+  return createUnifiedResponse(
+    text,
+    'apologetic',
+    'EventAgent',
+    language,
+    {
+      confidence: 0.7,
+      category: 'events',
+      sources: ['calendar', 'knowledge_base']
+    }
+  );
+}
+```
+
+## 時間範囲翻訳
+
+### translateTimeRange()
+
+```typescript
+private translateTimeRange(timeRange: string): string {
+  const translations: Record<string, string> = {
+    'today': '今日',
+    'thisWeek': '今週',
+    'nextWeek': '来週',
+    'thisMonth': '今月'
+  };
+
+  return translations[timeRange] || timeRange;
+}
+```
+
+## エラーハンドリング
+
+### ツールエラー処理
+
+```typescript
+// Calendar tool error handling
+let calendarResult: any = { success: false, data: null };
+if (calendarTool) {
+  try {
+    calendarResult = await calendarTool.execute({
+      action: 'searchEvents',
+      timeRange,
+      query
+    });
+  } catch (error) {
+    console.error('[EventAgent] Calendar tool error:', error);
+    // Continue with RAG search even if calendar fails
+  }
+}
+
+// RAG tool error handling
+let knowledgeResult: any = { success: false, data: null };
+if (ragTool) {
+  try {
+    knowledgeResult = await ragTool.execute({
+      query,
+      language,
+      limit: 10
+    });
+  } catch (error) {
+    console.error('[EventAgent] RAG search error:', error);
+    // Continue even if RAG search fails
+  }
+}
+```
+
+### フォールバック戦略
+
+| エラーケース | 対応 |
+|------------|------|
+| カレンダー取得失敗 | RAG検索結果のみ使用 |
+| RAG検索失敗 | カレンダー結果のみ使用 |
+| 両方失敗 | getNoEventsResponse()を返す |
+
+## LangGraph版の仕様
+
+### Python型定義
+
+```python
+from typing import TypedDict, Literal
+
+TimeRange = Literal["today", "thisWeek", "nextWeek", "thisMonth"]
+SupportedLanguage = Literal["ja", "en"]
+
+class CalendarEvent(TypedDict):
+    title: str
+    start: str
+    end: str | None
+    description: str | None
+
+class EventQueryInput(TypedDict):
+    query: str
+    language: SupportedLanguage
+
+class UnifiedAgentResponse(TypedDict):
+    text: str
+    emotion: str
+    agent_name: str
+    language: SupportedLanguage
+    metadata: dict
+```
+
+### ノード関数シグネチャ
+
+```python
+async def event_agent_node(state: WorkflowState) -> dict:
+    """
+    イベントエージェントノード: イベント情報の取得と応答生成
+
+    Args:
+        state: ワークフロー状態（query, language, session_id等を含む）
+
+    Returns:
+        dict: response, emotion, sources を含む辞書
+    """
+    pass
+```
+
+## パフォーマンス指標
+
+### 目標値
+
+| 指標 | 目標 |
+|-----|------|
+| 平均応答時間 | 1.5秒以下 |
+| カレンダー取得成功率 | 95%以上 |
+| RAG検索成功率 | 98%以上 |
+| マルチソース統合成功率 | 90%以上 |
+| イベント情報精度 | 100% |
+
+### 処理時間内訳
+
+```
+Total: ~1.5s
+├─ カレンダーAPI: 500-800ms
+├─ RAG検索: 300-500ms
+├─ LLM生成: 400-600ms
+└─ その他: 50-100ms
+```
+
+## バージョン履歴
+
+| バージョン | 日付 | 変更内容 |
+|-----------|------|---------|
+| 1.0 | 2024-01 | 初期実装（Mastra） |
+| 1.1 | 2024-07 | マルチソース統合追加 |
+| 1.2 | 2024-12 | エモーションタグ強化 |
+| 2.0 | 予定 | LangGraph移行 |

--- a/docs/migration/agents/event-agent/TESTING.md
+++ b/docs/migration/agents/event-agent/TESTING.md
@@ -1,0 +1,795 @@
+# Event Agent - テスト戦略
+
+> テストケース・検証方法・品質基準
+
+## テスト概要
+
+Event Agentは複数のデータソース（カレンダー、RAG）を統合し、時間範囲に基づいてイベント情報を提供します。高品質な応答と正確な時間範囲処理が求められます。
+
+### テストレベル
+
+| レベル | 対象 | 目的 |
+|-------|------|------|
+| 単体テスト | 各メソッド | 個別機能の検証 |
+| 統合テスト | マルチソース統合 | カレンダー+RAG連携検証 |
+| エンドツーエンドテスト | ワークフロー全体 | 実運用シナリオ検証 |
+| パフォーマンステスト | 応答時間 | 1.5秒以内のレスポンス確認 |
+
+## 単体テストケース
+
+### 1. 時間範囲抽出テスト
+
+```python
+# tests/test_event_agent.py
+
+import pytest
+from backend.agents.event_agent import EventAgent
+
+class TestTimeRangeExtraction:
+    """時間範囲抽出のテスト"""
+
+    @pytest.fixture
+    def event_agent(self):
+        return EventAgent(llm_client=None, tools={})
+
+    @pytest.mark.parametrize("query,expected_range", [
+        # 今日
+        ("今日のイベントは？", "today"),
+        ("今日は何かイベントある？", "today"),
+        ("本日のスケジュール", "today"),
+        ("What events are happening today?", "today"),
+        ("Today's schedule", "today"),
+
+        # 今週
+        ("今週のイベントを教えて", "thisWeek"),
+        ("今週は何がありますか？", "thisWeek"),
+        ("What's happening this week?", "thisWeek"),
+        ("Events this week", "thisWeek"),
+
+        # 来週
+        ("来週の勉強会は？", "nextWeek"),
+        ("来週のスケジュール", "nextWeek"),
+        ("Next week's events", "nextWeek"),
+        ("What's planned for next week?", "nextWeek"),
+
+        # 今月
+        ("今月のイベント一覧", "thisMonth"),
+        ("今月は何があるの？", "thisMonth"),
+        ("Events this month", "thisMonth"),
+        ("This month's schedule", "thisMonth"),
+
+        # デフォルト（今週）
+        ("イベント情報", "thisWeek"),
+        ("何かイベントある？", "thisWeek"),
+        ("Events", "thisWeek"),
+    ])
+    def test_extract_time_range(self, event_agent, query, expected_range):
+        """時間範囲抽出の正確性を検証"""
+        result = event_agent._extract_time_range(query)
+        assert result == expected_range, f"Query: {query}"
+```
+
+### 2. カレンダーイベント取得テスト
+
+```python
+class TestCalendarEventRetrieval:
+    """カレンダーイベント取得のテスト"""
+
+    @pytest.fixture
+    def mock_calendar_tool(self):
+        """カレンダーツールのモック"""
+        class MockCalendarTool:
+            async def execute(self, params):
+                if params["timeRange"] == "today":
+                    return {
+                        "success": True,
+                        "data": {
+                            "events": [
+                                {
+                                    "title": "TypeScript勉強会",
+                                    "start": "2025-01-15T19:00:00",
+                                    "end": "2025-01-15T21:00:00",
+                                    "description": "TypeScriptの基礎から応用まで"
+                                }
+                            ]
+                        }
+                    }
+                else:
+                    return {"success": True, "data": {"events": []}}
+        return MockCalendarTool()
+
+    @pytest.mark.asyncio
+    async def test_get_calendar_events_success(self, mock_calendar_tool):
+        """カレンダーイベント取得成功時のテスト"""
+        event_agent = EventAgent(
+            llm_client=None,
+            tools={"calendarService": mock_calendar_tool}
+        )
+
+        result = await event_agent._get_calendar_events("today", "今日のイベント")
+
+        assert result["success"] is True
+        assert len(result["data"]["events"]) == 1
+        assert result["data"]["events"][0]["title"] == "TypeScript勉強会"
+
+    @pytest.mark.asyncio
+    async def test_get_calendar_events_error(self):
+        """カレンダーツールエラー時の処理"""
+        class ErrorCalendarTool:
+            async def execute(self, params):
+                raise Exception("Calendar API error")
+
+        event_agent = EventAgent(
+            llm_client=None,
+            tools={"calendarService": ErrorCalendarTool()}
+        )
+
+        result = await event_agent._get_calendar_events("today", "今日のイベント")
+
+        assert result["success"] is False
+        assert result["data"] is None
+```
+
+### 3. イベントフォーマットテスト
+
+```python
+class TestEventFormatting:
+    """イベントフォーマットのテスト"""
+
+    @pytest.fixture
+    def event_agent(self):
+        return EventAgent(llm_client=None, tools={})
+
+    @pytest.fixture
+    def sample_events(self):
+        return [
+            {
+                "title": "TypeScript勉強会",
+                "start": "2025-01-15T19:00:00",
+                "end": "2025-01-15T21:00:00",
+                "description": "TypeScriptの基礎から応用まで"
+            },
+            {
+                "title": "Reactハンズオン",
+                "start": "2025-01-17T18:30:00",
+                "end": "2025-01-17T20:30:00",
+                "description": None
+            }
+        ]
+
+    def test_format_calendar_events_japanese(self, event_agent, sample_events):
+        """日本語イベントフォーマット"""
+        result = event_agent._format_calendar_events(sample_events, "ja")
+
+        assert "TypeScript勉強会" in result
+        assert "時間:" in result
+        assert "2025/01/15 19:00:00" in result
+        assert "TypeScriptの基礎から応用まで" in result
+        assert "説明なし" in result  # description=Noneの場合
+
+    def test_format_calendar_events_english(self, event_agent, sample_events):
+        """英語イベントフォーマット"""
+        result = event_agent._format_calendar_events(sample_events, "en")
+
+        assert "TypeScript勉強会" in result
+        assert "Time:" in result
+        assert "2025/01/15 19:00:00" in result
+        assert "TypeScriptの基礎から応用まで" in result
+        assert "No description" in result
+
+    def test_format_empty_events(self, event_agent):
+        """空イベントリストのフォーマット"""
+        result = event_agent._format_calendar_events([], "ja")
+        assert result == ""
+```
+
+### 4. RAG検索統合テスト
+
+```python
+class TestRAGSearchIntegration:
+    """RAG検索統合のテスト"""
+
+    @pytest.fixture
+    def mock_rag_tool(self):
+        class MockRAGTool:
+            async def execute(self, params):
+                return {
+                    "success": True,
+                    "results": [
+                        {"content": "エンジニアカフェでは毎週イベントを開催しています。"},
+                        {"content": "勉強会は平日夜に開催されます。"}
+                    ]
+                }
+        return MockRAGTool()
+
+    @pytest.mark.asyncio
+    async def test_search_event_knowledge(self, mock_rag_tool):
+        """RAG検索によるイベント知識取得"""
+        event_agent = EventAgent(
+            llm_client=None,
+            tools={"ragSearch": mock_rag_tool}
+        )
+
+        result = await event_agent._search_event_knowledge("イベント情報", "ja")
+
+        assert result["success"] is True
+        assert "results" in result
+        assert len(result["results"]) == 2
+
+    def test_extract_knowledge_context_results_format(self):
+        """RAG結果からコンテキスト抽出（results形式）"""
+        event_agent = EventAgent(llm_client=None, tools={})
+
+        knowledge_result = {
+            "success": True,
+            "results": [
+                {"content": "コンテンツ1"},
+                {"content": "コンテンツ2"}
+            ]
+        }
+
+        context = event_agent._extract_knowledge_context(knowledge_result)
+
+        assert "コンテンツ1" in context
+        assert "コンテンツ2" in context
+
+    def test_extract_knowledge_context_data_format(self):
+        """RAG結果からコンテキスト抽出（data.context形式）"""
+        event_agent = EventAgent(llm_client=None, tools={})
+
+        knowledge_result = {
+            "success": True,
+            "data": {
+                "context": "統合されたコンテキスト"
+            }
+        }
+
+        context = event_agent._extract_knowledge_context(knowledge_result)
+
+        assert context == "統合されたコンテキスト"
+```
+
+### 5. エモーション決定テスト
+
+```python
+class TestEmotionDetermination:
+    """エモーション決定のテスト"""
+
+    @pytest.fixture
+    def event_agent(self):
+        return EventAgent(llm_client=None, tools={})
+
+    @pytest.mark.parametrize("has_calendar,has_knowledge,expected_emotion", [
+        # カレンダーイベントあり
+        (True, True, "excited"),
+        (True, False, "excited"),
+
+        # カレンダーイベントなし、知識ベースあり
+        (False, True, "helpful"),
+
+        # 両方なし
+        (False, False, "apologetic"),
+    ])
+    def test_determine_emotion(
+        self,
+        event_agent,
+        has_calendar,
+        has_knowledge,
+        expected_emotion
+    ):
+        """エモーション決定ロジックの検証"""
+        emotion = event_agent._determine_emotion(has_calendar, has_knowledge)
+        assert emotion == expected_emotion
+```
+
+### 6. イベント不在応答テスト
+
+```python
+class TestNoEventsResponse:
+    """イベント不在応答のテスト"""
+
+    @pytest.fixture
+    def event_agent(self):
+        return EventAgent(llm_client=None, tools={})
+
+    @pytest.mark.parametrize("time_range,language", [
+        ("today", "ja"),
+        ("thisWeek", "ja"),
+        ("nextWeek", "ja"),
+        ("thisMonth", "ja"),
+        ("today", "en"),
+        ("thisWeek", "en"),
+    ])
+    def test_get_no_events_response(self, event_agent, time_range, language):
+        """イベント不在応答の生成"""
+        response = event_agent._get_no_events_response(time_range, language)
+
+        assert response["agent_name"] == "EventAgent"
+        assert response["emotion"] == "apologetic"
+        assert response["language"] == language
+        assert "[sad]" in response["text"]
+        assert response["metadata"]["confidence"] == 0.7
+        assert response["metadata"]["category"] == "events"
+        assert "calendar" in response["metadata"]["sources"]
+        assert "knowledge_base" in response["metadata"]["sources"]
+```
+
+## 統合テストケース
+
+### マルチソース統合テスト
+
+```python
+# tests/test_event_agent_integration.py
+
+import pytest
+from backend.agents.event_agent import EventAgent
+
+class TestMultiSourceIntegration:
+    """マルチソース統合のテスト"""
+
+    @pytest.fixture
+    def mock_tools(self):
+        """カレンダーとRAGツールのモック"""
+        class MockCalendarTool:
+            async def execute(self, params):
+                return {
+                    "success": True,
+                    "data": {
+                        "events": [
+                            {
+                                "title": "TypeScript勉強会",
+                                "start": "2025-01-15T19:00:00",
+                                "end": "2025-01-15T21:00:00",
+                                "description": "初心者歓迎"
+                            }
+                        ]
+                    }
+                }
+
+        class MockRAGTool:
+            async def execute(self, params):
+                return {
+                    "success": True,
+                    "results": [
+                        {"content": "勉強会は毎週開催されます"}
+                    ]
+                }
+
+        class MockLLM:
+            async def generate(self, prompt):
+                return "[happy]今週はTypeScript勉強会があります。1月15日19時から21時まで開催されます。"
+
+        return {
+            "calendarService": MockCalendarTool(),
+            "ragSearch": MockRAGTool()
+        }, MockLLM()
+
+    @pytest.mark.asyncio
+    async def test_answer_event_query_with_both_sources(self, mock_tools):
+        """カレンダーとRAG両方からデータを取得するテスト"""
+        tools, llm = mock_tools
+        event_agent = EventAgent(llm_client=llm, tools=tools)
+
+        response = await event_agent.answer_event_query(
+            query="今週のイベントは？",
+            language="ja"
+        )
+
+        assert response["agent_name"] == "EventAgent"
+        assert response["emotion"] == "excited"
+        assert "[happy]" in response["text"]
+        assert "TypeScript" in response["text"]
+        assert response["metadata"]["category"] == "events"
+        assert "calendar" in response["metadata"]["sources"]
+        assert "knowledge_base" in response["metadata"]["sources"]
+
+    @pytest.mark.asyncio
+    async def test_answer_event_query_calendar_only(self):
+        """カレンダーのみからデータを取得するテスト"""
+        class MockCalendarTool:
+            async def execute(self, params):
+                return {
+                    "success": True,
+                    "data": {
+                        "events": [{"title": "イベント", "start": "2025-01-15T19:00:00"}]
+                    }
+                }
+
+        class MockRAGTool:
+            async def execute(self, params):
+                return {"success": False}
+
+        class MockLLM:
+            async def generate(self, prompt):
+                return "[happy]イベントがあります"
+
+        tools = {
+            "calendarService": MockCalendarTool(),
+            "ragSearch": MockRAGTool()
+        }
+        event_agent = EventAgent(llm_client=MockLLM(), tools=tools)
+
+        response = await event_agent.answer_event_query("イベントは？", "ja")
+
+        assert response["emotion"] == "excited"
+        assert "calendar" in response["metadata"]["sources"]
+        assert "knowledge_base" not in response["metadata"]["sources"]
+
+    @pytest.mark.asyncio
+    async def test_answer_event_query_no_events(self):
+        """イベント0件のテスト"""
+        class MockCalendarTool:
+            async def execute(self, params):
+                return {"success": True, "data": {"events": []}}
+
+        class MockRAGTool:
+            async def execute(self, params):
+                return {"success": False}
+
+        tools = {
+            "calendarService": MockCalendarTool(),
+            "ragSearch": MockRAGTool()
+        }
+        event_agent = EventAgent(llm_client=None, tools=tools)
+
+        response = await event_agent.answer_event_query("今日のイベント", "ja")
+
+        assert response["emotion"] == "apologetic"
+        assert "[sad]" in response["text"]
+        assert "見つかりませんでした" in response["text"]
+```
+
+### エラーハンドリングテスト
+
+```python
+class TestErrorHandling:
+    """エラーハンドリングのテスト"""
+
+    @pytest.mark.asyncio
+    async def test_calendar_api_error_fallback_to_rag(self):
+        """カレンダーAPI失敗時のRAGフォールバック"""
+        class ErrorCalendarTool:
+            async def execute(self, params):
+                raise Exception("Calendar API down")
+
+        class MockRAGTool:
+            async def execute(self, params):
+                return {
+                    "success": True,
+                    "results": [{"content": "イベント情報"}]
+                }
+
+        class MockLLM:
+            async def generate(self, prompt):
+                return "[relaxed]イベント情報をご案内します"
+
+        tools = {
+            "calendarService": ErrorCalendarTool(),
+            "ragSearch": MockRAGTool()
+        }
+        event_agent = EventAgent(llm_client=MockLLM(), tools=tools)
+
+        response = await event_agent.answer_event_query("イベント", "ja")
+
+        # RAGのみで応答生成
+        assert response["text"] is not None
+        assert "knowledge_base" in response["metadata"]["sources"]
+        assert "calendar" not in response["metadata"]["sources"]
+
+    @pytest.mark.asyncio
+    async def test_both_sources_fail(self):
+        """両方のソース失敗時の処理"""
+        class ErrorTool:
+            async def execute(self, params):
+                raise Exception("API error")
+
+        tools = {
+            "calendarService": ErrorTool(),
+            "ragSearch": ErrorTool()
+        }
+        event_agent = EventAgent(llm_client=None, tools=tools)
+
+        response = await event_agent.answer_event_query("イベント", "ja")
+
+        # イベント不在応答を返す
+        assert response["emotion"] == "apologetic"
+        assert "[sad]" in response["text"]
+```
+
+## パフォーマンステスト
+
+### レスポンスタイム計測
+
+```python
+import time
+import asyncio
+
+class TestPerformance:
+    """パフォーマンステスト"""
+
+    @pytest.fixture
+    def fast_mock_tools(self):
+        """高速モックツール"""
+        class FastCalendarTool:
+            async def execute(self, params):
+                await asyncio.sleep(0.3)  # 300ms
+                return {
+                    "success": True,
+                    "data": {"events": [{"title": "イベント", "start": "2025-01-15T19:00:00"}]}
+                }
+
+        class FastRAGTool:
+            async def execute(self, params):
+                await asyncio.sleep(0.2)  # 200ms
+                return {"success": True, "results": [{"content": "情報"}]}
+
+        class FastLLM:
+            async def generate(self, prompt):
+                await asyncio.sleep(0.5)  # 500ms
+                return "[happy]イベント情報"
+
+        return {
+            "calendarService": FastCalendarTool(),
+            "ragSearch": FastRAGTool()
+        }, FastLLM()
+
+    @pytest.mark.asyncio
+    async def test_response_time(self, fast_mock_tools):
+        """応答時間のテスト"""
+        tools, llm = fast_mock_tools
+        event_agent = EventAgent(llm_client=llm, tools=tools)
+
+        start = time.perf_counter()
+        await event_agent.answer_event_query("今週のイベント", "ja")
+        elapsed = (time.perf_counter() - start) * 1000  # ms
+
+        # 目標: 1.5秒以内
+        # 並列実行により、最大値（500ms LLM）+ オーバーヘッドのみ
+        assert elapsed < 1500, f"Response time {elapsed:.2f}ms exceeds 1500ms"
+
+    @pytest.mark.asyncio
+    async def test_concurrent_queries(self, fast_mock_tools):
+        """同時クエリ処理のテスト"""
+        tools, llm = fast_mock_tools
+        event_agent = EventAgent(llm_client=llm, tools=tools)
+
+        queries = [
+            ("今日のイベント", "ja"),
+            ("今週のイベント", "ja"),
+            ("来週のイベント", "ja"),
+        ]
+
+        start = time.perf_counter()
+        results = await asyncio.gather(*[
+            event_agent.answer_event_query(q, lang)
+            for q, lang in queries
+        ])
+        elapsed = (time.perf_counter() - start) * 1000
+
+        assert len(results) == 3
+        # 3件の同時処理が3秒以内
+        assert elapsed < 3000, f"Concurrent processing took {elapsed:.2f}ms"
+```
+
+## エンドツーエンドテスト
+
+### ワークフロー統合テスト
+
+```python
+# tests/test_event_workflow.py
+
+import pytest
+from backend.workflows.main_workflow import MainWorkflow
+
+class TestEventWorkflow:
+    """EventAgentワークフロー統合テスト"""
+
+    @pytest.fixture
+    def workflow(self):
+        return MainWorkflow()
+
+    @pytest.mark.asyncio
+    async def test_event_query_routing(self, workflow):
+        """イベントクエリのルーティングテスト"""
+        result = await workflow.ainvoke({
+            "query": "今週のイベントは？",
+            "session_id": "test_session",
+            "language": "ja"
+        })
+
+        assert result["metadata"]["agent"] == "EventAgent"
+        assert result["metadata"]["category"] == "events"
+        assert result["response"] is not None
+
+    @pytest.mark.asyncio
+    async def test_multiple_time_ranges(self, workflow):
+        """複数時間範囲のテスト"""
+        test_cases = [
+            ("今日のイベント", "today"),
+            ("今週のイベント", "thisWeek"),
+            ("来週のイベント", "nextWeek"),
+            ("今月のイベント", "thisMonth"),
+        ]
+
+        for query, expected_range in test_cases:
+            result = await workflow.ainvoke({
+                "query": query,
+                "session_id": "test_session",
+                "language": "ja"
+            })
+
+            assert result["metadata"]["agent"] == "EventAgent"
+            # 時間範囲が正しく処理されたことを確認
+            assert result["response"] is not None
+```
+
+## 回帰テストマトリクス
+
+### イベントクエリ精度テスト
+
+| カテゴリ | テストケース数 | 目標精度 |
+|---------|--------------|---------|
+| 時間範囲抽出 | 20 | 100% |
+| カレンダー統合 | 15 | 95% |
+| RAG検索統合 | 12 | 98% |
+| イベントフォーマット | 10 | 100% |
+| エモーション生成 | 8 | 100% |
+| エラーハンドリング | 10 | 95% |
+| マルチソース統合 | 15 | 90% |
+| **合計** | **90** | **95%以上** |
+
+## テスト実行方法
+
+### ローカル実行
+
+```bash
+# 全テスト実行
+pytest tests/test_event_agent.py -v
+
+# 特定のテストクラスのみ
+pytest tests/test_event_agent.py::TestTimeRangeExtraction -v
+
+# 統合テスト
+pytest tests/test_event_agent_integration.py -v
+
+# パフォーマンステストのみ
+pytest tests/test_event_agent.py::TestPerformance -v
+
+# カバレッジレポート付き
+pytest tests/test_event_agent.py --cov=backend/agents/event_agent --cov-report=html
+```
+
+### CI/CD連携
+
+```yaml
+# .github/workflows/test-event-agent.yml
+
+name: Event Agent Tests
+
+on:
+  push:
+    paths:
+      - 'backend/agents/event_agent.py'
+      - 'backend/tools/calendar_service.py'
+      - 'tests/test_event_agent.py'
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+      - name: Install dependencies
+        run: |
+          pip install -r backend/requirements.txt
+          pip install pytest pytest-asyncio pytest-cov
+      - name: Run tests
+        run: |
+          pytest tests/test_event_agent.py -v --cov=backend/agents/event_agent
+      - name: Upload coverage
+        uses: codecov/codecov-action@v3
+```
+
+## 品質基準
+
+### 合格基準
+
+| 項目 | 基準 |
+|-----|------|
+| 単体テストカバレッジ | 90%以上 |
+| 統合テストカバレッジ | 85%以上 |
+| 時間範囲抽出精度 | 100% |
+| イベント情報精度 | 100% |
+| 平均応答時間 | 1.5秒以下 |
+| カレンダー統合成功率 | 95%以上 |
+| RAG統合成功率 | 98%以上 |
+| マルチソース統合成功率 | 90%以上 |
+
+### リリース前チェックリスト
+
+- [ ] 全単体テストがパス
+- [ ] 統合テストがパス
+- [ ] パフォーマンステストが基準を満たす
+- [ ] 時間範囲抽出が全パターンで動作
+- [ ] 日英両言語でのテストが完了
+- [ ] エラーハンドリングが適切に機能
+- [ ] マルチソース統合が正常動作
+- [ ] エモーションタグが正しく生成される
+- [ ] カレンダーAPI連携が動作
+- [ ] RAG検索が正常動作
+- [ ] コードレビュー完了
+- [ ] ドキュメント更新完了
+
+## テストデータ
+
+### サンプルイベントデータ
+
+```python
+# tests/fixtures/event_fixtures.py
+
+SAMPLE_EVENTS = [
+    {
+        "title": "TypeScript勉強会",
+        "start": "2025-01-15T19:00:00+09:00",
+        "end": "2025-01-15T21:00:00+09:00",
+        "description": "TypeScriptの基礎から応用まで学びます。初心者歓迎！"
+    },
+    {
+        "title": "Reactハンズオン",
+        "start": "2025-01-17T18:30:00+09:00",
+        "end": "2025-01-17T20:30:00+09:00",
+        "description": "Reactでウェブアプリを作ってみよう"
+    },
+    {
+        "title": "AI/ML勉強会",
+        "start": "2025-01-20T14:00:00+09:00",
+        "end": "2025-01-20T16:00:00+09:00",
+        "description": None
+    }
+]
+
+SAMPLE_RAG_RESULTS = [
+    {"content": "エンジニアカフェでは毎週様々なイベントを開催しています。"},
+    {"content": "勉強会は平日夜19時から開催されることが多いです。"},
+    {"content": "参加費は無料、ドリンク代のみ別途必要です。"}
+]
+```
+
+## デバッグガイド
+
+### ログ出力例
+
+```python
+# イベントエージェントのログ設定
+import logging
+
+logging.basicConfig(
+    level=logging.DEBUG,
+    format='[%(asctime)s] %(levelname)s - %(name)s - %(message)s'
+)
+
+# 出力例
+# [2025-01-15 19:00:00] INFO - EventAgent - Processing event query: 今週のイベント
+# [2025-01-15 19:00:00] DEBUG - EventAgent - Time range extracted: thisWeek
+# [2025-01-15 19:00:01] DEBUG - EventAgent - Calendar result: {'success': True, 'data': {...}}
+# [2025-01-15 19:00:01] DEBUG - EventAgent - Knowledge context: エンジニアカフェでは...
+# [2025-01-15 19:00:02] INFO - EventAgent - Response generated with emotion: excited
+```
+
+### トラブルシューティング
+
+| 問題 | 確認事項 | 解決策 |
+|-----|---------|-------|
+| イベントが取得できない | カレンダーAPIキー | 環境変数確認 |
+| 時間範囲が不正 | クエリのキーワード | パターンマッチング追加 |
+| フォーマットエラー | 日付形式 | ISO 8601形式確認 |
+| 応答が遅い | 並列処理 | asyncio.gather使用確認 |
+
+## 参考リンク
+
+- [pytest ドキュメント](https://docs.pytest.org/)
+- [pytest-asyncio](https://pytest-asyncio.readthedocs.io/)
+- [Google Calendar API テスト](https://developers.google.com/calendar/api/guides/testing)

--- a/docs/migration/agents/general-knowledge-agent/MIGRATION-GUIDE.md
+++ b/docs/migration/agents/general-knowledge-agent/MIGRATION-GUIDE.md
@@ -1,0 +1,603 @@
+# General Knowledge Agent - 移行ガイド
+
+> Mastra (TypeScript) → LangGraph (Python) 移行手順
+
+## 移行概要
+
+### 現在の実装（Mastra/TypeScript）
+
+```
+engineer-cafe-navigator-repo/frontend/src/
+└── mastra/agents/general-knowledge-agent.ts    # 209行
+```
+
+### 移行先（LangGraph/Python）
+
+```
+backend/
+├── agents/
+│   └── general_knowledge_agent.py              # 新規作成
+├── tools/
+│   ├── rag_search.py                           # 既存（利用）
+│   └── web_search.py                           # 新規作成
+└── workflows/
+    └── main_workflow.py                        # 既存（修正）
+```
+
+## 移行ステップ
+
+### Step 1: ウェブ検索ツールの作成
+
+**新規ファイル**: `backend/tools/web_search.py`
+
+```python
+# backend/tools/web_search.py
+
+from typing import TypedDict, Literal
+import httpx
+from langchain.tools import tool
+
+SupportedLanguage = Literal["ja", "en"]
+
+class WebSearchInput(TypedDict):
+    query: str
+    language: SupportedLanguage
+
+class WebSearchResult(TypedDict):
+    success: bool
+    text: str | None
+    data: dict | None
+
+@tool
+def general_web_search(query: str, language: str = "ja") -> WebSearchResult:
+    """
+    一般的なウェブ検索を実行
+
+    Args:
+        query: 検索クエリ
+        language: 言語 ('ja' または 'en')
+
+    Returns:
+        WebSearchResult: 検索結果
+    """
+    try:
+        # TODO: 実際のWeb検索APIを統合
+        # 例: Google Custom Search API, Bing API, DuckDuckGo API など
+
+        # プレースホルダー実装
+        search_results = _perform_web_search(query, language)
+
+        if not search_results:
+            return {
+                "success": False,
+                "text": None,
+                "data": None
+            }
+
+        # 検索結果をテキストに整形
+        context = _format_search_results(search_results, language)
+
+        return {
+            "success": True,
+            "text": context,
+            "data": {"context": context}
+        }
+
+    except Exception as e:
+        print(f"[WebSearch] Error: {e}")
+        return {
+            "success": False,
+            "text": None,
+            "data": None
+        }
+
+def _perform_web_search(query: str, language: str) -> list[dict]:
+    """
+    実際のウェブ検索を実行（プレースホルダー）
+
+    実装例:
+    - Google Custom Search API
+    - Bing Web Search API
+    - DuckDuckGo API
+    """
+    # TODO: 実装
+    return []
+
+def _format_search_results(results: list[dict], language: str) -> str:
+    """
+    検索結果をテキストに整形
+    """
+    if not results:
+        return ""
+
+    formatted = []
+    for result in results[:5]:  # 上位5件
+        title = result.get("title", "")
+        snippet = result.get("snippet", "")
+        formatted.append(f"{title}\n{snippet}")
+
+    return "\n\n".join(formatted)
+```
+
+### Step 2: General Knowledge Agent 本体の移行
+
+**新規ファイル**: `backend/agents/general_knowledge_agent.py`
+
+```python
+# backend/agents/general_knowledge_agent.py
+
+from typing import TypedDict, Literal
+import re
+from langchain_core.messages import HumanMessage, SystemMessage
+from langchain_google_genai import ChatGoogleGenerativeAI
+
+SupportedLanguage = Literal["ja", "en"]
+EmotionType = Literal["helpful", "apologetic"]
+
+class GeneralKnowledgeMetadata(TypedDict):
+    confidence: float
+    category: str
+    sources: list[str]
+    processing_info: dict
+
+class UnifiedAgentResponse(TypedDict):
+    text: str
+    emotion: EmotionType
+    agent_name: str
+    language: SupportedLanguage
+    metadata: GeneralKnowledgeMetadata
+
+class GeneralKnowledgeAgent:
+    """一般的な質問に対応するエージェント"""
+
+    def __init__(self, llm: ChatGoogleGenerativeAI):
+        self.llm = llm
+        self.name = "GeneralKnowledgeAgent"
+
+        self.instructions = """You are a general knowledge specialist who can answer a wide range of questions.
+You handle:
+- General information about Engineer Cafe
+- AI and technology topics
+- Fukuoka tech scene and startup information
+- Questions that don't fit specific categories
+Use both knowledge base and web search when appropriate.
+Always respond in the same language as the question.
+
+IMPORTANT: Always start your response with an emotion tag.
+Available emotions: [happy], [sad], [angry], [relaxed], [surprised]
+
+Use [relaxed] for informational responses about general topics
+Use [happy] when sharing exciting tech news or positive information
+Use [surprised] for unexpected or innovative topics
+Use [sad] when unable to find information or discussing challenges"""
+
+    async def answer_general_query(
+        self,
+        query: str,
+        language: SupportedLanguage,
+        rag_search_tool,
+        web_search_tool
+    ) -> UnifiedAgentResponse:
+        """
+        一般的な質問に回答
+
+        Args:
+            query: ユーザーからの質問
+            language: 言語
+            rag_search_tool: RAG検索ツール
+            web_search_tool: Web検索ツール
+
+        Returns:
+            UnifiedAgentResponse: 統一レスポンス
+        """
+        print(f"[GeneralKnowledgeAgent] Processing general query: query={query}, language={language}")
+
+        # ウェブ検索が必要かどうか判定
+        needs_web_search = self._should_use_web_search(query)
+
+        # ナレッジベース検索（常に実行）
+        context = ""
+        sources = []
+
+        try:
+            kb_result = await rag_search_tool.ainvoke({
+                "query": query,
+                "language": language,
+                "limit": 10
+            })
+
+            if kb_result.get("success"):
+                if kb_result.get("results"):
+                    # 結果配列の場合
+                    context = "\n\n".join([r["content"] for r in kb_result["results"]])
+                    sources.append("knowledge base")
+                elif kb_result.get("data", {}).get("context"):
+                    # データオブジェクトの場合
+                    context = kb_result["data"]["context"]
+                    sources.append("knowledge base")
+        except Exception as e:
+            print(f"[GeneralKnowledgeAgent] RAG search error: {e}")
+
+        # ウェブ検索（条件付き）
+        if needs_web_search or not context:
+            try:
+                web_result = await web_search_tool.ainvoke({
+                    "query": query,
+                    "language": language
+                })
+
+                if web_result.get("success"):
+                    web_context = web_result.get("text") or web_result.get("data", {}).get("context", "")
+                    if web_context:
+                        context = f"{context}\n\n{web_context}" if context else web_context
+                        sources.append("web search")
+            except Exception as e:
+                print(f"[GeneralKnowledgeAgent] Web search error: {e}")
+
+        # コンテキストがない場合はデフォルトレスポンス
+        if not context:
+            return self._get_default_general_response(language)
+
+        # プロンプト構築
+        prompt = self._build_general_prompt(query, context, sources, language)
+
+        # LLM生成
+        messages = [
+            SystemMessage(content=self.instructions),
+            HumanMessage(content=prompt)
+        ]
+        response = await self.llm.ainvoke(messages)
+        response_text = response.content
+
+        # 信頼度計算
+        confidence = self._calculate_confidence(sources)
+
+        # 感情抽出
+        emotion = self._extract_emotion(response_text)
+
+        return {
+            "text": response_text,
+            "emotion": emotion,
+            "agent_name": self.name,
+            "language": language,
+            "metadata": {
+                "confidence": confidence,
+                "category": "general_knowledge",
+                "sources": sources,
+                "processing_info": {
+                    "enhancedRag": False
+                }
+            }
+        }
+
+    def _should_use_web_search(self, query: str) -> bool:
+        """ウェブ検索が必要かどうか判定"""
+        lower_query = query.lower()
+
+        # ウェブ検索が必要なキーワード
+        web_search_keywords = [
+            # 日本語
+            '最新', '現在', '今', 'ニュース', 'トレンド', 'スタートアップ', 'ベンチャー',
+            '技術', 'ai', '人工知能', '機械学習', 'プログラミング',
+            # 英語
+            'latest', 'current', 'now', 'news', 'trend', 'startup', 'venture',
+            'technology', 'artificial intelligence', 'machine learning', 'programming'
+        ]
+
+        return any(keyword in lower_query for keyword in web_search_keywords)
+
+    def _build_general_prompt(
+        self,
+        query: str,
+        context: str,
+        sources: list[str],
+        language: SupportedLanguage
+    ) -> str:
+        """プロンプトを構築"""
+        source_info = " and ".join(sources)
+
+        if language == "en":
+            return f"""Answer the following question using the provided information from {source_info}.
+
+Question: {query}
+
+Information:
+{context}
+
+Provide a comprehensive but concise answer. If the information is from web search, mention that it's current information. Be helpful and informative."""
+        else:
+            return f"""{source_info}から提供された情報を使用して、次の質問に答えてください。
+
+質問: {query}
+
+情報:
+{context}
+
+包括的だが簡潔な回答を提供してください。情報がウェブ検索からのものである場合は、それが最新の情報であることを述べてください。役立つ情報を提供してください。"""
+
+    def _calculate_confidence(self, sources: list[str]) -> float:
+        """信頼度を計算"""
+        has_kb = "knowledge_base" in sources or "knowledge base" in sources
+        has_web = "web_search" in sources or "web search" in sources
+
+        if has_kb and has_web:
+            return 0.9
+        elif has_kb:
+            return 0.8
+        elif has_web:
+            return 0.6
+        else:
+            return 0.3
+
+    def _extract_emotion(self, text: str) -> EmotionType:
+        """テキストから感情を抽出"""
+        if text.startswith("[sad]"):
+            return "apologetic"
+        else:
+            return "helpful"
+
+    def _get_default_general_response(self, language: SupportedLanguage) -> UnifiedAgentResponse:
+        """デフォルトレスポンスを生成"""
+        if language == "en":
+            text = "[sad]I'm sorry, I couldn't find specific information to answer your question. Please try rephrasing your question or ask about something else."
+        else:
+            text = "[sad]申し訳ございません。ご質問に答えるための具体的な情報が見つかりませんでした。質問を言い換えていただくか、別のことについてお尋ねください。"
+
+        return {
+            "text": text,
+            "emotion": "apologetic",
+            "agent_name": self.name,
+            "language": language,
+            "metadata": {
+                "confidence": 0.3,
+                "category": "general_knowledge",
+                "sources": ["fallback"],
+                "processing_info": {
+                    "enhancedRag": False
+                }
+            }
+        }
+```
+
+### Step 3: ワークフローへの統合
+
+**修正ファイル**: `backend/workflows/main_workflow.py`
+
+```python
+# backend/workflows/main_workflow.py
+
+from backend.agents.general_knowledge_agent import GeneralKnowledgeAgent
+from backend.tools.rag_search import rag_search_tool
+from backend.tools.web_search import general_web_search
+from langchain_google_genai import ChatGoogleGenerativeAI
+
+class MainWorkflow:
+    def __init__(self):
+        self.llm = ChatGoogleGenerativeAI(
+            model="gemini-2.0-flash-exp",
+            temperature=0.7
+        )
+        self.general_knowledge_agent = GeneralKnowledgeAgent(self.llm)
+        self.graph = self._build_graph()
+
+    async def _general_knowledge_node(self, state: WorkflowState) -> dict:
+        """General Knowledgeノード"""
+        query = state.get("query", "")
+        language = state.get("language", "ja")
+
+        # General Knowledge Agentを使用
+        response = await self.general_knowledge_agent.answer_general_query(
+            query=query,
+            language=language,
+            rag_search_tool=rag_search_tool,
+            web_search_tool=general_web_search
+        )
+
+        return {
+            "response": response["text"],
+            "metadata": {
+                **state.get("metadata", {}),
+                "agent": response["agent_name"],
+                "confidence": response["metadata"]["confidence"],
+                "sources": response["metadata"]["sources"]
+            }
+        }
+
+    def _build_graph(self):
+        """ワークフローグラフを構築"""
+        from langgraph.graph import StateGraph, END
+
+        workflow = StateGraph(WorkflowState)
+
+        # ノードを追加
+        workflow.add_node("router", self._router_node)
+        workflow.add_node("general_knowledge", self._general_knowledge_node)
+        # ... 他のノード
+
+        # エッジを追加
+        workflow.set_entry_point("router")
+        workflow.add_conditional_edges(
+            "router",
+            self._route_decision,
+            {
+                "general_knowledge": "general_knowledge",
+                # ... 他のルート
+            }
+        )
+        workflow.add_edge("general_knowledge", END)
+
+        return workflow.compile()
+```
+
+## 移行チェックリスト
+
+### Phase 1: 準備
+
+- [ ] 既存のTypeScriptコードを完全に理解した
+- [ ] Web検索APIを選定した（Google Custom Search, Bing, etc.）
+- [ ] APIキーと認証情報を準備した
+- [ ] テスト環境を準備した
+
+### Phase 2: ツール開発
+
+- [ ] `web_search.py` を作成した
+- [ ] Web検索APIを統合した
+- [ ] 検索結果フォーマット機能を実装した
+- [ ] 単体テストを作成・通過した
+
+### Phase 3: Agent本体
+
+- [ ] `general_knowledge_agent.py` を作成した
+- [ ] `_should_use_web_search()` メソッドを実装した
+- [ ] `_build_general_prompt()` メソッドを実装した
+- [ ] `_calculate_confidence()` メソッドを実装した
+- [ ] `_get_default_general_response()` メソッドを実装した
+- [ ] 単体テストを作成・通過した
+
+### Phase 4: ワークフロー統合
+
+- [ ] `main_workflow.py` にGeneral Knowledge Agentを統合した
+- [ ] ルーティング条件を正しく設定した
+- [ ] エンドツーエンドテストを通過した
+
+### Phase 5: 検証
+
+- [ ] 全クエリパターンをテストした
+- [ ] パフォーマンスを計測した（目標: 4秒以下）
+- [ ] 信頼度計算が正しく動作することを確認した
+- [ ] ウェブ検索が適切にトリガーされることを確認した
+- [ ] ログ出力を確認した
+
+## Web検索API統合オプション
+
+### Option 1: Google Custom Search API
+
+```python
+import httpx
+
+async def _perform_web_search(query: str, language: str) -> list[dict]:
+    api_key = os.getenv("GOOGLE_CUSTOM_SEARCH_API_KEY")
+    cx = os.getenv("GOOGLE_CUSTOM_SEARCH_CX")
+
+    url = "https://www.googleapis.com/customsearch/v1"
+    params = {
+        "key": api_key,
+        "cx": cx,
+        "q": query,
+        "lr": f"lang_{language}",
+        "num": 5
+    }
+
+    async with httpx.AsyncClient() as client:
+        response = await client.get(url, params=params)
+        data = response.json()
+
+        return [
+            {
+                "title": item["title"],
+                "snippet": item["snippet"],
+                "link": item["link"]
+            }
+            for item in data.get("items", [])
+        ]
+```
+
+### Option 2: Bing Web Search API
+
+```python
+async def _perform_web_search(query: str, language: str) -> list[dict]:
+    api_key = os.getenv("BING_SEARCH_API_KEY")
+
+    url = "https://api.bing.microsoft.com/v7.0/search"
+    headers = {"Ocp-Apim-Subscription-Key": api_key}
+    params = {
+        "q": query,
+        "mkt": "ja-JP" if language == "ja" else "en-US",
+        "count": 5
+    }
+
+    async with httpx.AsyncClient() as client:
+        response = await client.get(url, headers=headers, params=params)
+        data = response.json()
+
+        return [
+            {
+                "title": item["name"],
+                "snippet": item["snippet"],
+                "link": item["url"]
+            }
+            for item in data.get("webPages", {}).get("value", [])
+        ]
+```
+
+### Option 3: DuckDuckGo (無料)
+
+```python
+from duckduckgo_search import DDGS
+
+async def _perform_web_search(query: str, language: str) -> list[dict]:
+    with DDGS() as ddgs:
+        results = list(ddgs.text(
+            query,
+            region="jp-jp" if language == "ja" else "us-en",
+            max_results=5
+        ))
+
+        return [
+            {
+                "title": r["title"],
+                "snippet": r["body"],
+                "link": r["href"]
+            }
+            for r in results
+        ]
+```
+
+## トラブルシューティング
+
+### よくある問題
+
+| 問題 | 原因 | 解決策 |
+|-----|------|-------|
+| Web検索が動作しない | APIキー未設定 | 環境変数を確認 |
+| レスポンスが遅い | Web検索のタイムアウト | タイムアウト設定を調整 |
+| 信頼度が低い | ソースが見つからない | キーワードリストを拡張 |
+| 感情タグが正しくない | LLMの出力形式 | プロンプトを調整 |
+
+## パフォーマンス最適化
+
+### キャッシング戦略
+
+```python
+from functools import lru_cache
+import hashlib
+
+class GeneralKnowledgeAgent:
+    def __init__(self, llm):
+        self.llm = llm
+        self._search_cache = {}
+
+    async def _cached_web_search(self, query: str, language: str) -> dict:
+        """キャッシュ付きウェブ検索"""
+        cache_key = hashlib.md5(f"{query}:{language}".encode()).hexdigest()
+
+        if cache_key in self._search_cache:
+            print("[GeneralKnowledgeAgent] Using cached web search result")
+            return self._search_cache[cache_key]
+
+        result = await web_search_tool.ainvoke({
+            "query": query,
+            "language": language
+        })
+
+        self._search_cache[cache_key] = result
+        return result
+```
+
+## 参考リンク
+
+- [Google Custom Search API](https://developers.google.com/custom-search)
+- [Bing Web Search API](https://www.microsoft.com/en-us/bing/apis/bing-web-search-api)
+- [DuckDuckGo Search](https://github.com/deedy5/duckduckgo_search)
+- [LangChain Tools](https://python.langchain.com/docs/modules/agents/tools/)
+- [元実装: general-knowledge-agent.ts](../../engineer-cafe-navigator-repo/frontend/src/mastra/agents/general-knowledge-agent.ts)

--- a/docs/migration/agents/general-knowledge-agent/SPEC.md
+++ b/docs/migration/agents/general-knowledge-agent/SPEC.md
@@ -1,0 +1,493 @@
+# General Knowledge Agent - 技術仕様書
+
+> 入出力仕様・API定義・データ構造
+
+## 入力仕様
+
+### メイン入力: `answerGeneralQuery()`
+
+```typescript
+interface GeneralQueryInput {
+  query: string;              // ユーザーからの入力テキスト
+  language: SupportedLanguage; // 'ja' | 'en'
+}
+```
+
+#### 入力例
+
+```typescript
+// 一般情報クエリ
+{
+  query: "エンジニアカフェについて教えて",
+  language: "ja"
+}
+
+// 技術トレンドクエリ
+{
+  query: "最新のAI技術について教えて",
+  language: "ja"
+}
+
+// 福岡のスタートアップ情報
+{
+  query: "Tell me about Fukuoka's tech scene",
+  language: "en"
+}
+
+// 情報が見つからない場合
+{
+  query: "明日の天気は？",
+  language: "ja"
+}
+```
+
+## 出力仕様
+
+### メイン出力: `UnifiedAgentResponse`
+
+```typescript
+interface UnifiedAgentResponse {
+  text: string;              // 生成された回答テキスト（感情タグ付き）
+  emotion: EmotionType;      // 'helpful' | 'apologetic'
+  agentName: string;         // 'GeneralKnowledgeAgent'
+  language: SupportedLanguage; // 'ja' | 'en'
+  metadata: {
+    confidence: number;      // 信頼度 (0.3 - 0.9)
+    category: string;        // 'general_knowledge'
+    sources: string[];       // データソース配列
+    processingInfo: {
+      enhancedRag: boolean;  // false (Enhanced RAG不使用)
+    };
+  };
+}
+```
+
+#### 出力例
+
+```typescript
+// ナレッジベースと検索の両方を使用
+{
+  text: "[relaxed]エンジニアカフェは福岡市中央区にあるコワーキングスペースです。最新のWeb検索によると、現在多くのスタートアップ企業が利用しています。",
+  emotion: "helpful",
+  agentName: "GeneralKnowledgeAgent",
+  language: "ja",
+  metadata: {
+    confidence: 0.9,
+    category: "general_knowledge",
+    sources: ["knowledge base", "web search"],
+    processingInfo: {
+      enhancedRag: false
+    }
+  }
+}
+
+// ナレッジベースのみ
+{
+  text: "[relaxed]Engineer Cafe is a coworking space located in Fukuoka City. It provides a collaborative environment for engineers and entrepreneurs.",
+  emotion: "helpful",
+  agentName: "GeneralKnowledgeAgent",
+  language: "en",
+  metadata: {
+    confidence: 0.8,
+    category: "general_knowledge",
+    sources: ["knowledge base"],
+    processingInfo: {
+      enhancedRag: false
+    }
+  }
+}
+
+// ウェブ検索のみ
+{
+  text: "[happy]最新のAI技術については、2025年現在、生成AIやマルチモーダルモデルが急速に発展しています。",
+  emotion: "helpful",
+  agentName: "GeneralKnowledgeAgent",
+  language: "ja",
+  metadata: {
+    confidence: 0.6,
+    category: "general_knowledge",
+    sources: ["web search"],
+    processingInfo: {
+      enhancedRag: false
+    }
+  }
+}
+
+// 情報が見つからない場合
+{
+  text: "[sad]申し訳ございません。ご質問に答えるための具体的な情報が見つかりませんでした。質問を言い換えていただくか、別のことについてお尋ねください。",
+  emotion: "apologetic",
+  agentName: "GeneralKnowledgeAgent",
+  language: "ja",
+  metadata: {
+    confidence: 0.3,
+    category: "general_knowledge",
+    sources: ["fallback"],
+    processingInfo: {
+      enhancedRag: false
+    }
+  }
+}
+```
+
+## データソース仕様
+
+### ウェブ検索判定キーワード
+
+#### 日本語キーワード
+
+```typescript
+const japaneseWebSearchKeywords = [
+  '最新',        // Latest
+  '現在',        // Current
+  '今',          // Now
+  'ニュース',    // News
+  'トレンド',    // Trend
+  'スタートアップ', // Startup
+  'ベンチャー',  // Venture
+  '技術',        // Technology
+  'AI',
+  '人工知能',    // Artificial Intelligence
+  '機械学習',    // Machine Learning
+  'プログラミング' // Programming
+];
+```
+
+#### 英語キーワード
+
+```typescript
+const englishWebSearchKeywords = [
+  'latest',
+  'current',
+  'now',
+  'news',
+  'trend',
+  'startup',
+  'venture',
+  'technology',
+  'ai',
+  'artificial intelligence',
+  'machine learning',
+  'programming'
+];
+```
+
+### データソース優先順位
+
+| データソース組み合わせ | 信頼度 | 使用条件 |
+|---------------------|-------|---------|
+| Knowledge Base + Web Search | 0.9 | 両方のソースで情報が見つかった場合 |
+| Knowledge Base のみ | 0.8 | ナレッジベースのみで情報が見つかった場合 |
+| Web Search のみ | 0.6 | ウェブ検索のみで情報が見つかった場合 |
+| Fallback | 0.3 | どのソースでも情報が見つからない場合 |
+
+## 感情タグ仕様
+
+### 感情マッピング
+
+```typescript
+interface EmotionMapping {
+  situation: string;
+  tag: string;
+  examples: string[];
+}
+
+const emotionRules: EmotionMapping[] = [
+  {
+    situation: "一般情報の提供",
+    tag: "[relaxed]",
+    examples: [
+      "エンジニアカフェについて教えて",
+      "福岡の情報を知りたい"
+    ]
+  },
+  {
+    situation: "技術ニュース・ポジティブ情報",
+    tag: "[happy]",
+    examples: [
+      "最新のAI技術について教えて",
+      "福岡のスタートアップシーンについて"
+    ]
+  },
+  {
+    situation: "革新的・驚きの情報",
+    tag: "[surprised]",
+    examples: [
+      "画期的な技術について",
+      "予想外の発見について"
+    ]
+  },
+  {
+    situation: "情報が見つからない・課題について",
+    tag: "[sad]",
+    examples: [
+      "情報が見つかりませんでした",
+      "現在は対応していません"
+    ]
+  }
+];
+```
+
+### emotion プロパティマッピング
+
+| 感情タグ | emotion値 | 使用場面 |
+|---------|----------|---------|
+| `[relaxed]` | `helpful` | 一般的な情報提供 |
+| `[happy]` | `helpful` | ポジティブな技術情報 |
+| `[surprised]` | `helpful` | 革新的な情報 |
+| `[sad]` | `apologetic` | 情報なし・エラー |
+
+## ツール仕様
+
+### ragSearch ツール
+
+**入力:**
+```typescript
+{
+  query: string;     // 検索クエリ
+  language: SupportedLanguage; // 言語
+  limit: number;     // 取得件数（デフォルト: 10）
+}
+```
+
+**出力:**
+```typescript
+{
+  success: boolean;
+  results?: Array<{
+    content: string;
+    similarity: number;
+  }>;
+  data?: {
+    context: string;
+  };
+}
+```
+
+### generalWebSearch ツール
+
+**入力:**
+```typescript
+{
+  query: string;     // 検索クエリ
+  language: SupportedLanguage; // 言語
+}
+```
+
+**出力:**
+```typescript
+{
+  success: boolean;
+  text?: string;     // 検索結果テキスト
+  data?: {
+    context: string;
+  };
+}
+```
+
+## 内部処理フロー
+
+### 処理シーケンス
+
+```
+1. answerGeneralQuery(query, language) 呼び出し
+   │
+   ├─2. ウェブ検索判定
+   │    └─ shouldUseWebSearch(query)
+   │         → キーワードマッチング
+   │
+   ├─3. ナレッジベース検索（常に実行）
+   │    └─ ragSearch.execute({ query, language, limit: 10 })
+   │         → 成功: context += KB results
+   │         → 失敗: エラーログ
+   │
+   ├─4. ウェブ検索（条件付き実行）
+   │    └─ if (needsWebSearch || !context)
+   │         → generalWebSearch.execute({ query, language })
+   │              → 成功: context += web results
+   │              → 失敗: エラーログ
+   │
+   ├─5. コンテキスト評価
+   │    └─ if (!context)
+   │         → getDefaultGeneralResponse(language)
+   │
+   ├─6. プロンプト構築
+   │    └─ buildGeneralPrompt(query, context, sources, language)
+   │
+   ├─7. LLM生成
+   │    └─ generate([{ role: 'user', content: prompt }])
+   │
+   └─8. レスポンス構築
+        └─ createUnifiedResponse(text, emotion, agentName, language, metadata)
+```
+
+## プロンプト構築仕様
+
+### 英語プロンプト
+
+```typescript
+`Answer the following question using the provided information from ${sourceInfo}.
+
+Question: ${query}
+
+Information:
+${context}
+
+Provide a comprehensive but concise answer. If the information is from web search, mention that it's current information. Be helpful and informative.`
+```
+
+### 日本語プロンプト
+
+```typescript
+`${sourceInfo}から提供された情報を使用して、次の質問に答えてください。
+
+質問: ${query}
+
+情報:
+${context}
+
+包括的だが簡潔な回答を提供してください。情報がウェブ検索からのものである場合は、それが最新の情報であることを述べてください。役立つ情報を提供してください。`
+```
+
+## エラーハンドリング
+
+### エラーケース
+
+| ケース | 対応 | 信頼度 |
+|-------|------|-------|
+| RAG検索エラー | エラーログ、処理継続 | 0.6（Web検索成功時） |
+| Web検索エラー | エラーログ、処理継続 | 0.8（KB検索成功時） |
+| 両方エラー | デフォルトレスポンス | 0.3 |
+| コンテキストなし | デフォルトレスポンス | 0.3 |
+
+### ログ出力
+
+```typescript
+// 正常系
+console.log('[GeneralKnowledgeAgent] Processing general query:', { query, language });
+
+// エラー系
+console.error('[GeneralKnowledgeAgent] RAG search error:', error);
+console.error('[GeneralKnowledgeAgent] Web search error:', error);
+```
+
+## LangGraph版の仕様
+
+### Python型定義
+
+```python
+from typing import TypedDict, Literal
+from enum import Enum
+
+class SupportedLanguage(str, Enum):
+    JA = "ja"
+    EN = "en"
+
+class EmotionType(str, Enum):
+    HELPFUL = "helpful"
+    APOLOGETIC = "apologetic"
+
+class GeneralQueryInput(TypedDict):
+    query: str
+    language: SupportedLanguage
+
+class GeneralKnowledgeMetadata(TypedDict):
+    confidence: float
+    category: str
+    sources: list[str]
+    processing_info: dict
+
+class UnifiedAgentResponse(TypedDict):
+    text: str
+    emotion: EmotionType
+    agent_name: str
+    language: SupportedLanguage
+    metadata: GeneralKnowledgeMetadata
+```
+
+### ノード関数シグネチャ
+
+```python
+def general_knowledge_node(state: WorkflowState) -> dict:
+    """
+    General Knowledgeノード: 一般的な質問に対する回答を生成
+
+    Args:
+        state: ワークフロー状態（query, language, context等を含む）
+
+    Returns:
+        dict: response, metadata を含む辞書
+    """
+    pass
+
+def should_use_web_search(query: str) -> bool:
+    """
+    ウェブ検索が必要かどうかを判定
+
+    Args:
+        query: ユーザークエリ
+
+    Returns:
+        bool: ウェブ検索が必要な場合True
+    """
+    pass
+```
+
+## 信頼度計算ロジック
+
+### 計算アルゴリズム
+
+```typescript
+function calculateConfidence(sources: string[]): number {
+  const hasKnowledgeBase = sources.includes('knowledge_base');
+  const hasWebSearch = sources.includes('web_search');
+
+  if (hasKnowledgeBase && hasWebSearch) {
+    return 0.9;  // 両方のソース
+  } else if (hasKnowledgeBase) {
+    return 0.8;  // ナレッジベースのみ
+  } else if (hasWebSearch) {
+    return 0.6;  // ウェブ検索のみ
+  } else {
+    return 0.3;  // フォールバック
+  }
+}
+```
+
+### 信頼度区分
+
+| 信頼度範囲 | 評価 | データソース |
+|-----------|------|-------------|
+| 0.9 | 非常に高い | KB + Web |
+| 0.8 | 高い | KB のみ |
+| 0.6 - 0.7 | 中程度 | Web のみ |
+| 0.3 - 0.5 | 低い | Fallback |
+
+## パフォーマンス目標
+
+### 応答時間目標
+
+| 処理段階 | 目標時間 |
+|---------|---------|
+| KB検索 | 500ms以下 |
+| Web検索 | 2000ms以下 |
+| LLM生成 | 1500ms以下 |
+| **合計** | **4000ms以下** |
+
+### リソース使用制限
+
+| リソース | 制限 |
+|---------|------|
+| KB検索結果 | 10件まで |
+| Web検索結果 | 1ページ分 |
+| コンテキスト長 | 4000文字以内 |
+| LLM生成トークン | 500トークン以内 |
+
+## バージョン履歴
+
+| バージョン | 日付 | 変更内容 |
+|-----------|------|---------|
+| 1.0 | 2024-01 | 初期実装（Mastra） |
+| 1.1 | 2024-07 | Web検索統合 |
+| 1.2 | 2024-12 | 感情タグ強化 |
+| 2.0 | 予定 | LangGraph移行 |

--- a/docs/migration/agents/general-knowledge-agent/TESTING.md
+++ b/docs/migration/agents/general-knowledge-agent/TESTING.md
@@ -1,0 +1,576 @@
+# General Knowledge Agent - テスト戦略
+
+> テストケース・検証方法・品質基準
+
+## テスト概要
+
+General Knowledge Agentは情報源の組み合わせとウェブ検索判定が重要なため、多様なシナリオのテストが必要です。
+
+### テストレベル
+
+| レベル | 対象 | 目的 |
+|-------|------|------|
+| 単体テスト | 各メソッド | 個別機能の検証 |
+| 統合テスト | ツール連携 | RAG + Web検索の連携検証 |
+| エンドツーエンドテスト | ワークフロー全体 | 実際のユースケース検証 |
+
+## 単体テストケース
+
+### 1. ウェブ検索判定テスト
+
+```python
+# tests/test_general_knowledge_agent.py
+
+import pytest
+from backend.agents.general_knowledge_agent import GeneralKnowledgeAgent
+
+class TestWebSearchDetection:
+    """ウェブ検索判定のテスト"""
+
+    @pytest.fixture
+    def agent(self):
+        from unittest.mock import MagicMock
+        llm = MagicMock()
+        return GeneralKnowledgeAgent(llm)
+
+    @pytest.mark.parametrize("query,should_search", [
+        # ウェブ検索が必要
+        ("最新のAI技術について教えて", True),
+        ("現在の福岡のスタートアップシーンは？", True),
+        ("今のトレンドについて知りたい", True),
+        ("最新ニュースを教えて", True),
+        ("What are the latest AI trends?", True),
+        ("Tell me about current technology news", True),
+
+        # ウェブ検索が不要
+        ("エンジニアカフェの営業時間は？", False),
+        ("料金を教えてください", False),
+        ("場所はどこですか？", False),
+        ("Wi-Fiはありますか？", False),
+        ("What is Engineer Cafe?", False),
+        ("Tell me about the facilities", False),
+    ])
+    def test_should_use_web_search(self, agent, query, should_search):
+        result = agent._should_use_web_search(query)
+        assert result == should_search, f"Query: {query}"
+```
+
+### 2. 信頼度計算テスト
+
+```python
+class TestConfidenceCalculation:
+    """信頼度計算のテスト"""
+
+    @pytest.fixture
+    def agent(self):
+        from unittest.mock import MagicMock
+        llm = MagicMock()
+        return GeneralKnowledgeAgent(llm)
+
+    @pytest.mark.parametrize("sources,expected_confidence", [
+        # 両方のソース
+        (["knowledge base", "web search"], 0.9),
+        (["knowledge_base", "web_search"], 0.9),
+
+        # ナレッジベースのみ
+        (["knowledge base"], 0.8),
+        (["knowledge_base"], 0.8),
+
+        # ウェブ検索のみ
+        (["web search"], 0.6),
+        (["web_search"], 0.6),
+
+        # フォールバック
+        ([], 0.3),
+        (["fallback"], 0.3),
+    ])
+    def test_calculate_confidence(self, agent, sources, expected_confidence):
+        confidence = agent._calculate_confidence(sources)
+        assert confidence == expected_confidence, f"Sources: {sources}"
+```
+
+### 3. プロンプト構築テスト
+
+```python
+class TestPromptBuilding:
+    """プロンプト構築のテスト"""
+
+    @pytest.fixture
+    def agent(self):
+        from unittest.mock import MagicMock
+        llm = MagicMock()
+        return GeneralKnowledgeAgent(llm)
+
+    def test_build_general_prompt_japanese(self, agent):
+        query = "エンジニアカフェについて教えて"
+        context = "エンジニアカフェは福岡のコワーキングスペースです。"
+        sources = ["knowledge base"]
+        language = "ja"
+
+        prompt = agent._build_general_prompt(query, context, sources, language)
+
+        assert "knowledge base" in prompt
+        assert query in prompt
+        assert context in prompt
+        assert "質問:" in prompt
+        assert "情報:" in prompt
+
+    def test_build_general_prompt_english(self, agent):
+        query = "Tell me about Engineer Cafe"
+        context = "Engineer Cafe is a coworking space in Fukuoka."
+        sources = ["knowledge base", "web search"]
+        language = "en"
+
+        prompt = agent._build_general_prompt(query, context, sources, language)
+
+        assert "knowledge base and web search" in prompt
+        assert query in prompt
+        assert context in prompt
+        assert "Question:" in prompt
+        assert "Information:" in prompt
+```
+
+### 4. デフォルトレスポンステスト
+
+```python
+class TestDefaultResponse:
+    """デフォルトレスポンスのテスト"""
+
+    @pytest.fixture
+    def agent(self):
+        from unittest.mock import MagicMock
+        llm = MagicMock()
+        return GeneralKnowledgeAgent(llm)
+
+    def test_default_response_japanese(self, agent):
+        response = agent._get_default_general_response("ja")
+
+        assert response["text"].startswith("[sad]")
+        assert response["emotion"] == "apologetic"
+        assert response["agent_name"] == "GeneralKnowledgeAgent"
+        assert response["language"] == "ja"
+        assert response["metadata"]["confidence"] == 0.3
+        assert response["metadata"]["sources"] == ["fallback"]
+
+    def test_default_response_english(self, agent):
+        response = agent._get_default_general_response("en")
+
+        assert response["text"].startswith("[sad]")
+        assert response["emotion"] == "apologetic"
+        assert response["agent_name"] == "GeneralKnowledgeAgent"
+        assert response["language"] == "en"
+        assert response["metadata"]["confidence"] == 0.3
+```
+
+## 統合テストケース
+
+### 5. マルチソースレスポンステスト
+
+```python
+# tests/test_general_knowledge_integration.py
+
+import pytest
+from unittest.mock import AsyncMock, MagicMock
+from backend.agents.general_knowledge_agent import GeneralKnowledgeAgent
+
+class TestMultiSourceResponse:
+    """マルチソースレスポンスのテスト"""
+
+    @pytest.fixture
+    def agent(self):
+        llm = MagicMock()
+        llm.ainvoke = AsyncMock(return_value=MagicMock(content="[relaxed]テスト回答"))
+        return GeneralKnowledgeAgent(llm)
+
+    @pytest.fixture
+    def rag_search_tool(self):
+        tool = AsyncMock()
+        tool.ainvoke = AsyncMock(return_value={
+            "success": True,
+            "results": [
+                {"content": "ナレッジベースの情報"}
+            ]
+        })
+        return tool
+
+    @pytest.fixture
+    def web_search_tool(self):
+        tool = AsyncMock()
+        tool.ainvoke = AsyncMock(return_value={
+            "success": True,
+            "text": "ウェブ検索の情報"
+        })
+        return tool
+
+    @pytest.mark.asyncio
+    async def test_both_sources_success(self, agent, rag_search_tool, web_search_tool):
+        """両方のソースから情報を取得"""
+        response = await agent.answer_general_query(
+            query="最新のAI技術について教えて",
+            language="ja",
+            rag_search_tool=rag_search_tool,
+            web_search_tool=web_search_tool
+        )
+
+        assert response["metadata"]["confidence"] == 0.9
+        assert "knowledge base" in response["metadata"]["sources"]
+        assert "web search" in response["metadata"]["sources"]
+        assert response["emotion"] == "helpful"
+
+    @pytest.mark.asyncio
+    async def test_knowledge_base_only(self, agent, rag_search_tool, web_search_tool):
+        """ナレッジベースのみから情報を取得"""
+        # ウェブ検索を無効化
+        agent._should_use_web_search = lambda q: False
+
+        response = await agent.answer_general_query(
+            query="エンジニアカフェについて教えて",
+            language="ja",
+            rag_search_tool=rag_search_tool,
+            web_search_tool=web_search_tool
+        )
+
+        assert response["metadata"]["confidence"] == 0.8
+        assert response["metadata"]["sources"] == ["knowledge base"]
+
+    @pytest.mark.asyncio
+    async def test_web_search_only(self, agent, rag_search_tool, web_search_tool):
+        """ウェブ検索のみから情報を取得"""
+        # ナレッジベースを失敗させる
+        rag_search_tool.ainvoke = AsyncMock(return_value={"success": False})
+
+        response = await agent.answer_general_query(
+            query="最新のニュースを教えて",
+            language="ja",
+            rag_search_tool=rag_search_tool,
+            web_search_tool=web_search_tool
+        )
+
+        assert response["metadata"]["confidence"] == 0.6
+        assert response["metadata"]["sources"] == ["web search"]
+```
+
+### 6. フォールバック処理テスト
+
+```python
+class TestFallbackHandling:
+    """フォールバック処理のテスト"""
+
+    @pytest.fixture
+    def agent(self):
+        llm = MagicMock()
+        return GeneralKnowledgeAgent(llm)
+
+    @pytest.fixture
+    def failed_rag_search_tool(self):
+        tool = AsyncMock()
+        tool.ainvoke = AsyncMock(return_value={"success": False})
+        return tool
+
+    @pytest.fixture
+    def failed_web_search_tool(self):
+        tool = AsyncMock()
+        tool.ainvoke = AsyncMock(return_value={"success": False})
+        return tool
+
+    @pytest.mark.asyncio
+    async def test_all_sources_fail(self, agent, failed_rag_search_tool, failed_web_search_tool):
+        """全てのソースが失敗した場合"""
+        response = await agent.answer_general_query(
+            query="テストクエリ",
+            language="ja",
+            rag_search_tool=failed_rag_search_tool,
+            web_search_tool=failed_web_search_tool
+        )
+
+        assert response["text"].startswith("[sad]")
+        assert response["emotion"] == "apologetic"
+        assert response["metadata"]["confidence"] == 0.3
+        assert response["metadata"]["sources"] == ["fallback"]
+
+    @pytest.mark.asyncio
+    async def test_rag_exception_handling(self, agent, failed_web_search_tool):
+        """RAG検索で例外が発生した場合"""
+        rag_tool = AsyncMock()
+        rag_tool.ainvoke = AsyncMock(side_effect=Exception("RAG error"))
+
+        response = await agent.answer_general_query(
+            query="テストクエリ",
+            language="ja",
+            rag_search_tool=rag_tool,
+            web_search_tool=failed_web_search_tool
+        )
+
+        # エラーハンドリングにより、デフォルトレスポンスが返される
+        assert response["metadata"]["confidence"] == 0.3
+```
+
+## エンドツーエンドテスト
+
+### 7. ワークフロー統合テスト
+
+```python
+# tests/test_general_knowledge_e2e.py
+
+import pytest
+from backend.workflows.main_workflow import MainWorkflow
+
+class TestGeneralKnowledgeWorkflow:
+    """ワークフロー統合テスト"""
+
+    @pytest.fixture
+    def workflow(self):
+        return MainWorkflow()
+
+    @pytest.mark.asyncio
+    async def test_general_knowledge_routing(self, workflow):
+        """General Knowledgeへのルーティング"""
+        result = await workflow.graph.ainvoke({
+            "query": "福岡のスタートアップについて教えて",
+            "session_id": "test_session",
+            "language": "ja"
+        })
+
+        assert result["metadata"]["agent"] == "GeneralKnowledgeAgent"
+        assert result["metadata"]["confidence"] > 0.5
+        assert len(result["metadata"]["sources"]) > 0
+
+    @pytest.mark.asyncio
+    async def test_web_search_trigger(self, workflow):
+        """ウェブ検索が適切にトリガーされる"""
+        result = await workflow.graph.ainvoke({
+            "query": "最新のAIトレンドは？",
+            "session_id": "test_session",
+            "language": "ja"
+        })
+
+        # ウェブ検索がトリガーされるべき
+        assert "web search" in result["metadata"].get("sources", []) or \
+               "web_search" in result["metadata"].get("sources", [])
+```
+
+## パフォーマンステスト
+
+### 8. レスポンスタイム計測
+
+```python
+import time
+import asyncio
+
+class TestPerformance:
+    """パフォーマンステスト"""
+
+    @pytest.fixture
+    def agent(self):
+        from langchain_google_genai import ChatGoogleGenerativeAI
+        llm = ChatGoogleGenerativeAI(model="gemini-2.0-flash-exp")
+        return GeneralKnowledgeAgent(llm)
+
+    @pytest.mark.asyncio
+    async def test_response_time(self, agent, rag_search_tool, web_search_tool):
+        """レスポンスタイム計測"""
+        queries = [
+            "エンジニアカフェについて教えて",
+            "最新のAI技術について教えて",
+            "福岡のスタートアップシーンは？",
+        ]
+
+        times = []
+        for query in queries:
+            start = time.perf_counter()
+            await agent.answer_general_query(
+                query=query,
+                language="ja",
+                rag_search_tool=rag_search_tool,
+                web_search_tool=web_search_tool
+            )
+            elapsed = (time.perf_counter() - start) * 1000  # ms
+            times.append(elapsed)
+
+        avg_time = sum(times) / len(times)
+        max_time = max(times)
+
+        # 目標: 平均4000ms以下、最大6000ms以下
+        assert avg_time < 4000, f"Average time {avg_time:.2f}ms exceeds 4000ms"
+        assert max_time < 6000, f"Max time {max_time:.2f}ms exceeds 6000ms"
+```
+
+## テストカバレッジ目標
+
+### カバレッジマトリクス
+
+| テストカテゴリ | テストケース数 | カバレッジ目標 |
+|--------------|--------------|--------------|
+| ウェブ検索判定 | 12 | 100% |
+| 信頼度計算 | 7 | 100% |
+| プロンプト構築 | 6 | 100% |
+| マルチソース処理 | 10 | 95% |
+| エラーハンドリング | 8 | 90% |
+| E2Eシナリオ | 15 | 85% |
+| **合計** | **58** | **95%以上** |
+
+## テスト実行方法
+
+### ローカル実行
+
+```bash
+# 全テスト実行
+pytest tests/test_general_knowledge_agent.py -v
+
+# 統合テストのみ
+pytest tests/test_general_knowledge_integration.py -v
+
+# E2Eテストのみ
+pytest tests/test_general_knowledge_e2e.py -v
+
+# カバレッジレポート付き
+pytest tests/test_general_knowledge_agent.py --cov=backend/agents/general_knowledge_agent --cov-report=html
+
+# パフォーマンステストのみ
+pytest tests/test_general_knowledge_agent.py::TestPerformance -v
+```
+
+### CI/CD連携
+
+```yaml
+# .github/workflows/test-general-knowledge-agent.yml
+
+name: General Knowledge Agent Tests
+
+on:
+  push:
+    paths:
+      - 'backend/agents/general_knowledge_agent.py'
+      - 'backend/tools/web_search.py'
+      - 'tests/test_general_knowledge_*.py'
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+      - name: Install dependencies
+        run: |
+          pip install -r backend/requirements.txt
+          pip install pytest pytest-asyncio pytest-cov
+      - name: Run tests
+        env:
+          GOOGLE_CUSTOM_SEARCH_API_KEY: ${{ secrets.GOOGLE_CUSTOM_SEARCH_API_KEY }}
+          GOOGLE_CUSTOM_SEARCH_CX: ${{ secrets.GOOGLE_CUSTOM_SEARCH_CX }}
+        run: |
+          pytest tests/test_general_knowledge_agent.py -v --cov=backend/agents/general_knowledge_agent
+```
+
+## 品質基準
+
+### 合格基準
+
+| 項目 | 基準 |
+|-----|------|
+| 単体テストカバレッジ | 95%以上 |
+| 統合テストカバレッジ | 90%以上 |
+| ウェブ検索判定精度 | 95%以上 |
+| 平均レスポンスタイム | 4000ms以下 |
+| 最大レスポンスタイム | 6000ms以下 |
+| 信頼度計算精度 | 100% |
+
+### リリース前チェックリスト
+
+- [ ] 全単体テストがパス
+- [ ] 全統合テストがパス
+- [ ] E2Eテストがパス
+- [ ] パフォーマンステストが基準を満たす
+- [ ] ウェブ検索判定が正しく動作
+- [ ] マルチソース処理が正常に動作
+- [ ] エラーハンドリングが適切に機能
+- [ ] コードレビュー完了
+- [ ] ドキュメント更新完了
+
+## テストデータ準備
+
+### モックデータ
+
+```python
+# tests/fixtures/general_knowledge_fixtures.py
+
+import pytest
+
+@pytest.fixture
+def mock_kb_results():
+    """ナレッジベース検索のモックデータ"""
+    return {
+        "success": True,
+        "results": [
+            {
+                "content": "エンジニアカフェは福岡市中央区にあるコワーキングスペースです。",
+                "similarity": 0.9
+            },
+            {
+                "content": "24時間365日利用可能で、様々な設備が整っています。",
+                "similarity": 0.85
+            }
+        ]
+    }
+
+@pytest.fixture
+def mock_web_results():
+    """ウェブ検索のモックデータ"""
+    return {
+        "success": True,
+        "text": "最新のAI技術について、2025年現在は生成AIとマルチモーダルモデルが主流です。"
+    }
+
+@pytest.fixture
+def test_queries():
+    """テストクエリのセット"""
+    return {
+        "general": [
+            "エンジニアカフェについて教えて",
+            "Tell me about Engineer Cafe"
+        ],
+        "web_search": [
+            "最新のAI技術について教えて",
+            "What are the latest technology trends?"
+        ],
+        "fallback": [
+            "明日の天気は？",
+            "What's the weather tomorrow?"
+        ]
+    }
+```
+
+## デバッグ・トラブルシューティング
+
+### よくある問題
+
+| 問題 | チェック項目 | 解決策 |
+|-----|------------|-------|
+| テストが失敗する | APIキー設定 | 環境変数を確認 |
+| タイムアウト | ネットワーク接続 | タイムアウト設定を調整 |
+| 信頼度が低い | ソース検出ロジック | ソース名の正規化を確認 |
+| 感情タグなし | LLM出力形式 | プロンプトのinstructionsを確認 |
+
+### デバッグログ設定
+
+```python
+import logging
+
+logging.basicConfig(
+    level=logging.DEBUG,
+    format='%(asctime)s - %(name)s - %(levelname)s - %(message)s'
+)
+
+logger = logging.getLogger('general_knowledge_agent')
+logger.setLevel(logging.DEBUG)
+```
+
+## 参考リンク
+
+- [pytest Documentation](https://docs.pytest.org/)
+- [pytest-asyncio](https://pytest-asyncio.readthedocs.io/)
+- [unittest.mock](https://docs.python.org/3/library/unittest.mock.html)
+- [元実装: general-knowledge-agent.ts](../../engineer-cafe-navigator-repo/frontend/src/mastra/agents/general-knowledge-agent.ts)

--- a/docs/migration/agents/slide-agent/MIGRATION-GUIDE.md
+++ b/docs/migration/agents/slide-agent/MIGRATION-GUIDE.md
@@ -1,0 +1,822 @@
+# Slide Agent (SlideNarrator) - 移行ガイド
+
+> Mastra (TypeScript) → LangGraph (Python) 移行手順
+
+## 移行概要
+
+### 現在の実装（Mastra/TypeScript）
+
+```
+engineer-cafe-navigator2025/frontend/src/
+├── mastra/agents/slide-narrator.ts    # 446行
+├── mastra/tools/narration-loader.ts   # ナレーション読み込みツール
+└── slides/narration/
+    ├── engineer-cafe-ja.json          # 日本語ナレーション
+    └── engineer-cafe-en.json          # 英語ナレーション
+```
+
+### 移行先（LangGraph/Python）
+
+```
+backend/
+├── agents/
+│   └── slide_narrator.py              # 新規作成
+├── tools/
+│   ├── narration_loader.py            # 新規作成
+│   └── text_to_speech.py              # 既存（修正）
+├── data/
+│   └── narrations/
+│       ├── engineer-cafe-ja.json      # コピー
+│       └── engineer-cafe-en.json      # コピー
+└── workflows/
+    └── presentation_workflow.py       # 新規作成
+```
+
+## 移行ステップ
+
+### Step 1: ナレーションデータの移行
+
+#### 1.1 JSONファイルのコピー
+
+```bash
+# ナレーションデータディレクトリを作成
+mkdir -p backend/data/narrations
+
+# ナレーションファイルをコピー
+cp frontend/src/slides/narration/*.json backend/data/narrations/
+```
+
+#### 1.2 データ構造の検証
+
+```python
+# backend/utils/narration_validator.py
+
+import json
+from typing import Dict, List, Any
+from pathlib import Path
+
+class NarrationValidator:
+    """ナレーションデータの検証"""
+
+    @staticmethod
+    def validate_narration_file(file_path: Path) -> bool:
+        """ナレーションファイルの構造を検証"""
+        try:
+            with open(file_path, 'r', encoding='utf-8') as f:
+                data = json.load(f)
+
+            # メタデータチェック
+            assert 'metadata' in data
+            assert 'title' in data['metadata']
+            assert 'language' in data['metadata']
+            assert 'speaker' in data['metadata']
+
+            # スライドチェック
+            assert 'slides' in data
+            assert isinstance(data['slides'], list)
+
+            for slide in data['slides']:
+                assert 'slideNumber' in slide
+                assert 'narration' in slide
+                assert 'auto' in slide['narration']
+                assert 'transitions' in slide
+
+            return True
+        except (AssertionError, json.JSONDecodeError, KeyError) as e:
+            print(f"Validation error: {e}")
+            return False
+```
+
+### Step 2: NarrationLoader ツールの移行
+
+**元ファイル**: `frontend/src/mastra/tools/narration-loader.ts`
+
+```python
+# backend/tools/narration_loader.py
+
+import json
+from pathlib import Path
+from typing import Dict, Any, Literal
+
+SupportedLanguage = Literal["ja", "en"]
+
+class NarrationLoader:
+    """ナレーションJSONファイルを読み込むツール"""
+
+    def __init__(self, narrations_dir: str = "backend/data/narrations"):
+        self.narrations_dir = Path(narrations_dir)
+
+    async def load(
+        self,
+        slide_file: str,
+        language: SupportedLanguage
+    ) -> Dict[str, Any]:
+        """
+        ナレーションJSONファイルを読み込む
+
+        Args:
+            slide_file: スライドファイル名（拡張子なし）
+            language: 言語コード ('ja' または 'en')
+
+        Returns:
+            ナレーションデータ（辞書形式）
+
+        Raises:
+            FileNotFoundError: ファイルが存在しない場合
+            json.JSONDecodeError: JSON解析に失敗した場合
+        """
+        file_path = self.narrations_dir / f"{slide_file}-{language}.json"
+
+        if not file_path.exists():
+            raise FileNotFoundError(
+                f"Narration file not found: {file_path}"
+            )
+
+        with open(file_path, 'r', encoding='utf-8') as f:
+            narration_data = json.load(f)
+
+        # データ構造の検証
+        self._validate_structure(narration_data)
+
+        return narration_data
+
+    def _validate_structure(self, data: Dict[str, Any]) -> None:
+        """ナレーションデータの構造を検証"""
+        required_keys = ['metadata', 'slides']
+        for key in required_keys:
+            if key not in data:
+                raise ValueError(f"Missing required key: {key}")
+
+        if not isinstance(data['slides'], list):
+            raise ValueError("'slides' must be a list")
+
+        for slide in data['slides']:
+            if 'slideNumber' not in slide or 'narration' not in slide:
+                raise ValueError("Invalid slide structure")
+```
+
+### Step 3: SlideNarrator エージェントの移行
+
+**元ファイル**: `frontend/src/mastra/agents/slide-narrator.ts`
+
+```python
+# backend/agents/slide_narrator.py
+
+from typing import Optional, Dict, Any, Literal
+from dataclasses import dataclass
+import re
+
+from langchain_core.messages import HumanMessage
+from backend.tools.narration_loader import NarrationLoader
+from backend.tools.text_to_speech import TextToSpeechService
+from backend.memory.simple_memory import SimpleMemory
+
+SupportedLanguage = Literal["ja", "en"]
+
+@dataclass
+class NarrationResult:
+    """ナレーション実行結果"""
+    narration: str
+    slide_number: int
+    audio_buffer: bytes
+    character_action: str
+    character_control_data: Optional[Dict] = None
+    emotion: Optional[str] = None
+
+@dataclass
+class NavigationResult:
+    """スライドナビゲーション結果"""
+    success: bool
+    narration: Optional[str] = None
+    slide_number: Optional[int] = None
+    audio_buffer: Optional[bytes] = None
+    character_action: Optional[str] = None
+    character_control_data: Optional[Dict] = None
+    emotion: Optional[str] = None
+    transition_message: Optional[str] = None
+
+class SlideNarrator:
+    """スライドナレーションエージェント"""
+
+    def __init__(
+        self,
+        model: Any,
+        memory: Optional[SimpleMemory] = None,
+        narration_loader: Optional[NarrationLoader] = None,
+        tts_service: Optional[TextToSpeechService] = None
+    ):
+        self.model = model
+        self.memory = memory or SimpleMemory()
+        self.narration_loader = narration_loader or NarrationLoader()
+        self.tts_service = tts_service or TextToSpeechService()
+
+        # 状態管理
+        self.current_slide: int = 1
+        self.total_slides: int = 0
+        self.auto_play: bool = False
+        self.narration_data: Optional[Dict] = None
+
+        # 外部エージェント（オプション）
+        self.voice_output_agent: Optional[Any] = None
+        self.character_control_agent: Optional[Any] = None
+
+        # エージェント指示
+        self.instructions = """You are a slide narration agent for Engineer Cafe presentations.
+Your role is to:
+1. Provide scripted narration for each slide
+2. Handle slide navigation commands
+3. Answer questions about slide content
+4. Maintain presentation flow and timing
+5. Coordinate with slide display and character animation
+
+Deliver narrations in a clear, engaging manner.
+Respond to navigation commands promptly.
+Provide informative answers to content questions.
+
+IMPORTANT: When answering questions about slides, always start your response with an emotion tag.
+Available emotions: [happy], [sad], [angry], [relaxed], [surprised]
+
+Use [relaxed] for informational answers about slide content
+Use [happy] when explaining exciting features or benefits
+Use [surprised] when the user asks unexpected questions
+Use [sad] when unable to find information in the current slide"""
+
+    async def load_narration(
+        self,
+        slide_file: str,
+        language: SupportedLanguage
+    ) -> None:
+        """
+        ナレーションJSONを読み込む
+
+        Args:
+            slide_file: スライドファイル名
+            language: 言語 ('ja' または 'en')
+        """
+        self.narration_data = await self.narration_loader.load(
+            slide_file, language
+        )
+        self.total_slides = len(self.narration_data['slides'])
+        self.current_slide = 1
+
+        # メモリに保存
+        await self.memory.store('currentSlide', self.current_slide)
+        await self.memory.store('totalSlides', self.total_slides)
+        await self.memory.store('narrationData', self.narration_data)
+
+    async def narrate_slide(
+        self,
+        slide_number: Optional[int] = None
+    ) -> NarrationResult:
+        """
+        スライドをナレーションする
+
+        Args:
+            slide_number: スライド番号（省略時は現在のスライド）
+
+        Returns:
+            NarrationResult: ナレーション結果
+        """
+        target_slide = slide_number or self.current_slide
+
+        if not self.narration_data:
+            raise ValueError("No narration data loaded")
+
+        if target_slide < 1 or target_slide > self.total_slides:
+            raise ValueError(f"Invalid slide number: {target_slide}")
+
+        # スライドデータを取得
+        slide_data = next(
+            (s for s in self.narration_data['slides']
+             if s['slideNumber'] == target_slide),
+            None
+        )
+
+        if not slide_data:
+            raise ValueError(f"No narration data for slide {target_slide}")
+
+        narration = slide_data['narration']['auto']
+
+        # 言語取得
+        language: SupportedLanguage = await self.memory.get('language') or 'ja'
+
+        # キャラクター制御決定
+        character_action = self._determine_character_action(slide_data)
+        emotion = self._extract_emotion_from_slide_content(slide_data)
+
+        # 音声生成
+        audio_buffer: bytes
+        character_control_data: Optional[Dict] = None
+
+        if self.voice_output_agent and self.character_control_agent:
+            # 統合エージェントを使用
+            import asyncio
+
+            voice_result, character_result = await asyncio.gather(
+                self.voice_output_agent.convert_text_to_speech(
+                    text=narration,
+                    language=language,
+                    emotion=emotion,
+                    agent_name='SlideNarrator'
+                ),
+                self.character_control_agent.process_character_control(
+                    emotion=emotion,
+                    text=narration,
+                    agent_name='SlideNarrator'
+                )
+            )
+
+            if not voice_result['success']:
+                raise RuntimeError(f"Voice output failed: {voice_result.get('error')}")
+
+            audio_buffer = voice_result['audioData']
+            character_control_data = character_result if character_result['success'] else None
+
+            # リップシンク処理
+            if character_control_data and audio_buffer:
+                lip_sync_result = await self.character_control_agent.process_character_control(
+                    audio_data=audio_buffer,
+                    agent_name='SlideNarrator'
+                )
+                if lip_sync_result['success'] and lip_sync_result.get('lipSyncData'):
+                    character_control_data['lipSyncData'] = lip_sync_result['lipSyncData']
+
+        else:
+            # フォールバック: 直接TTSサービスを使用
+            tts_result = await self.tts_service.text_to_speech(
+                text=narration,
+                language=language
+            )
+
+            if not tts_result['success']:
+                raise RuntimeError(f"Text-to-Speech failed: {tts_result.get('error')}")
+
+            # Base64からバイトに変換
+            import base64
+            audio_buffer = base64.b64decode(tts_result['audioBase64'])
+
+        # 現在のスライドを更新
+        self.current_slide = target_slide
+        await self.memory.store('currentSlide', self.current_slide)
+
+        return NarrationResult(
+            narration=narration,
+            slide_number=target_slide,
+            audio_buffer=audio_buffer,
+            character_action=character_action,
+            character_control_data=character_control_data,
+            emotion=emotion
+        )
+
+    async def next_slide(self) -> NavigationResult:
+        """次のスライドへ移動"""
+        if self.current_slide >= self.total_slides:
+            # 言語取得
+            language = await self.memory.get('language') or 'ja'
+            message = (
+                "This is the last slide. Would you like to go back to the beginning or ask any questions?"
+                if language == 'en' else
+                "最後のスライドです。最初に戻りますか、それとも何かご質問はございますか？"
+            )
+            return NavigationResult(success=False, transition_message=message)
+
+        # トランジションメッセージ取得
+        slide_data = next(
+            (s for s in self.narration_data['slides']
+             if s['slideNumber'] == self.current_slide),
+            None
+        )
+        transition_message = slide_data.get('transitions', {}).get('next') if slide_data else None
+
+        # 次スライドへ移動
+        self.current_slide += 1
+        result = await self.narrate_slide(self.current_slide)
+
+        return NavigationResult(
+            success=True,
+            narration=result.narration,
+            slide_number=result.slide_number,
+            audio_buffer=result.audio_buffer,
+            character_action=result.character_action,
+            character_control_data=result.character_control_data,
+            emotion=result.emotion,
+            transition_message=transition_message
+        )
+
+    async def previous_slide(self) -> NavigationResult:
+        """前のスライドへ移動"""
+        if self.current_slide <= 1:
+            # 言語取得
+            language = await self.memory.get('language') or 'ja'
+            message = (
+                "This is the first slide. Would you like to continue forward?"
+                if language == 'en' else
+                "最初のスライドです。先に進みますか？"
+            )
+            return NavigationResult(success=False, transition_message=message)
+
+        # トランジションメッセージ取得
+        slide_data = next(
+            (s for s in self.narration_data['slides']
+             if s['slideNumber'] == self.current_slide),
+            None
+        )
+        transition_message = slide_data.get('transitions', {}).get('previous') if slide_data else None
+
+        # 前スライドへ移動
+        self.current_slide -= 1
+        result = await self.narrate_slide(self.current_slide)
+
+        return NavigationResult(
+            success=True,
+            narration=result.narration,
+            slide_number=result.slide_number,
+            audio_buffer=result.audio_buffer,
+            character_action=result.character_action,
+            character_control_data=result.character_control_data,
+            emotion=result.emotion,
+            transition_message=transition_message
+        )
+
+    async def goto_slide(self, slide_number: int) -> NavigationResult:
+        """指定スライドへ移動"""
+        if slide_number < 1 or slide_number > self.total_slides:
+            return NavigationResult(success=False)
+
+        result = await self.narrate_slide(slide_number)
+
+        return NavigationResult(
+            success=True,
+            narration=result.narration,
+            slide_number=result.slide_number,
+            audio_buffer=result.audio_buffer,
+            character_action=result.character_action,
+            character_control_data=result.character_control_data,
+            emotion=result.emotion
+        )
+
+    async def answer_slide_question(self, question: str) -> str:
+        """
+        スライド内容に関する質問に回答
+
+        Args:
+            question: 質問文
+
+        Returns:
+            回答テキスト
+        """
+        if not self.narration_data:
+            raise ValueError("No narration data loaded")
+
+        # 現在のスライドデータ取得
+        current_slide_data = next(
+            (s for s in self.narration_data['slides']
+             if s['slideNumber'] == self.current_slide),
+            None
+        )
+
+        # 言語取得
+        language = await self.memory.get('language') or 'ja'
+
+        # onDemand応答チェック
+        if current_slide_data and 'onDemand' in current_slide_data.get('narration', {}):
+            on_demand = current_slide_data['narration']['onDemand']
+
+            # キーワードマッチング
+            for keyword, response in on_demand.items():
+                if keyword.lower() in question.lower():
+                    return response
+
+        # 動的応答生成
+        slide_context = str(current_slide_data) if current_slide_data else ''
+
+        prompt = (
+            f"Answer this question about slide {self.current_slide}: {question}\nSlide context: {slide_context}"
+            if language == 'en' else
+            f"スライド{self.current_slide}について以下の質問に答えてください: {question}\nスライドの内容: {slide_context}"
+        )
+
+        # LLMで応答生成
+        messages = [HumanMessage(content=prompt)]
+        response = await self.model.ainvoke(messages)
+
+        return response.content
+
+    def _determine_character_action(self, slide_data: Dict) -> str:
+        """スライド内容からキャラクターアクションを決定"""
+        narration = slide_data['narration']['auto'].lower()
+
+        if 'welcome' in narration or 'ようこそ' in narration:
+            return 'greeting'
+        elif 'service' in narration or 'サービス' in narration:
+            return 'presenting'
+        elif 'price' in narration or '料金' in narration:
+            return 'explaining'
+        elif 'thank' in narration or 'ありがとう' in narration:
+            return 'bowing'
+        else:
+            return 'neutral'
+
+    def _extract_emotion_from_slide_content(self, slide_data: Dict) -> str:
+        """スライド内容から感情を抽出"""
+        narration = slide_data['narration']['auto'].lower()
+
+        if any(kw in narration for kw in ['welcome', 'ようこそ', 'hello']):
+            return 'happy'
+        elif any(kw in narration for kw in ['price', '料金', 'cost']):
+            return 'explaining'
+        elif any(kw in narration for kw in ['service', 'サービス', 'feature']):
+            return 'confident'
+        elif any(kw in narration for kw in ['thank', 'ありがとう', 'appreciate']):
+            return 'grateful'
+        elif any(kw in narration for kw in ['question', '質問', 'help']):
+            return 'curious'
+        else:
+            return 'neutral'
+
+    async def get_current_slide_info(self) -> Dict:
+        """現在のスライド情報を取得"""
+        slide_data = next(
+            (s for s in self.narration_data['slides']
+             if s['slideNumber'] == self.current_slide),
+            None
+        ) if self.narration_data else None
+
+        return {
+            'currentSlide': self.current_slide,
+            'totalSlides': self.total_slides,
+            'slideData': slide_data
+        }
+
+    async def set_auto_play(self, enabled: bool, interval: Optional[int] = None) -> None:
+        """自動再生設定"""
+        self.auto_play = enabled
+        await self.memory.store('autoPlay', enabled)
+
+        if enabled and interval:
+            await self.memory.store('autoPlayInterval', interval)
+
+    async def start_auto_play(self) -> None:
+        """自動再生開始"""
+        if not self.auto_play:
+            return
+
+        # TODO: 自動進行ロジックの実装
+        # 指定間隔でnext_slide()を呼び出す
+        pass
+
+    async def stop_auto_play(self) -> None:
+        """自動再生停止"""
+        self.auto_play = False
+        await self.memory.store('autoPlay', False)
+```
+
+### Step 4: ワークフローへの統合
+
+```python
+# backend/workflows/presentation_workflow.py
+
+from langgraph.graph import StateGraph, END
+from typing import TypedDict, Literal
+
+from backend.agents.slide_narrator import SlideNarrator
+
+class PresentationState(TypedDict):
+    """プレゼンテーションワークフローの状態"""
+    slide_file: str
+    language: str
+    action: Literal["load", "next", "previous", "goto", "question"]
+    slide_number: int | None
+    question: str | None
+    result: dict | None
+    error: str | None
+
+class PresentationWorkflow:
+    """スライドプレゼンテーションワークフロー"""
+
+    def __init__(self, slide_narrator: SlideNarrator):
+        self.slide_narrator = slide_narrator
+        self.graph = self._build_graph()
+
+    def _build_graph(self) -> StateGraph:
+        """ワークフローグラフを構築"""
+        workflow = StateGraph(PresentationState)
+
+        # ノード追加
+        workflow.add_node("load_narration", self._load_narration_node)
+        workflow.add_node("next_slide", self._next_slide_node)
+        workflow.add_node("previous_slide", self._previous_slide_node)
+        workflow.add_node("goto_slide", self._goto_slide_node)
+        workflow.add_node("answer_question", self._answer_question_node)
+
+        # エントリーポイント
+        workflow.set_entry_point("load_narration")
+
+        # 条件付きエッジ
+        workflow.add_conditional_edges(
+            "load_narration",
+            self._action_router,
+            {
+                "next": "next_slide",
+                "previous": "previous_slide",
+                "goto": "goto_slide",
+                "question": "answer_question",
+                "end": END
+            }
+        )
+
+        # 各ノードから終了へ
+        workflow.add_edge("next_slide", END)
+        workflow.add_edge("previous_slide", END)
+        workflow.add_edge("goto_slide", END)
+        workflow.add_edge("answer_question", END)
+
+        return workflow.compile()
+
+    async def _load_narration_node(self, state: PresentationState) -> dict:
+        """ナレーション読み込みノード"""
+        try:
+            await self.slide_narrator.load_narration(
+                state['slide_file'],
+                state['language']
+            )
+            return {"error": None}
+        except Exception as e:
+            return {"error": str(e)}
+
+    async def _next_slide_node(self, state: PresentationState) -> dict:
+        """次スライドノード"""
+        try:
+            result = await self.slide_narrator.next_slide()
+            return {"result": result.__dict__, "error": None}
+        except Exception as e:
+            return {"error": str(e)}
+
+    async def _previous_slide_node(self, state: PresentationState) -> dict:
+        """前スライドノード"""
+        try:
+            result = await self.slide_narrator.previous_slide()
+            return {"result": result.__dict__, "error": None}
+        except Exception as e:
+            return {"error": str(e)}
+
+    async def _goto_slide_node(self, state: PresentationState) -> dict:
+        """指定スライドへ移動ノード"""
+        try:
+            slide_number = state.get('slide_number')
+            if slide_number is None:
+                raise ValueError("slide_number is required for goto action")
+
+            result = await self.slide_narrator.goto_slide(slide_number)
+            return {"result": result.__dict__, "error": None}
+        except Exception as e:
+            return {"error": str(e)}
+
+    async def _answer_question_node(self, state: PresentationState) -> dict:
+        """質問応答ノード"""
+        try:
+            question = state.get('question')
+            if not question:
+                raise ValueError("question is required for question action")
+
+            answer = await self.slide_narrator.answer_slide_question(question)
+            return {"result": {"answer": answer}, "error": None}
+        except Exception as e:
+            return {"error": str(e)}
+
+    def _action_router(self, state: PresentationState) -> str:
+        """アクションに基づいてルーティング"""
+        if state.get('error'):
+            return "end"
+
+        action = state.get('action', 'end')
+
+        action_map = {
+            'next': 'next',
+            'previous': 'previous',
+            'goto': 'goto',
+            'question': 'question'
+        }
+
+        return action_map.get(action, 'end')
+```
+
+## 移行チェックリスト
+
+### Phase 1: 準備
+
+- [ ] 既存のTypeScriptコードを完全に理解した
+- [ ] Pythonの依存パッケージを確認した（langchain, langgraph等）
+- [ ] テスト環境を準備した
+- [ ] ナレーションJSONファイルを確認した
+
+### Phase 2: データ移行
+
+- [ ] `backend/data/narrations/` ディレクトリを作成した
+- [ ] ナレーションJSONファイルをコピーした
+- [ ] データ構造の検証スクリプトを作成した
+- [ ] 全ナレーションファイルが正しく読み込めることを確認した
+
+### Phase 3: ツール移行
+
+- [ ] `narration_loader.py` を作成した
+- [ ] ファイル読み込み機能をテストした
+- [ ] エラーハンドリングを実装した
+- [ ] 単体テストを作成・通過した
+
+### Phase 4: SlideNarrator本体
+
+- [ ] `slide_narrator.py` を作成した
+- [ ] 全メソッドを移行した（loadNarration, narrateSlide, etc.）
+- [ ] キャラクターアクション決定ロジックを移行した
+- [ ] 感情抽出ロジックを移行した
+- [ ] 単体テストを作成・通過した
+
+### Phase 5: 音声統合
+
+- [ ] TextToSpeechServiceとの統合を実装した
+- [ ] VoiceOutputAgentとの統合を実装した（オプション）
+- [ ] CharacterControlAgentとの統合を実装した（オプション）
+- [ ] リップシンク処理を実装した
+
+### Phase 6: ワークフロー統合
+
+- [ ] `presentation_workflow.py` を作成した
+- [ ] 全アクション（load, next, previous, goto, question）を実装した
+- [ ] 条件付きエッジを正しく設定した
+- [ ] エンドツーエンドテストを通過した
+
+### Phase 7: 検証
+
+- [ ] 全ナビゲーションパターンをテストした
+- [ ] 質問応答機能をテストした
+- [ ] onDemand応答をテストした
+- [ ] トランジションメッセージをテストした
+- [ ] パフォーマンスを計測した
+- [ ] ログ出力を確認した
+
+## トラブルシューティング
+
+### よくある問題
+
+| 問題 | 原因 | 解決策 |
+|-----|------|-------|
+| JSONファイルが読み込めない | ファイルパスの不整合 | 絶対パスを使用し、`Path`オブジェクトで管理 |
+| 日本語が正しく表示されない | エンコーディングの問題 | `open(..., encoding='utf-8')` を使用 |
+| スライド番号がずれる | 0始まりと1始まりの混同 | スライド番号は1始まりに統一 |
+| 音声生成が失敗する | TTSサービスの設定不備 | API キーとサービス設定を確認 |
+| async/await エラー | 非同期処理の不整合 | 全ての呼び出し元を確認 |
+
+### デバッグのヒント
+
+```python
+# ナレーションデータのダンプ
+import json
+print(json.dumps(slide_narrator.narration_data, indent=2, ensure_ascii=False))
+
+# 現在のスライド情報を確認
+slide_info = await slide_narrator.get_current_slide_info()
+print(f"Current: {slide_info['currentSlide']}/{slide_info['totalSlides']}")
+
+# キャラクターアクション決定のテスト
+slide_data = narration_data['slides'][0]
+action = slide_narrator._determine_character_action(slide_data)
+print(f"Character action: {action}")
+```
+
+## パフォーマンス最適化
+
+### ナレーションデータのキャッシュ
+
+```python
+from functools import lru_cache
+
+class NarrationLoader:
+    @lru_cache(maxsize=10)
+    async def load(self, slide_file: str, language: str) -> Dict:
+        """キャッシュ付きナレーション読み込み"""
+        # ... 実装 ...
+```
+
+### 音声生成の並列化
+
+```python
+# 複数スライドの音声を事前生成
+import asyncio
+
+async def preload_audio(slide_numbers: list[int]):
+    """複数スライドの音声を並列で事前生成"""
+    tasks = [
+        slide_narrator.narrate_slide(num)
+        for num in slide_numbers
+    ]
+    results = await asyncio.gather(*tasks)
+    return results
+```
+
+## 参考リンク
+
+- [LangGraph ドキュメント](https://langchain-ai.github.io/langgraph/)
+- [Mastra ドキュメント](https://mastra.dev)
+- [元実装: slide-narrator.ts](/Users/teradakousuke/Developer/engineer-cafe-navigator2025/frontend/src/mastra/agents/slide-narrator.ts)
+- [ナレーションデータ例](/Users/teradakousuke/Developer/engineer-cafe-navigator2025/frontend/src/slides/narration/engineer-cafe-ja.json)

--- a/docs/migration/agents/slide-agent/SPEC.md
+++ b/docs/migration/agents/slide-agent/SPEC.md
@@ -1,0 +1,507 @@
+# Slide Agent (SlideNarrator) - 技術仕様書
+
+> 入出力仕様・API定義・データ構造
+
+## 入力仕様
+
+### メイン入力: スライド操作
+
+```typescript
+interface LoadNarrationInput {
+  slideFile: string;           // スライドファイル名 (例: 'engineer-cafe')
+  language: SupportedLanguage; // 'ja' | 'en'
+}
+
+interface SlideNavigationInput {
+  slideNumber?: number;  // 特定のスライド番号（オプション）
+}
+
+interface SlideQuestionInput {
+  question: string;      // スライド内容に関する質問
+}
+
+interface AutoPlayInput {
+  enabled: boolean;      // 自動再生の有効/無効
+  interval?: number;     // 自動進行の間隔（ミリ秒、デフォルト30秒）
+}
+```
+
+#### 入力例
+
+```typescript
+// ナレーション読み込み
+{
+  slideFile: "engineer-cafe",
+  language: "ja"
+}
+
+// スライド移動
+{
+  slideNumber: 3  // 3枚目のスライドへ移動
+}
+
+// スライドに関する質問
+{
+  question: "集中スペースはいくつありますか？"
+}
+
+// 自動再生設定
+{
+  enabled: true,
+  interval: 45000  // 45秒間隔
+}
+```
+
+## 出力仕様
+
+### メイン出力: `NarrationResult`
+
+```typescript
+interface NarrationResult {
+  narration: string;              // ナレーションテキスト
+  slideNumber: number;            // 現在のスライド番号
+  audioBuffer: ArrayBuffer;       // 音声データ
+  characterAction: string;        // キャラクターアクション
+  characterControlData?: any;     // キャラクター制御データ
+  emotion?: string;               // 感情タグ
+}
+
+interface NavigationResult {
+  success: boolean;               // 成功/失敗
+  narration?: string;             // ナレーションテキスト
+  slideNumber?: number;           // スライド番号
+  audioBuffer?: ArrayBuffer;      // 音声データ
+  characterAction?: string;       // キャラクターアクション
+  characterControlData?: any;     // キャラクター制御データ
+  emotion?: string;               // 感情タグ
+  transitionMessage?: string;     // トランジションメッセージ
+}
+
+interface SlideInfo {
+  currentSlide: number;           // 現在のスライド番号
+  totalSlides: number;            // 総スライド数
+  slideData: any;                 // スライドデータ
+}
+```
+
+#### 出力例
+
+```typescript
+// ナレーション実行結果
+{
+  narration: "皆さん、エンジニアカフェへようこそ。ここはエンジニアが学び、交流し、成長できる無料の公共スペースです。",
+  slideNumber: 1,
+  audioBuffer: ArrayBuffer(12345),
+  characterAction: "greeting",
+  characterControlData: {
+    emotion: "happy",
+    lipSyncData: [...]
+  },
+  emotion: "happy"
+}
+
+// 次スライド移動結果
+{
+  success: true,
+  narration: "エンジニアカフェは福岡市と市民の協力で生まれました...",
+  slideNumber: 2,
+  audioBuffer: ArrayBuffer(23456),
+  characterAction: "presenting",
+  emotion: "confident",
+  transitionMessage: "それでは、エンジニアカフェについて詳しくご説明いたします。"
+}
+
+// 最終スライドでの次スライド試行
+{
+  success: false,
+  transitionMessage: "最後のスライドです。最初に戻りますか、それとも何かご質問はございますか？"
+}
+```
+
+## ナレーションデータ構造
+
+### JSON Schema
+
+```json
+{
+  "metadata": {
+    "title": "string",           // プレゼンテーションタイトル
+    "language": "ja | en",       // 言語
+    "speaker": "string",         // TTS音声の種類
+    "version": "string"          // データバージョン
+  },
+  "slides": [
+    {
+      "slideNumber": "number",   // スライド番号（1から開始）
+      "narration": {
+        "auto": "string",        // 自動ナレーション（スライド表示時）
+        "onEnter": "string",     // 進入時の短いメッセージ
+        "onDemand": {
+          "keyword": "response"  // キーワードに対する応答
+        }
+      },
+      "transitions": {
+        "next": "string | null",     // 次スライドへの遷移メッセージ
+        "previous": "string | null"  // 前スライドへの遷移メッセージ
+      }
+    }
+  ]
+}
+```
+
+### 実データ例
+
+```json
+{
+  "metadata": {
+    "title": "エンジニアカフェ案内",
+    "language": "ja",
+    "speaker": "ja-JP-Neural2-B",
+    "version": "2.0"
+  },
+  "slides": [
+    {
+      "slideNumber": 1,
+      "narration": {
+        "auto": "皆さん、エンジニアカフェへようこそ。ここはエンジニアが学び、交流し、成長できる無料の公共スペースです。",
+        "onEnter": "エンジニアカフェへようこそ。こちらは施設案内の最初のスライドです。",
+        "onDemand": {
+          "詳しく": "エンジニアカフェは2019年8月に福岡市の「エンジニアフレンドリーシティ福岡」の一環として誕生した公共のコワーキングスペースです。",
+          "無料": "完全無料でご利用いただける公共施設です。",
+          "場所": "福岡市の赤煉瓦文化館内に位置し、重要文化財である歴史ある建物の中でお仕事していただけます。"
+        }
+      },
+      "transitions": {
+        "next": "それでは、エンジニアカフェについて詳しくご説明いたします。",
+        "previous": null
+      }
+    },
+    {
+      "slideNumber": 4,
+      "narration": {
+        "auto": "地下には4つの特徴的なスペースがあります。ミーティングスペースは2名以上でホームページから予約が必要です。",
+        "onEnter": "地下スペースの詳細についてご説明します。",
+        "onDemand": {
+          "ミーティングスペース": "2名以上から利用可能で、ホームページから事前予約が必要です。",
+          "集中スペース": "6ブース完備で予約不要ですが、おしゃべりは完全禁止です。",
+          "Makersスペース": "3Dプリンタやレーザーカッターが利用できます。初回利用時は講習が必須です。"
+        }
+      },
+      "transitions": {
+        "next": "利用時間と延長についてご説明します。",
+        "previous": "コワーキングスペースに戻ります。"
+      }
+    }
+  ]
+}
+```
+
+## キャラクターアクションマッピング
+
+### アクション決定ロジック
+
+`determineCharacterAction(slideData)` メソッドはスライドのナレーション内容からキャラクターアクションを決定します。
+
+| ナレーション内容（キーワード） | アクション | 説明 |
+|-------------------------|----------|------|
+| `welcome`, `ようこそ` | `greeting` | 挨拶のジェスチャー |
+| `service`, `サービス` | `presenting` | プレゼンテーションの動作 |
+| `price`, `料金` | `explaining` | 説明する動作 |
+| `thank`, `ありがとう` | `bowing` | お辞儀 |
+| その他 | `neutral` | 通常の姿勢 |
+
+### 実装例
+
+```typescript
+private determineCharacterAction(slideData: any): string {
+  const narration = slideData.narration.auto.toLowerCase();
+
+  if (narration.includes('welcome') || narration.includes('ようこそ')) {
+    return 'greeting';
+  } else if (narration.includes('service') || narration.includes('サービス')) {
+    return 'presenting';
+  } else if (narration.includes('price') || narration.includes('料金')) {
+    return 'explaining';
+  } else if (narration.includes('thank') || narration.includes('ありがとう')) {
+    return 'bowing';
+  } else {
+    return 'neutral';
+  }
+}
+```
+
+## 感情抽出マッピング
+
+### 感情決定ロジック
+
+`extractEmotionFromSlideContent(slideData)` メソッドはスライド内容から感情タグを抽出します。
+
+| ナレーション内容（キーワード） | 感情タグ | 説明 |
+|-------------------------|---------|------|
+| `welcome`, `ようこそ`, `hello` | `happy` | 歓迎・喜び |
+| `price`, `料金`, `cost` | `explaining` | 説明的 |
+| `service`, `サービス`, `feature` | `confident` | 自信 |
+| `thank`, `ありがとう`, `appreciate` | `grateful` | 感謝 |
+| `question`, `質問`, `help` | `curious` | 好奇心 |
+| その他 | `neutral` | 中立 |
+
+### エージェント指示における感情タグ
+
+エージェントの指示文には以下の感情タグが使用されます：
+
+```typescript
+// 質問回答時の感情タグ
+const emotionTags = [
+  '[happy]',      // 興奮する機能や利点を説明する時
+  '[sad]',        // 情報が見つからない時
+  '[angry]',      // （通常は使用しない）
+  '[relaxed]',    // 情報的な回答をする時（デフォルト）
+  '[surprised]'   // 予期しない質問を受けた時
+];
+```
+
+## メソッド一覧
+
+### ナレーション管理
+
+| メソッド | 説明 | 戻り値 |
+|---------|------|-------|
+| `loadNarration(slideFile, language)` | ナレーションJSONを読み込む | `Promise<void>` |
+| `narrateSlide(slideNumber?)` | スライドをナレーションする | `Promise<NarrationResult>` |
+| `answerSlideQuestion(question)` | スライドに関する質問に回答 | `Promise<string>` |
+
+### ナビゲーション
+
+| メソッド | 説明 | 戻り値 |
+|---------|------|-------|
+| `nextSlide()` | 次のスライドへ移動 | `Promise<NavigationResult>` |
+| `previousSlide()` | 前のスライドへ移動 | `Promise<NavigationResult>` |
+| `gotoSlide(slideNumber)` | 指定スライドへ移動 | `Promise<NavigationResult>` |
+| `getCurrentSlideInfo()` | 現在のスライド情報を取得 | `Promise<SlideInfo>` |
+
+### 自動再生
+
+| メソッド | 説明 | 戻り値 |
+|---------|------|-------|
+| `setAutoPlay(enabled, interval?)` | 自動再生設定 | `Promise<void>` |
+| `startAutoPlay()` | 自動再生開始 | `Promise<void>` |
+| `stopAutoPlay()` | 自動再生停止 | `Promise<void>` |
+
+### 内部メソッド
+
+| メソッド | 説明 | 戻り値 |
+|---------|------|-------|
+| `determineCharacterAction(slideData)` | キャラクターアクション決定 | `string` |
+| `extractEmotionFromSlideContent(slideData)` | 感情タグ抽出 | `string` |
+
+## 内部処理フロー
+
+### ナレーション実行フロー
+
+```
+1. narrateSlide(slideNumber?) 呼び出し
+   │
+   ├─2. スライド番号検証
+   │    └─ targetSlide が範囲内か確認
+   │
+   ├─3. ナレーションデータ取得
+   │    └─ slides配列から該当スライドを検索
+   │
+   ├─4. 言語取得
+   │    └─ memory.get('language')
+   │
+   ├─5. キャラクター制御決定
+   │    ├─ determineCharacterAction(slideData) → アクション
+   │    └─ extractEmotionFromSlideContent(slideData) → 感情
+   │
+   ├─6. 音声・キャラクター処理（並列）
+   │    ├─ voiceOutputAgent.convertTextToSpeech()
+   │    └─ characterControlAgent.processCharacterControl()
+   │
+   ├─7. リップシンク処理
+   │    └─ characterControlAgent.processCharacterControl({audioData})
+   │
+   └─8. 結果返却
+        └─ {narration, slideNumber, audioBuffer, characterAction, emotion}
+```
+
+### スライドナビゲーションフロー
+
+```
+1. nextSlide() / previousSlide() / gotoSlide() 呼び出し
+   │
+   ├─2. 境界チェック
+   │    ├─ nextSlide: currentSlide >= totalSlides → エラーメッセージ
+   │    ├─ previousSlide: currentSlide <= 1 → エラーメッセージ
+   │    └─ gotoSlide: 範囲外 → エラーメッセージ
+   │
+   ├─3. トランジションメッセージ取得
+   │    └─ slideData.transitions.next/previous
+   │
+   ├─4. スライド番号更新
+   │    └─ currentSlide を更新
+   │
+   ├─5. ナレーション実行
+   │    └─ narrateSlide(新しいslideNumber)
+   │
+   └─6. 結果返却
+        └─ {success, narration, slideNumber, audioBuffer, transitionMessage}
+```
+
+### 質問応答フロー
+
+```
+1. answerSlideQuestion(question) 呼び出し
+   │
+   ├─2. 現在のスライドデータ取得
+   │    └─ slides.find(s => s.slideNumber === currentSlide)
+   │
+   ├─3. onDemand応答チェック
+   │    ├─ slideData.narration.onDemand を確認
+   │    └─ キーワードマッチ → 定義済み応答を返す
+   │
+   ├─4. 動的応答生成（onDemandに該当なし）
+   │    ├─ スライドコンテキストを作成
+   │    ├─ プロンプト生成（言語に応じて）
+   │    └─ this.generate() でLLM応答生成
+   │
+   └─5. 応答返却
+        └─ 文字列応答
+```
+
+## エージェント統合
+
+### VoiceOutputAgent統合
+
+```typescript
+// 音声出力エージェントとの連携
+setVoiceOutputAgent(agent: any): void
+
+// 音声生成
+const voiceResult = await this.voiceOutputAgent.convertTextToSpeech({
+  text: narration,
+  language,
+  emotion,
+  agentName: 'SlideNarrator'
+});
+```
+
+### CharacterControlAgent統合
+
+```typescript
+// キャラクター制御エージェントとの連携
+setCharacterControlAgent(agent: any): void
+
+// キャラクター制御
+const characterResult = await this.characterControlAgent.processCharacterControl({
+  emotion,
+  text: narration,
+  agentName: 'SlideNarrator'
+});
+
+// リップシンク生成
+const lipSyncResult = await this.characterControlAgent.processCharacterControl({
+  audioData: audioBuffer,
+  agentName: 'SlideNarrator'
+});
+```
+
+## メモリ管理
+
+### メモリ保存データ
+
+| キー | 値の型 | 説明 |
+|-----|-------|------|
+| `currentSlide` | `number` | 現在のスライド番号 |
+| `totalSlides` | `number` | 総スライド数 |
+| `narrationData` | `object` | ナレーションデータ全体 |
+| `autoPlay` | `boolean` | 自動再生の有効/無効 |
+| `autoPlayInterval` | `number` | 自動再生間隔（ミリ秒） |
+| `language` | `SupportedLanguage` | 言語設定 |
+
+## エラーハンドリング
+
+### エラーケース
+
+| ケース | エラーメッセージ | 対応 |
+|-------|--------------|------|
+| ナレーション未読み込み | `No narration data loaded` | loadNarration()を先に呼び出す |
+| 無効なスライド番号 | `Invalid slide number: ${number}` | 1〜totalSlidesの範囲を指定 |
+| スライドデータ不在 | `No narration data for slide ${number}` | ナレーションJSONを確認 |
+| 音声生成失敗 | `Text-to-Speech failed: ${error}` | voiceServiceの設定を確認 |
+| 音声出力エージェント失敗 | `Voice output failed: ${error}` | voiceOutputAgentの設定を確認 |
+
+### ログ出力
+
+```typescript
+// 正常系
+console.log(`[SlideNarrator] Loaded narration for ${slideFile} (${language})`);
+console.log(`[SlideNarrator] Narrating slide ${slideNumber}`);
+
+// エラー系
+console.error('Failed to load narration:', error);
+console.error(`Text-to-Speech failed: ${error}`);
+```
+
+## LangGraph版の仕様
+
+### Python型定義
+
+```python
+from typing import TypedDict, Literal, Optional
+from dataclasses import dataclass
+
+SupportedLanguage = Literal["ja", "en"]
+
+@dataclass
+class NarrationResult:
+    narration: str
+    slide_number: int
+    audio_buffer: bytes
+    character_action: str
+    character_control_data: Optional[dict] = None
+    emotion: Optional[str] = None
+
+@dataclass
+class NavigationResult:
+    success: bool
+    narration: Optional[str] = None
+    slide_number: Optional[int] = None
+    audio_buffer: Optional[bytes] = None
+    character_action: Optional[str] = None
+    character_control_data: Optional[dict] = None
+    emotion: Optional[str] = None
+    transition_message: Optional[str] = None
+
+@dataclass
+class SlideInfo:
+    current_slide: int
+    total_slides: int
+    slide_data: dict
+```
+
+### ノード関数シグネチャ
+
+```python
+async def slide_narrator_node(state: WorkflowState) -> dict:
+    """
+    スライドナレーターノード: プレゼンテーションスライドのナレーションを実行
+
+    Args:
+        state: ワークフロー状態（slide_action, slide_number, question等を含む）
+
+    Returns:
+        dict: narration_result, audio_data, character_control を含む辞書
+    """
+    pass
+```
+
+## バージョン履歴
+
+| バージョン | 日付 | 変更内容 |
+|-----------|------|---------|
+| 1.0 | 2024-01 | 初期実装（Mastra） |
+| 1.1 | 2024-06 | VoiceOutputAgent/CharacterControlAgent統合 |
+| 1.2 | 2024-09 | 自動再生機能追加 |
+| 1.3 | 2024-11 | onDemand応答機能強化 |
+| 2.0 | 予定 | LangGraph移行 |

--- a/docs/migration/agents/slide-agent/TESTING.md
+++ b/docs/migration/agents/slide-agent/TESTING.md
@@ -1,0 +1,827 @@
+# Slide Agent (SlideNarrator) - テスト戦略
+
+> テストケース・検証方法・品質基準
+
+## テスト概要
+
+SlideNarrator は音声ナレーション、キャラクター制御、スライドナビゲーションを統合した複雑なエージェントです。各機能を個別にテストし、統合テストで全体の動作を検証します。
+
+### テストレベル
+
+| レベル | 対象 | 目的 |
+|-------|------|------|
+| 単体テスト | 各メソッド | 個別機能の検証 |
+| 統合テスト | ワークフロー連携 | エンドツーエンド検証 |
+| パフォーマンステスト | 音声生成・スライド遷移 | レスポンス時間計測 |
+| 回帰テスト | 全ナビゲーションパターン | 既存機能の維持確認 |
+
+## 単体テストケース
+
+### 1. ナレーション読み込みテスト
+
+```python
+# tests/test_slide_narrator.py
+
+import pytest
+from backend.agents.slide_narrator import SlideNarrator
+from backend.tools.narration_loader import NarrationLoader
+from backend.memory.simple_memory import SimpleMemory
+
+class TestNarrationLoading:
+    """ナレーション読み込みのテスト"""
+
+    @pytest.fixture
+    def narrator(self):
+        return SlideNarrator(
+            model=None,  # モックモデル
+            memory=SimpleMemory(),
+            narration_loader=NarrationLoader()
+        )
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("slide_file,language,expected_slides", [
+        ("engineer-cafe", "ja", 10),
+        ("engineer-cafe", "en", 10),
+    ])
+    async def test_load_narration_success(
+        self,
+        narrator,
+        slide_file,
+        language,
+        expected_slides
+    ):
+        """正常にナレーションを読み込めることを確認"""
+        await narrator.load_narration(slide_file, language)
+
+        assert narrator.narration_data is not None
+        assert narrator.total_slides == expected_slides
+        assert narrator.current_slide == 1
+        assert len(narrator.narration_data['slides']) == expected_slides
+
+    @pytest.mark.asyncio
+    async def test_load_narration_invalid_file(self, narrator):
+        """存在しないファイルでエラーが発生することを確認"""
+        with pytest.raises(FileNotFoundError):
+            await narrator.load_narration("nonexistent", "ja")
+
+    @pytest.mark.asyncio
+    async def test_load_narration_invalid_language(self, narrator):
+        """サポートされていない言語でエラーが発生することを確認"""
+        with pytest.raises(FileNotFoundError):
+            await narrator.load_narration("engineer-cafe", "fr")
+
+    @pytest.mark.asyncio
+    async def test_narration_data_structure(self, narrator):
+        """ナレーションデータの構造を検証"""
+        await narrator.load_narration("engineer-cafe", "ja")
+
+        # メタデータの検証
+        assert 'metadata' in narrator.narration_data
+        assert narrator.narration_data['metadata']['language'] == 'ja'
+        assert 'title' in narrator.narration_data['metadata']
+
+        # スライドデータの検証
+        for slide in narrator.narration_data['slides']:
+            assert 'slideNumber' in slide
+            assert 'narration' in slide
+            assert 'auto' in slide['narration']
+            assert 'transitions' in slide
+```
+
+### 2. スライドナレーションテスト
+
+```python
+class TestSlideNarration:
+    """スライドナレーションのテスト"""
+
+    @pytest.fixture
+    async def loaded_narrator(self):
+        """ナレーション読み込み済みのナレーター"""
+        narrator = SlideNarrator(
+            model=None,
+            memory=SimpleMemory(),
+            narration_loader=NarrationLoader()
+        )
+        await narrator.load_narration("engineer-cafe", "ja")
+        return narrator
+
+    @pytest.mark.asyncio
+    async def test_narrate_current_slide(self, loaded_narrator):
+        """現在のスライドをナレーション"""
+        result = await loaded_narrator.narrate_slide()
+
+        assert result.slide_number == 1
+        assert result.narration is not None
+        assert len(result.narration) > 0
+        assert result.character_action in [
+            'greeting', 'presenting', 'explaining', 'bowing', 'neutral'
+        ]
+        assert result.emotion in [
+            'happy', 'explaining', 'confident', 'grateful', 'curious', 'neutral'
+        ]
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("slide_number,expected_action", [
+        (1, "greeting"),      # "ようこそ" を含む
+        (3, "neutral"),       # 一般的な説明
+        (10, "neutral"),      # 最終スライド
+    ])
+    async def test_narrate_specific_slide(
+        self,
+        loaded_narrator,
+        slide_number,
+        expected_action
+    ):
+        """特定のスライドをナレーション"""
+        result = await loaded_narrator.narrate_slide(slide_number)
+
+        assert result.slide_number == slide_number
+        assert result.character_action == expected_action
+
+    @pytest.mark.asyncio
+    async def test_narrate_invalid_slide_number(self, loaded_narrator):
+        """無効なスライド番号でエラー"""
+        with pytest.raises(ValueError, match="Invalid slide number"):
+            await loaded_narrator.narrate_slide(0)
+
+        with pytest.raises(ValueError, match="Invalid slide number"):
+            await loaded_narrator.narrate_slide(999)
+
+    @pytest.mark.asyncio
+    async def test_narrate_without_loading(self):
+        """ナレーション未読み込みでエラー"""
+        narrator = SlideNarrator(
+            model=None,
+            memory=SimpleMemory()
+        )
+
+        with pytest.raises(ValueError, match="No narration data loaded"):
+            await narrator.narrate_slide()
+```
+
+### 3. スライドナビゲーションテスト
+
+```python
+class TestSlideNavigation:
+    """スライドナビゲーションのテスト"""
+
+    @pytest.fixture
+    async def loaded_narrator(self):
+        narrator = SlideNarrator(
+            model=None,
+            memory=SimpleMemory(),
+            narration_loader=NarrationLoader()
+        )
+        await narrator.load_narration("engineer-cafe", "ja")
+        return narrator
+
+    @pytest.mark.asyncio
+    async def test_next_slide_success(self, loaded_narrator):
+        """次のスライドへ正常に移動"""
+        result = await loaded_narrator.next_slide()
+
+        assert result.success is True
+        assert result.slide_number == 2
+        assert result.narration is not None
+        assert result.transition_message is not None
+
+    @pytest.mark.asyncio
+    async def test_next_slide_at_last_slide(self, loaded_narrator):
+        """最後のスライドで次へ移動を試みる"""
+        # 最後のスライドへ移動
+        loaded_narrator.current_slide = loaded_narrator.total_slides
+
+        result = await loaded_narrator.next_slide()
+
+        assert result.success is False
+        assert "最後のスライド" in result.transition_message
+
+    @pytest.mark.asyncio
+    async def test_previous_slide_success(self, loaded_narrator):
+        """前のスライドへ正常に移動"""
+        # スライド2へ移動
+        loaded_narrator.current_slide = 2
+
+        result = await loaded_narrator.previous_slide()
+
+        assert result.success is True
+        assert result.slide_number == 1
+        assert result.narration is not None
+
+    @pytest.mark.asyncio
+    async def test_previous_slide_at_first_slide(self, loaded_narrator):
+        """最初のスライドで前へ移動を試みる"""
+        result = await loaded_narrator.previous_slide()
+
+        assert result.success is False
+        assert "最初のスライド" in result.transition_message
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("target_slide", [1, 5, 10])
+    async def test_goto_slide_success(self, loaded_narrator, target_slide):
+        """指定スライドへ正常に移動"""
+        result = await loaded_narrator.goto_slide(target_slide)
+
+        assert result.success is True
+        assert result.slide_number == target_slide
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("invalid_slide", [0, -1, 999])
+    async def test_goto_slide_invalid(self, loaded_narrator, invalid_slide):
+        """無効なスライド番号での移動は失敗"""
+        result = await loaded_narrator.goto_slide(invalid_slide)
+
+        assert result.success is False
+
+    @pytest.mark.asyncio
+    async def test_navigation_sequence(self, loaded_narrator):
+        """スライドナビゲーションのシーケンステスト"""
+        # 1 → 2 → 3 → 2 → 5
+        await loaded_narrator.next_slide()  # 2
+        assert loaded_narrator.current_slide == 2
+
+        await loaded_narrator.next_slide()  # 3
+        assert loaded_narrator.current_slide == 3
+
+        await loaded_narrator.previous_slide()  # 2
+        assert loaded_narrator.current_slide == 2
+
+        await loaded_narrator.goto_slide(5)  # 5
+        assert loaded_narrator.current_slide == 5
+```
+
+### 4. 質問応答テスト
+
+```python
+class TestSlideQuestionAnswering:
+    """スライド質問応答のテスト"""
+
+    @pytest.fixture
+    async def loaded_narrator(self):
+        narrator = SlideNarrator(
+            model=MockLLM(),  # モックLLM
+            memory=SimpleMemory(),
+            narration_loader=NarrationLoader()
+        )
+        await narrator.load_narration("engineer-cafe", "ja")
+        return narrator
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("question,expected_keyword", [
+        ("詳しく教えて", "2019年8月"),           # onDemand応答
+        ("無料ですか？", "完全無料"),             # onDemand応答
+        ("場所はどこ？", "赤煉瓦文化館"),         # onDemand応答
+    ])
+    async def test_on_demand_answers(
+        self,
+        loaded_narrator,
+        question,
+        expected_keyword
+    ):
+        """onDemand応答のテスト"""
+        answer = await loaded_narrator.answer_slide_question(question)
+
+        assert answer is not None
+        assert expected_keyword in answer
+
+    @pytest.mark.asyncio
+    async def test_dynamic_answer_generation(self, loaded_narrator):
+        """LLMによる動的応答生成のテスト"""
+        # onDemandに定義されていない質問
+        question = "このスライドのポイントは何ですか？"
+
+        answer = await loaded_narrator.answer_slide_question(question)
+
+        assert answer is not None
+        assert len(answer) > 0
+
+    @pytest.mark.asyncio
+    async def test_question_without_narration_data(self):
+        """ナレーション未読み込み時の質問でエラー"""
+        narrator = SlideNarrator(model=MockLLM(), memory=SimpleMemory())
+
+        with pytest.raises(ValueError, match="No narration data loaded"):
+            await narrator.answer_slide_question("質問")
+
+    @pytest.mark.asyncio
+    async def test_slide_4_facility_questions(self, loaded_narrator):
+        """スライド4（地下施設）の質問応答"""
+        # スライド4へ移動
+        await loaded_narrator.goto_slide(4)
+
+        test_cases = [
+            ("ミーティングスペースについて", "2名以上"),
+            ("集中スペースについて", "6ブース"),
+            ("Makersスペースについて", "3Dプリンタ"),
+        ]
+
+        for question, expected_keyword in test_cases:
+            answer = await loaded_narrator.answer_slide_question(question)
+            assert expected_keyword in answer
+```
+
+### 5. キャラクターアクション決定テスト
+
+```python
+class TestCharacterActionDetermination:
+    """キャラクターアクション決定のテスト"""
+
+    @pytest.fixture
+    def narrator(self):
+        return SlideNarrator(model=None, memory=SimpleMemory())
+
+    @pytest.mark.parametrize("narration_text,expected_action", [
+        ("皆さん、エンジニアカフェへようこそ", "greeting"),
+        ("サービスについてご説明します", "presenting"),
+        ("料金は以下の通りです", "explaining"),
+        ("ご利用ありがとうございました", "bowing"),
+        ("通常のナレーション", "neutral"),
+        ("Welcome to Engineer Cafe", "greeting"),
+        ("Our service includes", "presenting"),
+        ("The price is", "explaining"),
+        ("Thank you for visiting", "bowing"),
+    ])
+    def test_determine_character_action(
+        self,
+        narrator,
+        narration_text,
+        expected_action
+    ):
+        """ナレーション内容からキャラクターアクションを決定"""
+        slide_data = {
+            'narration': {'auto': narration_text}
+        }
+
+        action = narrator._determine_character_action(slide_data)
+        assert action == expected_action
+```
+
+### 6. 感情抽出テスト
+
+```python
+class TestEmotionExtraction:
+    """感情抽出のテスト"""
+
+    @pytest.fixture
+    def narrator(self):
+        return SlideNarrator(model=None, memory=SimpleMemory())
+
+    @pytest.mark.parametrize("narration_text,expected_emotion", [
+        ("ようこそ、エンジニアカフェへ", "happy"),
+        ("料金についてご説明します", "explaining"),
+        ("サービスの特徴をお伝えします", "confident"),
+        ("ご質問はございますか？", "curious"),
+        ("ありがとうございました", "grateful"),
+        ("通常のナレーション", "neutral"),
+        ("Welcome to the cafe", "happy"),
+        ("The cost is 100 yen", "explaining"),
+        ("Our service features", "confident"),
+        ("Do you have any questions?", "curious"),
+        ("Thank you very much", "grateful"),
+    ])
+    def test_extract_emotion(
+        self,
+        narrator,
+        narration_text,
+        expected_emotion
+    ):
+        """ナレーション内容から感情を抽出"""
+        slide_data = {
+            'narration': {'auto': narration_text}
+        }
+
+        emotion = narrator._extract_emotion_from_slide_content(slide_data)
+        assert emotion == expected_emotion
+```
+
+### 7. 自動再生テスト
+
+```python
+class TestAutoPlay:
+    """自動再生のテスト"""
+
+    @pytest.fixture
+    async def loaded_narrator(self):
+        narrator = SlideNarrator(
+            model=None,
+            memory=SimpleMemory(),
+            narration_loader=NarrationLoader()
+        )
+        await narrator.load_narration("engineer-cafe", "ja")
+        return narrator
+
+    @pytest.mark.asyncio
+    async def test_set_auto_play_enabled(self, loaded_narrator):
+        """自動再生を有効化"""
+        await loaded_narrator.set_auto_play(True, 5000)
+
+        assert loaded_narrator.auto_play is True
+        assert await loaded_narrator.memory.get('autoPlay') is True
+        assert await loaded_narrator.memory.get('autoPlayInterval') == 5000
+
+    @pytest.mark.asyncio
+    async def test_set_auto_play_disabled(self, loaded_narrator):
+        """自動再生を無効化"""
+        await loaded_narrator.set_auto_play(False)
+
+        assert loaded_narrator.auto_play is False
+        assert await loaded_narrator.memory.get('autoPlay') is False
+
+    @pytest.mark.asyncio
+    async def test_stop_auto_play(self, loaded_narrator):
+        """自動再生を停止"""
+        await loaded_narrator.set_auto_play(True)
+        await loaded_narrator.stop_auto_play()
+
+        assert loaded_narrator.auto_play is False
+```
+
+## 統合テストケース
+
+### エンドツーエンドテスト
+
+```python
+# tests/test_presentation_workflow.py
+
+import pytest
+from backend.workflows.presentation_workflow import PresentationWorkflow
+from backend.agents.slide_narrator import SlideNarrator
+
+class TestPresentationWorkflow:
+    """プレゼンテーションワークフローの統合テスト"""
+
+    @pytest.fixture
+    def workflow(self):
+        narrator = SlideNarrator(
+            model=MockLLM(),
+            memory=SimpleMemory(),
+            narration_loader=NarrationLoader()
+        )
+        return PresentationWorkflow(narrator)
+
+    @pytest.mark.asyncio
+    async def test_full_presentation_flow(self, workflow):
+        """完全なプレゼンテーションフローのテスト"""
+        # ナレーション読み込み
+        result = await workflow.graph.ainvoke({
+            "slide_file": "engineer-cafe",
+            "language": "ja",
+            "action": "load",
+            "slide_number": None,
+            "question": None
+        })
+        assert result['error'] is None
+
+        # 次スライドへ移動
+        result = await workflow.graph.ainvoke({
+            "slide_file": "engineer-cafe",
+            "language": "ja",
+            "action": "next",
+            "slide_number": None,
+            "question": None
+        })
+        assert result['result']['success'] is True
+        assert result['result']['slide_number'] == 2
+
+        # 特定スライドへ移動
+        result = await workflow.graph.ainvoke({
+            "slide_file": "engineer-cafe",
+            "language": "ja",
+            "action": "goto",
+            "slide_number": 5,
+            "question": None
+        })
+        assert result['result']['success'] is True
+        assert result['result']['slide_number'] == 5
+
+        # 質問応答
+        result = await workflow.graph.ainvoke({
+            "slide_file": "engineer-cafe",
+            "language": "ja",
+            "action": "question",
+            "slide_number": None,
+            "question": "このスライドについて教えて"
+        })
+        assert result['result']['answer'] is not None
+
+    @pytest.mark.asyncio
+    async def test_complete_navigation_sequence(self, workflow):
+        """完全なナビゲーションシーケンステスト"""
+        # ナレーション読み込み
+        await workflow.graph.ainvoke({
+            "slide_file": "engineer-cafe",
+            "language": "ja",
+            "action": "load",
+            "slide_number": None,
+            "question": None
+        })
+
+        # スライド1→10まで全て移動
+        for i in range(1, 11):
+            if i > 1:
+                result = await workflow.graph.ainvoke({
+                    "slide_file": "engineer-cafe",
+                    "language": "ja",
+                    "action": "next",
+                    "slide_number": None,
+                    "question": None
+                })
+                assert result['result']['slide_number'] == i
+
+        # 最終スライドで次へ移動を試みる
+        result = await workflow.graph.ainvoke({
+            "slide_file": "engineer-cafe",
+            "language": "ja",
+            "action": "next",
+            "slide_number": None,
+            "question": None
+        })
+        assert result['result']['success'] is False
+```
+
+## パフォーマンステスト
+
+### レスポンスタイム計測
+
+```python
+import time
+
+class TestPerformance:
+    """パフォーマンステスト"""
+
+    @pytest.fixture
+    async def loaded_narrator(self):
+        narrator = SlideNarrator(
+            model=MockLLM(),
+            memory=SimpleMemory(),
+            narration_loader=NarrationLoader()
+        )
+        await narrator.load_narration("engineer-cafe", "ja")
+        return narrator
+
+    @pytest.mark.asyncio
+    async def test_narration_loading_time(self):
+        """ナレーション読み込み時間のテスト"""
+        narrator = SlideNarrator(
+            model=None,
+            memory=SimpleMemory(),
+            narration_loader=NarrationLoader()
+        )
+
+        start = time.perf_counter()
+        await narrator.load_narration("engineer-cafe", "ja")
+        elapsed = (time.perf_counter() - start) * 1000  # ms
+
+        # 目標: 100ms以下
+        assert elapsed < 100, f"Loading took {elapsed:.2f}ms, expected < 100ms"
+
+    @pytest.mark.asyncio
+    async def test_slide_navigation_time(self, loaded_narrator):
+        """スライドナビゲーション時間のテスト"""
+        times = []
+
+        for _ in range(5):
+            start = time.perf_counter()
+            await loaded_narrator.next_slide()
+            elapsed = (time.perf_counter() - start) * 1000  # ms
+            times.append(elapsed)
+
+        avg_time = sum(times) / len(times)
+
+        # 目標: 平均50ms以下（音声生成を除く）
+        assert avg_time < 50, f"Average navigation time {avg_time:.2f}ms, expected < 50ms"
+
+    @pytest.mark.asyncio
+    async def test_question_answering_time(self, loaded_narrator):
+        """質問応答時間のテスト"""
+        questions = [
+            "詳しく教えて",
+            "無料ですか？",
+            "場所はどこ？"
+        ]
+
+        times = []
+        for question in questions:
+            start = time.perf_counter()
+            await loaded_narrator.answer_slide_question(question)
+            elapsed = (time.perf_counter() - start) * 1000  # ms
+            times.append(elapsed)
+
+        avg_time = sum(times) / len(times)
+        max_time = max(times)
+
+        # 目標: 平均200ms以下、最大500ms以下
+        assert avg_time < 200, f"Average time {avg_time:.2f}ms, expected < 200ms"
+        assert max_time < 500, f"Max time {max_time:.2f}ms, expected < 500ms"
+```
+
+## 回帰テストマトリクス
+
+### 機能カバレッジテスト
+
+| カテゴリ | テストケース数 | 目標成功率 |
+|---------|--------------|----------|
+| ナレーション読み込み | 5 | 100% |
+| スライドナレーション | 8 | 100% |
+| スライドナビゲーション | 12 | 100% |
+| 質問応答（onDemand） | 10 | 100% |
+| 質問応答（動的） | 5 | 90% |
+| キャラクターアクション | 9 | 100% |
+| 感情抽出 | 11 | 100% |
+| 自動再生 | 4 | 100% |
+| エラーハンドリング | 6 | 100% |
+| **合計** | **70** | **98%以上** |
+
+## テスト実行方法
+
+### ローカル実行
+
+```bash
+# 全テスト実行
+pytest tests/test_slide_narrator.py -v
+
+# 特定のテストクラスのみ
+pytest tests/test_slide_narrator.py::TestSlideNavigation -v
+
+# パフォーマンステストのみ
+pytest tests/test_slide_narrator.py::TestPerformance -v
+
+# カバレッジレポート付き
+pytest tests/test_slide_narrator.py --cov=backend/agents/slide_narrator --cov-report=html
+
+# 非同期テストのみ
+pytest tests/test_slide_narrator.py -m asyncio
+```
+
+### CI/CD連携
+
+```yaml
+# .github/workflows/test-slide-agent.yml
+
+name: Slide Agent Tests
+
+on:
+  push:
+    paths:
+      - 'backend/agents/slide_narrator.py'
+      - 'backend/tools/narration_loader.py'
+      - 'backend/workflows/presentation_workflow.py'
+      - 'tests/test_slide_narrator.py'
+      - 'backend/data/narrations/*.json'
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+      - name: Install dependencies
+        run: |
+          pip install -r backend/requirements.txt
+          pip install pytest pytest-asyncio pytest-cov
+      - name: Run tests
+        run: |
+          pytest tests/test_slide_narrator.py -v --cov=backend/agents/slide_narrator
+      - name: Upload coverage
+        uses: codecov/codecov-action@v3
+```
+
+## モックオブジェクト
+
+### MockLLM
+
+```python
+# tests/mocks/mock_llm.py
+
+class MockLLM:
+    """LLMのモック"""
+
+    async def ainvoke(self, messages):
+        """モック応答を返す"""
+        class MockResponse:
+            content = "これはモックの応答です。スライドの内容について説明しています。"
+
+        return MockResponse()
+```
+
+### MockTTSService
+
+```python
+# tests/mocks/mock_tts.py
+
+import base64
+
+class MockTTSService:
+    """TTSサービスのモック"""
+
+    async def text_to_speech(self, text: str, language: str) -> dict:
+        """モック音声データを返す"""
+        # ダミーの音声データ
+        dummy_audio = b"mock_audio_data"
+        audio_base64 = base64.b64encode(dummy_audio).decode('utf-8')
+
+        return {
+            'success': True,
+            'audioBase64': audio_base64
+        }
+```
+
+## 品質基準
+
+### 合格基準
+
+| 項目 | 基準 |
+|-----|------|
+| 単体テストカバレッジ | 95%以上 |
+| 機能テスト成功率 | 98%以上 |
+| ナレーション読み込み時間 | 100ms以下 |
+| スライドナビゲーション時間 | 50ms以下（音声生成除く） |
+| 質問応答時間（onDemand） | 平均200ms以下 |
+| 質問応答時間（動的） | 平均2000ms以下 |
+| 回帰テスト | 全パス |
+
+### リリース前チェックリスト
+
+- [ ] 全単体テストがパス
+- [ ] 統合テストがパス
+- [ ] パフォーマンステストが基準を満たす
+- [ ] 全ナレーションファイルが正しく読み込める
+- [ ] 全スライドへの移動が正常に動作する
+- [ ] onDemand応答が全て正しく機能する
+- [ ] キャラクターアクション決定が正確
+- [ ] 感情抽出が正確
+- [ ] エラーハンドリングが適切
+- [ ] コードレビュー完了
+- [ ] ドキュメント更新完了
+
+## デバッグツール
+
+### ナレーションデータビューア
+
+```python
+# tools/debug/narration_viewer.py
+
+import json
+from pathlib import Path
+
+def view_narration_data(slide_file: str, language: str):
+    """ナレーションデータを読みやすく表示"""
+    file_path = Path(f"backend/data/narrations/{slide_file}-{language}.json")
+
+    with open(file_path, 'r', encoding='utf-8') as f:
+        data = json.load(f)
+
+    print(f"=== {data['metadata']['title']} ===")
+    print(f"Language: {data['metadata']['language']}")
+    print(f"Total Slides: {len(data['slides'])}\n")
+
+    for slide in data['slides']:
+        print(f"--- Slide {slide['slideNumber']} ---")
+        print(f"Auto: {slide['narration']['auto']}")
+        if 'onDemand' in slide['narration']:
+            print(f"On-Demand Keywords: {list(slide['narration']['onDemand'].keys())}")
+        print()
+
+# 使用例
+view_narration_data("engineer-cafe", "ja")
+```
+
+### スライドナビゲーションシミュレーター
+
+```python
+# tools/debug/navigation_simulator.py
+
+import asyncio
+from backend.agents.slide_narrator import SlideNarrator
+
+async def simulate_navigation():
+    """スライドナビゲーションをシミュレート"""
+    narrator = SlideNarrator(
+        model=None,
+        memory=SimpleMemory(),
+        narration_loader=NarrationLoader()
+    )
+
+    await narrator.load_narration("engineer-cafe", "ja")
+
+    print(f"Total Slides: {narrator.total_slides}")
+
+    # 全スライドを移動
+    for i in range(1, narrator.total_slides + 1):
+        result = await narrator.goto_slide(i)
+        print(f"Slide {i}: {result.character_action} - {result.emotion}")
+        print(f"  Narration: {result.narration[:50]}...")
+
+# 実行
+asyncio.run(simulate_navigation())
+```
+
+## 参考リンク
+
+- [pytest ドキュメント](https://docs.pytest.org/)
+- [pytest-asyncio ドキュメント](https://pytest-asyncio.readthedocs.io/)
+- [元実装: slide-narrator.ts](/Users/teradakousuke/Developer/engineer-cafe-navigator2025/frontend/src/mastra/agents/slide-narrator.ts)
+- [ナレーションデータ例](/Users/teradakousuke/Developer/engineer-cafe-navigator2025/frontend/src/slides/narration/engineer-cafe-ja.json)


### PR DESCRIPTION
## Summary
- Add comprehensive SPEC.md, MIGRATION-GUIDE.md, and TESTING.md for 4 agents assigned to テリスケ
- Documents follow router-agent template structure for consistency

## Agents Documented

| Agent | Description | Files Added |
|-------|-------------|-------------|
| **business-info-agent** | Business hours, pricing, location queries with Enhanced RAG | SPEC.md, MIGRATION-GUIDE.md, TESTING.md |
| **event-agent** | Calendar and event information with time range extraction | SPEC.md, MIGRATION-GUIDE.md, TESTING.md |
| **general-knowledge-agent** | Web search and multi-source confidence scoring | SPEC.md, MIGRATION-GUIDE.md, TESTING.md |
| **slide-agent** | Slide narration with VRM character control | SPEC.md, MIGRATION-GUIDE.md, TESTING.md |

## Documentation Contents

Each agent now has:
- **SPEC.md**: Input/output specifications, processing flow, LangGraph types
- **MIGRATION-GUIDE.md**: TypeScript to Python migration steps with code examples
- **TESTING.md**: Comprehensive test cases with pytest examples

## Changes
- 12 files added
- 7,947 lines added

## Test plan
- [ ] Review SPEC.md for accuracy against actual implementation
- [ ] Verify MIGRATION-GUIDE.md code examples compile
- [ ] Check TESTING.md test cases cover main functionality

🤖 Generated with [Claude Code](https://claude.com/claude-code)