### PR TITLE
Feature/clarification agent implementation

### DIFF
--- a/backend/agents/clarification_agent.py
+++ b/backend/agents/clarification_agent.py
@@ -53,6 +53,10 @@ class ClarificationAgent:
     このクラスは骨組みのみを提供します。完全実装は専門エンジニア（Chie）が担当。
     """
 
+    # 共通メタデータ定数
+    _AGENT_NAME = "ClarificationAgent"
+    _DEFAULT_SOURCES = ["clarification_system"]
+
     def __init__(self):
         """
         初期化
@@ -64,6 +68,36 @@ class ClarificationAgent:
         """
         logger.info("ClarificationAgent骨組み初期化")
         # TODO: OpenRouterProvider等の初期化
+
+
+    def _create_result(
+        self,
+        message: str,
+        category: ClarificationCategory,
+        confidence: float = 0.9,
+    ) -> ClarificationResult:
+        """
+        ClarificationResultを生成するヘルパーメソッド
+        
+        Args:
+            message: 応答メッセージ
+            category: 曖昧性のカテゴリ
+            confidence: 信頼度スコア（デフォルト：0.9）
+        
+        Returns:
+            ClarificationResult: 感情タグ付きの応答とメタデータ
+        """
+        tagged_message = add_emotion_tag(message, 'surprised')
+        return {
+            "response": tagged_message,
+            "emotion": "surprised",
+            "metadata": {
+                "agent": self._AGENT_NAME,
+                "confidence": confidence,
+                "category": category,
+                "sources": self._DEFAULT_SOURCES,
+            }
+        }
 
     async def handle_clarification(
         self,
@@ -101,18 +135,7 @@ class ClarificationAgent:
                       "お聞かせください！"
             )
 
-            tagged_message = add_emotion_tag(clarification_message, 'surprised')
-
-            return {
-                "response": tagged_message,
-                "emotion": "surprised",
-                "metadata": {
-                    "agent": "ClarificationAgent",
-                    "confidence": 0.9,
-                    "category": "cafe-clarification-needed",
-                    "sources": ["clarification_system"]
-                }
-            }
+            return self._create_result(clarification_message, "cafe-clarification-needed")
 
         # 会議室の曖昧性解消
         if category == 'meeting-room-clarification-needed':
@@ -128,18 +151,7 @@ class ClarificationAgent:
                       "どちらについてお知りになりたいですか？"
             )
 
-            tagged_message = add_emotion_tag(clarification_message, 'surprised')
-
-            return {
-                "response": tagged_message,
-                "emotion": "surprised",
-                "metadata": {
-                    "agent": "ClarificationAgent",
-                    "confidence": 0.9,
-                    "category": "meeting-room-clarification-needed",
-                    "sources": ["clarification_system"]
-                }
-            }
+            return self._create_result(clarification_message, "meeting-room-clarification-needed")
 
         # デフォルトの曖昧性解消
         default_message = (
@@ -148,18 +160,7 @@ class ClarificationAgent:
             else "お手伝いさせていただきます！もう少し詳しくお聞かせいただけますか？"
         )
 
-        tagged_message = add_emotion_tag(default_message, 'surprised')
-
-        return {
-            "response": tagged_message,
-            "emotion": "surprised",
-            "metadata": {
-                "agent": "ClarificationAgent",
-                "confidence": 0.7,
-                "category": "general-clarification-needed",
-                "sources": ["clarification_system"]
-            }
-        }
+        return self._create_result(default_message, "general-clarification-needed", confidence=0.7)
 
 
     async def detect_ambiguity(self, query: str, context: Optional[Dict[str, Any]] = None) -> bool:

--- a/backend/agents/clarification_agent.py
+++ b/backend/agents/clarification_agent.py
@@ -65,6 +65,103 @@ class ClarificationAgent:
         logger.info("ClarificationAgent骨組み初期化")
         # TODO: OpenRouterProvider等の初期化
 
+    async def handle_clarification(
+        self,
+        query: str,
+        category: ClarificationCategory,
+        language: SupportedLanguage,
+    ) -> ClarificationResult:
+        """
+        曖昧性解消の処理
+
+        RouterAgentからcategoryを受け取り、固定メッセージで曖昧性を解消します。
+        LLMを使用せず、高速で一貫性のある応答を提供します。
+
+        Args:
+            query: ユーザーからの入力テキスト（現在は使用されないが、将来の拡張用）
+            category: 曖昧性の種類（RouterAgentが判定済み）
+            language: 応答言語
+
+        Returns:
+            ClarificationResult: 感情タグ付きの応答とメタデータ
+        """
+        logger.info(f"ClarificationAgent.handle_clarification: query={query}, category={category}, language={language}")
+
+        # カフェの曖昧性解消
+        if category == 'cafe-clarification-needed':
+            clarification_message = (
+                "I'd be happy to help! Are you asking about:\n"
+                "1. **Engineer Cafe** (the coworking space) - hours, facilities, usage\n"
+                "2. **Saino Cafe** (the attached cafe & bar) - menu, hours, prices\n\n"
+                "Please let me know which one you're interested in!"
+                if language == 'en'
+                else "お手伝いさせていただきます！どちらについてお聞きでしょうか：\n"
+                      "1. **エンジニアカフェ**（コワーキングスペース）- 営業時間、設備、利用方法\n"
+                      "2. **サイノカフェ**（併設のカフェ＆バー）- メニュー、営業時間、料金\n\n"
+                      "お聞かせください！"
+            )
+
+            tagged_message = add_emotion_tag(clarification_message, 'surprised')
+
+            return {
+                "response": tagged_message,
+                "emotion": "surprised",
+                "metadata": {
+                    "agent": "ClarificationAgent",
+                    "confidence": 0.9,
+                    "category": "cafe-clarification-needed",
+                    "sources": ["clarification_system"]
+                }
+            }
+
+        # 会議室の曖昧性解消
+        if category == 'meeting-room-clarification-needed':
+            clarification_message = (
+                "I'd be happy to help! We have two types of meeting spaces:\n"
+                "1. **Paid Meeting Rooms (2F)** - Private rooms with advance booking required (fees apply)\n"
+                "2. **Basement Meeting Spaces (B1)** - Free open spaces for casual meetings\n\n"
+                "Which one would you like to know about?"
+                if language == 'en'
+                else "お手伝いさせていただきます！会議スペースは2種類ございます：\n"
+                      "1. **有料会議室（2階）** - 事前予約制の個室（有料）\n"
+                      "2. **地下MTGスペース（地下1階）** - カジュアルな打ち合わせ用の無料スペース\n\n"
+                      "どちらについてお知りになりたいですか？"
+            )
+
+            tagged_message = add_emotion_tag(clarification_message, 'surprised')
+
+            return {
+                "response": tagged_message,
+                "emotion": "surprised",
+                "metadata": {
+                    "agent": "ClarificationAgent",
+                    "confidence": 0.9,
+                    "category": "meeting-room-clarification-needed",
+                    "sources": ["clarification_system"]
+                }
+            }
+
+        # デフォルトの曖昧性解消
+        default_message = (
+            "I'd be happy to help! Could you please provide more details about what you'd like to know?"
+            if language == 'en'
+            else "お手伝いさせていただきます！もう少し詳しくお聞かせいただけますか？"
+        )
+
+        tagged_message = add_emotion_tag(default_message, 'surprised')
+
+        return {
+            "response": tagged_message,
+            "emotion": "surprised",
+            "metadata": {
+                "agent": "ClarificationAgent",
+                "confidence": 0.7,
+                "category": "general-clarification-needed",
+                "sources": ["clarification_system"]
+            }
+        }
+
+
     async def detect_ambiguity(self, query: str, context: Optional[Dict[str, Any]] = None) -> bool:
         """
         曖昧さを検出

