### PR TITLE
feat(backend): Connpass API連携とICS形式カレンダー対応

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -6,18 +6,59 @@
 # Get your key at: https://openrouter.ai/keys
 # Supports 400+ models: OpenAI, Google Gemini, Anthropic, Meta, Mistral
 # All AI models (Router, QA, etc.) use OpenRouter API with automatic fallback
-OPENROUTER_API_KEY=sk-or-v1-your-key-here
+OPENROUTER_API_KEY=your-openrouter-api-key-here
 
 # Direct API Keys (Optional - for future features)
 # Note: Google Gemini models are accessed via OpenRouter API, not directly
 # OPENAI_API_KEY=sk-your-openai-key-here
-# GOOGLE_API_KEY=your-google-api-key-here  # Not used - Gemini via OpenRouter
 
+# ===========================================
+# Google Calendar (ICS形式)
+# ===========================================
+
+# Google Calendar ICS URL (イベント連携)
+# APIキー不要！公開ICSフィードを使用します。
+# 取得方法:
+# 1. Google Calendarを開く
+# 2. 設定 → カレンダーの統合
+# 3. 「iCal形式の公開URL」をコピー
+# 形式: https://calendar.google.com/calendar/ical/CALENDAR_ID/public/basic.ics
+GOOGLE_CALENDAR_ICAL_URL=https://calendar.google.com/calendar/ical/your-calendar-id/public/basic.ics
+
+# ===========================================
+# External APIs
+# ===========================================
+
+# Connpass API Key (Optional)
+# イベント連携を利用する場合、Connpass APIキーを設定してください
+# 取得方法: https://connpass.com/about/api/
+CONNPASS_API_KEY=your-connpass-api-key-here
+
+# ===========================================
 # Supabase Configuration
+# ===========================================
+# Dockerローカル: `supabase start` で表示される値を使用
+# 本番: Supabase Dashboardから取得
+
 SUPABASE_URL=http://127.0.0.1:54321
 SUPABASE_KEY=your-supabase-service-role-key
 
+# LangGraph Checkpointer用 PostgreSQL接続URI
+# Dockerローカルの場合: postgresql://postgres:postgres@127.0.0.1:54322/postgres
+# 本番の場合: Supabase DashboardのDatabase設定から取得
+SUPABASE_DB_URI=postgresql://postgres:postgres@127.0.0.1:54322/postgres
+
+# ===========================================
+# LangSmith (Optional - 評価・トレーシング)
+# ===========================================
+# LangSmithでエージェントの動作をトレースする場合に設定
+# 取得方法: https://smith.langchain.com/
+# LANGSMITH_API_KEY=your-langsmith-api-key-here
+# LANGSMITH_PROJECT=engineer-cafe-navigator
+
+# ===========================================
 # Application Settings
+# ===========================================
 ENVIRONMENT=development
 PORT=8000
 

--- a/backend/agents/event_agent.py
+++ b/backend/agents/event_agent.py
@@ -1,10 +1,14 @@
 """
 EventAgent - イベント情報エージェント
 イベント、カレンダー情報に関する質問に回答
+
+Google CalendarとConnpassの両方からイベント情報を取得し、統合して応答します。
 """
 
-from typing import Dict, Optional
+import asyncio
+from typing import Dict, Optional, List
 from backend.tools.calendar_service import CalendarService
+from backend.tools.connpass_service import ConnpassService
 from backend.llm import get_llm_provider, get_model_config
 
 
@@ -36,9 +40,10 @@ class EventAgent:
     def __init__(self):
         """EventAgentを初期化
 
-        CalendarServiceとLLMプロバイダーのインスタンスを作成します。
+        CalendarService、ConnpassService、LLMプロバイダーのインスタンスを作成します。
         """
         self.calendar_service = CalendarService()
