### PR TITLE
feat(backend): LangSmith統合による評価システム実装

### DIFF
--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -10,6 +10,7 @@ python = "^3.11"
 langgraph = "^0.2.0"
 langchain = "^0.3.0"
 langchain-openai = "^0.2.0"
+langsmith = "^0.1.0"
 pydantic = "^2.0.0"
 fastapi = "^0.115.0"
 uvicorn = {extras = ["standard"], version = "^0.30.0"}

--- a/backend/tests/utils/langsmith_integration.py
+++ b/backend/tests/utils/langsmith_integration.py
@@ -1,0 +1,342 @@
+"""
+LangSmith統合モジュール
+
+LangSmithを使用したエージェント評価・トレーシング機能を提供します。
+環境変数 LANGSMITH_API_KEY が必要です。
+
+参考: https://docs.smith.langchain.com/
+"""
+
+import os
+from typing import Dict, Any, List, Optional, Callable
+from dataclasses import dataclass, field
+from datetime import datetime
+
+try:
+    from langsmith import Client
+
+    LANGSMITH_AVAILABLE = True
+except ImportError:
+    LANGSMITH_AVAILABLE = False
+    Client = None
+
+
+@dataclass
+class EvaluationResult:
+    """評価結果"""
+
+    metric_name: str
+    score: float
+    passed: bool
+    threshold: float
+    details: Optional[Dict[str, Any]] = None
+
+
+@dataclass
+class AgentEvaluationReport:
+    """エージェント評価レポート"""
+
+    agent_name: str
+    timestamp: str
+    overall_passed: bool
+    pass_rate: float
+    results: List[EvaluationResult] = field(default_factory=list)
+    metadata: Dict[str, Any] = field(default_factory=dict)
+
+
+class LangSmithEvaluator:
+    """
+    LangSmith統合評価器
+
+    LangSmithのトレーシング・評価機能を使用してエージェントを評価します。
+    """
+
+    def __init__(self, project_name: str = "engineer-cafe-navigator"):
+        """
+        初期化
+
+        Args:
+            project_name: LangSmithプロジェクト名
+        """
+        self.project_name = project_name
+        self.client: Optional[Client] = None
+        self._initialize_client()
+
+    def _initialize_client(self) -> None:
+        """LangSmithクライアントを初期化"""
+        if not LANGSMITH_AVAILABLE:
+            return
+
+        api_key = os.getenv("LANGSMITH_API_KEY")
+        if api_key:
+            try:
+                self.client = Client(api_key=api_key)
+            except Exception:
+                self.client = None
+
+    @property
+    def is_available(self) -> bool:
+        """LangSmithが利用可能かどうか"""
+        return self.client is not None
+
+    async def trace_agent_run(
+        self,
+        agent_name: str,
+        inputs: Dict[str, Any],
+        outputs: Dict[str, Any],
+        metadata: Optional[Dict[str, Any]] = None,
+    ) -> Optional[str]:
+        """
+        エージェント実行をトレース
+
+        Args:
+            agent_name: エージェント名
+            inputs: 入力データ
+            outputs: 出力データ
+            metadata: メタデータ
+
+        Returns:
+            Optional[str]: ラン ID（トレース不可の場合はNone）
+        """
+        if not self.is_available:
+            return None
+
+        try:
+            run = self.client.create_run(
+                name=agent_name,
+                run_type="chain",
+                inputs=inputs,
+                outputs=outputs,
+                project_name=self.project_name,
+                extra=metadata or {},
+            )
+            return str(run.id) if hasattr(run, "id") else None
+        except Exception:
+            return None
+
+    async def evaluate_agent(
+        self,
+        agent_name: str,
+        test_cases: List[Dict[str, Any]],
+        evaluators: Optional[List[Callable]] = None,
+    ) -> AgentEvaluationReport:
+        """
+        エージェントを評価
+
+        Args:
+            agent_name: エージェント名
+            test_cases: テストケースのリスト
+            evaluators: カスタム評価関数のリスト
+
+        Returns:
+            AgentEvaluationReport: 評価レポート
+        """
+        results: List[EvaluationResult] = []
+        evaluators = evaluators or self._get_default_evaluators()
+
+        for test_case in test_cases:
+            agent_output = test_case.get("output", {})
+            expected_output = test_case.get("expected", {})
+
+            for evaluator_func in evaluators:
+                try:
+                    score = await evaluator_func(agent_output, expected_output)
+                    threshold = getattr(evaluator_func, "threshold", 0.7)
+                    results.append(
+                        EvaluationResult(
+                            metric_name=evaluator_func.__name__,
+                            score=score,
+                            passed=score >= threshold,
+                            threshold=threshold,
+                        )
+                    )
+                except Exception as e:
+                    results.append(
+                        EvaluationResult(
+                            metric_name=evaluator_func.__name__,
+                            score=0.0,
+                            passed=False,
+                            threshold=0.7,
+                            details={"error": str(e)},
+                        )
+                    )
+
+        passed_count = sum(1 for r in results if r.passed)
+        total_count = len(results)
+        pass_rate = passed_count / total_count if total_count > 0 else 0.0
+
+        return AgentEvaluationReport(
+            agent_name=agent_name,
+            timestamp=datetime.now().isoformat(),
+            overall_passed=pass_rate >= 0.8,
+            pass_rate=pass_rate,
+            results=results,
+            metadata={"total_tests": len(test_cases), "total_metrics": len(evaluators)},
+        )
+
+    def _get_default_evaluators(self) -> List[Callable]:
+        """デフォルト評価関数を取得"""
+        return [
+            evaluate_answer_presence,
+            evaluate_emotion_validity,
+            evaluate_response_format,
+            evaluate_language_consistency,
+        ]
+
+    async def create_dataset(
+        self, dataset_name: str, examples: List[Dict[str, Any]]
+    ) -> Optional[str]:
+        """
+        評価用データセットを作成
+
+        Args:
+            dataset_name: データセット名
+            examples: サンプルデータのリスト
+
+        Returns:
+            Optional[str]: データセット ID
+        """
+        if not self.is_available:
+            return None
+
+        try:
+            dataset = self.client.create_dataset(
+                dataset_name=dataset_name,
+                description=f"Evaluation dataset for {self.project_name}",
+            )
+
+            for example in examples:
+                self.client.create_example(
+                    inputs=example.get("inputs", {}),
+                    outputs=example.get("outputs", {}),
+                    dataset_id=dataset.id,
+                )
+
+            return str(dataset.id)
+        except Exception:
+            return None
+
+    def get_evaluation_summary(self, reports: List[AgentEvaluationReport]) -> Dict[str, Any]:
+        """
+        複数のレポートからサマリーを生成
+
+        Args:
+            reports: 評価レポートのリスト
+
+        Returns:
+            Dict[str, Any]: サマリー
+        """
+        total_agents = len(reports)
+        passed_agents = sum(1 for r in reports if r.overall_passed)
+
+        return {
+            "total_agents": total_agents,
+            "passed_agents": passed_agents,
+            "overall_pass_rate": passed_agents / total_agents if total_agents > 0 else 0.0,
+            "agent_results": {r.agent_name: r.pass_rate for r in reports},
+            "timestamp": datetime.now().isoformat(),
+        }
+
+
+# ==============================================================================
+# 評価関数
+# ==============================================================================
+
+
+async def evaluate_answer_presence(
+    agent_output: Dict[str, Any], expected_output: Optional[Dict[str, Any]] = None
+) -> float:
+    """回答が存在するかを評価"""
+    answer = agent_output.get("answer", "")
+    return 1.0 if answer and len(answer.strip()) > 0 else 0.0
+
+
+evaluate_answer_presence.threshold = 1.0
+
+
+async def evaluate_emotion_validity(
+    agent_output: Dict[str, Any], expected_output: Optional[Dict[str, Any]] = None
+) -> float:
+    """感情タグの妥当性を評価"""
+    valid_emotions = {"neutral", "happy", "sad", "surprised", "relaxed", "angry"}
+    emotion = agent_output.get("emotion", "")
+    return 1.0 if emotion in valid_emotions else 0.0
+
+
+evaluate_emotion_validity.threshold = 1.0
+
+
+async def evaluate_response_format(
+    agent_output: Dict[str, Any], expected_output: Optional[Dict[str, Any]] = None
+) -> float:
+    """レスポンス形式の妥当性を評価"""
+    required_fields = {"answer", "emotion"}
+    present_fields = set(agent_output.keys())
+    missing = required_fields - present_fields
+    return (
+        1.0 if len(missing) == 0 else (len(required_fields) - len(missing)) / len(required_fields)
+    )
+
+
+evaluate_response_format.threshold = 0.8
+
+
+async def evaluate_language_consistency(
+    agent_output: Dict[str, Any], expected_output: Optional[Dict[str, Any]] = None
+) -> float:
+    """言語の一貫性を評価（日本語/英語）"""
+    answer = agent_output.get("answer", "")
+    if not answer:
+        return 0.0
+
+    japanese_chars = sum(1 for c in answer if "\u3040" <= c <= "\u9fff")
+    total_alpha = sum(1 for c in answer if c.isalpha())
+
+    if total_alpha == 0:
+        return 1.0
+
+    jp_ratio = japanese_chars / total_alpha
+    return 1.0 if jp_ratio > 0.5 or jp_ratio < 0.1 else 0.7
+
+
+evaluate_language_consistency.threshold = 0.7
+
+
+# ==============================================================================
+# ヘルパー関数
+# ==============================================================================
+
+
+def create_langsmith_evaluator(
+    project_name: str = "engineer-cafe-navigator",
+) -> LangSmithEvaluator:
+    """
+    LangSmith評価器を作成
+
+    Args:
+        project_name: プロジェクト名
+
+    Returns:
+        LangSmithEvaluator: 評価器インスタンス
+    """
+    return LangSmithEvaluator(project_name=project_name)
+
+
+async def run_agent_evaluation(
+    agent_name: str,
+    test_cases: List[Dict[str, Any]],
+    project_name: str = "engineer-cafe-navigator",
+) -> AgentEvaluationReport:
+    """
+    エージェント評価を実行
+
+    Args:
+        agent_name: エージェント名
+        test_cases: テストケース
+        project_name: プロジェクト名
+
+    Returns:
+        AgentEvaluationReport: 評価レポート
+    """
+    evaluator = create_langsmith_evaluator(project_name)
+    return await evaluator.evaluate_agent(agent_name, test_cases)

