### PR TITLE
feat(agent): FacilityAgent実装完了 (LangGraph移行)

### DIFF
--- a/Plans.md
+++ b/Plans.md
@@ -74,10 +74,14 @@ Claude Code は PR 作成・更新時に以下を確認:
 
 > 担当: テリスケ, Natsumi, けいてぃー
 
-### 1.5 FacilityAgent 移行 `cc:TODO`
-- [ ] 地下施設キーワード検出 `cc:TODO`
-- [ ] 設備情報クエリ処理 `cc:TODO`
-- [ ] テストケース作成 `cc:TODO`
+### 1.5 FacilityAgent 移行 `cc:DONE`
+- [x] FacilityAgentクラス実装 (wifi/facility/basement requestType対応) `cc:DONE`
+- [x] 地下施設キーワード検出ロジック実装 `cc:DONE`
+- [x] クエリ拡張ロジック実装 (requestType別) `cc:DONE`
+- [x] Enhanced RAG統合 `cc:DONE`
+- [x] ワークフロー統合 (main_workflow.py) `cc:DONE`
+- [x] テストケース作成 (16テスト全PASS) `cc:DONE`
+- [x] CI/CD検証 (Ruff/Black/Pytest) `cc:DONE`
 
 ---
 

--- a/backend/agents/facility_agent.py
+++ b/backend/agents/facility_agent.py
@@ -1,0 +1,258 @@
+"""
+FacilityAgent - 施設情報エージェント
+Wi-Fi、電源、設備、地下施設に関する質問に回答
+"""
+
+from typing import Dict, Optional
+from backend.tools.enhanced_rag import EnhancedRAGSearch
+from backend.llm import get_llm_provider, get_model_config
+
+
+class FacilityAgent:
+    """施設情報エージェント"""
+
+    def __init__(self):
+        """初期化"""
+        self.enhanced_rag = EnhancedRAGSearch()
+        self.llm_provider = get_llm_provider()
+
+    async def answer_facility_query(
+        self,
+        query: str,
+        request_type: Optional[str] = None,
+        language: str = "ja",
+        session_id: Optional[str] = None,
+    ) -> Dict:
+        """
+        施設情報クエリに回答
+
+        Args:
+            query: ユーザークエリ
+            request_type: リクエストタイプ（wifi, facility, basement）
+            language: 言語（ja or en）
+            session_id: セッションID
+
+        Returns:
+            回答辞書 {answer, emotion, metadata}
+        """
+        print(
+            f"[FacilityAgent] Processing query: {query}, request_type: {request_type}, language: {language}"
+        )
+
+        # クエリ拡張（requestTypeに応じて）
+        enhanced_query = self._enhance_query(query, request_type, language)
+
+        # Enhanced RAG検索
+        rag_result = await self.enhanced_rag.search(
+            query=enhanced_query,
+            category="facility-info",
+            language=language,
+            include_advice=True,
+            max_results=10,
+        )
+
+        if not rag_result.get("success"):
+            return self._get_default_response(language, request_type)
+
+        # コンテキスト取得
+        context = rag_result.get("data", {}).get("context", "")
+
+        if not context:
+            return self._get_default_response(language, request_type)
+
+        # 地下施設フィルタリング（basement requestTypeの場合）
+        if request_type == "basement":
+            context = self._filter_basement_context(context, query, language)
+
+        # プロンプト構築
+        prompt = self._build_prompt(query, context, request_type, language)
+
+        # LLM応答生成
+        try:
+            response_text = await self.llm_provider.generate(
+                messages=[{"role": "user", "content": prompt}],
+                config=get_model_config("facility_info"),
+            )
+
+            # 感情タグを決定
+            emotion = self._determine_emotion(request_type, response_text)
+
+            return {
+                "answer": response_text,
+                "emotion": emotion,
+                "metadata": {
+                    "agent": "FacilityAgent",
+                    "confidence": 0.85,
+                    "category": "facility-info",
+                    "request_type": request_type,
+                    "sources": ["enhanced_rag"],
+                },
+            }
+
+        except Exception as e:
+            print(f"[FacilityAgent] LLM error: {e}")
+            return self._get_default_response(language, request_type)
+
+    def _enhance_query(self, query: str, request_type: Optional[str], language: str) -> str:
+        """クエリ拡張ロジック"""
+        # requestTypeに応じたキーワード追加
+        enhancement_keywords = {
+            "wifi": {
+                "ja": "無料Wi-Fi インターネット 接続方法 パスワード",
+                "en": "free Wi-Fi internet connection method password",
+            },
+            "facility": {
+                "ja": "設備 電源 コンセント プリンター 利用方法",
+                "en": "facilities power outlet printer usage",
+            },
+            "basement": {
+                "ja": "地下 B1 MTGスペース 集中スペース アンダースペース Makersスペース 予約 利用方法",
+                "en": "basement B1 MTG space focus space under space makers space reservation",
+            },
+        }
+
+        if request_type in enhancement_keywords:
+            keywords = enhancement_keywords[request_type].get(
+                language, enhancement_keywords[request_type].get("ja", "")
+            )
+            return f"{query} {keywords}"
+
+        return query
+
+    def _filter_basement_context(self, context: str, query: str, language: str) -> str:
+        """地下施設に関連するコンテキストのみに絞り込む"""
+        # 地下施設名キーワード
+        basement_keywords_ja = [
+            "MTGスペース",
+            "ミーティングスペース",
+            "集中スペース",
+            "アンダースペース",
+            "Makersスペース",
+            "地下",
+            "B1",
+            "basement",
+        ]
+
+        basement_keywords_en = [
+            "MTG space",
+            "meeting space",
+            "focus space",
+            "under space",
+            "makers space",
+            "basement",
+            "B1",
+        ]
+
+        keywords = basement_keywords_ja if language == "ja" else basement_keywords_en
+
+        # クエリに特定の施設名が含まれているかチェック
+        query_lower = query.lower()
+        for keyword in keywords:
+            if keyword.lower() in query_lower:
+                # 該当キーワードを含む段落のみを抽出
+                filtered_lines = []
+                for line in context.split("\n"):
+                    if keyword.lower() in line.lower():
+                        filtered_lines.append(line)
+
+                if filtered_lines:
+                    return "\n".join(filtered_lines)
+
+        # 特定の施設名がない場合は全地下施設情報を返す
+        return context
+
+    def _build_prompt(
+        self, query: str, context: str, request_type: Optional[str], language: str
+    ) -> str:
+        """プロンプト構築"""
+        print(
+            f"[FacilityAgent] Building prompt with query_length: {len(query)}, context_length: {len(context)}, request_type: {request_type}, language: {language}"
+        )
+
+        # requestTypeに応じたプロンプト
+        if request_type:
+            request_type_prompt = self._get_request_type_prompt(request_type, language)
+
+            if language == "en":
+                return f"""Extract ONLY the {request_type_prompt} from the following information to answer the question.
+
+Question: {query}
+Information: {context}
+
+Answer with ONLY the {request_type_prompt}. Maximum 2-3 sentences. Do not include any other information.
+IMPORTANT: Start your response with [relaxed] for information or [happy] for positive news."""
+            else:
+                return f"""次の情報から{request_type_prompt}のみを抽出して質問に答えてください。
+
+質問: {query}
+情報: {context}
+
+{request_type_prompt}のみを答えてください。最大2-3文。他の情報は含めないでください。
+重要: 情報提供の場合は[relaxed]、良いニュースの場合は[happy]で回答を始めてください。"""
+
+        else:
+            if language == "en":
+                return f"""Answer the question using the provided information. Be concise and direct.
+
+Question: {query}
+Information: {context}
+
+Answer briefly (2-3 sentences) with only the relevant information.
+IMPORTANT: Start your response with an emotion tag: [relaxed] for information, [happy] for positive news, [sad] for unavailable services."""
+            else:
+                return f"""提供された情報を使って質問に答えてください。簡潔で直接的に答えてください。
+
+質問: {query}
+情報: {context}
+
+関連する情報のみを簡潔に（2-3文）答えてください。
+重要: 感情タグで回答を始めてください: 情報提供は[relaxed]、良いニュースは[happy]、利用できないサービスは[sad]。"""
+
+    def _get_request_type_prompt(self, request_type: str, language: str) -> str:
+        """requestTypeに応じたプロンプト文言を取得"""
+        prompt_map = {
+            "wifi": {"en": "Wi-Fi information", "ja": "Wi-Fi情報"},
+            "facility": {"en": "facility information", "ja": "設備情報"},
+            "basement": {"en": "basement facility information", "ja": "地下施設情報"},
+        }
+
+        prompt = prompt_map.get(
+            request_type, {"en": "requested information", "ja": "要求された情報"}
+        )
+        return prompt.get(language, prompt.get("ja", ""))
+
+    def _determine_emotion(self, request_type: Optional[str], response_text: str) -> str:
+        """感情タグを決定"""
+        # レスポンステキストから感情タグを抽出
+        if "[happy]" in response_text.lower():
+            return "happy"
+        elif "[sad]" in response_text.lower():
+            return "sad"
+        elif "[relaxed]" in response_text.lower():
+            return "relaxed"
+
+        # request_typeに基づくデフォルト感情
+        if request_type in ["wifi", "facility"]:
+            return "informative"
+        elif request_type == "basement":
+            return "guiding"
+
+        return "helpful"
+
+    def _get_default_response(self, language: str, request_type: Optional[str]) -> Dict:
+        """デフォルト応答（情報が見つからない場合）"""
+        if language == "en":
+            text = "[sad]I'm sorry, I couldn't find the specific facility information you're looking for. Please try rephrasing your question or contact the staff for assistance."
+        else:
+            text = "[sad]申し訳ございません。お探しの施設情報が見つかりませんでした。質問を言い換えていただくか、スタッフにお問い合わせください。"
+
+        return {
+            "answer": text,
+            "emotion": "apologetic",
+            "metadata": {
+                "agent": "FacilityAgent",
+                "confidence": 0.3,
+                "request_type": request_type,
+                "sources": ["fallback"],
+            },
+        }