+        self.connpass_service = ConnpassService()
         self.llm_provider = get_llm_provider()
 
     async def answer_event_query(
@@ -109,15 +114,18 @@ class EventAgent:
         # クエリから時間範囲を抽出
         time_range = self.calendar_service.extract_time_range_from_query(query)
 
-        # Calendar Serviceでイベント取得
-        calendar_result = await self.calendar_service.search_events(time_range)
+        # クエリからキーワードを抽出（Connpass用）
+        keyword = self.connpass_service.extract_keyword_from_query(query)
 
-        if not calendar_result.get("success"):
-            return self._get_no_events_response(language, time_range)
+        # Google CalendarとConnpassを並列検索
+        calendar_result, connpass_result = await asyncio.gather(
+            self.calendar_service.search_events(time_range),
+            self.connpass_service.search_events(time_range, keyword=keyword),
+        )
 
-        # イベントデータ取得
-        events = calendar_result.get("data", {}).get("events", [])
-        event_count = calendar_result.get("data", {}).get("eventCount", 0)
+        # 両方の結果をマージ
+        events = self._merge_events(calendar_result, connpass_result)
+        event_count = len(events)
 
         # イベントなしの場合
         if event_count == 0:
@@ -137,6 +145,10 @@ class EventAgent:
             # イベントがある場合は happy
             emotion = "happy" if event_count > 0 else "sad"
 
+            # ソース別のイベント数をカウント
+            calendar_count = sum(1 for e in events if e.get("source") == "google_calendar")
+            connpass_count = sum(1 for e in events if e.get("source") == "connpass")
+
             return {
                 "answer": response_text,
                 "emotion": emotion,
@@ -144,6 +156,10 @@ class EventAgent:
                     "agent": "EventAgent",
                     "time_range": time_range,
                     "event_count": event_count,
+                    "sources": {
+                        "google_calendar": calendar_count,
+                        "connpass": connpass_count,
+                    },
                 },
             }
 
@@ -152,12 +168,12 @@ class EventAgent:
             return self._get_no_events_response(language, time_range)
 
     def _format_calendar_events(self, events: list, language: str) -> str:
-        """カレンダーイベントを整形
+        """イベントを整形（Google Calendar + Connpass両対応）
 
-        Google Calendar APIの生データをLLMに渡しやすい形式に整形します。
+        Google CalendarとConnpassのイベントをLLMに渡しやすい形式に整形します。
 
         Args:
-            events (list): Google Calendar APIから取得したイベントのリスト
+            events (list): イベントのリスト（source フィールドでソース判定）
             language (str): 言語（ja or en）
 
         Returns:
@@ -166,15 +182,16 @@ class EventAgent:
         Examples:
             >>> agent = EventAgent()
             >>> events = [
-            ...     {"title": "Workshop", "start": "2024-01-15T14:00:00", "description": "Python basics"}
+            ...     {"title": "Workshop", "start": "2024-01-15T14:00:00", "source": "google_calendar"}
             ... ]
             >>> formatted = agent._format_calendar_events(events, "ja")
             >>> print(formatted)
-            - Workshop（2024-01-15） - Python basics
+            - Workshop（2024-01-15）[カレンダー]
 
         Notes:
             - 日時はISO8601形式からYYYY-MM-DDに変換
             - 説明文は100文字に制限してトークン数を削減
+            - Connpassの場合は参加者数も表示
             - 空のイベントリストには空文字列を返す
         """
         if not events:
@@ -186,19 +203,46 @@ class EventAgent:
             title = event.get("title", "No Title")
             start = event.get("start", "")
             description = event.get("description", "")
-            _location = event.get("location", "")  # Reserved for future use
+            source = event.get("source", "unknown")
+            location = event.get("location", "")
 
             # 日時を整形
             start_str = start[:10] if start else "日時不明"
 
+            # ソースラベル
             if language == "en":
-                event_line = f"- {title} ({start_str})"
-                if description:
-                    event_line += f" - {description[:100]}"
+                source_label = "[Calendar]" if source == "google_calendar" else "[Connpass]"
             else:
-                event_line = f"- {title}（{start_str}）"
+                source_label = "[カレンダー]" if source == "google_calendar" else "[Connpass]"
+
+            # Connpassの場合は参加者情報を追加
+            participant_info = ""
+            if source == "connpass":
+                accepted = event.get("accepted", 0)
+                limit = event.get("limit")
+                if limit:
+                    if language == "en":
+                        participant_info = f" ({accepted}/{limit} participants)"
+                    else:
+                        participant_info = f"（{accepted}/{limit}名参加）"
+                elif accepted > 0:
+                    if language == "en":
+                        participant_info = f" ({accepted} participants)"
+                    else:
+                        participant_info = f"（{accepted}名参加）"
+
+            if language == "en":
+                event_line = f"- {title} ({start_str}){participant_info} {source_label}"
+                if location:
+                    event_line += f" @ {location}"
                 if description:
-                    event_line += f" - {description[:100]}"
+                    event_line += f" - {description[:80]}"
+            else:
+                event_line = f"- {title}（{start_str}）{participant_info} {source_label}"
+                if location:
+                    event_line += f" @ {location}"
+                if description:
+                    event_line += f" - {description[:80]}"
 
             formatted_lines.append(event_line)
 
@@ -331,3 +375,40 @@ Maximum 2-3 sentences."""
             "emotion": "sad",
             "metadata": {"agent": "EventAgent", "time_range": time_range, "event_count": 0},
         }