--- a/backend/tests/utils/test_langsmith_integration.py
+++ b/backend/tests/utils/test_langsmith_integration.py
@@ -1,0 +1,261 @@
+"""
+LangSmith統合のテスト
+"""
+
+import pytest
+from tests.utils.langsmith_integration import (
+    LangSmithEvaluator,
+    AgentEvaluationReport,
+    EvaluationResult,
+    evaluate_answer_presence,
+    evaluate_emotion_validity,
+    evaluate_response_format,
+    evaluate_language_consistency,
+    create_langsmith_evaluator,
+    run_agent_evaluation,
+)
+
+
+class TestEvaluationFunctions:
+    """評価関数のテスト"""
+
+    @pytest.mark.asyncio
+    async def test_evaluate_answer_presence_with_answer(self):
+        """回答がある場合のテスト"""
+        output = {"answer": "Wi-Fiは無料で利用できます。"}
+        score = await evaluate_answer_presence(output)
+        assert score == 1.0
+
+    @pytest.mark.asyncio
+    async def test_evaluate_answer_presence_without_answer(self):
+        """回答がない場合のテスト"""
+        output = {"emotion": "neutral"}
+        score = await evaluate_answer_presence(output)
+        assert score == 0.0
+
+    @pytest.mark.asyncio
+    async def test_evaluate_answer_presence_empty_answer(self):
+        """空の回答の場合のテスト"""
+        output = {"answer": "   "}
+        score = await evaluate_answer_presence(output)
+        assert score == 0.0
+
+    @pytest.mark.asyncio
+    async def test_evaluate_emotion_validity_valid(self):
+        """有効な感情タグのテスト"""
+        for emotion in ["neutral", "happy", "sad", "surprised", "relaxed", "angry"]:
+            output = {"emotion": emotion}
+            score = await evaluate_emotion_validity(output)
+            assert score == 1.0, f"Failed for emotion: {emotion}"
+
+    @pytest.mark.asyncio
+    async def test_evaluate_emotion_validity_invalid(self):
+        """無効な感情タグのテスト"""
+        output = {"emotion": "excited"}
+        score = await evaluate_emotion_validity(output)
+        assert score == 0.0
+
+    @pytest.mark.asyncio
+    async def test_evaluate_response_format_complete(self):
+        """完全なレスポンス形式のテスト"""
+        output = {"answer": "テスト回答", "emotion": "neutral"}
+        score = await evaluate_response_format(output)
+        assert score == 1.0
+
+    @pytest.mark.asyncio
+    async def test_evaluate_response_format_partial(self):
+        """部分的なレスポンス形式のテスト"""
+        output = {"answer": "テスト回答"}
+        score = await evaluate_response_format(output)
+        assert score == 0.5
+
+    @pytest.mark.asyncio
+    async def test_evaluate_language_consistency_japanese(self):
+        """日本語の一貫性テスト"""
+        output = {"answer": "これは日本語のテストです。"}
+        score = await evaluate_language_consistency(output)
+        assert score == 1.0
+
+    @pytest.mark.asyncio
+    async def test_evaluate_language_consistency_english(self):
+        """英語の一貫性テスト"""
+        output = {"answer": "This is an English test."}
+        score = await evaluate_language_consistency(output)
+        assert score == 1.0
+
+
+class TestLangSmithEvaluator:
+    """LangSmithEvaluatorのテスト"""
+
+    def test_create_evaluator(self):
+        """評価器の作成テスト"""
+        evaluator = create_langsmith_evaluator()
+        assert isinstance(evaluator, LangSmithEvaluator)
+        assert evaluator.project_name == "engineer-cafe-navigator"
+
+    def test_create_evaluator_custom_project(self):
+        """カスタムプロジェクト名での評価器作成テスト"""
+        evaluator = create_langsmith_evaluator("custom-project")
+        assert evaluator.project_name == "custom-project"
+
+    @pytest.mark.asyncio
+    async def test_evaluate_agent_basic(self):
+        """基本的なエージェント評価テスト"""
+        evaluator = LangSmithEvaluator()
+
+        test_cases = [
+            {
+                "output": {"answer": "Wi-Fiは無料です。", "emotion": "neutral"},
+                "expected": {},
+            }
+        ]
+
+        report = await evaluator.evaluate_agent("TestAgent", test_cases)
+
+        assert isinstance(report, AgentEvaluationReport)
+        assert report.agent_name == "TestAgent"
+        assert len(report.results) > 0
+
+    @pytest.mark.asyncio
+    async def test_evaluate_agent_multiple_cases(self):
+        """複数テストケースでのエージェント評価"""
+        evaluator = LangSmithEvaluator()
+
+        test_cases = [
+            {
+                "output": {"answer": "営業時間は10時から22時です。", "emotion": "happy"},
+                "expected": {},
+            },
+            {
+                "output": {"answer": "地下にはMTGスペースがあります。", "emotion": "neutral"},
+                "expected": {},
+            },
+            {
+                "output": {"answer": "申し訳ありません、分かりません。", "emotion": "sad"},
+                "expected": {},
+            },
+        ]
+
+        report = await evaluator.evaluate_agent("FacilityAgent", test_cases)
+
+        assert report.agent_name == "FacilityAgent"
+        assert report.metadata["total_tests"] == 3
+
+    @pytest.mark.asyncio
+    async def test_evaluate_agent_all_pass(self):
+        """全テスト合格のケース"""
+        evaluator = LangSmithEvaluator()
+
+        test_cases = [
+            {
+                "output": {"answer": "完璧な回答です。", "emotion": "happy"},
+                "expected": {},
+            }
+        ]
+
+        report = await evaluator.evaluate_agent("PerfectAgent", test_cases)
+
+        assert report.overall_passed is True
+        assert report.pass_rate >= 0.8
+
+
+class TestAgentEvaluationReport:
+    """AgentEvaluationReportのテスト"""
+
+    def test_report_creation(self):
+        """レポート作成テスト"""
+        result = EvaluationResult(
+            metric_name="test_metric",
+            score=0.9,
+            passed=True,
+            threshold=0.7,
+        )
+
+        report = AgentEvaluationReport(
+            agent_name="TestAgent",
+            timestamp="2025-01-24T10:00:00",
+            overall_passed=True,
+            pass_rate=0.9,
+            results=[result],
+        )
+
+        assert report.agent_name == "TestAgent"
+        assert report.overall_passed is True
+        assert len(report.results) == 1
+
+
+class TestRunAgentEvaluation:
+    """run_agent_evaluation関数のテスト"""
+
+    @pytest.mark.asyncio
+    async def test_run_evaluation(self):
+        """評価実行テスト"""
+        test_cases = [
+            {
+                "output": {"answer": "テスト回答", "emotion": "neutral"},
+                "expected": {},
+            }
+        ]
+
+        report = await run_agent_evaluation("TestAgent", test_cases)
+
+        assert isinstance(report, AgentEvaluationReport)
+        assert report.agent_name == "TestAgent"
+
+
+class TestLangSmithClientIntegration:
+    """LangSmithクライアント統合テスト（モック使用）"""
+
+    @pytest.mark.asyncio
+    async def test_trace_agent_run_without_client(self):
+        """クライアントなしでのトレーステスト"""
+        evaluator = LangSmithEvaluator()
+        evaluator.client = None
+
+        result = await evaluator.trace_agent_run(
+            agent_name="TestAgent",
+            inputs={"query": "test"},
+            outputs={"answer": "response"},
+        )
+
+        assert result is None
+
+    @pytest.mark.asyncio
+    async def test_create_dataset_without_client(self):
+        """クライアントなしでのデータセット作成テスト"""
+        evaluator = LangSmithEvaluator()
+        evaluator.client = None
+
+        result = await evaluator.create_dataset(
+            dataset_name="test-dataset",
+            examples=[{"inputs": {}, "outputs": {}}],
+        )
+
+        assert result is None
+
+    def test_get_evaluation_summary(self):
+        """評価サマリー生成テスト"""
+        evaluator = LangSmithEvaluator()
+
+        reports = [
+            AgentEvaluationReport(
+                agent_name="Agent1",
+                timestamp="2025-01-24T10:00:00",
+                overall_passed=True,
+                pass_rate=0.9,
+            ),
+            AgentEvaluationReport(
+                agent_name="Agent2",
+                timestamp="2025-01-24T10:00:00",
+                overall_passed=False,
+                pass_rate=0.6,
+            ),
+        ]
+
+        summary = evaluator.get_evaluation_summary(reports)
+
+        assert summary["total_agents"] == 2
+        assert summary["passed_agents"] == 1
+        assert summary["overall_pass_rate"] == 0.5
+        assert "Agent1" in summary["agent_results"]
+        assert "Agent2" in summary["agent_results"]