--- a/backend/tests/agents/test_facility_agent.py
+++ b/backend/tests/agents/test_facility_agent.py
@@ -1,0 +1,361 @@
+"""
+FacilityAgent テストスイート
+施設情報エージェントのテスト
+"""
+
+import pytest
+from unittest.mock import AsyncMock, patch
+from backend.agents.facility_agent import FacilityAgent
+
+
+class TestFacilityAgent:
+    """FacilityAgentのテストクラス"""
+
+    # ==========================================================================
+    # 初期化テスト
+    # ==========================================================================
+
+    def test_initialization_default(self):
+        """デフォルト設定での初期化テスト"""
+        agent = FacilityAgent()
+        assert agent is not None
+        assert hasattr(agent, "enhanced_rag")
+        assert hasattr(agent, "llm_provider")
+
+    # ==========================================================================
+    # 基本機能テスト - Wi-Fi
+    # ==========================================================================
+
+    @pytest.mark.asyncio
+    async def test_wifi_query_japanese(self):
+        """Wi-Fi関連のクエリテスト（日本語）"""
+        agent = FacilityAgent()
+
+        # モックの設定
+        with (
+            patch.object(agent.enhanced_rag, "search", new_callable=AsyncMock) as mock_rag,
+            patch.object(agent.llm_provider, "generate", new_callable=AsyncMock) as mock_llm,
+        ):
+
+            mock_rag.return_value = {
+                "success": True,
+                "data": {
+                    "context": "Wi-Fiは無料で利用できます。接続方法はスタッフにお尋ねください。",
+                    "results": [],
+                    "totalResults": 1,
+                },
+            }
+
+            mock_llm.return_value = (
+                "[relaxed]Wi-Fiは無料で利用可能です。接続方法はスタッフにお尋ねください。"
+            )
+
+            result = await agent.answer_facility_query(
+                query="Wi-Fiはありますか？",
+                request_type="wifi",
+                language="ja",
+                session_id="test_session",
+            )
+
+            # アサーション
+            assert result["answer"] is not None
+            assert "wifi" in result["answer"].lower() or "wi-fi" in result["answer"].lower()
+            assert result["emotion"] in ["relaxed", "informative", "helpful"]
+            assert result["metadata"]["agent"] == "FacilityAgent"
+            assert result["metadata"]["request_type"] == "wifi"
+
+    # ==========================================================================
+    # 基本機能テスト - 設備
+    # ==========================================================================
+
+    @pytest.mark.asyncio
+    async def test_facility_query_japanese(self):
+        """設備関連のクエリテスト（日本語）"""
+        agent = FacilityAgent()
+
+        with (
+            patch.object(agent.enhanced_rag, "search", new_callable=AsyncMock) as mock_rag,
+            patch.object(agent.llm_provider, "generate", new_callable=AsyncMock) as mock_llm,
+        ):
+
+            mock_rag.return_value = {
+                "success": True,
+                "data": {
+                    "context": "各席に電源コンセントがあります。プリンターは1階受付にあります。",
+                    "results": [],
+                    "totalResults": 1,
+                },
+            }
+
+            mock_llm.return_value = "[relaxed]各席に電源コンセントがあります。"
+
+            result = await agent.answer_facility_query(
+                query="電源は使えますか？",
+                request_type="facility",
+                language="ja",
+                session_id="test_session",
+            )
+
+            assert result["answer"] is not None
+            assert result["emotion"] in ["relaxed", "informative", "helpful"]
+            assert result["metadata"]["agent"] == "FacilityAgent"
+            assert result["metadata"]["request_type"] == "facility"
+
+    # ==========================================================================
+    # 基本機能テスト - 地下施設
+    # ==========================================================================
+
+    @pytest.mark.asyncio
+    async def test_basement_query_japanese(self):
+        """地下施設関連のクエリテスト（日本語）"""
+        agent = FacilityAgent()
+
+        with (
+            patch.object(agent.enhanced_rag, "search", new_callable=AsyncMock) as mock_rag,
+            patch.object(agent.llm_provider, "generate", new_callable=AsyncMock) as mock_llm,
+        ):
+
+            mock_rag.return_value = {
+                "success": True,
+                "data": {
+                    "context": "地下にはMTGスペース、集中スペース、アンダースペース、Makersスペースがあります。",
+                    "results": [],
+                    "totalResults": 1,
+                },
+            }
+
+            mock_llm.return_value = "[relaxed]地下にはMTGスペース、集中スペース、アンダースペース、Makersスペースがあります。"
+
+            result = await agent.answer_facility_query(
+                query="地下の会議室について教えて",
+                request_type="basement",
+                language="ja",
+                session_id="test_session",
+            )
+
+            assert result["answer"] is not None
+            assert result["emotion"] in ["relaxed", "guiding", "helpful"]
+            assert result["metadata"]["agent"] == "FacilityAgent"
+            assert result["metadata"]["request_type"] == "basement"
+
+    # ==========================================================================
+    # クエリ拡張テスト
+    # ==========================================================================
+
+    def test_enhance_query_wifi(self):
+        """Wi-Fiクエリ拡張テスト"""
+        agent = FacilityAgent()
+        query = "Wi-Fiはありますか？"
+        enhanced = agent._enhance_query(query, "wifi", "ja")
+
+        assert "Wi-Fi" in enhanced or "無料Wi-Fi" in enhanced
+        assert "インターネット" in enhanced or "接続" in enhanced
+
+    def test_enhance_query_facility(self):
+        """設備クエリ拡張テスト"""
+        agent = FacilityAgent()
+        query = "電源は？"
+        enhanced = agent._enhance_query(query, "facility", "ja")
+
+        assert "設備" in enhanced or "電源" in enhanced
+        assert "コンセント" in enhanced or "プリンター" in enhanced
+
+    def test_enhance_query_basement(self):
+        """地下施設クエリ拡張テスト"""
+        agent = FacilityAgent()
+        query = "地下の施設について"
+        enhanced = agent._enhance_query(query, "basement", "ja")
+
+        assert "地下" in enhanced or "B1" in enhanced
+        assert "MTGスペース" in enhanced or "集中スペース" in enhanced
+
+    # ==========================================================================
+    # 地下施設フィルタリングテスト
+    # ==========================================================================
+
+    def test_filter_basement_context_specific_space(self):
+        """特定の地下施設名を含むコンテキストフィルタリング"""
+        agent = FacilityAgent()
+        context = """
+        地下にはMTGスペースがあります。予約不要です。
+        集中スペースは静かな作業環境です。
+        アンダースペースはイベント用です。要予約。
+        """
+        query = "MTGスペースについて"
+        filtered = agent._filter_basement_context(context, query, "ja")
+
+        assert "MTGスペース" in filtered
+        # 特定の施設名のみに絞られる
+        assert "MTGスペース" in filtered
+
+    def test_filter_basement_context_general(self):
+        """一般的な地下施設クエリの場合、全情報を返す"""
+        agent = FacilityAgent()
+        context = """
+        地下にはMTGスペース、集中スペース、アンダースペース、Makersスペースがあります。
+        """
+        query = "地下の施設について"
+        filtered = agent._filter_basement_context(context, query, "ja")
+
+        # 一般的なクエリの場合は全情報を返す
+        assert "地下" in filtered or "MTGスペース" in filtered
+
+    # ==========================================================================
+    # 感情タグ決定テスト
+    # ==========================================================================
+
+    def test_determine_emotion_from_text(self):
+        """レスポンステキストから感情タグを抽出"""
+        agent = FacilityAgent()
+
+        assert agent._determine_emotion("wifi", "[happy]Wi-Fiは無料です") == "happy"
+        assert agent._determine_emotion("wifi", "[sad]Wi-Fiは利用できません") == "sad"
+        assert agent._determine_emotion("wifi", "[relaxed]Wi-Fiがあります") == "relaxed"
+
+    def test_determine_emotion_default(self):
+        """デフォルト感情タグ"""
+        agent = FacilityAgent()
+
+        # requestTypeに基づくデフォルト
+        assert agent._determine_emotion("wifi", "Wi-Fiがあります") == "informative"
+        assert agent._determine_emotion("facility", "電源があります") == "informative"
+        assert agent._determine_emotion("basement", "地下施設があります") == "guiding"
+
+    # ==========================================================================
+    # エラーハンドリングテスト
+    # ==========================================================================
+
+    @pytest.mark.asyncio
+    async def test_error_handling_rag_failure(self):
+        """RAG検索失敗時のエラーハンドリング"""
+        agent = FacilityAgent()
+
+        with patch.object(agent.enhanced_rag, "search", new_callable=AsyncMock) as mock_rag:
+
+            mock_rag.return_value = {"success": False, "error": "RAG search failed"}
+
+            result = await agent.answer_facility_query(
+                query="Wi-Fiはありますか？",
+                request_type="wifi",
+                language="ja",
+                session_id="test_session",
+            )
+
+            # フォールバック応答を返す
+            assert result["answer"] is not None
+            assert result["emotion"] == "apologetic"
+            assert result["metadata"]["confidence"] == 0.3
+            assert result["metadata"]["sources"] == ["fallback"]
+
+    @pytest.mark.asyncio
+    async def test_error_handling_empty_context(self):
+        """コンテキストが空の場合のエラーハンドリング"""
+        agent = FacilityAgent()
+
+        with patch.object(agent.enhanced_rag, "search", new_callable=AsyncMock) as mock_rag:
+
+            mock_rag.return_value = {"success": True, "data": {"context": "", "results": []}}
+
+            result = await agent.answer_facility_query(
+                query="Wi-Fiはありますか？",
+                request_type="wifi",
+                language="ja",
+                session_id="test_session",
+            )
+
+            # フォールバック応答を返す
+            assert result["answer"] is not None
+            assert result["emotion"] == "apologetic"
+
+    @pytest.mark.asyncio
+    async def test_error_handling_llm_failure(self):
+        """LLM生成失敗時のエラーハンドリング"""
+        agent = FacilityAgent()
+
+        with (
+            patch.object(agent.enhanced_rag, "search", new_callable=AsyncMock) as mock_rag,
+            patch.object(agent.llm_provider, "generate", new_callable=AsyncMock) as mock_llm,
+        ):
+
+            mock_rag.return_value = {
+                "success": True,
+                "data": {"context": "Wi-Fiがあります", "results": []},
+            }
+
+            mock_llm.side_effect = Exception("LLM error")
+
+            result = await agent.answer_facility_query(
+                query="Wi-Fiはありますか？",
+                request_type="wifi",
+                language="ja",
+                session_id="test_session",
+            )
+
+            # フォールバック応答を返す
+            assert result["answer"] is not None
+            assert result["emotion"] == "apologetic"
+
+    # ==========================================================================
+    # 英語クエリテスト
+    # ==========================================================================
+
+    @pytest.mark.asyncio
+    async def test_wifi_query_english(self):
+        """Wi-Fi関連のクエリテスト（英語）"""
+        agent = FacilityAgent()
+
+        with (
+            patch.object(agent.enhanced_rag, "search", new_callable=AsyncMock) as mock_rag,
+            patch.object(agent.llm_provider, "generate", new_callable=AsyncMock) as mock_llm,
+        ):
+
+            mock_rag.return_value = {
+                "success": True,
+                "data": {"context": "Free Wi-Fi is available.", "results": []},
+            }
+
+            mock_llm.return_value = "[relaxed]Free Wi-Fi is available."
+
+            result = await agent.answer_facility_query(
+                query="Is there Wi-Fi?",
+                request_type="wifi",
+                language="en",
+                session_id="test_session",
+            )
+
+            assert result["answer"] is not None
+            assert result["emotion"] in ["relaxed", "informative", "helpful"]
+
+    # ==========================================================================
+    # 統合テスト
+    # ==========================================================================
+
+    @pytest.mark.asyncio
+    async def test_integration_multiple_request_types(self):
+        """複数のrequestTypeで正常に動作するか"""
+        agent = FacilityAgent()
+
+        request_types = ["wifi", "facility", "basement"]
+
+        for request_type in request_types:
+            with (
+                patch.object(agent.enhanced_rag, "search", new_callable=AsyncMock) as mock_rag,
+                patch.object(agent.llm_provider, "generate", new_callable=AsyncMock) as mock_llm,
+            ):
+
+                mock_rag.return_value = {
+                    "success": True,
+                    "data": {"context": "テスト情報", "results": []},
+                }
+
+                mock_llm.return_value = f"[relaxed]テスト応答 for {request_type}"
+
+                result = await agent.answer_facility_query(
+                    query=f"{request_type}について教えて",
+                    request_type=request_type,
+                    language="ja",
+                    session_id="test_session",
+                )
+
+                assert result["answer"] is not None
+                assert result["metadata"]["request_type"] == request_type