+
+    def _merge_events(self, calendar_result: Dict, connpass_result: Dict) -> List[Dict]:
+        """Google CalendarとConnpassのイベントをマージ
+
+        両方のソースからイベントを取得し、開始日時順にソートして返します。
+
+        Args:
+            calendar_result: CalendarServiceの結果
+            connpass_result: ConnpassServiceの結果
+
+        Returns:
+            マージされたイベントのリスト（開始日時順）
+
+        Notes:
+            - 各イベントには "source" フィールド（google_calendar / connpass）が付与される
+            - 重複は除外されない（異なるソースのため基本的に重複しない想定）
+        """
+        events = []
+
+        # Google Calendarイベント
+        if calendar_result.get("success"):
+            calendar_events = calendar_result.get("data", {}).get("events", [])
+            for event in calendar_events:
+                event["source"] = "google_calendar"
+                events.append(event)
+
+        # Connpassイベント
+        if connpass_result.get("success"):
+            connpass_events = connpass_result.get("data", {}).get("events", [])
+            for event in connpass_events:
+                # source は既にConnpassServiceで付与済み
+                events.append(event)
+
+        # 開始日時でソート
+        events.sort(key=lambda e: e.get("start", "") or "")
+
+        return events

--- a/backend/tools/__init__.py
+++ b/backend/tools/__init__.py
@@ -2,5 +2,6 @@
 
 from backend.tools.enhanced_rag import EnhancedRAGSearch
 from backend.tools.calendar_service import CalendarService
+from backend.tools.connpass_service import ConnpassService
 
-__all__ = ["EnhancedRAGSearch", "CalendarService"]
+__all__ = ["EnhancedRAGSearch", "CalendarService", "ConnpassService"]

--- a/backend/tools/calendar_service.py
+++ b/backend/tools/calendar_service.py
@@ -1,11 +1,16 @@
 """
 Calendar Service Tool
-Google Calendar API連携によるイベント情報取得
+ICS/iCal形式によるイベント情報取得
+
+Google Calendar APIを使用せず、公開ICSフィードからイベントを取得します。
+これにより、Google Cloud APIキーなしで利用可能です。
 """
 
 import os
+import re
+import hashlib
 from datetime import datetime, timedelta
-from typing import List, Dict, Literal
+from typing import List, Dict, Literal, Optional
 import httpx
 
 
@@ -13,12 +18,11 @@ TimeRange = Literal["today", "thisWeek", "nextWeek", "thisMonth"]
 
 
 class CalendarService:
-    """Google Calendar APIサービス"""
+    """ICS/iCalカレンダーサービス"""
 
     def __init__(self):
         """初期化"""