### PR DESCRIPTION
## Summary
- LangSmithを使用したエージェント評価・トレーシングシステムを実装
- 環境変数 `LANGSMITH_API_KEY` はGitHub Secretsに設定済み

## 変更内容

### 依存関係
- `langsmith ^0.1.0` を追加

### 新規ファイル

**`tests/utils/langsmith_integration.py`**
- `LangSmithEvaluator` クラス
  - エージェント実行のトレーシング
  - カスタム評価メトリクスのサポート
  - 評価データセットの作成・管理
  - 評価レポートの生成

**評価関数**
| 関数名 | 説明 | 閾値 |
|--------|------|------|
| `evaluate_answer_presence` | 回答が存在するか | 1.0 |
| `evaluate_emotion_validity` | 感情タグが有効か | 1.0 |
| `evaluate_response_format` | レスポンス形式が正しいか | 0.8 |
| `evaluate_language_consistency` | 言語が一貫しているか | 0.7 |

**`tests/utils/test_langsmith_integration.py`**
- 19テストケース（全パス）

## 使用方法

```python
from tests.utils.langsmith_integration import run_agent_evaluation

report = await run_agent_evaluation(
    agent_name="FacilityAgent",
    test_cases=[
        {"output": {"answer": "Wi-Fiは無料です。", "emotion": "neutral"}}
    ]
)
print(f"Pass rate: {report.pass_rate}")
```

## Test plan
- [x] 19件のユニットテストがパス
- [x] ruff lint チェックパス
- [x] black フォーマットチェックパス
- [ ] 実際のLangSmith接続テスト（APIキー使用時）

🤖 Generated with [Claude Code](https://claude.com/claude-code)