--- a/backend/workflows/main_workflow.py
+++ b/backend/workflows/main_workflow.py
@@ -167,10 +167,23 @@ class MainWorkflow:
             "metadata": {**state.get("metadata", {}), **result.get("metadata", {})},
         }
 
-    def _facility_node(self, state: WorkflowState) -> dict:
+    async def _facility_node(self, state: WorkflowState) -> dict:
         """施設ノード: 施設情報を処理"""
-        # TODO: 施設エージェントの実装
-        return {"answer": "施設情報の取得中です。", "emotion": "neutral"}
+        from backend.agents.facility_agent import FacilityAgent
+
+        agent = FacilityAgent()
+        query = state.get("query", "")
+        language = state.get("language", "ja")
+        session_id = state.get("session_id", "")
+        request_type = state.get("metadata", {}).get("routing", {}).get("request_type")
+
+        result = await agent.answer_facility_query(query, request_type, language, session_id)
+
+        return {
+            "answer": result.get("answer", ""),
+            "emotion": result.get("emotion", "neutral"),
+            "metadata": {**state.get("metadata", {}), **result.get("metadata", {})},
+        }
 
     async def _event_node(self, state: WorkflowState) -> dict:
         """イベントノード: イベント情報を処理"""


### PR DESCRIPTION
## 📋 概要