-        self.calendar_id = os.getenv("GOOGLE_CALENDAR_ID", "")
-        self.api_key = os.getenv("GOOGLE_API_KEY", "")
+        self.ical_url = os.getenv("GOOGLE_CALENDAR_ICAL_URL", "")
 
     async def search_events(self, time_range: TimeRange = "thisWeek") -> Dict:
         """
@@ -36,18 +40,15 @@ class CalendarService:
             # 期間の開始日と終了日を計算
             time_min, time_max = self._calculate_time_range(time_range)
 
-            # Google Calendar APIでイベント取得
-            events = await self._fetch_calendar_events(time_min, time_max)
-
-            # イベントを整形
-            formatted_events = self._format_events(events)
+            # ICSからイベント取得
+            events = await self._fetch_ics_events(time_min, time_max)
 
             return {
                 "success": True,
                 "data": {
-                    "events": formatted_events,
+                    "events": events,
                     "timeRange": time_range,
-                    "eventCount": len(formatted_events),
+                    "eventCount": len(events),
                 },
             }
 
@@ -100,9 +101,11 @@ class CalendarService:
         week_end = week_start + timedelta(days=6, hours=23, minutes=59, seconds=59)
         return (week_start, week_end)
 
-    async def _fetch_calendar_events(self, time_min: datetime, time_max: datetime) -> List[Dict]:
+    async def _fetch_ics_events(
+        self, time_min: datetime, time_max: datetime
+    ) -> List[Dict]:
         """
-        Google Calendar APIからイベントを取得
+        ICSフィードからイベントを取得
 
         Args:
             time_min: 検索開始日時
@@ -111,74 +114,211 @@ class CalendarService:
         Returns:
             イベントのリスト
         """
-        if not self.calendar_id or not self.api_key:
-            print("[CalendarService] Calendar ID or API Key not configured")
+        if not self.ical_url:
+            print("[CalendarService] GOOGLE_CALENDAR_ICAL_URL not configured")
             return []
 
         try:
-            # ISO 8601形式に変換
-            time_min_str = time_min.isoformat() + "Z"
-            time_max_str = time_max.isoformat() + "Z"
-
-            # Google Calendar API v3エンドポイント
-            url = f"https://www.googleapis.com/calendar/v3/calendars/{self.calendar_id}/events"
-
-            params = {
-                "key": self.api_key,
-                "timeMin": time_min_str,
-                "timeMax": time_max_str,
-                "singleEvents": "true",
-                "orderBy": "startTime",
-                "maxResults": 50,
-            }
-
             async with httpx.AsyncClient() as client:
-                response = await client.get(url, params=params, timeout=30.0)
+                response = await client.get(self.ical_url, timeout=30.0)
 
                 if response.status_code != 200:
-                    print(f"[CalendarService] API error: {response.text}")
+                    print(f"[CalendarService] ICS fetch error: {response.status_code}")
                     return []
 
-                data = response.json()
-                return data.get("items", [])
+                ics_content = response.text
+                all_events = self._parse_ics_content(ics_content)
+
+                # 時間範囲でフィルタリング
+                filtered_events = self._filter_events_by_time(
+                    all_events, time_min, time_max
+                )
+
+                # 開始日時でソート
+                filtered_events.sort(
+                    key=lambda e: e.get("start") or "", reverse=False
+                )
+
+                return filtered_events
 
         except Exception as e:
-            print(f"[CalendarService] Fetch error: {e}")
+            print(f"[CalendarService] ICS fetch error: {e}")
             return []
 
-    def _format_events(self, events: List[Dict]) -> List[Dict]:
+    def _parse_ics_content(self, content: str) -> List[Dict]:
         """
-        イベントを整形
+        ICSコンテンツをパース
 
         Args:
-            events: 生のイベントデータ
+            content: ICSファイルの内容
 
         Returns:
