### PR TITLE
feat: 多言語TTS対応 - 英語TTSエンジン(Kokoro)をVoiceVoxと併用

### DIFF
--- a/backend/SETUP_STT_TTS.md
+++ b/backend/SETUP_STT_TTS.md
@@ -1,6 +1,6 @@
 # STT/TTS ローカル環境セットアップガイド
 
-このドキュメントは、Vosk（STT）と VoiceVox（TTS）のローカルセットアップ手順です。
+このドキュメントは、Vosk（STT）、VoiceVox（日本語TTS）、Kokoro TTS（英語TTS）のローカルセットアップ手順です。
 
 ## ディレクトリ構造
 
@@ -28,8 +28,9 @@ uv pip install -r requirements.txt
 ```
 
 このコマンドで以下が自動実行されます：
-- `vosk>=0.3.45` — ローカル音声認識エンジン
+- `vosk>=0.3.44` — ローカル音声認識エンジン
 - `soundfile>=0.12.1` — WAV ファイル処理
+- `langchain` / `langchain-core` — 他エージェント用（VoiceAgent の import 時に必要）
 
 ### 2. Vosk モデルのダウンロード
 
@@ -72,18 +73,24 @@ backend/models/
     └── ...同様の構造
 ```
 
-### 3. Docker Compose で VoiceVox を起動
+### 3. Docker Compose で TTS エンジンを起動
 
-`docker-compose.yml` に VoiceVox サービスが追加済みです。
+`docker-compose.yml` に VoiceVox（日本語TTS）と Kokoro TTS（英語TTS）サービスが追加済みです。
 
 ```bash
 # プロジェクトルートから実行
-docker compose up voicevox -d
+docker compose up voicevox kokoro-tts -d
 
 # VoiceVox が起動したか確認（Health check）
 curl http://localhost:50021/version
 # 期待される応答例: {"version":"0.14.1",...}
+
+# Kokoro TTS が起動したか確認（Health check）
+curl http://localhost:8880/v1/audio/voices
+# 期待される応答例: {"voices":[...]}
 ```
+
+**注意**: Kokoro TTSは英語テキスト用、VoiceVoxは日本語テキスト用です。システムは自動的に言語を判定して適切なTTSエンジンを選択します。
 
 ### 4. 環境変数設定
 
@@ -91,14 +98,21 @@ curl http://localhost:50021/version
 
 ```env
 # STT/TTS Provider settings
-TTS_PROVIDER=voicevox          # ローカル優先
+TTS_PROVIDER=voicevox          # ローカル優先（言語判定により自動切り替え）
 STT_PROVIDER=vosk             # ローカル優先
 VOICEVOX_API_URL=http://localhost:50021
+KOKORO_API_URL=http://localhost:8880  # Kokoro TTS API URL（英語TTS用）
 
 # Google Cloud（オプション・フォールバック用）
 # GOOGLE_CLOUD_CREDENTIALS=...
 # GOOGLE_CLOUD_PROJECT_ID=...
 ```
+
+**環境変数の説明**:
+- `TTS_PROVIDER`: TTSプロバイダ（`voicevox` または `google`）
+- `VOICEVOX_API_URL`: VoiceVoxエンジンのAPI URL（デフォルト: `http://localhost:50021`）
+- `KOKORO_API_URL`: Kokoro TTSエンジンのAPI URL（デフォルト: `http://localhost:8880`）
+- システムは自動的に言語を判定し、英語テキストにはKokoro TTS、日本語テキストにはVoiceVoxを使用します
 
 ## 動作確認
 
@@ -129,16 +143,35 @@ except Exception as e:
 "
 ```
 
-### 3. VoiceVox ヘルスチェック
+### 3. TTS エンジンのヘルスチェック
 
 ```bash
+# VoiceVox（日本語TTS）
 curl -s http://localhost:50021/version | jq .
 # 期待される応答: {"version":"0.14.1","build":"..."}