フェーズ1.5: FacilityAgent実装を完了しました。
Wi-Fi、設備、地下施設に関する質問に対応するエージェントをLangGraphで実装しました。

---

## ✅ 実装内容

### 1. FacilityAgentクラス実装

**ファイル**: `backend/agents/facility_agent.py`

**対応requestType**:
- `wifi`: Wi-Fi関連の質問
- `facility`: 設備全般の質問
- `basement`: 地下施設の質問

**主要機能**:
- クエリ拡張ロジック (requestType別キーワード追加)
- 地下施設フィルタリング (MTG/集中/Under/Makersスペース)
- Enhanced RAG統合
- 感情タグ自動決定
- エラーハンドリング (フォールバック応答)

### 2. ワークフロー統合

**ファイル**: `backend/workflows/main_workflow.py`

**変更内容**:
- `_facility_node()` メソッド実装
- FacilityAgentを非同期で呼び出し
- requestTypeをmetadataから取得して渡す

### 3. テストケース実装

**ファイル**: `backend/tests/agents/test_facility_agent.py`

**テスト内容** (16テスト全PASS):
- ✅ 初期化テスト
- ✅ Wi-Fi関連クエリテスト (日本語・英語)
- ✅ 設備関連クエリテスト
- ✅ 地下施設関連クエリテスト
- ✅ クエリ拡張ロジックテスト
- ✅ 地下施設フィルタリングテスト
- ✅ 感情タグ決定テスト
- ✅ エラーハンドリングテスト (RAG失敗/空コンテキスト/LLM失敗)
- ✅ 統合テスト (複数requestType)