-            整形されたイベントのリスト
+            パースされたイベントのリスト
         """
-        formatted_events = []
+        events = []
 
-        for event in events:
-            # 開始日時と終了日時を取得
-            start = event.get("start", {})
-            end = event.get("end", {})
+        # VEVENTブロックを抽出
+        vevent_pattern = r"BEGIN:VEVENT(.*?)END:VEVENT"
+        vevent_matches = re.findall(vevent_pattern, content, re.DOTALL)
 
-            start_datetime = start.get("dateTime") or start.get("date")
-            end_datetime = end.get("dateTime") or end.get("date")
+        for vevent in vevent_matches:
+            event = self._parse_vevent(vevent)
+            if event:
+                events.append(event)
 
-            formatted_event = {
-                "id": event.get("id", ""),
-                "title": event.get("summary", "No Title"),
-                "description": event.get("description", ""),
-                "location": event.get("location", ""),
-                "start": start_datetime,
-                "end": end_datetime,
-                "htmlLink": event.get("htmlLink", ""),
+        return events
+
+    def _parse_vevent(self, vevent_content: str) -> Optional[Dict]:
+        """
+        VEVENTブロックをパース
+
+        Args:
+            vevent_content: VEVENTの内容
+
+        Returns:
+            パースされたイベント辞書
+        """
+        try:
+            # 行継続（折り返し）を処理
+            # ICSでは長い行は改行+空白で継続される
+            content = re.sub(r"\r?\n[ \t]", "", vevent_content)
+            lines = content.strip().split("\n")
+
+            event_data: Dict[str, str] = {}
+
+            for line in lines:
+                line = line.strip()
+                if not line or ":" not in line:
+                    continue
+
+                # プロパティ名と値を分離
+                # 形式: PROPERTY;PARAM=VALUE:VALUE または PROPERTY:VALUE
+                if ";" in line.split(":")[0]:
+                    prop_part = line.split(":")[0]
+                    prop_name = prop_part.split(";")[0]
+                    value = ":".join(line.split(":")[1:])
+                else:
+                    parts = line.split(":", 1)
+                    prop_name = parts[0]
+                    value = parts[1] if len(parts) > 1 else ""
+
+                event_data[prop_name.upper()] = value
+
+            # 必須フィールドの確認
+            if "DTSTART" not in event_data:
+                return None
+
+            # IDの生成（UIDがない場合はハッシュ生成）
+            uid = event_data.get("UID", "")
+            if not uid:
+                uid = hashlib.md5(
+                    f"{event_data.get('SUMMARY', '')}{event_data.get('DTSTART', '')}".encode()
+                ).hexdigest()
+
+            # 日付のパース
+            start_str = self._parse_ics_date(event_data.get("DTSTART", ""))
+            end_str = self._parse_ics_date(event_data.get("DTEND", ""))
+
+            # 説明文のエスケープ解除
+            description = event_data.get("DESCRIPTION", "")
+            description = description.replace("\\n", "\n").replace("\\,", ",")
+
+            return {
+                "id": uid,
+                "title": event_data.get("SUMMARY", "No Title"),
+                "description": description,
+                "location": event_data.get("LOCATION", ""),
+                "start": start_str,
+                "end": end_str,
+                "htmlLink": event_data.get("URL", ""),
             }
 
-            formatted_events.append(formatted_event)
+        except Exception as e:
+            print(f"[CalendarService] VEVENT parse error: {e}")
+            return None
 
-        return formatted_events
+    def _parse_ics_date(self, date_str: str) -> str:
+        """
+        ICS日付文字列をISO形式に変換
+
+        ICSの日付形式:
+        - 20240115T090000Z (UTC)
+        - 20240115T090000 (ローカル)
+        - 20240115 (終日イベント)
+
+        Args:
+            date_str: ICS形式の日付文字列
+
+        Returns:
+            ISO 8601形式の日付文字列
+        """
+        if not date_str:
+            return ""
+
+        try:
+            # Z付きUTC時刻
+            if date_str.endswith("Z"):
+                date_str = date_str[:-1]
+                if "T" in date_str:
+                    dt = datetime.strptime(date_str, "%Y%m%dT%H%M%S")
+                else:
+                    dt = datetime.strptime(date_str, "%Y%m%d")
+                return dt.isoformat() + "Z"
+
+            # ローカル時刻（T付き）
+            if "T" in date_str:
+                dt = datetime.strptime(date_str, "%Y%m%dT%H%M%S")
+                return dt.isoformat()
+
+            # 終日イベント
+            dt = datetime.strptime(date_str, "%Y%m%d")
+            return dt.date().isoformat()
+
+        except Exception as e:
+            print(f"[CalendarService] Date parse error: {date_str} - {e}")
+            return date_str
+
+    def _filter_events_by_time(
+        self, events: List[Dict], time_min: datetime, time_max: datetime
+    ) -> List[Dict]:
+        """
+        時間範囲でイベントをフィルタリング
+
+        Args:
+            events: イベントリスト
+            time_min: 開始日時
+            time_max: 終了日時
+
+        Returns:
+            フィルタリングされたイベントリスト
+        """
+        filtered = []
+
+        for event in events:
+            start_str = event.get("start", "")
+            if not start_str:
+                continue
+
+            try:
+                # ISO形式からdatetimeに変換
+                if "T" in start_str:
+                    if start_str.endswith("Z"):
+                        event_start = datetime.fromisoformat(start_str[:-1])
+                    else:
+                        event_start = datetime.fromisoformat(start_str)
+                else:
+                    # 終日イベント
+                    event_start = datetime.fromisoformat(start_str)
+
+                # 時間範囲内かチェック
+                if time_min <= event_start <= time_max:
+                    filtered.append(event)
+
+            except Exception as e:
+                print(f"[CalendarService] Filter error: {start_str} - {e}")
+                continue
+
+        return filtered
 
     def extract_time_range_from_query(self, query: str) -> TimeRange:
         """