+
+# Kokoro TTS（英語TTS）
+curl -s http://localhost:8880/v1/audio/voices | jq .
+# 期待される応答: {"voices":[...]}
 ```
 
 ### 4. TTS テスト
 
+**実行場所**: プロジェクトルート（`engineercafe-navigator`）で実行する場合は `from backend.agents.voice_agent import VoiceAgent` を使用してください。`backend` で実行する場合は `from agents.voice_agent import VoiceAgent` でOKです。`ModuleNotFoundError: No module named 'langchain_core'` が出る場合は、先に「Q4」の手順で依存関係をインストールしてください。
+
+**日本語・英語をまとめて試す場合**（推奨）:
 ```bash
+# プロジェクトルートから
+python -m backend.scripts.test_tts
+```
+```bash
+# backend ディレクトリから
+python -m scripts.test_tts
+```
+上記で日本語（VoiceVox）と英語（Kokoro TTS）の両方を実行し、結果を表示します。
+
+```bash
+# 日本語TTSテスト（VoiceVox）
 python -c "
 import asyncio
 from agents.voice_agent import VoiceAgent
@@ -146,9 +179,28 @@ from agents.voice_agent import VoiceAgent
 async def test():
     agent = VoiceAgent(tts_provider='voicevox')
     result = await agent.text_to_speech('こんにちは', language='ja')