--- a/backend/agents/clarification_agent.py
+++ b/backend/agents/clarification_agent.py
@@ -18,13 +18,32 @@ TODO (専門エンジニア - Chie):
 """
 
 import logging
-from typing import Dict, Any, List, Optional
+from typing import Dict, Any, List, Optional, Literal, TypedDict
+
+from backend.utils.emotion_tagger import add_emotion_tag
+
 
 # TODO: 実装時に必要なインポート
 # from llm.openrouter import OpenRouterProvider
 # from llm.models import get_model_config
 
 logger = logging.getLogger(__name__)
+
+# 型定義
+SupportedLanguage = Literal["ja", "en"]
+
+ClarificationCategory = Literal[
+    "cafe-clarification-needed",
+    "meeting-room-clarification-needed",
+    "general-clarification-needed",
+]
+
+
+class ClarificationResult(TypedDict):
+    """Clarification Agentの出力結果"""
+    response: str  # 感情タグ付きテキスト
+    emotion: Literal["surprised"]
+    metadata: dict  # agent名, category, confidence など
 
 
 class ClarificationAgent:

--- a/backend/tests/agents/test_clarification_agent.py
+++ b/backend/tests/agents/test_clarification_agent.py
@@ -1,0 +1,273 @@
+"""
+ClarificationAgent のユニットテスト
+
+TESTING.mdに基づいた包括的なテストスイート
+"""
+
+import pytest
+from unittest.mock import patch
+from backend.agents.clarification_agent import ClarificationAgent
+
+
+class TestCategoryMessages:
+    """カテゴリ別メッセージ生成のテスト"""
+
+    @pytest.fixture
+    def agent(self):
+        return ClarificationAgent()
+
+    @pytest.mark.parametrize("category,language,expected_keywords", [
+        # カフェの曖昧性解消（日本語）
+        (
+            "cafe-clarification-needed",
+            "ja",
+            ["エンジニアカフェ", "サイノカフェ", "どちらについて"]
+        ),
+        # カフェの曖昧性解消（英語）
+        (
+            "cafe-clarification-needed",
+            "en",
+            ["Engineer Cafe", "Saino Cafe", "which one"]
+        ),
+        # 会議室の曖昧性解消（日本語）
+        (
+            "meeting-room-clarification-needed",
+            "ja",
+            ["有料会議室", "地下MTGスペース", "2種類"]
+        ),
+        # 会議室の曖昧性解消（英語）
+        (
+            "meeting-room-clarification-needed",
+            "en",
+            ["Paid Meeting Rooms", "Basement Meeting Spaces", "two types"]
+        ),
+        # デフォルトの曖昧性解消（日本語）
+        (
+            "general-clarification-needed",
+            "ja",
+            ["もう少し詳しく"]
+        ),
+        # デフォルトの曖昧性解消（英語）
+        (
+            "general-clarification-needed",
+            "en",
+            ["more details"]
+        ),
+    ])
+    @pytest.mark.asyncio
+    async def test_category_messages(self, agent, category, language, expected_keywords):
+        """カテゴリと言語に応じたメッセージが生成されることを確認"""
+        result = await agent.handle_clarification(
+            query="test query",
+            category=category,
+            language=language
+        )
+
+        response = result["response"]
+
+        # すべてのキーワードが含まれていることを確認
+        for keyword in expected_keywords:
+            assert keyword in response, f"Keyword '{keyword}' not found in response"
+
+        # 感情タグが付与されていることを確認
+        assert response.startswith("[surprised]"), "Emotion tag not found"
+
+
+class TestEmotionTag:
+    """感情タグ付与のテスト"""
+
+    @pytest.fixture
+    def agent(self):
+        return ClarificationAgent()
+
+    @pytest.mark.parametrize("category,language", [
+        ("cafe-clarification-needed", "ja"),
+        ("cafe-clarification-needed", "en"),
+        ("meeting-room-clarification-needed", "ja"),
+        ("meeting-room-clarification-needed", "en"),
+        ("general-clarification-needed", "ja"),
+        ("general-clarification-needed", "en"),
+    ])
+    @pytest.mark.asyncio
+    async def test_emotion_tag_always_surprised(self, agent, category, language):
+        """すべての応答に[surprised]タグが付与されることを確認"""
+        result = await agent.handle_clarification(
+            query="test query",
+            category=category,
+            language=language
+        )
+
+        assert result["emotion"] == "surprised"
+        assert result["response"].startswith("[surprised]")
+
+
+class TestMetadata:
+    """メタデータ設定のテスト"""
+
+    @pytest.fixture
+    def agent(self):
+        return ClarificationAgent()
+
+    @pytest.mark.parametrize("category,expected_confidence", [
+        ("cafe-clarification-needed", 0.9),
+        ("meeting-room-clarification-needed", 0.9),
+        ("general-clarification-needed", 0.7),
+    ])
+    @pytest.mark.asyncio
+    async def test_metadata_structure(self, agent, category, expected_confidence):
+        """メタデータが正しく設定されることを確認"""
+        result = await agent.handle_clarification(
+            query="test query",
+            category=category,
+            language="ja"
+        )
+
+        metadata = result["metadata"]
+
+        assert metadata["agent"] == "ClarificationAgent"
+        assert metadata["confidence"] == expected_confidence
+        assert metadata["category"] == category
+        assert metadata["sources"] == ["clarification_system"]
+
+    @pytest.mark.asyncio
+    async def test_metadata_language(self, agent):
+        """メタデータに言語情報が含まれることを確認（必要に応じて）"""
+        result_ja = await agent.handle_clarification(
+            query="test",
+            category="cafe-clarification-needed",
+            language="ja"
+        )
+
+        result_en = await agent.handle_clarification(
+            query="test",
+            category="cafe-clarification-needed",
+            language="en"
+        )
+
+        # 言語によってメッセージが異なることを確認
+        assert result_ja["response"] != result_en["response"]
+
+
+class TestErrorHandling:
+    """エラーハンドリングのテスト"""
+
+    @pytest.fixture
+    def agent(self):
+        return ClarificationAgent()
+
+    @pytest.mark.asyncio
+    async def test_invalid_category_fallback(self, agent):
+        """無効なカテゴリの場合、デフォルトメッセージを返す"""
+        # 無効なカテゴリを渡す（型チェックを回避するため、直接辞書を操作）
+        # 実際の実装では、無効なカテゴリは型チェックで防がれるが、
+        # エラーハンドリングのテストとして残す
+
+        # 正常系のテスト
+        result = await agent.handle_clarification(
+            query="test",
+            category="general-clarification-needed",
+            language="ja"
+        )
+
+        assert result["response"] is not None
+        assert result["emotion"] == "surprised"
+
+    @pytest.mark.asyncio
+    async def test_emotion_tagger_error_handling(self, agent):
+        """EmotionTaggerのエラーをハンドリング"""
+        # add_emotion_tagがエラーを起こした場合のテスト
+        # clarification_agent.pyで直接インポートされているため、
+        # clarification_agentモジュール内のadd_emotion_tagをパッチする
+        from backend.utils import emotion_tagger
+
+        with patch(
+            'backend.agents.clarification_agent.add_emotion_tag',
+            side_effect=Exception("Emotion tagger error")
+        ):
+
+            # 現在の実装ではエラーハンドリングがないため、例外が発生することを確認
+            with pytest.raises(Exception, match="Emotion tagger error"):
+                await agent.handle_clarification(
+                    query="test",
+                    category="cafe-clarification-needed",
+                    language="ja"
+                )
+
+class TestMessageContent:
+    """メッセージ内容の正確性テスト"""
+
+    @pytest.fixture
+    def agent(self):
+        return ClarificationAgent()
+
+    @pytest.mark.asyncio
+    async def test_cafe_clarification_ja_content(self, agent):
+        """カフェ曖昧性解消（日本語）のメッセージ内容を確認"""
+        result = await agent.handle_clarification(
+            query="カフェの営業時間は？",
+            category="cafe-clarification-needed",
+            language="ja"
+        )
+
+        response = result["response"]
+
+        # 必須要素の確認
+        assert "エンジニアカフェ" in response
+        assert "サイノカフェ" in response
+        assert "コワーキングスペース" in response
+        assert "カフェ＆バー" in response
+        assert "どちらについて" in response
+
+    @pytest.mark.asyncio
+    async def test_cafe_clarification_en_content(self, agent):
+        """カフェ曖昧性解消（英語）のメッセージ内容を確認"""
+        result = await agent.handle_clarification(
+            query="What are the cafe hours?",
+            category="cafe-clarification-needed",
+            language="en"
+        )
+
+        response = result["response"]
+
+        # 必須要素の確認
+        assert "Engineer Cafe" in response
+        assert "Saino Cafe" in response
+        assert "coworking space" in response
+        assert "cafe & bar" in response
+        assert "which one" in response.lower()
+
+    @pytest.mark.asyncio
+    async def test_meeting_room_clarification_ja_content(self, agent):
+        """会議室曖昧性解消（日本語）のメッセージ内容を確認"""
+        result = await agent.handle_clarification(
+            query="会議室の予約方法は？",
+            category="meeting-room-clarification-needed",
+            language="ja"
+        )
+
+        response = result["response"]
+
+        # 必須要素の確認
+        assert "有料会議室" in response
+        assert "地下MTGスペース" in response
+        assert "2階" in response or "2F" in response
+        assert "地下1階" in response or "B1" in response
+        assert "2種類" in response
+
+    @pytest.mark.asyncio
+    async def test_meeting_room_clarification_en_content(self, agent):
+        """会議室曖昧性解消（英語）のメッセージ内容を確認"""
+        result = await agent.handle_clarification(
+            query="How do I book a meeting room?",
+            category="meeting-room-clarification-needed",
+            language="en"
+        )
+
+        response = result["response"]
+
+        # 必須要素の確認
+        assert "Paid Meeting Rooms" in response
+        assert "Basement Meeting Spaces" in response
+        assert "2F" in response or "2nd floor" in response
+        assert "B1" in response or "basement" in response
+        assert "two types" in response.lower()

--- a/backend/tests/integration/test_clarification_agent_integration.py
+++ b/backend/tests/integration/test_clarification_agent_integration.py
@@ -1,0 +1,312 @@
+"""
+ClarificationAgent統合テスト
+
+ClarificationAgentがMainWorkflowに統合され、RouterAgentから正しくルーティングされ、
+適切な明確化メッセージを返すことを検証する統合テストスイート。
+
+テスト範囲:
+- ClarificationAgentとMainWorkflowの統合
+- カテゴリ別（cafe, meeting-room, general）の明確化メッセージ
+- 日本語/英語の両言語対応
+- 異常系（フォールバック処理）
+- メタデータ構造の検証
+"""
+
+import os
+import sys
+import pytest
+from unittest.mock import Mock, AsyncMock, MagicMock
+from backend.agents.clarification_agent import ClarificationAgent
+
+
+class TestMessageContent:
+    """メッセージ内容の正確性テスト"""
+
+    @pytest.fixture
+    def agent(self):
+        return ClarificationAgent()
+
+    @pytest.mark.asyncio
+    async def test_cafe_clarification_ja_content(self, agent):
+        """カフェ曖昧性解消（日本語）のメッセージ内容を確認"""
+        result = await agent.handle_clarification(
+            query="カフェの営業時間は？",
+            category="cafe-clarification-needed",
+            language="ja"
+        )
+        
+        response = result["response"]
+        
+        # 必須要素の確認
+        assert "エンジニアカフェ" in response
+        assert "サイノカフェ" in response
+        assert "コワーキングスペース" in response
+        assert "カフェ＆バー" in response
+        assert "どちらについて" in response
+
+    @pytest.mark.asyncio
+    async def test_cafe_clarification_en_content(self, agent):
+        """カフェ曖昧性解消（英語）のメッセージ内容を確認"""
+        result = await agent.handle_clarification(
+            query="What are the cafe hours?",
+            category="cafe-clarification-needed",
+            language="en"
+        )
+        
+        response = result["response"]
+        
+        # 必須要素の確認
+        assert "Engineer Cafe" in response
+        assert "Saino Cafe" in response
+        assert "coworking space" in response
+        assert "cafe & bar" in response
+        assert "which one" in response.lower()
+
+    @pytest.mark.asyncio
+    async def test_meeting_room_clarification_ja_content(self, agent):
+        """会議室曖昧性解消（日本語）のメッセージ内容を確認"""
+        result = await agent.handle_clarification(
+            query="会議室の予約方法は？",
+            category="meeting-room-clarification-needed",
+            language="ja"
+        )
+        
+        response = result["response"]
+        
+        # 必須要素の確認
+        assert "有料会議室" in response
+        assert "地下MTGスペース" in response
+        assert "2階" in response or "2F" in response
+        assert "地下1階" in response or "B1" in response
+        assert "2種類" in response
+
+    @pytest.mark.asyncio
+    async def test_meeting_room_clarification_en_content(self, agent):
+        """会議室曖昧性解消（英語）のメッセージ内容を確認"""
+        result = await agent.handle_clarification(
+            query="How do I book a meeting room?",
+            category="meeting-room-clarification-needed",
+            language="en"
+        )
+        
+        response = result["response"]
+        
+        # 必須要素の確認
+        assert "Paid Meeting Rooms" in response
+        assert "Basement Meeting Spaces" in response
+        assert "2F" in response or "2nd floor" in response
+        assert "B1" in response or "basement" in response
+        assert "two types" in response.lower()
+
+
+class TestClarificationIntegration:
+    """ClarificationAgentとワークフローの統合テスト（擬似E2E）"""
+
+    def setup_method(self):
+        """各テストメソッドの前に実行"""
+        # テスト用のダミーAPIキーを設定
+        os.environ["OPENROUTER_API_KEY"] = "test_dummy_api_key_for_testing"
+
+        # RouterAgentをモック（sys.modulesに登録してからインポート）
+        mock_router_agent_class = MagicMock()
+        mock_router_agent_instance = Mock()
+        mock_router_agent_instance.route_query = AsyncMock(return_value=Mock(
+            agent="ClarificationAgent",
+            category="cafe-clarification-needed",
+            request_type=None,
+            language="ja",
+            confidence=0.9,
+            debug_info={}
+        ))
+        mock_router_agent_class.return_value = mock_router_agent_instance
+        
+        # sys.modulesにモックを登録（インポート前に）
+        sys.modules['backend.agents.router_agent'] = MagicMock()
+        sys.modules['backend.agents.router_agent'].RouterAgent = mock_router_agent_class
+        
+        # これでMainWorkflowをインポートできる
+        from backend.workflows.main_workflow import MainWorkflow
+        self.workflow = MainWorkflow()
+        # モックをインスタンスに設定
+        self.workflow.router_agent = mock_router_agent_instance
+
+    @pytest.mark.asyncio
+    async def test_clarification_node_integration(self):
+        """Clarificationノードの統合テスト"""
+        test_cases = [
+            {
+                "query": "カフェの営業時間は？",
+                "expected_category": "cafe-clarification-needed",
+                "language": "ja"
+            },
+            {
+                "query": "会議室の予約方法は？",
+                "expected_category": "meeting-room-clarification-needed",
+                "language": "ja"
+            },
+            {
+                "query": "What are the cafe hours?",
+                "expected_category": "cafe-clarification-needed",
+                "language": "en"
+            },
+        ]
+
+        for case in test_cases:
+            # Router Agentがcategoryを設定する想定
+            state = {
+                "query": case["query"],
+                "session_id": "test_session",
+                "language": case["language"],
+                "messages": [],
+                "routed_to": None,
+                "answer": None,
+                "emotion": None,
+                "metadata": {
+                    "routing": {
+                        "category": case["expected_category"]
+                    }
+                },
+                "context": {},
+            }
+            
+            # Clarificationノードを直接呼び出し（awaitが必要）
+            result = await self.workflow._clarification_node(state)
+            
+            # 基本アサーション
+            assert result["answer"] is not None
+            assert result["emotion"] == "surprised"
+            
+            # メタデータ構造の確認（実装に合わせて修正）
+            assert "clarification" in result["metadata"]
+            assert result["metadata"]["clarification"]["agent"] == "ClarificationAgent"
+            assert result["metadata"]["requires_followup"] is True
+            assert result["metadata"]["clarification"]["clarification_type"] == case["expected_category"]
+            
+            # 感情タグが付与されていることを確認
+            assert "[surprised]" in result["answer"]
+
+    @pytest.mark.asyncio
+    async def test_full_workflow_with_clarification(self):
+        """Clarificationを含む完全なワークフローのテスト（モック版）"""
+        # Router AgentがClarificationAgentにルーティングする想定
+        result = await self.workflow.ainvoke({
+            "query": "カフェの営業時間は？",
+            "session_id": "test_session",
+            "language": "ja"
+        })
+        
+        # Router Agentが正しくClarificationAgentにルーティングすることを確認
+        # （Router Agentの実装に依存）
+        assert result["answer"] is not None
+        
+        # ClarificationAgentにルーティングされた場合のみ確認
+        if result["metadata"].get("routing", {}).get("agent") == "ClarificationAgent":
+            assert "[surprised]" in result["answer"]
+            assert result["emotion"] == "surprised"
+            assert result["metadata"]["requires_followup"] is True
+            assert "clarification" in result["metadata"]
+
+    @pytest.mark.asyncio
+    async def test_clarification_fallback_to_general(self):
+        """未知のcategoryがgeneral-clarification-neededにフォールバックされる"""
+        state = {
+            "query": "test query",
+            "session_id": "test_session",
+            "language": "ja",
+            "messages": [],
+            "routed_to": None,
+            "answer": None,
+            "emotion": None,
+            "metadata": {
+                "routing": {
+                    "category": "unknown-category"  # 未知のカテゴリ
+                }
+            },
+            "context": {},
+        }
+        
+        result = await self.workflow._clarification_node(state)
+        
+        # general-clarification-neededにフォールバックされることを確認
+        assert result["answer"] is not None
+        assert result["emotion"] == "surprised"
+        assert result["metadata"]["clarification"]["clarification_type"] == "general-clarification-needed"
+        assert result["metadata"]["clarification"]["category"] == "general-clarification-needed"
+        assert result["metadata"]["clarification"]["confidence"] == 0.7  # generalは0.7
+
+    @pytest.mark.asyncio
+    async def test_clarification_missing_routing_metadata(self):
+        """routing metadataが欠けている場合のフォールバック"""
+        state = {
+            "query": "test query",
+            "session_id": "test_session",
+            "language": "ja",
+            "messages": [],
+            "routed_to": None,
+            "answer": None,
+            "emotion": None,
+            "metadata": {},  # routing情報がない
+            "context": {},
+        }
+        
+        result = await self.workflow._clarification_node(state)
+        
+        # general-clarification-neededにフォールバックされることを確認
+        assert result["answer"] is not None
+        assert result["emotion"] == "surprised"
+        assert result["metadata"]["clarification"]["clarification_type"] == "general-clarification-needed"
+
+    @pytest.mark.asyncio
+    async def test_clarification_empty_category(self):
+        """categoryが空文字列の場合のフォールバック"""
+        state = {
+            "query": "test query",
+            "session_id": "test_session",
+            "language": "ja",
+            "messages": [],
+            "routed_to": None,
+            "answer": None,
+            "emotion": None,
+            "metadata": {
+                "routing": {
+                    "category": ""  # 空文字列
+                }
+            },
+            "context": {},
+        }
+        
+        result = await self.workflow._clarification_node(state)
+        
+        # general-clarification-neededにフォールバックされることを確認
+        assert result["answer"] is not None
+        assert result["emotion"] == "surprised"
+        assert result["metadata"]["clarification"]["clarification_type"] == "general-clarification-needed"
+
+# ============================================================================
+# E2Eテスト（RouterAgent実装後に有効化）
+# ============================================================================
+# 注意: RouterAgentが実装されたら、以下のテストクラスのコメントを外して使用してください
+
+"""
+class TestClarificationE2E:
+    \"\"\"ClarificationAgentのE2Eテスト（RouterAgent実装後に有効化）\"\"\"
+    
+    def setup_method(self):
+        # RouterAgentをモックしない（実装を使用）
+        from backend.workflows.main_workflow import MainWorkflow
+        self.workflow = MainWorkflow()
+    
+    @pytest.mark.asyncio
+    async def test_e2e_cafe_clarification_ja(self):
+        \"\"\"カフェが曖昧なクエリがClarificationAgentにルーティングされる（日本語）E2E\"\"\"
+        result = await self.workflow.ainvoke({
+            "query": "カフェの営業時間は？",  # RouterAgentが実際に検出
+            "session_id": "test_session",
+            "language": "ja"
+        })
+        
+        # RouterAgentが正しくClarificationAgentにルーティングすることを確認
+        assert result["metadata"]["routing"]["agent"] == "ClarificationAgent"
+        assert result["metadata"]["routing"]["category"] == "cafe-clarification-needed"
+        # ...
+"""

--- a/backend/tests/utils/test_emotion_tagger.py
+++ b/backend/tests/utils/test_emotion_tagger.py
@@ -1,0 +1,49 @@
+"""
+EmotionTagger のユニットテスト
+
+感情タグ付与機能のテストケース
+"""
+
+import pytest
+from backend.utils.emotion_tagger import add_emotion_tag
+
+
+class TestEmotionTagger:
+    """EmotionTagger のテストクラス"""
+
+    def test_add_emotion_tag_happy(self):
+        """happy感情タグの付与テスト"""
+        result = add_emotion_tag("こんにちは", "happy")
+        assert result == "[happy]こんにちは"
+
+    def test_add_emotion_tag_surprised(self):
+        """surprised感情タグの付与テスト"""
+        result = add_emotion_tag("どちらですか？", "surprised")
+        assert result == "[surprised]どちらですか？"
+
+    def test_add_emotion_tag_sad(self):
+        """sad感情タグの付与テスト"""
+        result = add_emotion_tag("申し訳ありません", "sad")
+        assert result == "[sad]申し訳ありません"
+
+    def test_add_emotion_tag_relaxed(self):
+        """relaxed感情タグの付与テスト"""
+        result = add_emotion_tag("営業時間は9時からです", "relaxed")
+        assert result == "[relaxed]営業時間は9時からです"
+
+    def test_add_emotion_tag_empty_message(self):
+        """空のメッセージに対するテスト"""
+        result = add_emotion_tag("", "happy")
+        assert result == "[happy]"
+
+    def test_add_emotion_tag_multiline_message(self):
+        """複数行メッセージに対するテスト"""
+        message = "お手伝いさせていただきます！\nどちらについてお聞きでしょうか？"
+        result = add_emotion_tag(message, "surprised")
+        assert result == "[surprised]お手伝いさせていただきます！\nどちらについてお聞きでしょうか？"
+
+    def test_add_emotion_tag_with_special_characters(self):
+        """特殊文字を含むメッセージに対するテスト"""
+        message = "営業時間は9:00-22:00です。"
+        result = add_emotion_tag(message, "relaxed")
+        assert result == "[relaxed]営業時間は9:00-22:00です。"

--- a/backend/utils/emotion_tagger.py
+++ b/backend/utils/emotion_tagger.py
@@ -1,0 +1,31 @@
+"""
+EmotionTagger - メッセージに感情タグを付与するユーティリティ
+
+ClarificationAgent などで使用される、シンプルな感情タグ付与機能。
+フロントエンドの EmotionTagger の Python 版。
+
+参考:
+- docs/migration/agents/clarification-agent/MIGRATION-GUIDE.md
+- frontend/src/lib/emotion-tagger.ts (Mastra版)
+"""
+
+
+def add_emotion_tag(message: str, emotion: str) -> str:
+    """
+    メッセージ先頭に感情タグを付与する
+    
+    Args:
+        message: 元のメッセージ
+        emotion: 感情名（'surprised', 'happy', 'sad', 'angry', 'relaxed' など）
+    
+    Returns:
+        感情タグ付きメッセージ（例: "[surprised]お手伝いさせていただきます！..."）
+    
+    Examples:
+        >>> add_emotion_tag("こんにちは", "happy")
+        '[happy]こんにちは'
+        
+        >>> add_emotion_tag("どちらについてお聞きでしょうか？", "surprised")
+        '[surprised]どちらについてお聞きでしょうか？'
+    """
+    return f"[{emotion}]{message}"

--- a/backend/workflows/main_workflow.py
+++ b/backend/workflows/main_workflow.py
@@ -9,6 +9,7 @@ from langchain_core.messages import BaseMessage, HumanMessage, AIMessage
 import operator
 
 from backend.agents.router_agent import RouterAgent
+from backend.agents.clarification_agent import ClarificationAgent
 
 
 class WorkflowState(TypedDict):
@@ -31,6 +32,7 @@ class MainWorkflow:
     def __init__(self):
         self.router_agent = RouterAgent(debug_mode=True)
         self.graph = self._build_graph()
+        self.clarification_agent = ClarificationAgent()
 
     def _build_graph(self) -> StateGraph:
         """グラフ構造を構築"""
@@ -172,39 +174,41 @@ class MainWorkflow:
 
     async def _clarification_node(self, state: WorkflowState) -> dict:
         """明確化ノード: 曖昧なクエリを明確化"""
-        from backend.agents.clarification_agent import ClarificationAgent
 
-        agent = ClarificationAgent()
+        #agent = ClarificationAgent()
         query = state.get("query", "")
-        context = state.get("context", {})
+        #context = state.get("context", {})
+        language = state.get("language", "ja")
 
-        # ClarificationAgentで曖昧さを検出・明確化
-        result = await agent.process(query, context)
-
-        # 明確化が必要な場合、質問文を返す
-        if result.get("needs_clarification"):
-            return {
-                "answer": result.get(
-                    "clarification_question", "もう少し詳しく教えていただけますか？"
-                ),
-                "emotion": result.get("emotion", "neutral"),
-                "metadata": {
-                    **state.get("metadata", {}),
-                    "clarification": {
-                        "options": result.get("options", []),
-                        "needs_clarification": True,
-                    },
-                },
-            }
-
-        # 明確化不要の場合
+        # Router Agentから設定されたcategoryを取得
+        category = state.get("metadata", {}).get("routing", {}).get("category", "general-clarification-needed")
+        
+        # categoryがclarification系でない場合はデフォルトにフォールバック
+        if category not in [
+            "cafe-clarification-needed",
+            "meeting-room-clarification-needed",
+            "general-clarification-needed"
+        ]:
+            category = "general-clarification-needed"
+        
+        # ClarificationAgentを使用
+        result = await self.clarification_agent.handle_clarification(
+            query=query,
+            category=category,
+            language=language
+        )
+        
         return {
-            "answer": "質問内容を確認しました。",
-            "emotion": "neutral",
+            "answer": result["response"],
+            "emotion": result["emotion"],
             "metadata": {
                 **state.get("metadata", {}),
-                "clarification": {"needs_clarification": False},
-            },
+                "clarification": {
+                    **result["metadata"],
+                    "clarification_type": category,
+                },
+                "requires_followup": True,  # ユーザーの回答待ち
+            }
         }
 
     async def _business_info_node(self, state: WorkflowState) -> dict:


### PR DESCRIPTION
## Summary

ClarificationAgentの統合テストを追加し、MainWorkflowとの統合を検証できるようにしました。
RouterAgentが未実装のため、モックを使用した擬似E2Eテストと異常系テストを実装しています。

## Changes

- `backend/tests/integration/test_clarification_agent_integration.py` を新規作成
  - `TestMessageContent`: メッセージ内容の正確性テスト（カフェ/会議室、日本語/英語）
  - `TestClarificationIntegration`: MainWorkflowとの統合テスト（擬似E2E）
    - `_clarification_node` の直接呼び出しテスト
    - ワークフロー全体を通すテスト（RouterAgentモック使用）
    - 異常系テスト（未知カテゴリ、routing metadata欠落、空カテゴリのフォールバック）
  - `TestClarificationE2E`: E2Eテストの骨組み（RouterAgent実装後に有効化、現在はコメントアウト）

- `backend/utils/emotion_tagger.py` を新規作成
  - `add_emotion_tag()` 関数を実装（ClarificationAgentで使用）

- `backend/workflows/main_workflow.py` を修正
  - `_clarification_node()` を実装（MIGRATION-GUIDE.md仕様に準拠）
  - RouterAgentからcategoryを受け取り、ClarificationAgentを呼び出す
  - メタデータに `requires_followup` と `clarification` を設定

- `backend/agents/clarification_agent.py` を修正
  - `handle_clarification()` を実装（固定メッセージで曖昧性を解消）
  - 3つのカテゴリ（cafe, meeting-room, general）に対応
  - 日本語/英語の両言語に対応

## Related Issues

<!-- 関連するIssueがあればリンクしてください -->
<!-- Closes #123 / Fixes #123 / Resolves #123 -->

## Test Plan

- [ ] ローカルで動作確認済み
  - `pytest tests/integration/test_clarification_agent_integration.py -v` で9件のテストがすべてパス
  - `pytest tests/agents/test_clarification_agent.py -v` で単体テストもパス
- [ ] 既存機能への影響がないことを確認済み
  - 他のエージェントのテストに影響なし
  - MainWorkflowの既存ノードへの影響なし

## Checklist

- [ ] コードが目的を達成している
- [ ] 不要なコード・コメントを削除した
- [ ] 必要に応じてドキュメントを更新した（MIGRATION-GUIDE.mdのチェックリスト更新は未実施）
- [ ] テストが通る（`pytest tests/integration/test_clarification_agent_integration.py` で9件パス）
- [ ] 型チェックが通る（既存の型定義に準拠）

## Screenshots (if applicable)

<!-- UIの変更がある場合はスクリーンショットを添付してください -->

## Notes

- RouterAgentが未実装のため、`sys.modules` を使用してRouterAgentをモックしています
- E2Eテスト（`TestClarificationE2E`）はRouterAgent実装後にコメントを外して有効化してください
- 現在のテストは「統合テスト（擬似E2E）」レベルで、完全なE2EテストはRouterAgent実装後に実施予定