--- a/backend/tools/connpass_service.py
+++ b/backend/tools/connpass_service.py
@@ -1,0 +1,332 @@
+"""
+Connpass Service Tool
+Connpass API v2連携によるイベント情報取得
+"""
+
+import os
+from datetime import datetime, timedelta
+from typing import List, Dict, Optional, Literal
+import httpx
+
+
+TimeRange = Literal["today", "thisWeek", "nextWeek", "thisMonth"]
+
+
+class ConnpassService:
+    """Connpass API v2サービス
+
+    Connpass API v2からイベント情報を取得します。
+    エンジニアカフェ関連のイベントや福岡エリアのイベントを検索できます。
+
+    Attributes:
+        api_key (str): Connpass APIキー
+        base_url (str): Connpass API v2エンドポイント
+
+    Examples:
+        >>> service = ConnpassService()
+        >>> result = await service.search_events(
+        ...     time_range="thisWeek",
+        ...     keyword="エンジニアカフェ"
+        ... )
+        >>> print(result["data"]["eventCount"])
+        5
+
+    Notes:
+        - API v2では X-API-Key ヘッダーが必須
+        - 1リクエストあたり最大100件まで取得可能
+        - 福岡県（prefecture=40）をデフォルトで指定
+    """
+
+    BASE_URL = "https://connpass.com/api/v2/events/"
+    FUKUOKA_PREFECTURE = "fukuoka"  # API v2では文字列で指定
+
+    def __init__(self):
+        """ConnpassServiceを初期化
+
+        環境変数からAPIキーを取得します。
+        """
+        self.api_key = os.getenv("CONNPASS_API_KEY", "")
+        if not self.api_key:
+            print("[ConnpassService] Warning: CONNPASS_API_KEY not configured")
+
+    async def search_events(
+        self,
+        time_range: TimeRange = "thisWeek",
+        keyword: Optional[str] = None,
+        prefecture: Optional[str] = None,
+        count: int = 20,
+    ) -> Dict:
+        """
+        Connpassからイベントを検索
+
+        Args:
+            time_range: 検索期間（today, thisWeek, nextWeek, thisMonth）
+            keyword: 検索キーワード（オプション）
+            prefecture: 都道府県コード（オプション、デフォルトは福岡）
+            count: 取得件数（最大100）
+
+        Returns:
+            イベント情報辞書 {success, data: {events, timeRange, eventCount, source}}
+
+        Examples:
+            >>> service = ConnpassService()
+            >>> result = await service.search_events(
+            ...     time_range="thisWeek",
+            ...     keyword="Python"
+            ... )
+            >>> print(result["success"])
+            True
+        """
+        try:
+            print(f"[ConnpassService] Searching events: time_range={time_range}, keyword={keyword}")
+
+            if not self.api_key:
+                print("[ConnpassService] API key not configured, returning empty result")
+                return {
+                    "success": False,
+                    "error": "CONNPASS_API_KEY not configured",
+                    "data": {"events": [], "timeRange": time_range, "eventCount": 0, "source": "connpass"},
+                }
+
+            # 時間範囲から日付リストを生成
+            ymd_list = self._get_ymd_list(time_range)
+
+            # Connpass APIでイベント取得
+            events = await self._fetch_connpass_events(
+                ymd_list=ymd_list,
+                keyword=keyword,
+                prefecture=prefecture or self.FUKUOKA_PREFECTURE,
+                count=count,
+            )
+
+            # イベントを整形
+            formatted_events = self._format_events(events)
+
+            return {
+                "success": True,
+                "data": {
+                    "events": formatted_events,
+                    "timeRange": time_range,
+                    "eventCount": len(formatted_events),
+                    "source": "connpass",
+                },
+            }
+
+        except Exception as e:
+            print(f"[ConnpassService] Error: {e}")
+            return {
+                "success": False,
+                "error": str(e),
+                "data": {"events": [], "timeRange": time_range, "eventCount": 0, "source": "connpass"},
+            }
+
+    def _get_ymd_list(self, time_range: TimeRange) -> List[str]:
+        """
+        時間範囲からYYYYMMDD形式の日付リストを生成
+
+        Args:
+            time_range: 検索期間
+
+        Returns:
+            日付リスト（YYYYMMDD形式）
+
+        Examples:
+            >>> service = ConnpassService()
+            >>> dates = service._get_ymd_list("today")
+            >>> print(dates)
+            ["20260125"]
+        """
+        now = datetime.now()
+        today = now.date()
+
+        if time_range == "today":
+            return [today.strftime("%Y%m%d")]
+
+        elif time_range == "thisWeek":
+            # 今週の月曜日から日曜日
+            weekday = today.weekday()
+            week_start = today - timedelta(days=weekday)
+            return [(week_start + timedelta(days=i)).strftime("%Y%m%d") for i in range(7)]
+
+        elif time_range == "nextWeek":
+            # 来週の月曜日から日曜日
+            weekday = today.weekday()
+            week_start = today - timedelta(days=weekday) + timedelta(weeks=1)
+            return [(week_start + timedelta(days=i)).strftime("%Y%m%d") for i in range(7)]
+
+        elif time_range == "thisMonth":
+            # 今月の1日から月末
+            month_start = today.replace(day=1)
+            if month_start.month == 12:
+                next_month = month_start.replace(year=month_start.year + 1, month=1)
+            else:
+                next_month = month_start.replace(month=month_start.month + 1)
+            days_in_month = (next_month - month_start).days
+            return [(month_start + timedelta(days=i)).strftime("%Y%m%d") for i in range(days_in_month)]
+
+        # デフォルトは今週
+        weekday = today.weekday()
+        week_start = today - timedelta(days=weekday)
+        return [(week_start + timedelta(days=i)).strftime("%Y%m%d") for i in range(7)]
+
+    async def _fetch_connpass_events(
+        self,
+        ymd_list: List[str],
+        keyword: Optional[str] = None,
+        prefecture: str = FUKUOKA_PREFECTURE,
+        count: int = 20,
+    ) -> List[Dict]:
+        """
+        Connpass API v2からイベントを取得
+
+        Args:
+            ymd_list: 検索日付リスト（YYYYMMDD形式）
+            keyword: 検索キーワード
+            prefecture: 都道府県コード
+            count: 取得件数
+
+        Returns:
+            イベントのリスト
+        """
+        try:
+            headers = {
+                "X-API-Key": self.api_key,
+                "User-Agent": "EngineerCafeNavigator/1.0",
+            }
+
+            params: Dict[str, str | int] = {
+                "prefecture": prefecture,
+                "order": 2,  # 開催日時順
+                "count": min(count, 100),
+            }
+
+            # 日付を指定（カンマ区切り）
+            if ymd_list:
+                params["ymd"] = ",".join(ymd_list)
+
+            # キーワード指定
+            if keyword:
+                params["keyword"] = keyword
+
+            async with httpx.AsyncClient() as client:
+                response = await client.get(
+                    self.BASE_URL,
+                    headers=headers,
+                    params=params,
+                    timeout=30.0,
+                )
+
+                if response.status_code != 200:
+                    print(f"[ConnpassService] API error: {response.status_code} - {response.text}")
+                    return []
+
+                data = response.json()
+                return data.get("events", [])
+
+        except Exception as e:
+            print(f"[ConnpassService] Fetch error: {e}")
+            return []
+
+    def _format_events(self, events: List[Dict]) -> List[Dict]:
+        """
+        Connpassイベントを整形
+
+        Args:
+            events: Connpass APIの生データ
+
+        Returns:
+            整形されたイベントのリスト（CalendarServiceと同じフォーマット）
+
+        Notes:
+            CalendarServiceと同じフォーマットに統一することで、
+            EventAgentでの処理を共通化できる
+        """
+        formatted_events = []
+
+        for event in events:
+            formatted_event = {
+                "id": str(event.get("event_id", "")),
+                "title": event.get("title", "No Title"),
+                "description": event.get("description", "")[:500],  # 長すぎる説明を制限
+                "location": event.get("place", "") or event.get("address", ""),
+                "start": event.get("started_at", ""),
+                "end": event.get("ended_at", ""),
+                "htmlLink": event.get("event_url", ""),
+                # Connpass固有フィールド
+                "source": "connpass",
+                "accepted": event.get("accepted", 0),
+                "limit": event.get("limit"),
+                "waiting": event.get("waiting", 0),
+                "owner_nickname": event.get("owner_nickname", ""),
+                "group_name": event.get("series", {}).get("title", "") if event.get("series") else "",
+            }
+
+            formatted_events.append(formatted_event)
+
+        return formatted_events
+
+    def extract_time_range_from_query(self, query: str) -> TimeRange:
+        """
+        クエリから時間範囲を抽出（CalendarServiceと同じロジック）
+
+        Args:
+            query: ユーザークエリ
+
+        Returns:
+            時間範囲（today, thisWeek, nextWeek, thisMonth）
+        """
+        query_lower = query.lower()
+
+        # 今日
+        if "今日" in query_lower or "today" in query_lower or "本日" in query_lower:
+            return "today"
+
+        # 今週
+        if "今週" in query_lower or "this week" in query_lower:
+            return "thisWeek"
+
+        # 来週
+        if "来週" in query_lower or "next week" in query_lower:
+            return "nextWeek"
+
+        # 今月
+        if "今月" in query_lower or "this month" in query_lower:
+            return "thisMonth"
+
+        # デフォルトは今週
+        return "thisWeek"
+
+    def extract_keyword_from_query(self, query: str) -> Optional[str]:
+        """
+        クエリから検索キーワードを抽出
+
+        Args:
+            query: ユーザークエリ
+
+        Returns:
+            キーワード（なければNone）
+
+        Examples:
+            >>> service = ConnpassService()
+            >>> keyword = service.extract_keyword_from_query("Pythonのイベントは？")
+            >>> print(keyword)
+            "Python"
+        """
+        # 技術キーワードのリスト
+        tech_keywords = [
+            "Python", "JavaScript", "TypeScript", "React", "Vue", "Next.js",
+            "Go", "Rust", "Java", "Kotlin", "Swift", "Flutter",
+            "AWS", "GCP", "Azure", "Docker", "Kubernetes",
+            "AI", "機械学習", "ML", "LLM", "生成AI", "ChatGPT",
+            "データ分析", "データサイエンス",
+            "Web", "フロントエンド", "バックエンド", "インフラ",
+            "セキュリティ", "DevOps", "SRE",
+            "スタートアップ", "起業", "キャリア",
+        ]
+
+        query_lower = query.lower()
+        for keyword in tech_keywords:
+            if keyword.lower() in query_lower:
+                return keyword
+
+        return None


### PR DESCRIPTION
## Summary
- ConnpassService（API v2）を追加し、時間範囲・キーワードによるイベント検索を実現
- CalendarServiceをGoogle Calendar APIからICS形式に移行（APIキー不要）
- EventAgentを拡張し、両ソースからの並列検索とイベント統合をサポート

## Changes
### 新規ファイル
- `backend/tools/connpass_service.py` - Connpass API v2サービス

### 変更ファイル
- `backend/tools/calendar_service.py` - ICS形式パーサーに書き換え
- `backend/agents/event_agent.py` - 並列検索とマージロジック追加
- `backend/tools/__init__.py` - ConnpassServiceをエクスポート
- `backend/.env.example` - 新しい環境変数の説明追加

## Test plan
- [ ] CalendarServiceがICS形式からイベントを正常にパースできることを確認
- [ ] ConnpassServiceがAPI v2からイベントを取得できることを確認
- [ ] EventAgentが両ソースを並列検索し、結果をマージできることを確認
- [ ] 時間範囲（today/thisWeek/nextWeek/thisMonth）ごとの検索が機能することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)