-    print('✅ TTS Result:')
+    print('✅ Japanese TTS Result (VoiceVox):')
     print(f\"  - Success: {result['success']}\")
     print(f\"  - Format: {result.get('format')}\")
+    print(f\"  - Language: {result.get('language')}\")
+    print(f\"  - Emotion: {result.get('emotion')}\")
+    print(f\"  - Audio length: {len(result.get('audioResponse', ''))} chars (base64)\")
+
+asyncio.run(test())
+"
+
+# 英語TTSテスト（Kokoro TTS）
+python -c "
+import asyncio
+from agents.voice_agent import VoiceAgent
+
+async def test():
+    agent = VoiceAgent(tts_provider='voicevox')
+    result = await agent.text_to_speech('Hello, welcome to Engineer Cafe!', language='en')
+    print('✅ English TTS Result (Kokoro TTS):')
+    print(f\"  - Success: {result['success']}\")
+    print(f\"  - Format: {result.get('format')}\")
+    print(f\"  - Language: {result.get('language')}\")
     print(f\"  - Emotion: {result.get('emotion')}\")
     print(f\"  - Audio length: {len(result.get('audioResponse', ''))} chars (base64)\")
 
@@ -176,6 +228,17 @@ docker ps | grep voicevox
 curl http://localhost:50021/version
 ```
 
+### Q2-2: Kokoro TTS に接続できない
+```
+RuntimeError: Kokoro TTS connection timeout: ...
+```
+
+→ `docker compose up kokoro-tts -d` で Kokoro TTS サービスが起動していることを確認：
+```bash
+docker ps | grep kokoro
+curl http://localhost:8880/v1/audio/voices
+```
+
 ### Q3: Google Cloud STT を使いたい
 1. Google Cloud 認証キーを取得
 2. `.env` に設定：
@@ -185,7 +248,26 @@ curl http://localhost:50021/version
    STT_PROVIDER=google
    ```
 
-### Q4: モデルファイルが大きくて DL が遅い
+### Q4: ModuleNotFoundError: No module named 'langchain_core'
+```
+from backend.agents.voice_agent import VoiceAgent で上記エラーになる
+```
+
+→ バックエンドの依存関係が入っていません。**プロジェクトルート**で次を実行してください：
+```bash
+cd /path/to/engineercafe-navigator
+pip install -r backend/requirements.txt
+```
+仮想環境を使う場合：
+```bash
+cd engineercafe-navigator
+python -m venv .venv
+source .venv/bin/activate   # Windows: .venv\Scripts\activate
+pip install -r backend/requirements.txt
+```
+その後、再度 TTS テストを実行してください。コマンドは **行頭の `#` を除いた1行**で実行します（`#` はコメントなのでシェルに貼るとエラーになります）。
+
+### Q5: モデルファイルが大きくて DL が遅い
 - 日本語のみ必要な場合は `vosk-model-ja` だけダウンロード
 - Wi-Fi が安定した環境で実行推奨（100MB × 2 = 約 200MB）
 
@@ -194,10 +276,10 @@ curl http://localhost:50021/version
 | ファイル | 説明 |
 |---------|------|
 | `backend/agents/stt_agent.py` | Vosk/Google STT クライアント実装 |
-| `backend/agents/voice_agent.py` | VoiceVox/Google TTS クライアント実装 |
+| `backend/agents/voice_agent.py` | VoiceVox/Kokoro TTS/Google TTS クライアント実装 |
 | `backend/requirements.txt` | vosk, soundfile 依存宣言 |
 | `backend/pyproject.toml` | Poetry/uv 互換依存宣言 |
-| `docker-compose.yml` | VoiceVox サービス定義 |
+| `docker-compose.yml` | VoiceVox と Kokoro TTS サービス定義 |
 | `backend/models/` | Vosk モデルの配置先（.gitignore で除外） |
 
 ## 参考リンク
@@ -206,3 +288,5 @@ curl http://localhost:50021/version
 - [Vosk Models](https://alphacephei.com/vosk/models)
 - [VoiceVox Engine](https://github.com/VOICEVOX/voicevox_engine)
 - [VoiceVox Docker Hub](https://hub.docker.com/r/voicevox/voicevox_engine)
+- [Kokoro FastAPI](https://github.com/remsky/Kokoro-FastAPI)
+- [Kokoro TTS Docker Setup](https://github.com/remsky/Kokoro-FastAPI/wiki/Setup-Docker)

--- a/backend/agents/voice_agent.py
+++ b/backend/agents/voice_agent.py
@@ -481,6 +481,77 @@ class VoiceVoxClient:
 
 
 # =============================================================================
+# Kokoro TTS Client (Local, WAV format)
+# =============================================================================
+
+
+class KokoroTTSClient:
+    """
+    英語TTS: Kokoro TTS エンジン
+
+    Kokoro TTSは英語・日本語・中国語に対応した軽量TTSエンジン。
+    Dockerで起動したKokoro FastAPI REST APIを使用します。
+    """
+
+    DEFAULT_VOICE_EN = "af_bella"  # 英語用デフォルトボイス
+
+    def __init__(self, api_url: str = "http://localhost:8880"):
+        """
+        Args:
+            api_url: Kokoro TTS Engine API URL
+        """
+        self.api_url = api_url.rstrip("/")
+        logger.info(f"KokoroTTSClient initialized: {self.api_url}")
+
+    async def synthesize_wav_base64(
+        self, text: str, lang: str, voice: Optional[str] = None
+    ) -> str:
+        """
+        テキストを音声に合成し、base64エンコードされたWAVを返す
+
+        Args:
+            text: 合成するテキスト
+            lang: 言語コード（現在は使用されないが、将来の拡張のために保持）
+            voice: ボイス名（未指定時はデフォルトボイスを使用）
+
+        Returns:
+            base64エンコードされたWAVデータ
+        """
+        if voice is None:
+            voice = self.DEFAULT_VOICE_EN
+
+        try:
+            async with httpx.AsyncClient(timeout=30) as client:
+                response = await client.post(
+                    f"{self.api_url}/v1/audio/speech",
+                    json={
+                        "model": "kokoro",
+                        "input": text,
+                        "voice": voice,
+                        "response_format": "wav",
+                    },
+                )
+
+                if response.status_code >= 400:
+                    raise RuntimeError(
+                        f"Kokoro TTS API Error {response.status_code}: {response.text}"
+                    )
+
+                wav_data = response.content
+                wav_b64 = base64.b64encode(wav_data).decode("utf-8")
+
+                logger.info(f"Kokoro TTS synthesis success: text_len={len(text)}")
+                return wav_b64
+
+        except httpx.TimeoutException as e:
+            logger.error(f"Kokoro TTS timeout: {e}")
+            raise RuntimeError(f"Kokoro TTS connection timeout: {e}")
+        except Exception as e:
+            logger.error(f"Kokoro TTS synthesis error: {e}", exc_info=True)
+            raise RuntimeError(f"Kokoro TTS synthesis error: {e}")
+
+
+# =============================================================================
 # VoiceAgent class (modified for provider switching + language detection + clarification)
 # =============================================================================
 
@@ -515,6 +586,11 @@ class VoiceAgent:
 
         self.clarification_agent = clarification_agent or ClarificationAgent()
         logger.info("ClarificationAgent initialized for voice_agent")
+
+        # Kokoro TTSクライアントを追加（英語TTS用）
+        kokoro_api_url = os.getenv("KOKORO_API_URL", "http://localhost:8880")
+        self.kokoro_client = KokoroTTSClient(api_url=kokoro_api_url)
+        logger.info(f"Kokoro TTS client initialized: {kokoro_api_url}")
 
     def _detect_category(self, text: str, language: str) -> Optional[ClarificationCategory]:
         """
@@ -602,20 +678,29 @@ class VoiceAgent:
             logger.warning("Text truncated to 5000 bytes")
 
         try:
-            # ステップ5: Provider ごとの呼び出し分岐
-            if self.tts_provider == "voicevox":
+            # ステップ5: 言語に基づいてTTSエンジンを選択
+            if language == "en":
+                # 英語 → Kokoro TTS
+                audio_b64 = await self.kokoro_client.synthesize_wav_base64(processed, language)
+                audio_format = "audio/wav"
+            elif self.tts_provider == "voicevox":
+                # 日本語 → VoiceVox
                 audio_b64 = await self.tts_client.synthesize_wav_base64(processed, language)
+                audio_format = "audio/wav"
             else:  # google
+                # Google TTS（既存のロジック）
                 tts_emotion = map_vrm_to_tts_emotion(vrm_emotion)
                 audio_b64 = await self.tts_client.synthesize_mp3_base64(
                     processed, language, tts_emotion
                 )
+                audio_format = "audio/mpeg"
+
             return {
                 "success": True,
                 "audioResponse": audio_b64,
                 "emotion": vrm_emotion,
                 "cleanText": processed,
-                "format": "audio/wav" if self.tts_provider == "voicevox" else "audio/mpeg",
+                "format": audio_format,
                 "language": language,
                 "ambiguity_resolved": ambiguity_category is not None,
             }
@@ -623,12 +708,20 @@ class VoiceAgent:
             logger.exception("TTS failed, trying fallback: %s", e)
             fb_text = fallback_error_message(language)
             try:
-                if self.tts_provider == "voicevox":
+                if language == "en":
+                    # 英語フォールバック → Kokoro TTS
+                    audio_b64 = await self.kokoro_client.synthesize_wav_base64(fb_text, language)
+                    audio_format = "audio/wav"
+                elif self.tts_provider == "voicevox":
+                    # 日本語フォールバック → VoiceVox
                     audio_b64 = await self.tts_client.synthesize_wav_base64(fb_text, language)
+                    audio_format = "audio/wav"
                 else:
+                    # Google TTSフォールバック
                     audio_b64 = await self.tts_client.synthesize_mp3_base64(
                         fb_text, language, "sad"
                     )
+                    audio_format = "audio/mpeg"
 
                 return {
                     "success": True,
@@ -636,7 +729,7 @@ class VoiceAgent:
                     "emotion": "sad",
                     "cleanText": fb_text,
                     "error": str(e),
-                    "format": "audio/wav" if self.tts_provider == "voicevox" else "audio/mpeg",
+                    "format": audio_format,
                 }
             except Exception as fallback_error:
                 logger.error(f"Fallback TTS also failed: {fallback_error}")

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -4,6 +4,7 @@ langchain>=0.3.0
 langchain-openai>=0.2.0
 langsmith>=0.1.0
 pydantic>=2.0.0
+pydantic-settings>=2.0.0
 fastapi>=0.115.0
 uvicorn[standard]>=0.30.0
 python-dotenv>=1.0.0
@@ -14,7 +15,7 @@ numpy>=1.24.0,<2.0
 scipy>=1.10.0
 google-generativeai>=0.8.0
 # Audio processing (STT/TTS)
-vosk>=0.3.45
+vosk>=0.3.44
 soundfile>=0.12.1
 
 # LangGraph Checkpointer (PostgreSQL)

--- a/backend/scripts/test_tts.py
+++ b/backend/scripts/test_tts.py
@@ -1,0 +1,66 @@
+"""
+日本語・英語 TTS の動作確認スクリプト
+
+VoiceVox（日本語）と Kokoro TTS（英語）を続けて試します。
+
+Usage:
+    プロジェクトルートから:
+        python -m backend.scripts.test_tts
+    backend から:
+        python -m scripts.test_tts
+"""
+
+import asyncio
+import sys
+
+
+def _ensure_path():
+    """backend から実行された場合にプロジェクトルートを path に追加"""
+    if "backend" not in sys.path and "backend.agents" not in str(sys.path):
+        try:
+            from pathlib import Path
+            backend_dir = Path(__file__).resolve().parent.parent
+            root = backend_dir.parent
+            if str(root) not in sys.path:
+                sys.path.insert(0, str(root))
+        except Exception:
+            pass
+
+
+async def main():
+    _ensure_path()
+    from backend.agents.voice_agent import VoiceAgent
+
+    agent = VoiceAgent(tts_provider="voicevox")
+
+    # 日本語
+    print("--- 日本語 TTS (VoiceVox) ---")
+    result_ja = await agent.text_to_speech("こんにちは、エンジニアカフェへようこそ！", language="ja")
+    print(f"  Success: {result_ja['success']}")
+    print(f"  Language: {result_ja.get('language')}")
+    print(f"  Format: {result_ja.get('format')}")
+    print(f"  Audio (base64 length): {len(result_ja.get('audioResponse', ''))}")
+    if not result_ja["success"]:
+        print(f"  Error: {result_ja.get('error')}")
+    print()
+
+    # 英語
+    print("--- 英語 TTS (Kokoro TTS) ---")
+    result_en = await agent.text_to_speech("Hello, welcome to Engineer Cafe!", language="en")
+    print(f"  Success: {result_en['success']}")
+    print(f"  Language: {result_en.get('language')}")
+    print(f"  Format: {result_en.get('format')}")
+    print(f"  Audio (base64 length): {len(result_en.get('audioResponse', ''))}")
+    if not result_en["success"]:
+        print(f"  Error: {result_en.get('error')}")
+    print()
+
+    if result_ja["success"] and result_en["success"]:
+        print("✅ 日本語・英語とも TTS 成功")
+    else:
+        print("⚠️ いずれかが失敗しています（VoiceVox / Kokoro TTS の起動を確認してください）")
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/backend/tests/agents/test_voice_agent.py
+++ b/backend/tests/agents/test_voice_agent.py
@@ -144,3 +144,93 @@ async def test_text_to_speech_fallback_on_error(monkeypatch):
     assert result["success"] is True
     assert result["audioResponse"] == "FALLBACK_BASE64"
     assert state["n"] == 2  # 1回失敗 + フォールバックで1回成功
+
+
+@pytest.mark.asyncio
+async def test_text_to_speech_routes_english_to_kokoro(monkeypatch):
+    """英語テキストがKokoro TTSにルーティングされることを確認"""
+    agent = VoiceAgent(tts_provider="voicevox")
+    kokoro_called = {"called": False}
+
+    async def fake_kokoro_synth(text, lang, voice=None):
+        kokoro_called["called"] = True
+        return "KOKORO_BASE64_WAV"
+
+    monkeypatch.setattr(agent.kokoro_client, "synthesize_wav_base64", fake_kokoro_synth)
+
+    result = await agent.text_to_speech(
+        text="Hello, how are you?",
+        language="en",
+    )
+
+    assert kokoro_called["called"] is True
+    assert result["success"] is True
+    assert result["audioResponse"] == "KOKORO_BASE64_WAV"
+    assert result["format"] == "audio/wav"
+    assert result["language"] == "en"
+
+
+@pytest.mark.asyncio
+async def test_text_to_speech_routes_japanese_to_voicevox(monkeypatch):
+    """日本語テキストがVoiceVoxにルーティングされることを確認"""
+    agent = VoiceAgent(tts_provider="voicevox")
+    voicevox_called = {"called": False}
+
+    async def fake_voicevox_synth(text, lang, speaker_id=None):
+        voicevox_called["called"] = True
+        return "VOICEVOX_BASE64_WAV"
+
+    monkeypatch.setattr(agent.tts_client, "synthesize_wav_base64", fake_voicevox_synth)
+
+    result = await agent.text_to_speech(
+        text="こんにちは、元気ですか？",
+        language="ja",
+    )
+
+    assert voicevox_called["called"] is True
+    assert result["success"] is True
+    assert result["audioResponse"] == "VOICEVOX_BASE64_WAV"
+    assert result["format"] == "audio/wav"
+    assert result["language"] == "ja"
+
+
+@pytest.mark.asyncio
+async def test_text_to_speech_auto_detects_language_and_routes(monkeypatch):
+    """言語自動検出が正しく動作し、適切なTTSエンジンにルーティングされることを確認"""
+    agent = VoiceAgent(tts_provider="voicevox")
+    kokoro_called = {"called": False}
+    voicevox_called = {"called": False}
+
+    async def fake_kokoro_synth(text, lang, voice=None):
+        kokoro_called["called"] = True
+        return "KOKORO_BASE64_WAV"
+
+    async def fake_voicevox_synth(text, lang, speaker_id=None):
+        voicevox_called["called"] = True
+        return "VOICEVOX_BASE64_WAV"
+
+    monkeypatch.setattr(agent.kokoro_client, "synthesize_wav_base64", fake_kokoro_synth)
+    monkeypatch.setattr(agent.tts_client, "synthesize_wav_base64", fake_voicevox_synth)
+
+    # 英語テキスト（言語未指定）
+    result_en = await agent.text_to_speech(
+        text="Hello, welcome to Engineer Cafe!",
+        language=None,  # 自動検出
+    )
+
+    assert kokoro_called["called"] is True
+    assert result_en["success"] is True
+    assert result_en["language"] == "en"
+
+    # リセット
+    kokoro_called["called"] = False
+
+    # 日本語テキスト（言語未指定）
+    result_ja = await agent.text_to_speech(
+        text="こんにちは、エンジニアカフェへようこそ！",
+        language=None,  # 自動検出
+    )
+
+    assert voicevox_called["called"] is True
+    assert result_ja["success"] is True
+    assert result_ja["language"] == "ja"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -49,6 +49,8 @@ services:
     depends_on:
       voicevox:
         condition: service_healthy
+      kokoro-tts:
+        condition: service_healthy
     networks:
       - engineer-cafe-network
     extra_hosts:
@@ -72,6 +74,21 @@ services:
     restart: unless-stopped
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:50021/version"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+
+  # Kokoro TTS Engine (Local) - for English TTS
+  kokoro-tts:
+    image: ghcr.io/remsky/kokoro-fastapi-cpu:latest
+    container_name: engineer-cafe-kokoro-tts
+    ports:
+      - "8880:8880"
+    networks:
+      - engineer-cafe-network
+    restart: unless-stopped
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:8880/v1/audio/voices"]
       interval: 10s
       timeout: 5s
       retries: 5


### PR DESCRIPTION
## 概要

Issue #65 の実装: 言語判定に基づいてTTSエンジンを自動切り替えし、英語テキストには Kokoro TTS を使用するようにしました。

## 変更内容

### 実装
- ✅ Kokoro TTS を英語TTSエンジンとして追加（ポート8880）
- ✅ `VoiceAgent` に言語判定ベースのルーティング実装
  - 日本語 → VoiceVox (port 50021)
  - 英語 → Kokoro TTS (port 8880)
- ✅ `KokoroTTSClient` クラス実装（`VoiceVoxClient` と同パターン）
- ✅ `docker-compose.yml` に Kokoro TTS サービス追加（ヘルスチェック付き）
- ✅ テスト追加（英語→Kokoro、日本語→VoiceVox分岐確認）
- ✅ ドキュメント更新（`SETUP_STT_TTS.md`）

### 変更ファイル
- `docker-compose.yml` - Kokoro TTS サービス追加
- `backend/agents/voice_agent.py` - KokoroTTSClient追加、ルーティング実装
- `backend/tests/agents/test_voice_agent.py` - テスト追加
- `backend/requirements.txt` - pydantic-settings追加
- `backend/SETUP_STT_TTS.md` - ドキュメント更新
- `backend/scripts/test_tts.py` - テストスクリプト追加（新規）

## 動作確認

- ✅ 日本語テキスト → VoiceVox で音声合成成功
- ✅ 英語テキスト → Kokoro TTS で音声合成成功
- ✅ テスト実行成功

## 参考

- [Kokoro FastAPI](https://github.com/remsky/Kokoro-FastAPI)
- [Issue #65](https://github.com/EngineerCafeJP/engineercafe-navigator/issues/65)

Closes #65
