### PR TITLE
feat(backend): LangGraph @tool wrappers for agents

### DIFF
--- a/backend/agents/__init__.py
+++ b/backend/agents/__init__.py
@@ -4,6 +4,16 @@ from backend.agents.business_info_agent import BusinessInfoAgent
 from backend.agents.event_agent import EventAgent
 from backend.agents.slide_agent import SlideAgent
 from .router_agent import RouterAgent, RouteResult
+from .agent_tools import (
+    get_all_agent_tools,
+    get_domain_agent_tools,
+    facility_query_tool,
+    business_info_tool,
+    event_info_tool,
+    general_knowledge_tool,
+    slide_action_tool,
+    memory_query_tool,
+)
 
 __all__ = [
     "BusinessInfoAgent",
@@ -11,4 +21,13 @@ __all__ = [
     "SlideAgent",
     "RouterAgent",
     "RouteResult",
+    # Tool wrappers for LangGraph ToolNode
+    "get_all_agent_tools",
+    "get_domain_agent_tools",
+    "facility_query_tool",
+    "business_info_tool",
+    "event_info_tool",
+    "general_knowledge_tool",
+    "slide_action_tool",
+    "memory_query_tool",
 ]

--- a/backend/agents/agent_tools.py
+++ b/backend/agents/agent_tools.py
@@ -1,0 +1,268 @@
+"""
+Agent Tools - LangGraph @tool ラッパー
+
+既存のエージェントを@toolデコレーターで包み、LangGraphのToolNodeで
+動的に呼び出せるようにする。
+
+各ドメインエージェントは固定パイプライン（RAG→LLM）を持つため、
+内部ロジックは変更せず、ツールインターフェースのみを提供する。
+
+使用例:
+    from langchain_core.tools import tool
+    from langgraph.prebuilt import ToolNode
+
+    # 全エージェントツールをToolNodeに登録
+    tools = get_all_agent_tools()
+    tool_node = ToolNode(tools)
+
+    # LLMにツールをバインド
+    llm_with_tools = llm.bind_tools(tools)
+"""
+
+from typing import Optional
+from langchain_core.tools import tool
+
+
+# 遅延インポート用のエージェントキャッシュ
+_agent_cache: dict = {}
+
+
+def _get_facility_agent():
+    """FacilityAgentの遅延初期化"""
+    if "facility" not in _agent_cache:
+        from backend.agents.facility_agent import FacilityAgent
+
+        _agent_cache["facility"] = FacilityAgent()
+    return _agent_cache["facility"]
+
+
+def _get_business_info_agent():
+    """BusinessInfoAgentの遅延初期化"""
+    if "business_info" not in _agent_cache:
+        from backend.agents.business_info_agent import BusinessInfoAgent
+
+        _agent_cache["business_info"] = BusinessInfoAgent()
+    return _agent_cache["business_info"]
+
+
+def _get_event_agent():
+    """EventAgentの遅延初期化"""
+    if "event" not in _agent_cache:
+        from backend.agents.event_agent import EventAgent
+
+        _agent_cache["event"] = EventAgent()
+    return _agent_cache["event"]
+
+
+def _get_general_knowledge_agent():
+    """GeneralKnowledgeAgentの遅延初期化"""
+    if "general_knowledge" not in _agent_cache:
+        from backend.agents.general_knowledge_agent import GeneralKnowledgeAgent
+
+        _agent_cache["general_knowledge"] = GeneralKnowledgeAgent()
+    return _agent_cache["general_knowledge"]
+
+
+def _get_slide_agent():
+    """SlideAgentの遅延初期化"""
+    if "slide" not in _agent_cache:
+        from backend.agents.slide_agent import SlideAgent
+
+        _agent_cache["slide"] = SlideAgent()
+    return _agent_cache["slide"]
+
+
+def _get_memory_agent():
+    """MemoryAgentの遅延初期化"""
+    if "memory" not in _agent_cache:
+        from backend.agents.memory_agent import MemoryAgent
+        from backend.utils.memory_helper import get_memory_helper
+
+        memory_helper = get_memory_helper()
+        _agent_cache["memory"] = MemoryAgent(memory_system=memory_helper)
+    return _agent_cache["memory"]
+
+
+@tool
+async def facility_query_tool(
+    query: str,
+    request_type: Optional[str] = None,
+    language: str = "ja",
+    session_id: Optional[str] = None,
+) -> str:
+    """施設情報に関する質問に回答するツール。
+
+    Wi-Fi、電源、コンセント、プリンター、地下施設（MTGスペース、集中スペース等）
+    に関する質問に対応します。
+
+    Args:
+        query: ユーザーからの施設に関する質問
+            例: "Wi-Fiは使えますか？", "電源はありますか？", "地下の集中スペースの予約方法は？"
+        request_type: リクエストタイプ（wifi, facility, basement）
+        language: 言語（ja, en）
+        session_id: セッションID
+
+    Returns:
+        施設情報に関する回答テキスト
+    """
+    agent = _get_facility_agent()
+    result = await agent.answer_facility_query(query, request_type, language, session_id)
+    return result.get("answer", "")
+
+
+@tool
+async def business_info_tool(
+    query: str,
+    request_type: Optional[str] = None,
+    language: str = "ja",
+    session_id: Optional[str] = None,
+) -> str:
+    """営業情報に関する質問に回答するツール。
+
+    営業時間、料金、予約、会員制度、支払い方法に関する質問に対応します。
+
+    Args:
+        query: ユーザーからの営業に関する質問
+            例: "営業時間は？", "料金はいくら？", "予約は必要？"
+        request_type: リクエストタイプ（hours, pricing, reservation, membership）
+        language: 言語（ja, en）
+        session_id: セッションID
+
+    Returns:
+        営業情報に関する回答テキスト
+    """
+    agent = _get_business_info_agent()
+    result = await agent.answer_business_query(query, request_type, language, session_id)
+    return result.get("answer", "")
+
+
+@tool
+async def event_info_tool(
+    query: str,
+    language: str = "ja",
+    session_id: Optional[str] = None,
+) -> str:
+    """イベント情報に関する質問に回答するツール。
+
+    開催予定のイベント、過去のイベント、イベント参加方法に関する質問に対応します。
+
+    Args:
+        query: ユーザーからのイベントに関する質問
+            例: "今月のイベントは？", "勉強会はありますか？"
+        language: 言語（ja, en）
+        session_id: セッションID
+
+    Returns:
+        イベント情報に関する回答テキスト
+    """
+    agent = _get_event_agent()
+    result = await agent.answer_event_query(query, language, session_id)
+    return result.get("answer", "")
+
+
+@tool
+async def general_knowledge_tool(
+    query: str,
+    language: str = "ja",
+    session_id: Optional[str] = None,
+) -> str:
+    """一般的な質問に回答するツール。
+
+    Engineer Cafeに関する一般情報、AI・技術トピック、福岡のテックシーンに関する
+    質問に対応します。ナレッジベースとWeb検索を組み合わせて回答します。
+
+    Args:
+        query: ユーザーからの一般的な質問
+            例: "AIの最新トレンドは？", "福岡のスタートアップは？"
+        language: 言語（ja, en）
+        session_id: セッションID
+
+    Returns:
+        一般知識に関する回答テキスト
+    """
+    agent = _get_general_knowledge_agent()
+    result = await agent.answer_general_query(query, language, session_id)
+    return result.get("answer", "")
+
+
+@tool
+async def slide_action_tool(
+    action: str,
+    query: Optional[str] = None,
+    language: str = "ja",
+) -> str:
+    """スライド操作に関するツール。
+
+    スライドのナレーション、ページ移動、質問応答に対応します。
+
+    Args:
+        action: アクション種別（narrate, next, previous, goto, question）
+        query: 質問テキスト（action="question"の場合に使用）
+        language: 言語（ja, en）
+
+    Returns:
+        スライド操作の結果テキスト
+    """
+    agent = _get_slide_agent()
+    result = await agent.handle_slide_action(action=action, query=query, language=language)
+    return result.get("answer", "")
+
+
+@tool
+async def memory_query_tool(
+    query: str,
+    session_id: str,
+    language: str = "ja",
+) -> str:
+    """会話履歴に関する質問に回答するツール。
+
+    「さっき何を聞いた？」「前に話したことを覚えてる？」などの
+    メモリ関連の質問に対応します。
+
+    Args:
+        query: ユーザーからの会話履歴に関する質問
+        session_id: セッションID（必須）
+        language: 言語（ja, en）
+
+    Returns:
+        会話履歴に関する回答テキスト
+    """
+    agent = _get_memory_agent()
+    result = await agent.process_memory_query(query, session_id, language)
+    return result.get("answer", "")
+
+
+def get_all_agent_tools() -> list:
+    """全エージェントツールのリストを取得
+
+    Returns:
+        LangGraph ToolNodeで使用可能なツールのリスト
+    """
+    return [
+        facility_query_tool,
+        business_info_tool,
+        event_info_tool,
+        general_knowledge_tool,
+        slide_action_tool,
+        memory_query_tool,
+    ]
+
+
+def get_domain_agent_tools() -> list:
+    """ドメインエージェントツールのみを取得（スライド・メモリ除く）
+
+    Returns:
+        ドメイン特化ツールのリスト
+    """
+    return [
+        facility_query_tool,
+        business_info_tool,
+        event_info_tool,
+        general_knowledge_tool,
+    ]
+
+
+def clear_agent_cache() -> None:
+    """エージェントキャッシュをクリア（テスト用）"""
+    global _agent_cache
+    _agent_cache = {}

--- a/backend/tests/agents/test_agent_tools.py
+++ b/backend/tests/agents/test_agent_tools.py
@@ -1,0 +1,234 @@
+"""
+Agent Tools テスト
+
+@toolデコレーターで包んだエージェントツールのテスト。
+"""
+
+import pytest
+from unittest.mock import AsyncMock, Mock, patch
+
+
+class TestAgentToolsBasic:
+    """基本的なツール機能のテスト"""
+
+    def test_get_all_agent_tools_returns_list(self):
+        """get_all_agent_toolsがツールリストを返すことを確認"""
+        from backend.agents.agent_tools import get_all_agent_tools
+
+        tools = get_all_agent_tools()
+        assert isinstance(tools, list)
+        assert len(tools) == 6  # 6つのエージェントツール
+
+    def test_get_domain_agent_tools_returns_subset(self):
+        """get_domain_agent_toolsがドメインツールのみを返すことを確認"""
+        from backend.agents.agent_tools import get_domain_agent_tools
+
+        tools = get_domain_agent_tools()
+        assert isinstance(tools, list)
+        assert len(tools) == 4  # facility, business_info, event, general_knowledge
+
+    def test_clear_agent_cache(self):
+        """clear_agent_cacheがキャッシュをクリアすることを確認"""
+        from backend.agents import agent_tools
+
+        # キャッシュに何か入れる
+        agent_tools._agent_cache["test"] = "value"
+        assert "test" in agent_tools._agent_cache
+
+        # クリア
+        agent_tools.clear_agent_cache()
+        assert "test" not in agent_tools._agent_cache
+
+
+class TestFacilityQueryTool:
+    """facility_query_toolのテスト"""
+
+    @pytest.mark.asyncio
+    @patch("backend.agents.agent_tools._get_facility_agent")
+    async def test_facility_query_tool_calls_agent(self, mock_get_agent):
+        """facility_query_toolがFacilityAgentを呼び出すことを確認"""
+        from backend.agents.agent_tools import facility_query_tool, clear_agent_cache
+
+        clear_agent_cache()
+
+        mock_agent = AsyncMock()
+        mock_agent.answer_facility_query = AsyncMock(
+            return_value={"answer": "Wi-Fiは無料でご利用いただけます。", "emotion": "relaxed"}
+        )
+        mock_get_agent.return_value = mock_agent
+
+        # ツール関数を直接呼び出し（@toolラッパーの内部関数）
+        result = await facility_query_tool.coroutine(
+            query="Wi-Fiは使えますか？", request_type="wifi", language="ja"
+        )
+
+        assert result == "Wi-Fiは無料でご利用いただけます。"
+        mock_agent.answer_facility_query.assert_called_once_with(
+            "Wi-Fiは使えますか？", "wifi", "ja", None
+        )
+
+
+class TestBusinessInfoTool:
+    """business_info_toolのテスト"""
+
+    @pytest.mark.asyncio
+    @patch("backend.agents.agent_tools._get_business_info_agent")
+    async def test_business_info_tool_calls_agent(self, mock_get_agent):
+        """business_info_toolがBusinessInfoAgentを呼び出すことを確認"""
+        from backend.agents.agent_tools import business_info_tool, clear_agent_cache
+
+        clear_agent_cache()
+
+        mock_agent = AsyncMock()
+        mock_agent.answer_business_query = AsyncMock(
+            return_value={"answer": "9時から22時まで営業しています。", "emotion": "informative"}
+        )
+        mock_get_agent.return_value = mock_agent
+
+        result = await business_info_tool.coroutine(
+            query="営業時間は？", request_type="hours", language="ja"
+        )
+
+        assert result == "9時から22時まで営業しています。"
+
+
+class TestEventInfoTool:
+    """event_info_toolのテスト"""
+
+    @pytest.mark.asyncio
+    @patch("backend.agents.agent_tools._get_event_agent")
+    async def test_event_info_tool_calls_agent(self, mock_get_agent):
+        """event_info_toolがEventAgentを呼び出すことを確認"""
+        from backend.agents.agent_tools import event_info_tool, clear_agent_cache
+
+        clear_agent_cache()
+
+        mock_agent = AsyncMock()
+        mock_agent.answer_event_query = AsyncMock(
+            return_value={"answer": "今月はAI勉強会があります。", "emotion": "happy"}
+        )
+        mock_get_agent.return_value = mock_agent
+
+        result = await event_info_tool.coroutine(query="今月のイベントは？", language="ja")
+
+        assert result == "今月はAI勉強会があります。"
+
+
+class TestGeneralKnowledgeTool:
+    """general_knowledge_toolのテスト"""
+
+    @pytest.mark.asyncio
+    @patch("backend.agents.agent_tools._get_general_knowledge_agent")
+    async def test_general_knowledge_tool_calls_agent(self, mock_get_agent):
+        """general_knowledge_toolがGeneralKnowledgeAgentを呼び出すことを確認"""
+        from backend.agents.agent_tools import general_knowledge_tool, clear_agent_cache
+
+        clear_agent_cache()
+
+        mock_agent = AsyncMock()
+        mock_agent.answer_general_query = AsyncMock(
+            return_value={"answer": "AIの最新トレンドは...", "emotion": "relaxed"}
+        )
+        mock_get_agent.return_value = mock_agent
+
+        result = await general_knowledge_tool.coroutine(query="AIの最新トレンドは？", language="ja")
+
+        assert result == "AIの最新トレンドは..."
+
+
+class TestSlideActionTool:
+    """slide_action_toolのテスト"""
+
+    @pytest.mark.asyncio
+    @patch("backend.agents.agent_tools._get_slide_agent")
+    async def test_slide_action_tool_calls_agent(self, mock_get_agent):
+        """slide_action_toolがSlideAgentを呼び出すことを確認"""
+        from backend.agents.agent_tools import slide_action_tool, clear_agent_cache
+
+        clear_agent_cache()
+
+        mock_agent = AsyncMock()
+        mock_agent.handle_slide_action = AsyncMock(
+            return_value={"answer": "このスライドは...", "emotion": "neutral"}
+        )
+        mock_get_agent.return_value = mock_agent
+
+        result = await slide_action_tool.coroutine(action="narrate", language="ja")
+
+        assert result == "このスライドは..."
+
+
+class TestMemoryQueryTool:
+    """memory_query_toolのテスト"""
+
+    @pytest.mark.asyncio
+    @patch("backend.agents.agent_tools._get_memory_agent")
+    async def test_memory_query_tool_calls_agent(self, mock_get_agent):
+        """memory_query_toolがMemoryAgentを呼び出すことを確認"""
+        from backend.agents.agent_tools import memory_query_tool, clear_agent_cache
+
+        clear_agent_cache()
+
+        mock_agent = AsyncMock()
+        mock_agent.process_memory_query = AsyncMock(
+            return_value={"answer": "営業時間について質問されていました。", "emotion": "relaxed"}
+        )
+        mock_get_agent.return_value = mock_agent
+
+        result = await memory_query_tool.coroutine(
+            query="さっき何を聞いた？", session_id="test-session", language="ja"
+        )
+
+        assert result == "営業時間について質問されていました。"
+
+
+class TestToolMetadata:
+    """ツールメタデータのテスト"""
+
+    def test_facility_tool_has_docstring(self):
+        """facility_query_toolにdocstringがあることを確認"""
+        from backend.agents.agent_tools import facility_query_tool
+
+        assert facility_query_tool.description is not None
+        assert "Wi-Fi" in facility_query_tool.description
+
+    def test_business_info_tool_has_docstring(self):
+        """business_info_toolにdocstringがあることを確認"""
+        from backend.agents.agent_tools import business_info_tool
+
+        assert business_info_tool.description is not None
+        assert "営業" in business_info_tool.description
+
+    def test_all_tools_are_callable(self):
+        """全ツールがcoroutine属性を持つことを確認"""
+        from backend.agents.agent_tools import get_all_agent_tools
+
+        for tool in get_all_agent_tools():
+            assert hasattr(tool, "coroutine")
+            assert callable(tool.coroutine)
+
+
+class TestLazyInitialization:
+    """遅延初期化のテスト"""
+
+    @patch("backend.agents.facility_agent.FacilityAgent")
+    def test_facility_agent_lazy_init(self, mock_agent_class):
+        """FacilityAgentが遅延初期化されることを確認"""
+        from backend.agents import agent_tools
+
+        agent_tools.clear_agent_cache()
+
+        # キャッシュが空であることを確認
+        assert "facility" not in agent_tools._agent_cache
+
+        # _get_facility_agentを呼び出すとエージェントが作成される
+        mock_agent_class.return_value = Mock()
+        agent = agent_tools._get_facility_agent()
+
+        mock_agent_class.assert_called_once()
+        assert "facility" in agent_tools._agent_cache
+
+        # 2回目の呼び出しではキャッシュから返される
+        agent2 = agent_tools._get_facility_agent()
+        assert agent is agent2
+        mock_agent_class.assert_called_once()  # 1回のみ


### PR DESCRIPTION
## Summary

- LangGraph `@tool`デコレーターで既存エージェントをラップするagent_tools.pyを追加
- ドメインエージェントは固定パイプライン（RAG→LLM）のため、内部ロジックは変更せず
- ToolNodeでの動的ツール選択を可能にするオプショナルなインターフェース

## 追加ツール

| ツール | 対応エージェント | 用途 |
|--------|------------------|------|
| `facility_query_tool` | FacilityAgent | Wi-Fi、電源、地下施設 |
| `business_info_tool` | BusinessInfoAgent | 営業時間、料金、予約 |
| `event_info_tool` | EventAgent | イベント情報 |
| `general_knowledge_tool` | GeneralKnowledgeAgent | AI/技術トピック |
| `slide_action_tool` | SlideAgent | スライド操作 |
| `memory_query_tool` | MemoryAgent | 会話履歴 |

## 使用例

```python
from backend.agents import get_all_agent_tools
from langgraph.prebuilt import ToolNode

tools = get_all_agent_tools()
tool_node = ToolNode(tools)
llm_with_tools = llm.bind_tools(tools)
```

## Test plan

- [x] agent_toolsテスト（13テスト）
- [x] main_workflowテスト（8テスト）
- [x] ruff + black チェック

🤖 Generated with [Claude Code](https://claude.com/claude-code)