### PR TITLE
docs: ドキュメントを現在の実装状況に更新

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 [![TypeScript](https://img.shields.io/badge/TypeScript-5.8.3-blue)](https://www.typescriptlang.org/)
 [![Python](https://img.shields.io/badge/Python-3.11+-blue)](https://www.python.org/)
 [![LangGraph](https://img.shields.io/badge/LangGraph-0.2.0-blue)](https://langchain-ai.github.io/langgraph/)
-[![Mastra](https://img.shields.io/badge/Mastra-0.10.5-green)](https://mastra.ai/)
+[![LangSmith](https://img.shields.io/badge/LangSmith-Evaluation-orange)](https://smith.langchain.com/)
 [![React](https://img.shields.io/badge/React-19.1.0-61dafb)](https://reactjs.org/)
 
 ## 📖 プロジェクト概要
@@ -128,13 +128,15 @@ make dev      # 開発サーバー起動
 
 ### Frontend (NextJS)
 
-NextJSベースのフロントエンドアプリケーション。Mastraフレームワークを使用してAIエージェント機能を提供します。
+NextJSベースのフロントエンドアプリケーション。UIとユーザーインタラクションを担当し、AIロジックはバックエンド（LangGraph）に委譲します。
+
+> **📌 移行中**: フロントエンドのMastraロジックをLangGraphバックエンドに移行中です。詳細は [Issue #37-42](https://github.com/EngineerCafeJP/engineercafe-navigator/issues) を参照。
 
 **主要機能:**
 - 音声AIエージェントインターフェース
-- VRMキャラクター表示
+- VRMキャラクター表示（Three.js）
 - リアルタイム会話
-- スライドプレゼンテーション
+- スライドプレゼンテーション（Marp）
 
 **詳細:** [frontend/README.md](frontend/README.md)
 
@@ -142,22 +144,44 @@ NextJSベースのフロントエンドアプリケーション。Mastraフレ�
 
 Python版LangGraphを使用したAIエージェントバックエンド。FastAPIでRESTful APIを提供します。
 
+**実装済みエージェント（9種）:**
+| エージェント | 責務 |
+|-------------|------|
+| BusinessInfoAgent | 営業時間・料金・アクセス |
+| FacilityAgent | 設備・Wi-Fi・地下施設 |
+| EventAgent | イベント・カレンダー |
+| SlideAgent | スライド表示・ナレーション |
+| GeneralKnowledgeAgent | Web検索（範囲外質問） |
+| MemoryAgent | 会話履歴・コンテキスト |
+| ClarificationAgent | 曖昧解消 |
+| VoiceAgent | 音声処理（STT/TTS） |
+| CharacterControlAgent | VRM制御 |
+
 **主要機能:**
 - LangGraphワークフローによるエージェント実行
-- 複数エージェントのルーティング
-- 会話メモリ管理
-- RAG（Retrieval-Augmented Generation）統合
+- LangSmithによる評価・トレーシング
+- 会話メモリ管理（3分TTL）
+- Enhanced RAG統合
 
 **詳細:** [backend/README.md](backend/README.md)
 
 ## 🆕 最新アップデート
 
+### 🚧 進行中: フロントエンド→LangGraph移行（2026-01）
+
+フロントエンドのクライアントサイド処理をLangGraphバックエンドに移行中：
+- **[#37](https://github.com/EngineerCafeJP/engineercafe-navigator/issues/37)** QueryClassifier → RouterAgent
+- **[#38](https://github.com/EngineerCafeJP/engineercafe-navigator/issues/38)** EmotionTagger → Agent統一
+- **[#39](https://github.com/EngineerCafeJP/engineercafe-navigator/issues/39)** 会話メモリ → LangGraph State
+- **[#40](https://github.com/EngineerCafeJP/engineercafe-navigator/issues/40)** フロントエンド薄型化
+- **[#42](https://github.com/EngineerCafeJP/engineercafe-navigator/issues/42)** Next.js → Vite移行検討
+
 ### ✅ LangGraph統合完了（2026-01-13）
 
 - **🔗 モノレポ構造への移行** - Frontend（NextJS）とBackend（Python LangGraph）を分離 ✅
-- **📊 Python版LangGraphワークフロー** - RouterAgent, GeneralKnowledgeAgent含む7つのエージェント実装完了 ✅
+- **📊 9エージェント実装完了** - 単体テスト62件全パス ✅
 - **🔄 FastAPIバックエンド** - RESTful APIによるフロントエンドとバックエンドの統合完了 ✅
-- **💾 グラフベースのワークフロー** - 条件分岐ルーティングと状態管理の実装完了 ✅
+- **📈 LangSmith統合** - エージェント評価・トレーシングシステム実装 ✅
 - **🧪 テスト基盤整備** - pytest + AsyncMockによる包括的なテストスイート構築 ✅
 - **🐳 開発環境整備** - Docker + mise + Makefile による統一開発コマンド整備 ✅
 - **🔍 Web検索統合** - Google Gemini API with Search Grounding による最新情報取得 ✅
@@ -204,14 +228,16 @@ cd frontend && pnpm build
 - **Framework**: Next.js 15.3.2
 - **Language**: TypeScript 5.8.3
 - **UI**: React 19.1.0
-- **AI Framework**: Mastra 0.10.5
-- **3D**: Three.js + VRM
+- **3D**: Three.js + @pixiv/three-vrm
+- **Styling**: Tailwind CSS v3.4.17
 
 ### Backend
 - **Framework**: FastAPI
 - **Language**: Python 3.11+
 - **AI Framework**: LangGraph 0.2.0
-- **LLM**: LangChain (OpenAI, Google Gemini)
+- **LLM**: LangChain (OpenRouter, Google Gemini)
+- **Evaluation**: LangSmith
+- **Database**: Supabase (PostgreSQL + pgvector)
 
 ## 📖 ドキュメント
 
@@ -241,5 +267,6 @@ ISC License
 ## 🙏 謝辞
 
 - [LangGraph](https://github.com/langchain-ai/langgraph) - AIエージェントワークフロー
-- [Mastra](https://mastra.ai/) - AIフレームワーク
+- [LangSmith](https://smith.langchain.com/) - エージェント評価・トレーシング
 - [Next.js](https://nextjs.org/) - Reactフレームワーク
+- [FastAPI](https://fastapi.tiangolo.com/) - Python Webフレームワーク

--- a/backend/README.md
+++ b/backend/README.md
@@ -2,6 +2,23 @@
 
 Python版LangGraphを使用したAIエージェントバックエンドシステムです。
 
+## 🤖 実装済みエージェント（9種）
+
+| エージェント | ファイル | 責務 |
+|-------------|----------|------|
+| RouterAgent | `router_agent.py` | クエリルーティング・分類 |
+| BusinessInfoAgent | `business_info_agent.py` | 営業時間・料金・アクセス |
+| FacilityAgent | `facility_agent.py` | 設備・Wi-Fi・地下施設 |
+| EventAgent | `event_agent.py` | イベント・カレンダー |
+| SlideAgent | `slide_agent.py` | スライド表示・ナレーション |
+| GeneralKnowledgeAgent | `general_knowledge_agent.py` | Web検索（範囲外質問） |
+| MemoryAgent | `memory_agent.py` | 会話履歴・コンテキスト |
+| ClarificationAgent | `clarification_agent.py` | 曖昧解消 |
+| VoiceAgent | `voice_agent.py` | 音声処理（STT/TTS） |
+| CharacterControlAgent | `character_control_agent.py` | VRM制御 |
+
+**テスト状況**: 62件全パス ✅
+
 ## セットアップ
 
 ### Poetryを使用する場合
@@ -32,9 +49,17 @@ OPENAI_API_KEY=your_openai_api_key
 # OpenRouter API
 OPENROUTER_API_KEY=your_openrouter_api_key
 
+# Google API (GeneralKnowledgeAgent用)
+GOOGLE_API_KEY=your_google_api_key
+
 # Supabase
 SUPABASE_URL=your_supabase_url
 SUPABASE_KEY=your_supabase_key
+
+# LangSmith（評価・トレーシング）
+LANGCHAIN_TRACING_V2=true
+LANGCHAIN_API_KEY=your_langsmith_api_key
+LANGCHAIN_PROJECT=engineer-cafe-navigator
 
 # その他
 ENVIRONMENT=development
@@ -60,30 +85,61 @@ python -m uvicorn main:app --reload --host 0.0.0.0 --port 8000
 - `POST /api/chat` - チャットエンドポイント
 - `POST /api/agent/invoke` - LangGraphエージェントの実行
 
+## テスト
+
+```bash
+# 全テスト実行
+poetry run pytest
+
+# 特定のエージェントテスト
+poetry run pytest tests/agents/test_router_agent.py -v
+
+# カバレッジ付き
+poetry run pytest --cov=agents --cov-report=html
+```
+
+## コード品質
+
+```bash
+# フォーマット
+poetry run black .
+
+# リンター
+poetry run ruff check .
+
+# 型チェック
+poetry run mypy .
+```
+
 ## プロジェクト構造
 
 ```
 backend/
 ├── main.py                 # FastAPIアプリケーション
-├── agents/                 # LangGraphエージェント
+├── agents/                 # LangGraphエージェント（9種）
 │   ├── __init__.py
-│   ├── router_agent.py
-│   ├── business_info_agent.py
-│   └── ...
+│   ├── router_agent.py           # クエリルーティング
+│   ├── business_info_agent.py    # 営業情報
+│   ├── facility_agent.py         # 設備情報
+│   ├── event_agent.py            # イベント情報
+│   ├── slide_agent.py            # スライド表示
+│   ├── general_knowledge_agent.py # Web検索
+│   ├── memory_agent.py           # 会話履歴
+│   ├── clarification_agent.py    # 曖昧解消
+│   ├── voice_agent.py            # 音声処理
+│   └── character_control_agent.py # VRM制御
 ├── workflows/              # LangGraphワークフロー
 │   ├── __init__.py
 │   └── main_workflow.py
 ├── tools/                  # エージェントツール
-│   ├── __init__.py
 │   └── ...
 ├── models/                 # データモデル
-│   ├── __init__.py
 │   └── ...
 ├── utils/                  # ユーティリティ
-│   ├── __init__.py
 │   └── ...
-└── tests/                  # テスト
-    └── ...
+└── tests/                  # テスト（62件）
+    ├── agents/             # エージェントテスト
+    └── utils/              # ユーティリティテスト
 ```
 
 ## 📖 関連ドキュメント

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -2,12 +2,12 @@
 
 > Current implementation status and roadmap for Engineer Cafe Navigator
 
-Last Updated: 2025-07-03
+Last Updated: 2026-01-24
 
 ## 🟢 Implemented Features
 
 ### Core Features
-- ✅ **8-Agent Architecture** - MainQAWorkflow coordinating specialized agents
+- ✅ **9-Agent Architecture** - LangGraph backend coordinating specialized agents
 - ✅ **Voice Processing API** - Speech recognition, AI response generation, and text-to-speech using Google Cloud
 - ✅ **Google Cloud Service Account Authentication** - Secure authentication without API keys
 - ✅ **Multi-language Support** - Japanese and English voice interactions
@@ -32,10 +32,11 @@ Last Updated: 2025-07-03
 - ✅ **GET /api/backgrounds** - Background image list
 
 ### Technical Implementation
-- ✅ **Next.js 15.3.2** with App Router
+- ✅ **Next.js 15.3.2** with App Router (Frontend - 移行検討中)
 - ✅ **React 19.1.0** with TypeScript 5.8.3
-- ✅ **Mastra 0.10.5** for AI agent orchestration
-- ✅ **Google Gemini 2.5 Flash Preview** for AI responses
+- ✅ **LangGraph 0.2.0** for AI agent orchestration (Backend)
+- ✅ **LangSmith** for evaluation and tracing
+- ✅ **Google Gemini API** for AI responses
 - ✅ **Three.js 0.176.0** with @pixiv/three-vrm 3.4.1
 - ✅ **Tailwind CSS v3.4.17** (NOT v4)
 - ✅ **PostgreSQL with pgvector** via Supabase 2.49.8
@@ -46,15 +47,17 @@ Last Updated: 2025-07-03
 - ✅ **Lip-sync System** - Optimized with intelligent caching
 - ✅ **Production Monitoring** - Real-time metrics and alerting
 
-### 8-Agent Architecture (NEW - 2025/07/03)
-- ✅ **MainQAWorkflow** - Central coordinator for all specialized agents
+### 9-Agent Architecture (LangGraph Backend - 2026/01)
 - ✅ **RouterAgent** - Context-dependent query routing and classification
 - ✅ **BusinessInfoAgent** - Hours, pricing, location with Enhanced RAG
 - ✅ **FacilityAgent** - Equipment, basement facilities with Enhanced RAG
-- ✅ **MemoryAgent** - Conversation history and context management
 - ✅ **EventAgent** - Calendar and event information
-- ✅ **GeneralKnowledgeAgent** - Out-of-scope queries via web search
+- ✅ **SlideAgent** - Slide presentation and narration
+- ✅ **GeneralKnowledgeAgent** - Out-of-scope queries via Google Gemini Search
+- ✅ **MemoryAgent** - Conversation history and context management
 - ✅ **ClarificationAgent** - Ambiguous query clarification
+- ✅ **VoiceAgent** - STT/TTS processing
+- ✅ **CharacterControlAgent** - VRM character control
 
 ## 🔴 Features NOT Implemented (Despite Being Referenced)
 
@@ -177,7 +180,14 @@ pnpm check:deployment       # Check deployment readiness
 
 ## 🔄 Migration Notes
 
-### Recent Changes (2025-07-03)
+### Recent Changes (2026-01)
+1. **LangGraph Backend統合完了** - Python LangGraphバックエンドへの完全移行
+2. **9-Agent Architecture** - 9種のエージェント実装完了（62テストパス）
+3. **LangSmith統合** - エージェント評価・トレーシングシステム実装
+4. **フロントエンド→LangGraph移行開始** - Issue #37-42で段階的移行
+5. **Web検索統合** - Google Gemini API with Search Grounding
+
+### Previous Changes (2025-07-03)
 1. **8-Agent Architecture** - Complete migration to multi-agent system with MainQAWorkflow
 2. **ClarificationAgent Implementation** - Ambiguity resolution for cafe/meeting room queries
 3. **Legacy Code Removal** - Deleted old EnhancedQAAgent (2,342 lines)


### PR DESCRIPTION
## Summary
- README.md、docs/STATUS.md、backend/README.mdを現在の実装状況に更新
- MastraからLangSmith/LangGraphへの移行を反映
- フロントエンド→LangGraph移行Issue（#37-42）への参照を追加

## 変更内容

### README.md
- MastraバッジをLangSmithバッジに変更
- 9エージェント一覧テーブル追加
- フロントエンド→LangGraph移行Issue（#37-42）追記
- 技術スタック更新（LangSmith、Supabase追加）
- 謝辞セクション更新（FastAPI追加、Mastra削除）

### docs/STATUS.md
- 日付更新（2025-07-03 → 2026-01-24）
- 8→9エージェントアーキテクチャに更新
- LangGraph統合完了を最新変更として追加
- MastraをLangGraphに更新

### backend/README.md
- 9エージェント一覧テーブル追加
- LangSmith環境変数追加
- テスト・コード品質コマンド追加
- プロジェクト構造を詳細化

## Test plan
- [ ] ドキュメントの内容が正確か確認
- [ ] リンクが正しく機能するか確認
- [ ] 技術スタック情報が最新か確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)