---

## 📊 CI/CD 状況

### ✅ パス
- `ruff check .` - ✅ PASS
- `black --check .` - ✅ PASS  
- `pytest tests/agents/test_facility_agent.py -v` - ✅ 16/16 PASS

---

## 🔧 実装詳細

### クエリ拡張例

**Wi-Fi**:
```python
"Wi-Fiはありますか？" 
→ "Wi-Fiはありますか？ 無料Wi-Fi インターネット 接続方法 パスワード"
```

**地下施設**:
```python
"地下の会議室について" 
→ "地下の会議室について 地下 B1 MTGスペース 集中スペース アンダースペース Makersスペース"
```

### 地下施設フィルタリング

クエリに特定の施設名が含まれる場合、該当する施設情報のみに絞り込み:
```python
query = "MTGスペースについて"
→ MTGスペース関連の情報のみを返す
```

---

## 🚀 次のステップ

フェーズ1.5 完了により、以下が実装済み:
- ✅ RouterAgent (フェーズ1.1)
- ✅ BusinessInfoAgent (フェーズ1.2)
- ✅ EventAgent (フェーズ1.3)
- ✅ SlideAgent (フェーズ1.4)
- ✅ **FacilityAgent (フェーズ1.5)** ← 今回

**次のフェーズ**:
- フェーズ2.2: ClarificationAgent実装
- フェーズ2.3: LanguageClassifier実装

---

## 📝 関連ドキュメント

- [FacilityAgent README](docs/migration/agents/facility-agent/README.md)
- [Enhanced RAG](backend/tools/enhanced_rag.py)
- [BusinessInfoAgent](backend/agents/business_info_agent.py) (参考実装)

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)