### PR TITLE
エンジニアカフェ用語の認識精度向上・Vosk カスタム語彙管理API

### DIFF
--- a/backend/agents/stt_agent.py
+++ b/backend/agents/stt_agent.py
@@ -591,24 +591,46 @@ class STTAgent:
 
         return vosk_result
 
+    def _load_custom_vocabulary(self) -> List[str]:
+        """JSONファイルからカスタム語彙の単語リストを同期的に読み込む。
+
+        ファイルが存在しない場合やエラー時は空リストを返す。
+        """
+        try:
+            from api.stt_vocabulary import _load_vocabulary_sync
+
+            vocabulary = _load_vocabulary_sync()
+            return [v["word"] for v in vocabulary]
+        except Exception as e:
+            logger.warning(f"Failed to load custom vocabulary from JSON: {e}")
+            return []
+
     def _resolve_grammar(self, conversation_stage: Optional[str]) -> Optional[Dict[str, List[str]]]:
         """会話ステージに応じた Grammar 辞書を解決する。
 
+        JSONファイルのカスタム語彙をベースに、ステージ固有ワードを合成する。
+
         優先順位:
-        1. conversation_stage 指定あり → STAGE_GRAMMARS[stage]
-        2. use_grammar=True → ENGINEER_CAFE_GRAMMAR
+        1. conversation_stage 指定あり → STAGE_GRAMMARS[stage] + カスタム語彙
+        2. use_grammar=True → ENGINEER_CAFE_GRAMMAR + カスタム語彙
         3. それ以外 → None
         """
+        custom_words = self._load_custom_vocabulary()
+
+        def _merge(base: Dict[str, List[str]]) -> Dict[str, List[str]]:
+            """ベースgrammarにカスタム語彙を重複なしでマージする。"""
+            return {lang: list(dict.fromkeys(words + custom_words)) for lang, words in base.items()}
+
         if conversation_stage and conversation_stage in STAGE_GRAMMARS:
-            return STAGE_GRAMMARS[conversation_stage]
+            return _merge(STAGE_GRAMMARS[conversation_stage])
         if conversation_stage and conversation_stage not in STAGE_GRAMMARS:
             logger.warning(
                 f"Unknown conversation_stage '{conversation_stage}', "
                 f"falling back to ENGINEER_CAFE_GRAMMAR"
             )
-            return ENGINEER_CAFE_GRAMMAR
+            return _merge(ENGINEER_CAFE_GRAMMAR)
         if self.use_grammar:
-            return ENGINEER_CAFE_GRAMMAR
+            return _merge(ENGINEER_CAFE_GRAMMAR)
         return None
 
     async def speech_to_text(

--- a/backend/agents/stt_agent.py
+++ b/backend/agents/stt_agent.py
@@ -5,7 +5,12 @@ STTAgent - Speech-to-Text エージェント
 
 仕様:
 - 入力: WAV バイナリ（16kHz, 16bit, mono 推奨）
-- 出力: dict {success, transcript, confidence, provider, error}
+- 出力: dict {success, transcript, confidence, language, provider, error}
+
+機能:
+- 日英Voskモデル自動切換え（language=None 時に両モデル並列実行、confidence比較で選択）
+- word-level confidence 取得
+- ドメイン固有語彙のGrammarサポート（opt-in）
 
 注意:
 - Vosk モデルが存在しない場合は RuntimeError を投げ、ダウンロード案内を出します。
@@ -20,10 +25,193 @@ import io
 import json
 import logging
 import os
-from typing import Any, Dict, Optional
+from dataclasses import dataclass, field
+from typing import Any, Dict, List, Optional
 import concurrent.futures
 
 logger = logging.getLogger(__name__)
+
+
+# -----------------------------------------------------------------------------
+# TranscriptionResult
+# -----------------------------------------------------------------------------
+
+
+@dataclass
+class TranscriptionResult:
+    """Vosk 認識結果（confidence 付き）"""
+
+    text: str
+    confidence: Optional[float]  # 平均 word confidence (0.0-1.0)
+    language: str
+    word_confidences: List[Dict[str, Any]] = field(default_factory=list)
+
+
+# -----------------------------------------------------------------------------
+# Domain-specific grammar for Engineer Cafe (opt-in)
+# -----------------------------------------------------------------------------
+
+ENGINEER_CAFE_GRAMMAR: Dict[str, List[str]] = {
+    "ja": [
+        "エンジニアカフェ",
+        "エンジニアカフェラボ",
+        "営業時間",
+        "会議室",
+        "ミーティング",
+        "ミートアップ",
+        "集中スペース",
+        "メーカーズスペース",
+        "地下",
+        "赤煉瓦",
+        "天神",
+        "博多",
+        "ハカタ",
+        "福岡",
+        "ワイファイ",
+        "Wi-Fi",
+        "イベント",
+        "コワーキング",
+        "コワーキングスペース",
+        "予約",
+        "受付",
+        "料金",
+        "無料",
+        "駐車場",
+        "駐輪場",
+        "サイノ",
+    ],
+    "en": [
+        "engineer cafe",
+        "engineer cafe lab",
+        "business hours",
+        "meeting room",
+        "focus space",
+        "makers space",
+        "basement",
+        "red brick",
+        "tenjin",
+        "hakata",
+        "fukuoka",
+        "wifi",
+        "event",
+        "meetup",
+        "coworking",
+        "coworking space",
+        "reservation",
+        "reception",
+        "price",
+        "free",
+        "parking",
+        "saino",
+    ],
+}
+
+
+# -----------------------------------------------------------------------------
+# Stage-specific grammars (greeting -> service_selection -> confirmation)
+# -----------------------------------------------------------------------------
+
+STAGE_GRAMMARS: Dict[str, Dict[str, List[str]]] = {
+    "greeting": {
+        "ja": [
+            "こんにちは",
+            "おはようございます",
+            "こんばんは",
+            "すみません",
+            "はじめまして",
+            "エンジニアカフェ",
+            "受付",
+            "サイノ",
+        ],
+        "en": [
+            "hello",
+            "hi",
+            "good morning",
+            "good afternoon",
+            "excuse me",
+            "engineer cafe",
+            "reception",
+            "saino",
+        ],
+    },
+    "service_selection": {
+        "ja": [
+            "会議室",
+            "コワーキングスペース",
+            "コワーキング",
+            "集中スペース",
+            "メーカーズスペース",
+            "Wi-Fi",
+            "ワイファイ",
+            "イベント",
+            "ミートアップ",
+            "ミーティング",
+            "予約",
+            "料金",
+            "営業時間",
+            "駐車場",
+            "駐輪場",
+            "エンジニアカフェラボ",
+            "サイノ",
+        ],
+        "en": [
+            "meeting room",
+            "coworking space",
+            "coworking",
+            "focus space",
+            "makers space",
+            "wifi",
+            "event",
+            "meetup",
+            "reservation",
+            "price",
+            "business hours",
+            "parking",
+            "engineer cafe lab",
+            "saino",
+        ],
+    },
+    "confirmation": {
+        "ja": [
+            "はい",
+            "いいえ",
+            "そうです",
+            "違います",
+            "お願いします",
+            "キャンセル",
+            "ありがとう",
+            "ありがとうございます",
+            "了解",
+            "わかりました",
+        ],
+        "en": [
+            "yes",
+            "no",
+            "correct",
+            "that's right",
+            "cancel",
+            "please",
+            "thank you",
+            "thanks",
+            "okay",
+            "understood",
+        ],
+    },
+}
+
+VALID_STAGES = tuple(STAGE_GRAMMARS.keys())
+
+
+# -----------------------------------------------------------------------------
+# Default model paths
+# -----------------------------------------------------------------------------
+
+DEFAULT_MODEL_PATHS: Dict[str, str] = {
+    "ja": "models/vosk-model-ja",
+    "en": "models/vosk-model-en-us",
+}
+
+SUPPORTED_LANGUAGES = ("ja", "en")
 
 
 # -----------------------------------------------------------------------------
@@ -32,55 +220,50 @@ logger = logging.getLogger(__name__)
 
 
 class LocalSTTClient:
-    DEFAULT_MODEL_PATH_JA = "models/vosk-model-ja"
-    DEFAULT_MODEL_PATH_EN = "models/vosk-model-en-us"
-
-    def __init__(
-        self, model_path_ja: str = DEFAULT_MODEL_PATH_JA, model_path_en: str = DEFAULT_MODEL_PATH_EN
-    ):
-        self.model_path_ja = model_path_ja
-        self.model_path_en = model_path_en
-        self._model_ja = None
-        self._model_en = None
+    def __init__(self, model_paths: Optional[Dict[str, str]] = None):
+        self.model_paths = {**DEFAULT_MODEL_PATHS, **(model_paths or {})}
+        self._models: Dict[str, Any] = {}
         logger.info("LocalSTTClient initialized (models will be loaded on first use)")
 
     def _load_model(self, lang: str):
+        if lang not in self.model_paths:
+            raise ValueError(
+                f"Unsupported language: {lang}. Supported: {list(self.model_paths.keys())}"
+            )
+
+        if lang in self._models:
+            return self._models[lang]
+
         try:
             from vosk import Model
         except ImportError:
             logger.error("Vosk not installed. Install with: pip install vosk")
             raise RuntimeError("Vosk not installed. Install with: pip install vosk")
 
-        if lang == "ja":
-            if self._model_ja is None:
-                model_path = os.path.expanduser(self.model_path_ja)
-                if not os.path.exists(model_path):
-                    logger.warning(f"Vosk model not found at {model_path}")
-                    raise RuntimeError(
-                        f"Vosk model not found: {model_path}. Download from https://alphacephei.com/vosk/models"
-                    )
-                self._model_ja = Model(model_path)
-                logger.info(f"Loaded Vosk Japanese model from {model_path}")
-            return self._model_ja
+        model_path = os.path.expanduser(self.model_paths[lang])
+        if not os.path.exists(model_path):
+            logger.warning(f"Vosk model not found at {model_path}")
+            raise RuntimeError(
+                f"Vosk model not found: {model_path}. "
+                f"Download from https://alphacephei.com/vosk/models"
+            )
 
-        else:
-            if self._model_en is None:
-                model_path = os.path.expanduser(self.model_path_en)
-                if not os.path.exists(model_path):
-                    logger.warning(f"Vosk model not found at {model_path}")
-                    raise RuntimeError(
-                        f"Vosk model not found: {model_path}. Download from https://alphacephei.com/vosk/models"
-                    )
-                self._model_en = Model(model_path)
-                logger.info(f"Loaded Vosk English model from {model_path}")
-            return self._model_en
+        self._models[lang] = Model(model_path)
+        logger.info(f"Loaded Vosk {lang} model from {model_path}")
+        return self._models[lang]
 
-    def _sync_transcribe(self, audio_data: bytes, language: str = "ja") -> str:
+    def _sync_transcribe(
+        self,
+        audio_data: bytes,
+        language: str = "ja",
+        grammar: Optional[List[str]] = None,
+    ) -> TranscriptionResult:
         """Synchronous Vosk transcription (called via thread pool).
 
         注意: 入力は WAV (PCM) で、可能であれば 16kHz, 16bit, mono を推奨します。
         """
         import wave
+
         from vosk import KaldiRecognizer
 
         bio = io.BytesIO(audio_data)
@@ -95,7 +278,14 @@ class LocalSTTClient:
             )
 
         model = self._load_model(language)
-        rec = KaldiRecognizer(model, sample_rate)
+
+        if grammar:
+            grammar_json = json.dumps(grammar)
+            rec = KaldiRecognizer(model, sample_rate, grammar_json)
+        else:
+            rec = KaldiRecognizer(model, sample_rate)
+
+        rec.SetWords(True)
         rec.AcceptWaveform(frames)
         result_json = rec.FinalResult()
 
@@ -106,9 +296,22 @@ class LocalSTTClient:
             raise RuntimeError("Failed to parse Vosk recognition result")
 
         text = result.get("text", "")
-        if not text and isinstance(result.get("result"), list):
-            parts = [p.get("word", "") for p in result.get("result", [])]
-            text = " ".join([p for p in parts if p])
+
+        # Extract word-level confidences
+        word_results = result.get("result", [])
+        word_confidences = [
+            {"word": w.get("word", ""), "conf": w.get("conf", 0.0)} for w in word_results
+        ]
+
+        # Compute average confidence
+        if word_confidences:
+            avg_confidence = sum(w["conf"] for w in word_confidences) / len(word_confidences)
+        else:
+            avg_confidence = None
+
+        # Fallback: assemble text from word results
+        if not text and word_results:
+            text = " ".join(w.get("word", "") for w in word_results).strip()
 
         text = (text or "").strip()
         if not text:
@@ -116,17 +319,79 @@ class LocalSTTClient:
             raise RuntimeError("Vosk returned empty recognition result")
 
         logger.info(f"Vosk transcription success: {text[:100]}")
-        return text
+        return TranscriptionResult(
+            text=text,
+            confidence=avg_confidence,
+            language=language,
+            word_confidences=word_confidences,
+        )
 
-    async def transcribe(self, audio_data: bytes, language: str = "ja") -> str:
-        """WAVバイト列を受け取り、テキストを返します (thread pool経由)。"""
+    async def transcribe(
+        self,
+        audio_data: bytes,
+        language: str = "ja",
+        grammar: Optional[List[str]] = None,
+    ) -> TranscriptionResult:
+        """WAVバイト列を受け取り、TranscriptionResult を返します (thread pool経由)。"""
         try:
             loop = asyncio.get_running_loop()
             with concurrent.futures.ThreadPoolExecutor() as pool:
-                return await loop.run_in_executor(pool, self._sync_transcribe, audio_data, language)
+                return await loop.run_in_executor(
+                    pool,
+                    lambda: self._sync_transcribe(audio_data, language, grammar),
+                )
         except Exception as e:
             logger.exception("Vosk transcription error: %s", e)
             raise
+
+    async def transcribe_auto_detect(
+        self,
+        audio_data: bytes,
+        grammar: Optional[Dict[str, List[str]]] = None,
+    ) -> TranscriptionResult:
+        """日英両モデルで並列認識し、confidence が高い方の結果を返す。
+
+        Args:
+            audio_data: WAV bytes
+            grammar: 言語別 grammar dict, e.g. {"ja": [...], "en": [...]}
+
+        Returns:
+            confidence が高い方の TranscriptionResult
+        """
+
+        async def _run_model(lang: str) -> Optional[TranscriptionResult]:
+            lang_grammar = (grammar or {}).get(lang)
+            try:
+                return await self.transcribe(audio_data, lang, grammar=lang_grammar)
+            except RuntimeError as e:
+                logger.debug(f"Auto-detect: {lang} model returned error: {e}")
+                return None
+
+        results = await asyncio.gather(
+            _run_model("ja"),
+            _run_model("en"),
+        )
+
+        valid_results = [r for r in results if r is not None]
+
+        if not valid_results:
+            raise RuntimeError(
+                "Auto-detect failed: neither Japanese nor English model produced a result"
+            )
+
+        if len(valid_results) == 1:
+            return valid_results[0]
+
+        best = max(
+            valid_results,
+            key=lambda r: r.confidence if r.confidence is not None else 0.0,
+        )
+        other_langs = [r.language for r in valid_results if r is not best]
+        logger.info(
+            f"Auto-detect: selected {best.language} "
+            f"(confidence={best.confidence:.3f}) over {other_langs}"
+        )
+        return best
 
 
 # -----------------------------------------------------------------------------
@@ -141,6 +406,10 @@ class GoogleSTTClient:
             "GOOGLE_APPLICATION_CREDENTIALS"
         )
         logger.info("GoogleSTTClient initialized (credentials must be configured for use)")
+
+    def is_available(self) -> bool:
+        """Google Cloud STT の認証情報が設定されているか確認"""
+        return bool(self.credentials_source)
 
     def _sync_transcribe(self, audio_data: bytes, language: str = "ja") -> str:
         # Synchronous blocking call to Google Cloud Speech API
@@ -183,13 +452,23 @@ class GoogleSTTClient:
 
 
 # -----------------------------------------------------------------------------
-# STTAgent - provider switching
+# STTAgent - provider switching with auto-detection
 # -----------------------------------------------------------------------------
 
 
 class STTAgent:
-    def __init__(self, stt_provider: Optional[str] = None, stt_client: Optional[Any] = None):
+    def __init__(
+        self,
+        stt_provider: Optional[str] = None,
+        stt_client: Optional[Any] = None,
+        use_grammar: bool = False,
+        language_processor: Optional[Any] = None,
+        confidence_threshold: float = 0.4,
+        fallback_client: Optional[Any] = None,
+    ):
         self.stt_provider = stt_provider or os.getenv("STT_PROVIDER", "vosk")
+        self.use_grammar = use_grammar
+        self.confidence_threshold = confidence_threshold
         if stt_client:
             self.stt_client = stt_client
         elif self.stt_provider == "vosk":
@@ -199,27 +478,199 @@ class STTAgent:
         else:
             raise ValueError(f"Unknown STT provider: {self.stt_provider}")
 
-    async def speech_to_text(self, audio_data: bytes, language: str = "ja") -> Dict[str, Any]:
-        """Unified interface for speech-to-text
+        # #9: Fallback client (Google STT) for low-confidence Vosk results
+        if fallback_client is not None:
+            self.fallback_client = fallback_client
+        elif self.stt_provider == "vosk":
+            self.fallback_client = GoogleSTTClient()
+        else:
+            self.fallback_client = None
+
+        # #1: LanguageProcessor for post-validation of Vosk language detection
+        if language_processor is not None:
+            self.language_processor = language_processor
+        else:
+            try:
+                from backend.utils.language_processor import LanguageProcessor
+
+                self.language_processor = LanguageProcessor(default_language="ja")
+            except ImportError:
+                logger.warning("LanguageProcessor not available, skipping language validation")
+                self.language_processor = None
+
+    async def _validate_language(
+        self,
+        result: TranscriptionResult,
+        audio_data: bytes,
+    ) -> TranscriptionResult:
+        """LanguageProcessor で Vosk の言語選択を後検証し、不一致なら再認識を試行する。"""
+        if self.language_processor is None:
+            return result
+        if not isinstance(self.stt_client, LocalSTTClient):
+            return result
+
+        try:
+            lp_result = self.language_processor.detect_language(result.text)
+        except Exception as e:
+            logger.debug(f"LanguageProcessor failed: {e}")
+            return result
+
+        lp_lang = lp_result["detected"]
+        lp_confidence = lp_result["confidence"]
+
+        # 言語が一致、または LP の confidence が低ければそのまま返す
+        if lp_lang == result.language or lp_confidence < 0.7:
+            return result
+
+        # LP が ja/en 以外を示す場合は Vosk 結果を信頼
+        if lp_lang not in SUPPORTED_LANGUAGES:
+            return result
+
+        logger.info(
+            f"LanguageProcessor suggests '{lp_lang}' (conf={lp_confidence:.2f}) "
+            f"instead of Vosk '{result.language}', re-transcribing..."
+        )
+
+        try:
+            grammar_list = ENGINEER_CAFE_GRAMMAR.get(lp_lang) if self.use_grammar else None
+            alt_result = await self.stt_client.transcribe(audio_data, lp_lang, grammar=grammar_list)
+            if alt_result.confidence is not None and (
+                result.confidence is None or alt_result.confidence > result.confidence
+            ):
+                logger.info(
+                    f"Language corrected: {result.language} -> {lp_lang} "
+                    f"(conf {result.confidence} -> {alt_result.confidence})"
+                )
+                return alt_result
+        except RuntimeError as e:
+            logger.debug(f"Re-transcription with {lp_lang} failed: {e}")
+
+        return result
+
+    async def _try_fallback(
+        self,
+        audio_data: bytes,
+        language: str,
+        vosk_result: Dict[str, Any],
+    ) -> Dict[str, Any]:
+        """低信頼度の場合に Google STT でフォールバックを試行する。"""
+        if self.fallback_client is None:
+            return vosk_result
+
+        if (
+            hasattr(self.fallback_client, "is_available")
+            and not self.fallback_client.is_available()
+        ):
+            logger.debug("Google STT credentials not configured, skipping fallback")
+            return vosk_result
+
+        vosk_confidence = vosk_result.get("confidence")
+        if vosk_confidence is None or vosk_confidence >= self.confidence_threshold:
+            return vosk_result
+
+        logger.info(
+            f"Vosk confidence {vosk_confidence:.3f} < threshold {self.confidence_threshold}, "
+            f"attempting Google STT fallback..."
+        )
+
+        try:
+            google_transcript = await self.fallback_client.transcribe(audio_data, language)
+            if google_transcript and google_transcript.strip():
+                logger.info(f"Google STT fallback succeeded: {google_transcript[:100]}")
+                return {
+                    "success": True,
+                    "transcript": google_transcript,
+                    "confidence": None,
+                    "language": language,
+                    "provider": "google-fallback",
+                    "fallback_used": True,
+                    "original_confidence": vosk_confidence,
+                }
+        except Exception as e:
+            logger.warning(f"Google STT fallback failed: {e}, using Vosk result")
+
+        return vosk_result
+
+    def _resolve_grammar(self, conversation_stage: Optional[str]) -> Optional[Dict[str, List[str]]]:
+        """会話ステージに応じた Grammar 辞書を解決する。
+
+        優先順位:
+        1. conversation_stage 指定あり → STAGE_GRAMMARS[stage]
+        2. use_grammar=True → ENGINEER_CAFE_GRAMMAR
+        3. それ以外 → None
+        """
+        if conversation_stage and conversation_stage in STAGE_GRAMMARS:
+            return STAGE_GRAMMARS[conversation_stage]
+        if conversation_stage and conversation_stage not in STAGE_GRAMMARS:
+            logger.warning(
+                f"Unknown conversation_stage '{conversation_stage}', "
+                f"falling back to ENGINEER_CAFE_GRAMMAR"
+            )
+            return ENGINEER_CAFE_GRAMMAR
+        if self.use_grammar:
+            return ENGINEER_CAFE_GRAMMAR
+        return None
+
+    async def speech_to_text(
+        self,
+        audio_data: bytes,
+        language: Optional[str] = "ja",
+        conversation_stage: Optional[str] = None,
+    ) -> Dict[str, Any]:
+        """Unified interface for speech-to-text.
+
+        Args:
+            audio_data: WAV bytes
+            language: "ja", "en", or None for auto-detection
+            conversation_stage: "greeting", "service_selection", "confirmation", or None
 
         Returns:
-            {success: bool, transcript: str, confidence: Optional[float], provider: str, error: Optional[str]}
+            {success, transcript, confidence, language, provider, error}
         """
         provider = self.stt_provider
+        grammar = self._resolve_grammar(conversation_stage)
         try:
-            transcript = await self.stt_client.transcribe(audio_data, language)
-            return {
-                "success": True,
-                "transcript": transcript,
-                "confidence": None,
-                "provider": provider,
-            }
+            if language is None and isinstance(self.stt_client, LocalSTTClient):
+                result = await self.stt_client.transcribe_auto_detect(audio_data, grammar=grammar)
+            else:
+                lang = language or "ja"
+                if isinstance(self.stt_client, LocalSTTClient):
+                    grammar_list = (grammar or {}).get(lang) if grammar else None
+                    result = await self.stt_client.transcribe(
+                        audio_data, lang, grammar=grammar_list
+                    )
+                else:
+                    result = await self.stt_client.transcribe(audio_data, lang)
+
+            # Handle TranscriptionResult vs str (GoogleSTTClient returns str)
+            if isinstance(result, TranscriptionResult):
+                # #1: LanguageProcessor post-validation
+                validated = await self._validate_language(result, audio_data)
+                response = {
+                    "success": True,
+                    "transcript": validated.text,
+                    "confidence": validated.confidence,
+                    "language": validated.language,
+                    "provider": provider,
+                    "language_validated": validated is not result,
+                }
+                # #9: Low-confidence fallback to Google STT
+                return await self._try_fallback(audio_data, validated.language, response)
+            else:
+                return {
+                    "success": True,
+                    "transcript": result,
+                    "confidence": None,
+                    "language": language or "ja",
+                    "provider": provider,
+                }
         except Exception as e:
             logger.error(f"STT failed ({provider}): {e}")
             return {
                 "success": False,
                 "transcript": "",
                 "confidence": 0.0,
+                "language": language or "unknown",
                 "provider": provider,
                 "error": str(e),
             }

--- a/backend/api/stt_vocabulary.py
+++ b/backend/api/stt_vocabulary.py
@@ -1,0 +1,271 @@
+"""
+STT Custom Vocabulary API Router
+
+Vosk STT の認識精度向上のためのカスタム語彙管理 API。
+語彙は backend/data/stt_vocabulary.json に保存される。
+"""
+
+import asyncio
+import base64
+import json
+import logging
+import os
+import uuid
+from datetime import datetime, timezone
+from typing import List, Literal, Optional
+
+from fastapi import APIRouter, HTTPException
+from pydantic import BaseModel, Field
+
+from backend.agents.stt_agent import LocalSTTClient
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(tags=["stt-vocabulary"])
+
+# JSONファイルのパス（このファイルから見た相対パスで解決）
+_DATA_DIR = os.path.join(os.path.dirname(os.path.dirname(__file__)), "data")
+VOCABULARY_FILE = os.path.join(_DATA_DIR, "stt_vocabulary.json")
+
+# ファイル読み書きの排他制御
+_file_lock = asyncio.Lock()
+
+VocabularyCategory = Literal["facility", "location", "service", "event"]
+
+
+# =============================================================================
+# Pydantic Models
+# =============================================================================
+
+
+class VocabularyItem(BaseModel):
+    id: str
+    word: str
+    reading: str
+    category: VocabularyCategory
+    priority: int = Field(default=5, ge=1, le=10)
+    created_at: str
+    updated_at: str
+
+
+class VocabularyCreateRequest(BaseModel):
+    word: str = Field(..., min_length=1, max_length=100)
+    reading: str = Field(..., min_length=1, max_length=100)
+    category: VocabularyCategory
+    priority: int = Field(default=5, ge=1, le=10)
+
+
+class VocabularyUpdateRequest(BaseModel):
+    word: Optional[str] = Field(None, min_length=1, max_length=100)
+    reading: Optional[str] = Field(None, min_length=1, max_length=100)
+    category: Optional[VocabularyCategory] = None
+    priority: Optional[int] = Field(None, ge=1, le=10)
+
+
+class VocabularyListResponse(BaseModel):
+    success: bool
+    data: List[VocabularyItem]
+    total: int
+
+
+class VocabularyResponse(BaseModel):
+    success: bool
+    data: Optional[VocabularyItem] = None
+    error: Optional[str] = None
+
+
+class VocabularyTestRequest(BaseModel):
+    audio_base64: str = Field(..., description="base64エンコードされたWAV音声データ")
+    language: str = Field(default="ja", pattern=r"^(ja|en)$")
+    category: Optional[VocabularyCategory] = Field(
+        None, description="テスト対象カテゴリ（未指定時は全語彙）"
+    )
+
+
+class VocabularyTestResponse(BaseModel):
+    success: bool
+    transcript: Optional[str] = None
+    grammar_words: List[str] = []
+    error: Optional[str] = None
+
+
+# =============================================================================
+# File I/O helpers
+# =============================================================================
+
+
+def _load_vocabulary_sync() -> List[dict]:
+    """JSONファイルから語彙一覧を同期的に読み込む"""
+    if not os.path.exists(VOCABULARY_FILE):
+        return []
+    with open(VOCABULARY_FILE, encoding="utf-8") as f:
+        data = json.load(f)
+    return data.get("vocabulary", [])
+
+
+def _save_vocabulary_sync(vocabulary: List[dict]) -> None:
+    """語彙一覧をJSONファイルに同期的に書き出す"""
+    os.makedirs(os.path.dirname(VOCABULARY_FILE), exist_ok=True)
+    with open(VOCABULARY_FILE, "w", encoding="utf-8") as f:
+        json.dump({"vocabulary": vocabulary}, f, ensure_ascii=False, indent=2)
+
+
+async def _load_vocabulary() -> List[dict]:
+    async with _file_lock:
+        loop = asyncio.get_running_loop()
+        return await loop.run_in_executor(None, _load_vocabulary_sync)
+
+
+async def _save_vocabulary(vocabulary: List[dict]) -> None:
+    async with _file_lock:
+        loop = asyncio.get_running_loop()
+        await loop.run_in_executor(None, _save_vocabulary_sync, vocabulary)
+
+
+def _now_iso() -> str:
+    return datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+# =============================================================================
+# Grammar helpers
+# =============================================================================
+
+
+def build_grammar_words(vocabulary: List[dict], category: Optional[str] = None) -> List[str]:
+    """語彙リストをVosk Grammar用の単語リストに変換する。
+
+    Args:
+        vocabulary: 語彙レコードのリスト
+        category: カテゴリフィルタ（未指定時は全語彙）
+
+    Returns:
+        ["word1", "word2", "[unk]"] 形式のリスト（[unk]で未知語も認識可能）
+    """
+    filtered = (
+        vocabulary if category is None else [v for v in vocabulary if v["category"] == category]
+    )
+    # priority降順でソート
+    filtered = sorted(filtered, key=lambda v: v.get("priority", 5), reverse=True)
+    words = [v["word"] for v in filtered]
+    words.append("[unk]")
+    return words
+
+
+# =============================================================================
+# Endpoints
+# =============================================================================
+
+
+@router.get("/stt/vocabulary", response_model=VocabularyListResponse)
+async def list_vocabulary(category: Optional[VocabularyCategory] = None):
+    """登録済みカスタム語彙一覧取得"""
+    vocabulary = await _load_vocabulary()
+    if category:
+        vocabulary = [v for v in vocabulary if v["category"] == category]
+    items = [VocabularyItem(**v) for v in vocabulary]
+    return VocabularyListResponse(success=True, data=items, total=len(items))
+
+
+@router.post("/stt/vocabulary/test", response_model=VocabularyTestResponse)
+async def test_vocabulary(request: VocabularyTestRequest):
+    """テスト音声で認識精度確認
+
+    base64エンコードされたWAVを受け取り、カスタム語彙Grammarを使って
+    Voskで認識し結果を返す。
+    """
+    try:
+        audio_bytes = base64.b64decode(request.audio_base64)
+    except Exception:
+        raise HTTPException(status_code=400, detail="Invalid base64 audio data")
+
+    vocabulary = await _load_vocabulary()
+    grammar_words = build_grammar_words(vocabulary, category=request.category)
+
+    try:
+        client = LocalSTTClient()
+        result = await client.transcribe(
+            audio_bytes, language=request.language, grammar=grammar_words
+        )
+        return VocabularyTestResponse(
+            success=True,
+            transcript=result.text,
+            grammar_words=grammar_words,
+        )
+    except Exception as e:
+        logger.error("STT test failed: %s", e)
+        return VocabularyTestResponse(
+            success=False,
+            grammar_words=grammar_words,
+            error=str(e),
+        )
+
+
+@router.post("/stt/vocabulary", response_model=VocabularyResponse, status_code=201)
+async def create_vocabulary(request: VocabularyCreateRequest):
+    """語彙追加"""
+    vocabulary = await _load_vocabulary()
+
+    # 重複チェック
+    if any(v["word"] == request.word for v in vocabulary):
+        raise HTTPException(status_code=409, detail=f"Word '{request.word}' already exists")
+
+    now = _now_iso()
+    new_item = {
+        "id": str(uuid.uuid4()),
+        "word": request.word,
+        "reading": request.reading,
+        "category": request.category,
+        "priority": request.priority,
+        "created_at": now,
+        "updated_at": now,
+    }
+    vocabulary.append(new_item)
+    await _save_vocabulary(vocabulary)
+
+    return VocabularyResponse(success=True, data=VocabularyItem(**new_item))
+
+
+@router.put("/stt/vocabulary/{vocabulary_id}", response_model=VocabularyResponse)
+async def update_vocabulary(vocabulary_id: str, request: VocabularyUpdateRequest):
+    """語彙編集"""
+    vocabulary = await _load_vocabulary()
+
+    idx = next((i for i, v in enumerate(vocabulary) if v["id"] == vocabulary_id), None)
+    if idx is None:
+        raise HTTPException(status_code=404, detail="Vocabulary entry not found")
+
+    # word変更時の重複チェック
+    if request.word and request.word != vocabulary[idx]["word"]:
+        if any(v["word"] == request.word for v in vocabulary):
+            raise HTTPException(status_code=409, detail=f"Word '{request.word}' already exists")
+
+    item = vocabulary[idx]
+    if request.word is not None:
+        item["word"] = request.word
+    if request.reading is not None:
+        item["reading"] = request.reading
+    if request.category is not None:
+        item["category"] = request.category
+    if request.priority is not None:
+        item["priority"] = request.priority
+    item["updated_at"] = _now_iso()
+
+    vocabulary[idx] = item
+    await _save_vocabulary(vocabulary)
+
+    return VocabularyResponse(success=True, data=VocabularyItem(**item))
+
+
+@router.delete("/stt/vocabulary/{vocabulary_id}", response_model=VocabularyResponse)
+async def delete_vocabulary(vocabulary_id: str):
+    """語彙削除"""
+    vocabulary = await _load_vocabulary()
+
+    idx = next((i for i, v in enumerate(vocabulary) if v["id"] == vocabulary_id), None)
+    if idx is None:
+        raise HTTPException(status_code=404, detail="Vocabulary entry not found")
+
+    removed = vocabulary.pop(idx)
+    await _save_vocabulary(vocabulary)
+
+    return VocabularyResponse(success=True, data=VocabularyItem(**removed))

--- a/backend/data/stt_vocabulary.json
+++ b/backend/data/stt_vocabulary.json
@@ -1,0 +1,58 @@
+{
+  "vocabulary": [
+    {
+      "id": "a1b2c3d4-0001-0000-0000-000000000001",
+      "word": "エンジニアカフェ",
+      "reading": "えんじにあかふぇ",
+      "category": "facility",
+      "priority": 10,
+      "created_at": "2026-02-19T00:00:00Z",
+      "updated_at": "2026-02-19T00:00:00Z"
+    },
+    {
+      "id": "a1b2c3d4-0001-0000-0000-000000000002",
+      "word": "博多",
+      "reading": "はかた",
+      "category": "location",
+      "priority": 8,
+      "created_at": "2026-02-19T00:00:00Z",
+      "updated_at": "2026-02-19T00:00:00Z"
+    },
+    {
+      "id": "a1b2c3d4-0001-0000-0000-000000000003",
+      "word": "天神",
+      "reading": "てんじん",
+      "category": "location",
+      "priority": 8,
+      "created_at": "2026-02-19T00:00:00Z",
+      "updated_at": "2026-02-19T00:00:00Z"
+    },
+    {
+      "id": "a1b2c3d4-0001-0000-0000-000000000004",
+      "word": "コワーキングスペース",
+      "reading": "こわーきんぐすぺーす",
+      "category": "service",
+      "priority": 7,
+      "created_at": "2026-02-19T00:00:00Z",
+      "updated_at": "2026-02-19T00:00:00Z"
+    },
+    {
+      "id": "a1b2c3d4-0001-0000-0000-000000000005",
+      "word": "ミートアップ",
+      "reading": "みーとあっぷ",
+      "category": "event",
+      "priority": 7,
+      "created_at": "2026-02-19T00:00:00Z",
+      "updated_at": "2026-02-19T00:00:00Z"
+    },
+    {
+      "id": "a1b2c3d4-0001-0000-0000-000000000006",
+      "word": "Wi-Fi",
+      "reading": "わいふぁい",
+      "category": "service",
+      "priority": 6,
+      "created_at": "2026-02-19T00:00:00Z",
+      "updated_at": "2026-02-19T00:00:00Z"
+    }
+  ]
+}

--- a/backend/main.py
+++ b/backend/main.py
@@ -32,7 +32,7 @@ app.add_middleware(
     CORSMiddleware,
     allow_origins=_allowed_origins,
     allow_credentials=True,
-    allow_methods=["GET", "POST", "OPTIONS"],
+    allow_methods=["GET", "POST", "PUT", "DELETE", "OPTIONS"],
     allow_headers=["Content-Type", "Authorization"],
 )
 
@@ -347,6 +347,11 @@ async def character_api(request: CharacterRequest):
 from api.knowledge import router as knowledge_router  # noqa: E402
 
 app.include_router(knowledge_router, prefix="/api")
+
+# STT Custom Vocabulary API Router
+from api.stt_vocabulary import router as stt_vocabulary_router  # noqa: E402
+
+app.include_router(stt_vocabulary_router, prefix="/api")
 
 
 if __name__ == "__main__":

--- a/backend/main.py
+++ b/backend/main.py
@@ -123,6 +123,7 @@ class VoiceRequest(BaseModel):
     language: Optional[str] = "ja"
     text: Optional[str] = None
     streaming: Optional[bool] = False
+    conversationStage: Optional[str] = None
 
 
 class VoiceResponse(BaseModel):
@@ -133,6 +134,8 @@ class VoiceResponse(BaseModel):
     emotion: Optional[str] = None
     sessionId: Optional[str] = None
     error: Optional[str] = None
+    detectedLanguage: Optional[str] = None
+    confidence: Optional[float] = None
 
 
 # @app.post("/api/voice", response_model=VoiceResponse)
@@ -166,8 +169,10 @@ class VoiceResponse(BaseModel):
 
 # backend/main.py（PR3差分イメージ）
 from agents.voice_agent import VoiceAgent  # noqa: E402 # 追加
+from agents.stt_agent import STTAgent  # noqa: E402
 
 voice_agent = VoiceAgent()  # アプリ起動時に1回生成
+stt_agent = STTAgent()  # STT: Vosk自動言語切換え対応
 
 
 @app.post("/api/voice", response_model=VoiceResponse)
@@ -198,12 +203,32 @@ async def voice_api(request: VoiceRequest):
             )
 
         elif request.action == "process_voice":
-            # Phase1では未実装のままでOK
+            if not request.audioData:
+                raise HTTPException(status_code=400, detail="Missing audioData for process_voice")
+
+            import base64
+
+            audio_bytes = base64.b64decode(request.audioData)
+
+            stt_result = await stt_agent.speech_to_text(
+                audio_bytes,
+                language=request.language,
+                conversation_stage=request.conversationStage,
+            )
+
+            if not stt_result["success"]:
+                return VoiceResponse(
+                    success=False,
+                    error=stt_result.get("error", "STT failed"),
+                    sessionId=request.sessionId,
+                )
+
             return VoiceResponse(
                 success=True,
-                transcript="音声処理中...",
-                response="音声処理機能は実装中です。",
+                transcript=stt_result["transcript"],
                 emotion="neutral",
+                detectedLanguage=stt_result.get("language"),
+                confidence=stt_result.get("confidence"),
                 sessionId=request.sessionId,
             )
 

--- a/backend/tests/agents/test_stt_agent.py
+++ b/backend/tests/agents/test_stt_agent.py
@@ -570,7 +570,8 @@ class TestSTTAgentAutoDetect:
         mock_client.transcribe.assert_awaited_once()
 
     @pytest.mark.asyncio
-    async def test_auto_detect_with_grammar_enabled(self):
+    @patch.object(STTAgent, "_load_custom_vocabulary", return_value=[])
+    async def test_auto_detect_with_grammar_enabled(self, _mock_vocab):
         """STTAgent with use_grammar=True passes grammar to auto-detect"""
         mock_client = MagicMock(spec=LocalSTTClient)
         mock_client.transcribe_auto_detect = AsyncMock(
@@ -861,7 +862,8 @@ class TestStageGrammar:
             assert stage in VALID_STAGES
 
     @pytest.mark.asyncio
-    async def test_stage_grammar_greeting(self):
+    @patch.object(STTAgent, "_load_custom_vocabulary", return_value=[])
+    async def test_stage_grammar_greeting(self, _mock_vocab):
         """greeting stage uses STAGE_GRAMMARS['greeting']"""
         mock_client = MagicMock(spec=LocalSTTClient)
         mock_client.transcribe = AsyncMock(
@@ -886,7 +888,8 @@ class TestStageGrammar:
         assert grammar_arg == STAGE_GRAMMARS["greeting"]["ja"]
 
     @pytest.mark.asyncio
-    async def test_stage_grammar_service_selection(self):
+    @patch.object(STTAgent, "_load_custom_vocabulary", return_value=[])
+    async def test_stage_grammar_service_selection(self, _mock_vocab):
         """service_selection stage uses STAGE_GRAMMARS['service_selection']"""
         mock_client = MagicMock(spec=LocalSTTClient)
         mock_client.transcribe = AsyncMock(
@@ -911,7 +914,8 @@ class TestStageGrammar:
         assert grammar_arg == STAGE_GRAMMARS["service_selection"]["en"]
 
     @pytest.mark.asyncio
-    async def test_stage_grammar_confirmation(self):
+    @patch.object(STTAgent, "_load_custom_vocabulary", return_value=[])
+    async def test_stage_grammar_confirmation(self, _mock_vocab):
         """confirmation stage uses STAGE_GRAMMARS['confirmation']"""
         mock_client = MagicMock(spec=LocalSTTClient)
         mock_client.transcribe = AsyncMock(

--- a/backend/tests/agents/test_stt_agent.py
+++ b/backend/tests/agents/test_stt_agent.py
@@ -7,7 +7,15 @@ import wave
 import numpy as np
 from unittest.mock import AsyncMock, MagicMock, patch
 
-from backend.agents.stt_agent import LocalSTTClient, GoogleSTTClient, STTAgent
+from backend.agents.stt_agent import (
+    LocalSTTClient,
+    GoogleSTTClient,
+    STTAgent,
+    TranscriptionResult,
+    ENGINEER_CAFE_GRAMMAR,
+    STAGE_GRAMMARS,
+    VALID_STAGES,
+)
 
 # ==============================================================================
 # Helpers: vosk mock context manager
@@ -68,18 +76,18 @@ class TestLocalSTTClient:
     def test_init_default_paths(self):
         """LocalSTTClient initializes with default Vosk model paths"""
         client = LocalSTTClient()
-        assert client.model_path_ja == "models/vosk-model-ja"
-        assert client.model_path_en == "models/vosk-model-en-us"
+        assert client.model_paths["ja"] == "models/vosk-model-ja"
+        assert client.model_paths["en"] == "models/vosk-model-en-us"
 
     def test_init_custom_paths(self):
         """LocalSTTClient accepts custom model paths"""
-        client = LocalSTTClient(model_path_ja="custom/ja", model_path_en="custom/en")
-        assert client.model_path_ja == "custom/ja"
-        assert client.model_path_en == "custom/en"
+        client = LocalSTTClient(model_paths={"ja": "custom/ja", "en": "custom/en"})
+        assert client.model_paths["ja"] == "custom/ja"
+        assert client.model_paths["en"] == "custom/en"
 
     def test_load_model_not_found_raises_error(self):
         """LocalSTTClient raises RuntimeError if Vosk model not found"""
-        client = LocalSTTClient(model_path_ja="/nonexistent/path")
+        client = LocalSTTClient(model_paths={"ja": "/nonexistent/path"})
 
         # Mock vosk import so the "model not found" path is reached even if vosk is not installed
         with _vosk_patched():
@@ -89,15 +97,20 @@ class TestLocalSTTClient:
         assert "not found" in str(exc_info.value).lower()
         assert "alphacephei.com" in str(exc_info.value)  # Download URL in error message
 
+    def test_load_model_unsupported_language(self):
+        """LocalSTTClient raises ValueError for unsupported language"""
+        client = LocalSTTClient()
+        with pytest.raises(ValueError, match="Unsupported language"):
+            client._load_model("fr")
+
     @pytest.mark.asyncio
     async def test_transcribe_vosk_success(self, test_wav_16khz):
-        """LocalSTTClient.transcribe returns text for valid WAV input"""
+        """LocalSTTClient.transcribe returns TranscriptionResult for valid WAV input"""
         client = LocalSTTClient()
 
-        # Mock Vosk's KaldiRecognizer
         mock_recognizer = MagicMock()
         mock_recognizer.FinalResult.return_value = json.dumps(
-            {"result": [{"conf": 1.0, "word": "こんにちは"}], "text": "こんにちは"}
+            {"result": [{"conf": 0.95, "word": "こんにちは"}], "text": "こんにちは"}
         )
 
         with _vosk_patched():
@@ -106,8 +119,11 @@ class TestLocalSTTClient:
                 mock_load.return_value = MagicMock()
 
                 result = await client.transcribe(test_wav_16khz, language="ja")
-                assert isinstance(result, str)
-                assert "こんにちは" in result
+                assert isinstance(result, TranscriptionResult)
+                assert result.text == "こんにちは"
+                assert result.confidence == pytest.approx(0.95)
+                assert result.language == "ja"
+                assert len(result.word_confidences) == 1
 
     @pytest.mark.asyncio
     async def test_transcribe_empty_result_raises_error(self, test_wav_16khz):
@@ -141,6 +157,240 @@ class TestLocalSTTClient:
 
 
 # ==============================================================================
+# Confidence Extraction Tests
+# ==============================================================================
+
+
+class TestConfidenceExtraction:
+    """Tests for word-level confidence extraction"""
+
+    @pytest.mark.asyncio
+    async def test_average_confidence_multiple_words(self, test_wav_16khz):
+        """Confidence is averaged across all words"""
+        client = LocalSTTClient()
+        mock_recognizer = MagicMock()
+        mock_recognizer.FinalResult.return_value = json.dumps(
+            {
+                "result": [
+                    {"conf": 0.9, "word": "エンジニア"},
+                    {"conf": 0.8, "word": "カフェ"},
+                ],
+                "text": "エンジニア カフェ",
+            }
+        )
+
+        with _vosk_patched():
+            _vosk_mock.KaldiRecognizer.return_value = mock_recognizer
+            with patch("backend.agents.stt_agent.LocalSTTClient._load_model"):
+                result = await client.transcribe(test_wav_16khz, language="ja")
+                assert result.confidence == pytest.approx(0.85)
+                assert len(result.word_confidences) == 2
+
+    @pytest.mark.asyncio
+    async def test_no_word_results_confidence_none(self, test_wav_16khz):
+        """When Vosk returns text but no word-level results, confidence is None"""
+        client = LocalSTTClient()
+        mock_recognizer = MagicMock()
+        mock_recognizer.FinalResult.return_value = json.dumps({"text": "こんにちは"})
+
+        with _vosk_patched():
+            _vosk_mock.KaldiRecognizer.return_value = mock_recognizer
+            with patch("backend.agents.stt_agent.LocalSTTClient._load_model"):
+                result = await client.transcribe(test_wav_16khz, language="ja")
+                assert result.confidence is None
+                assert result.word_confidences == []
+
+    @pytest.mark.asyncio
+    async def test_set_words_called(self, test_wav_16khz):
+        """SetWords(True) is called on the recognizer"""
+        client = LocalSTTClient()
+        mock_recognizer = MagicMock()
+        mock_recognizer.FinalResult.return_value = json.dumps(
+            {"result": [{"conf": 1.0, "word": "test"}], "text": "test"}
+        )
+
+        with _vosk_patched():
+            _vosk_mock.KaldiRecognizer.return_value = mock_recognizer
+            with patch("backend.agents.stt_agent.LocalSTTClient._load_model"):
+                await client.transcribe(test_wav_16khz, language="en")
+                mock_recognizer.SetWords.assert_called_once_with(True)
+
+
+# ==============================================================================
+# Grammar Support Tests
+# ==============================================================================
+
+
+class TestGrammarSupport:
+    """Tests for domain-specific grammar support"""
+
+    @pytest.mark.asyncio
+    async def test_grammar_passed_to_recognizer(self, test_wav_16khz):
+        """When grammar is provided, KaldiRecognizer receives grammar JSON"""
+        client = LocalSTTClient()
+        mock_recognizer = MagicMock()
+        mock_recognizer.FinalResult.return_value = json.dumps(
+            {"result": [{"conf": 1.0, "word": "エンジニアカフェ"}], "text": "エンジニアカフェ"}
+        )
+
+        with _vosk_patched():
+            _vosk_mock.KaldiRecognizer.return_value = mock_recognizer
+            with patch("backend.agents.stt_agent.LocalSTTClient._load_model") as mock_load:
+                mock_load.return_value = MagicMock()
+                grammar = ["エンジニアカフェ", "営業時間"]
+                await client.transcribe(test_wav_16khz, language="ja", grammar=grammar)
+
+                # KaldiRecognizer called with 3 args (model, rate, grammar_json)
+                call_args = _vosk_mock.KaldiRecognizer.call_args
+                assert len(call_args[0]) == 3
+
+    @pytest.mark.asyncio
+    async def test_no_grammar_standard_recognizer(self, test_wav_16khz):
+        """Without grammar, KaldiRecognizer is called with 2 args"""
+        client = LocalSTTClient()
+        mock_recognizer = MagicMock()
+        mock_recognizer.FinalResult.return_value = json.dumps(
+            {"result": [{"conf": 1.0, "word": "テスト"}], "text": "テスト"}
+        )
+
+        with _vosk_patched():
+            _vosk_mock.KaldiRecognizer.return_value = mock_recognizer
+            with patch("backend.agents.stt_agent.LocalSTTClient._load_model"):
+                await client.transcribe(test_wav_16khz, language="ja")
+                call_args = _vosk_mock.KaldiRecognizer.call_args
+                assert len(call_args[0]) == 2
+
+    def test_grammar_constants_defined(self):
+        """ENGINEER_CAFE_GRAMMAR has ja and en entries"""
+        assert "ja" in ENGINEER_CAFE_GRAMMAR
+        assert "en" in ENGINEER_CAFE_GRAMMAR
+        assert len(ENGINEER_CAFE_GRAMMAR["ja"]) > 0
+        assert len(ENGINEER_CAFE_GRAMMAR["en"]) > 0
+
+
+# ==============================================================================
+# Auto-Detection Tests
+# ==============================================================================
+
+
+class TestAutoDetection:
+    """Tests for automatic language detection (dual-model)"""
+
+    @pytest.mark.asyncio
+    async def test_auto_detect_picks_higher_confidence(self, test_wav_16khz):
+        """Auto-detect selects the model with higher average confidence"""
+        client = LocalSTTClient()
+
+        ja_result = TranscriptionResult(
+            text="何か",
+            confidence=0.3,
+            language="ja",
+            word_confidences=[{"word": "何か", "conf": 0.3}],
+        )
+        en_result = TranscriptionResult(
+            text="hello",
+            confidence=0.95,
+            language="en",
+            word_confidences=[{"word": "hello", "conf": 0.95}],
+        )
+
+        with patch.object(client, "transcribe", new_callable=AsyncMock) as mock_transcribe:
+            mock_transcribe.side_effect = [ja_result, en_result]
+
+            result = await client.transcribe_auto_detect(test_wav_16khz)
+            assert result.language == "en"
+            assert result.text == "hello"
+            assert result.confidence == pytest.approx(0.95)
+
+    @pytest.mark.asyncio
+    async def test_auto_detect_picks_japanese(self, test_wav_16khz):
+        """Auto-detect selects Japanese when it has higher confidence"""
+        client = LocalSTTClient()
+
+        ja_result = TranscriptionResult(
+            text="こんにちは",
+            confidence=0.92,
+            language="ja",
+            word_confidences=[{"word": "こんにちは", "conf": 0.92}],
+        )
+        en_result = TranscriptionResult(
+            text="con itchy wa",
+            confidence=0.4,
+            language="en",
+            word_confidences=[{"word": "con", "conf": 0.4}],
+        )
+
+        with patch.object(client, "transcribe", new_callable=AsyncMock) as mock_transcribe:
+            mock_transcribe.side_effect = [ja_result, en_result]
+
+            result = await client.transcribe_auto_detect(test_wav_16khz)
+            assert result.language == "ja"
+            assert result.text == "こんにちは"
+
+    @pytest.mark.asyncio
+    async def test_auto_detect_fallback_when_one_fails(self, test_wav_16khz):
+        """If one model produces empty result, the other is used"""
+        client = LocalSTTClient()
+
+        en_result = TranscriptionResult(
+            text="hello",
+            confidence=0.8,
+            language="en",
+            word_confidences=[{"word": "hello", "conf": 0.8}],
+        )
+
+        with patch.object(client, "transcribe", new_callable=AsyncMock) as mock_transcribe:
+            mock_transcribe.side_effect = [
+                RuntimeError("Vosk returned empty recognition result"),
+                en_result,
+            ]
+
+            result = await client.transcribe_auto_detect(test_wav_16khz)
+            assert result.language == "en"
+
+    @pytest.mark.asyncio
+    async def test_auto_detect_both_fail_raises(self, test_wav_16khz):
+        """If both models fail, RuntimeError is raised"""
+        client = LocalSTTClient()
+
+        with patch.object(client, "transcribe", new_callable=AsyncMock) as mock_transcribe:
+            mock_transcribe.side_effect = RuntimeError("Vosk returned empty recognition result")
+
+            with pytest.raises(RuntimeError, match="Auto-detect failed"):
+                await client.transcribe_auto_detect(test_wav_16khz)
+
+    @pytest.mark.asyncio
+    async def test_auto_detect_with_grammar(self, test_wav_16khz):
+        """Auto-detect passes per-language grammar to each model"""
+        client = LocalSTTClient()
+
+        ja_result = TranscriptionResult(
+            text="エンジニアカフェ",
+            confidence=0.99,
+            language="ja",
+            word_confidences=[{"word": "エンジニアカフェ", "conf": 0.99}],
+        )
+        en_result = TranscriptionResult(
+            text="engineer cafe",
+            confidence=0.7,
+            language="en",
+            word_confidences=[{"word": "engineer", "conf": 0.7}],
+        )
+
+        with patch.object(client, "transcribe", new_callable=AsyncMock) as mock_transcribe:
+            mock_transcribe.side_effect = [ja_result, en_result]
+
+            grammar = {"ja": ["エンジニアカフェ"], "en": ["engineer cafe"]}
+            result = await client.transcribe_auto_detect(test_wav_16khz, grammar=grammar)
+
+            assert result.language == "ja"
+            # Verify grammar was passed to each call
+            calls = mock_transcribe.call_args_list
+            assert calls[0].kwargs.get("grammar") == ["エンジニアカフェ"]
+            assert calls[1].kwargs.get("grammar") == ["engineer cafe"]
+
+
+# ==============================================================================
 # GoogleSTTClient Tests
 # ==============================================================================
 
@@ -167,7 +417,7 @@ class TestGoogleSTTClient:
 
 
 # ==============================================================================
-# STTAgent Tests (Provider Switching)
+# STTAgent Tests (Provider Switching + Auto-Detection)
 # ==============================================================================
 
 
@@ -207,19 +457,37 @@ class TestSTTAgent:
         agent = STTAgent(stt_client=mock_client)
         assert agent.stt_client is mock_client
 
+    def test_init_use_grammar_default_false(self):
+        """STTAgent use_grammar defaults to False"""
+        with patch("backend.agents.stt_agent.LocalSTTClient"):
+            agent = STTAgent()
+            assert agent.use_grammar is False
+
+    def test_init_use_grammar_true(self):
+        """STTAgent accepts use_grammar=True"""
+        with patch("backend.agents.stt_agent.LocalSTTClient"):
+            agent = STTAgent(use_grammar=True)
+            assert agent.use_grammar is True
+
     @pytest.mark.asyncio
-    async def test_speech_to_text_success(self):
-        """STTAgent.speech_to_text returns unified success response"""
-        mock_client = AsyncMock()
-        mock_client.transcribe.return_value = "Test transcript"
+    async def test_speech_to_text_success_with_confidence(self):
+        """STTAgent.speech_to_text returns confidence from TranscriptionResult"""
+        mock_client = AsyncMock(spec=LocalSTTClient)
+        mock_client.transcribe.return_value = TranscriptionResult(
+            text="こんにちは",
+            confidence=0.88,
+            language="ja",
+            word_confidences=[{"word": "こんにちは", "conf": 0.88}],
+        )
 
         agent = STTAgent(stt_provider="vosk", stt_client=mock_client)
         result = await agent.speech_to_text(b"test_audio", language="ja")
 
         assert result["success"] is True
-        assert result["transcript"] == "Test transcript"
+        assert result["transcript"] == "こんにちは"
         assert result["provider"] == "vosk"
-        assert result["confidence"] is None
+        assert result["confidence"] == pytest.approx(0.88)
+        assert result["language"] == "ja"
 
     @pytest.mark.asyncio
     async def test_speech_to_text_failure(self):
@@ -235,6 +503,124 @@ class TestSTTAgent:
         assert result["confidence"] == 0.0
         assert result["provider"] == "vosk"
         assert "Vosk error" in result["error"]
+        assert result["language"] == "ja"
+
+    @pytest.mark.asyncio
+    async def test_speech_to_text_google_returns_str(self):
+        """STTAgent handles GoogleSTTClient string return type"""
+        mock_client = AsyncMock()
+        mock_client.transcribe.return_value = "Hello world"
+
+        agent = STTAgent(stt_provider="google", stt_client=mock_client)
+        result = await agent.speech_to_text(b"test_audio", language="en")
+
+        assert result["success"] is True
+        assert result["transcript"] == "Hello world"
+        assert result["confidence"] is None
+        assert result["language"] == "en"
+
+
+# ==============================================================================
+# STTAgent Auto-Detection Tests
+# ==============================================================================
+
+
+class TestSTTAgentAutoDetect:
+    """Tests for STTAgent auto-detection integration"""
+
+    @pytest.mark.asyncio
+    async def test_language_none_triggers_auto_detect(self):
+        """STTAgent with language=None uses auto-detect"""
+        mock_client = MagicMock(spec=LocalSTTClient)
+        mock_client.transcribe_auto_detect = AsyncMock(
+            return_value=TranscriptionResult(
+                text="hello",
+                confidence=0.9,
+                language="en",
+                word_confidences=[],
+            )
+        )
+
+        agent = STTAgent(stt_provider="vosk", stt_client=mock_client)
+        result = await agent.speech_to_text(b"audio", language=None)
+
+        assert result["success"] is True
+        assert result["language"] == "en"
+        assert result["confidence"] == pytest.approx(0.9)
+        mock_client.transcribe_auto_detect.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_explicit_language_uses_single_model(self):
+        """STTAgent with explicit language uses single model (no auto-detect)"""
+        mock_client = MagicMock(spec=LocalSTTClient)
+        mock_client.transcribe = AsyncMock(
+            return_value=TranscriptionResult(
+                text="こんにちは",
+                confidence=0.85,
+                language="ja",
+                word_confidences=[],
+            )
+        )
+
+        agent = STTAgent(stt_provider="vosk", stt_client=mock_client)
+        result = await agent.speech_to_text(b"audio", language="ja")
+
+        assert result["success"] is True
+        assert result["language"] == "ja"
+        mock_client.transcribe.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_auto_detect_with_grammar_enabled(self):
+        """STTAgent with use_grammar=True passes grammar to auto-detect"""
+        mock_client = MagicMock(spec=LocalSTTClient)
+        mock_client.transcribe_auto_detect = AsyncMock(
+            return_value=TranscriptionResult(
+                text="エンジニアカフェ",
+                confidence=0.95,
+                language="ja",
+                word_confidences=[],
+            )
+        )
+
+        agent = STTAgent(stt_provider="vosk", stt_client=mock_client, use_grammar=True)
+        await agent.speech_to_text(b"audio", language=None)
+
+        call_kwargs = mock_client.transcribe_auto_detect.call_args.kwargs
+        assert call_kwargs["grammar"] == ENGINEER_CAFE_GRAMMAR
+
+    @pytest.mark.asyncio
+    async def test_auto_detect_without_grammar(self):
+        """STTAgent with use_grammar=False passes None grammar"""
+        mock_client = MagicMock(spec=LocalSTTClient)
+        mock_client.transcribe_auto_detect = AsyncMock(
+            return_value=TranscriptionResult(
+                text="hello",
+                confidence=0.9,
+                language="en",
+                word_confidences=[],
+            )
+        )
+
+        agent = STTAgent(stt_provider="vosk", stt_client=mock_client, use_grammar=False)
+        await agent.speech_to_text(b"audio", language=None)
+
+        call_kwargs = mock_client.transcribe_auto_detect.call_args.kwargs
+        assert call_kwargs["grammar"] is None
+
+    @pytest.mark.asyncio
+    async def test_auto_detect_failure_returns_error_dict(self):
+        """STTAgent auto-detect failure returns error response"""
+        mock_client = MagicMock(spec=LocalSTTClient)
+        mock_client.transcribe_auto_detect = AsyncMock(
+            side_effect=RuntimeError("Auto-detect failed: neither model produced a result")
+        )
+
+        agent = STTAgent(stt_provider="vosk", stt_client=mock_client)
+        result = await agent.speech_to_text(b"audio", language=None)
+
+        assert result["success"] is False
+        assert "Auto-detect failed" in result["error"]
+        assert result["language"] == "unknown"
 
 
 # ==============================================================================
@@ -248,25 +634,540 @@ async def test_stt_agent_with_mock_vosk():
     # Create mock Vosk recognizer
     mock_recognizer = MagicMock()
     mock_recognizer.FinalResult.return_value = json.dumps(
-        {"text": "エンジニアカフェについて教えてください"}
+        {
+            "result": [
+                {"conf": 0.92, "word": "エンジニアカフェ"},
+                {"conf": 0.88, "word": "について"},
+                {"conf": 0.90, "word": "教えてください"},
+            ],
+            "text": "エンジニアカフェについて教えてください",
+        }
     )
 
     with _vosk_patched():
         _vosk_mock.KaldiRecognizer.return_value = mock_recognizer
         with patch("backend.agents.stt_agent.LocalSTTClient._load_model"):
-            # Create agent with Vosk (default)
             agent = STTAgent(stt_provider="vosk")
 
-            # Generate test audio
             test_wav = generate_test_wav(sample_rate=16000)
-
-            # Transcribe
             result = await agent.speech_to_text(test_wav, language="ja")
 
-            # Verify result structure
             assert result["success"] is True
             assert result["provider"] == "vosk"
             assert "カフェ" in result["transcript"]
+            assert result["confidence"] is not None
+            assert result["confidence"] > 0.8
+            assert result["language"] == "ja"
+
+
+@pytest.mark.asyncio
+async def test_stt_agent_auto_detect_integration():
+    """Integration test: STTAgent auto-detect with mocked Vosk"""
+
+    call_count = 0
+
+    def make_recognizer(*args, **kwargs):
+        nonlocal call_count
+        call_count += 1
+        rec = MagicMock()
+        if call_count % 2 == 1:
+            # Japanese model (low confidence for English audio)
+            rec.FinalResult.return_value = json.dumps(
+                {
+                    "result": [{"conf": 0.3, "word": "はろう"}],
+                    "text": "はろう",
+                }
+            )
+        else:
+            # English model (high confidence)
+            rec.FinalResult.return_value = json.dumps(
+                {
+                    "result": [{"conf": 0.95, "word": "hello"}],
+                    "text": "hello",
+                }
+            )
+        return rec
+
+    with _vosk_patched():
+        _vosk_mock.KaldiRecognizer.side_effect = make_recognizer
+        with patch("backend.agents.stt_agent.LocalSTTClient._load_model"):
+            agent = STTAgent(stt_provider="vosk")
+
+            test_wav = generate_test_wav(sample_rate=16000)
+            result = await agent.speech_to_text(test_wav, language=None)
+
+            assert result["success"] is True
+            assert result["language"] == "en"
+            assert result["transcript"] == "hello"
+            assert result["confidence"] == pytest.approx(0.95)
+
+
+# ==============================================================================
+# #1: LanguageProcessor Post-Validation Tests
+# ==============================================================================
+
+
+class TestLanguageProcessorValidation:
+    """Tests for LanguageProcessor post-validation of Vosk language detection"""
+
+    @pytest.mark.asyncio
+    async def test_language_processor_validates_language(self):
+        """LP confirms Vosk's language choice — no re-transcription"""
+        mock_client = MagicMock(spec=LocalSTTClient)
+        mock_client.transcribe = AsyncMock(
+            return_value=TranscriptionResult(
+                text="こんにちは",
+                confidence=0.9,
+                language="ja",
+                word_confidences=[{"word": "こんにちは", "conf": 0.9}],
+            )
+        )
+
+        mock_lp = MagicMock()
+        mock_lp.detect_language.return_value = {
+            "detected": "ja",
+            "confidence": 0.9,
+            "is_mixed": False,
+            "languages": {"ja": 0.9},
+        }
+
+        agent = STTAgent(
+            stt_provider="vosk",
+            stt_client=mock_client,
+            language_processor=mock_lp,
+            fallback_client=None,
+        )
+        result = await agent.speech_to_text(b"audio", language="ja")
+
+        assert result["success"] is True
+        assert result["language"] == "ja"
+        assert result["language_validated"] is False  # No correction needed
+
+    @pytest.mark.asyncio
+    async def test_language_processor_corrects_language(self):
+        """LP detects different language, re-transcription has higher confidence"""
+        mock_client = MagicMock(spec=LocalSTTClient)
+
+        original = TranscriptionResult(
+            text="con itchy wa",
+            confidence=0.4,
+            language="en",
+            word_confidences=[{"word": "con", "conf": 0.4}],
+        )
+        corrected = TranscriptionResult(
+            text="こんにちは",
+            confidence=0.92,
+            language="ja",
+            word_confidences=[{"word": "こんにちは", "conf": 0.92}],
+        )
+        mock_client.transcribe = AsyncMock(side_effect=[original, corrected])
+
+        mock_lp = MagicMock()
+        mock_lp.detect_language.return_value = {
+            "detected": "ja",
+            "confidence": 0.9,
+            "is_mixed": False,
+            "languages": {"ja": 0.9},
+        }
+
+        agent = STTAgent(
+            stt_provider="vosk",
+            stt_client=mock_client,
+            language_processor=mock_lp,
+            fallback_client=None,
+        )
+        result = await agent.speech_to_text(b"audio", language="en")
+
+        assert result["success"] is True
+        assert result["transcript"] == "こんにちは"
+        assert result["language"] == "ja"
+        assert result["language_validated"] is True
+
+    @pytest.mark.asyncio
+    async def test_language_processor_low_confidence_skips(self):
+        """LP confidence < 0.7 — skip language correction"""
+        mock_client = MagicMock(spec=LocalSTTClient)
+        mock_client.transcribe = AsyncMock(
+            return_value=TranscriptionResult(
+                text="hello",
+                confidence=0.6,
+                language="en",
+                word_confidences=[{"word": "hello", "conf": 0.6}],
+            )
+        )
+
+        mock_lp = MagicMock()
+        mock_lp.detect_language.return_value = {
+            "detected": "ja",
+            "confidence": 0.5,  # Low LP confidence
+            "is_mixed": True,
+            "languages": {"ja": 0.5, "en": 0.5},
+        }
+
+        agent = STTAgent(
+            stt_provider="vosk",
+            stt_client=mock_client,
+            language_processor=mock_lp,
+            fallback_client=None,
+        )
+        result = await agent.speech_to_text(b"audio", language="en")
+
+        assert result["success"] is True
+        assert result["language"] == "en"  # Original Vosk result kept
+        assert result["language_validated"] is False
+
+    @pytest.mark.asyncio
+    async def test_language_processor_none_skips_validation(self):
+        """When language_processor is None, no validation occurs"""
+        mock_client = MagicMock(spec=LocalSTTClient)
+        mock_client.transcribe = AsyncMock(
+            return_value=TranscriptionResult(
+                text="hello",
+                confidence=0.8,
+                language="en",
+                word_confidences=[{"word": "hello", "conf": 0.8}],
+            )
+        )
+
+        agent = STTAgent(
+            stt_provider="vosk",
+            stt_client=mock_client,
+            language_processor=None,
+            fallback_client=None,
+        )
+        result = await agent.speech_to_text(b"audio", language="en")
+
+        assert result["success"] is True
+        assert result["language_validated"] is False
+
+
+# ==============================================================================
+# #7: Stage Grammar Tests
+# ==============================================================================
+
+
+class TestStageGrammar:
+    """Tests for conversation stage-based grammar switching"""
+
+    def test_stage_grammars_constant_defined(self):
+        """STAGE_GRAMMARS has greeting, service_selection, confirmation"""
+        assert "greeting" in STAGE_GRAMMARS
+        assert "service_selection" in STAGE_GRAMMARS
+        assert "confirmation" in STAGE_GRAMMARS
+
+    def test_valid_stages_tuple(self):
+        """VALID_STAGES contains all stage keys"""
+        for stage in ("greeting", "service_selection", "confirmation"):
+            assert stage in VALID_STAGES
+
+    @pytest.mark.asyncio
+    async def test_stage_grammar_greeting(self):
+        """greeting stage uses STAGE_GRAMMARS['greeting']"""
+        mock_client = MagicMock(spec=LocalSTTClient)
+        mock_client.transcribe = AsyncMock(
+            return_value=TranscriptionResult(
+                text="こんにちは",
+                confidence=0.95,
+                language="ja",
+                word_confidences=[{"word": "こんにちは", "conf": 0.95}],
+            )
+        )
+
+        agent = STTAgent(
+            stt_provider="vosk",
+            stt_client=mock_client,
+            language_processor=None,
+            fallback_client=None,
+        )
+        await agent.speech_to_text(b"audio", language="ja", conversation_stage="greeting")
+
+        call_kwargs = mock_client.transcribe.call_args
+        grammar_arg = call_kwargs.kwargs.get("grammar") or call_kwargs[1].get("grammar")
+        assert grammar_arg == STAGE_GRAMMARS["greeting"]["ja"]
+
+    @pytest.mark.asyncio
+    async def test_stage_grammar_service_selection(self):
+        """service_selection stage uses STAGE_GRAMMARS['service_selection']"""
+        mock_client = MagicMock(spec=LocalSTTClient)
+        mock_client.transcribe = AsyncMock(
+            return_value=TranscriptionResult(
+                text="meeting room",
+                confidence=0.9,
+                language="en",
+                word_confidences=[{"word": "meeting", "conf": 0.9}],
+            )
+        )
+
+        agent = STTAgent(
+            stt_provider="vosk",
+            stt_client=mock_client,
+            language_processor=None,
+            fallback_client=None,
+        )
+        await agent.speech_to_text(b"audio", language="en", conversation_stage="service_selection")
+
+        call_kwargs = mock_client.transcribe.call_args
+        grammar_arg = call_kwargs.kwargs.get("grammar") or call_kwargs[1].get("grammar")
+        assert grammar_arg == STAGE_GRAMMARS["service_selection"]["en"]
+
+    @pytest.mark.asyncio
+    async def test_stage_grammar_confirmation(self):
+        """confirmation stage uses STAGE_GRAMMARS['confirmation']"""
+        mock_client = MagicMock(spec=LocalSTTClient)
+        mock_client.transcribe = AsyncMock(
+            return_value=TranscriptionResult(
+                text="はい",
+                confidence=0.99,
+                language="ja",
+                word_confidences=[{"word": "はい", "conf": 0.99}],
+            )
+        )
+
+        agent = STTAgent(
+            stt_provider="vosk",
+            stt_client=mock_client,
+            language_processor=None,
+            fallback_client=None,
+        )
+        await agent.speech_to_text(b"audio", language="ja", conversation_stage="confirmation")
+
+        call_kwargs = mock_client.transcribe.call_args
+        grammar_arg = call_kwargs.kwargs.get("grammar") or call_kwargs[1].get("grammar")
+        assert grammar_arg == STAGE_GRAMMARS["confirmation"]["ja"]
+
+    @pytest.mark.asyncio
+    async def test_stage_grammar_unknown_falls_back(self):
+        """Unknown stage falls back to ENGINEER_CAFE_GRAMMAR"""
+        mock_client = MagicMock(spec=LocalSTTClient)
+        mock_client.transcribe = AsyncMock(
+            return_value=TranscriptionResult(
+                text="テスト",
+                confidence=0.8,
+                language="ja",
+                word_confidences=[{"word": "テスト", "conf": 0.8}],
+            )
+        )
+
+        agent = STTAgent(
+            stt_provider="vosk",
+            stt_client=mock_client,
+            language_processor=None,
+            fallback_client=None,
+        )
+        await agent.speech_to_text(b"audio", language="ja", conversation_stage="unknown_stage")
+
+        call_kwargs = mock_client.transcribe.call_args
+        grammar_arg = call_kwargs.kwargs.get("grammar") or call_kwargs[1].get("grammar")
+        assert grammar_arg == ENGINEER_CAFE_GRAMMAR["ja"]
+
+    @pytest.mark.asyncio
+    async def test_stage_grammar_none_uses_default(self):
+        """No stage + use_grammar=True → ENGINEER_CAFE_GRAMMAR"""
+        mock_client = MagicMock(spec=LocalSTTClient)
+        mock_client.transcribe = AsyncMock(
+            return_value=TranscriptionResult(
+                text="エンジニアカフェ",
+                confidence=0.95,
+                language="ja",
+                word_confidences=[{"word": "エンジニアカフェ", "conf": 0.95}],
+            )
+        )
+
+        agent = STTAgent(
+            stt_provider="vosk",
+            stt_client=mock_client,
+            use_grammar=True,
+            language_processor=None,
+            fallback_client=None,
+        )
+        await agent.speech_to_text(b"audio", language="ja")
+
+        call_kwargs = mock_client.transcribe.call_args
+        grammar_arg = call_kwargs.kwargs.get("grammar") or call_kwargs[1].get("grammar")
+        assert grammar_arg == ENGINEER_CAFE_GRAMMAR["ja"]
+
+    @pytest.mark.asyncio
+    async def test_stage_grammar_none_no_grammar(self):
+        """No stage + use_grammar=False → no grammar"""
+        mock_client = MagicMock(spec=LocalSTTClient)
+        mock_client.transcribe = AsyncMock(
+            return_value=TranscriptionResult(
+                text="テスト",
+                confidence=0.8,
+                language="ja",
+                word_confidences=[{"word": "テスト", "conf": 0.8}],
+            )
+        )
+
+        agent = STTAgent(
+            stt_provider="vosk",
+            stt_client=mock_client,
+            use_grammar=False,
+            language_processor=None,
+            fallback_client=None,
+        )
+        await agent.speech_to_text(b"audio", language="ja")
+
+        call_kwargs = mock_client.transcribe.call_args
+        grammar_arg = call_kwargs.kwargs.get("grammar") or call_kwargs[1].get("grammar")
+        assert grammar_arg is None
+
+
+# ==============================================================================
+# #9: Low-Confidence Fallback Tests
+# ==============================================================================
+
+
+class TestLowConfidenceFallback:
+    """Tests for low-confidence fallback to Google STT"""
+
+    @pytest.mark.asyncio
+    async def test_fallback_triggered_on_low_confidence(self):
+        """Low Vosk confidence triggers Google STT fallback"""
+        mock_client = MagicMock(spec=LocalSTTClient)
+        mock_client.transcribe = AsyncMock(
+            return_value=TranscriptionResult(
+                text="あ",
+                confidence=0.2,
+                language="ja",
+                word_confidences=[{"word": "あ", "conf": 0.2}],
+            )
+        )
+
+        mock_fallback = MagicMock()
+        mock_fallback.is_available.return_value = True
+        mock_fallback.transcribe = AsyncMock(return_value="こんにちは")
+
+        agent = STTAgent(
+            stt_provider="vosk",
+            stt_client=mock_client,
+            language_processor=None,
+            fallback_client=mock_fallback,
+            confidence_threshold=0.4,
+        )
+        result = await agent.speech_to_text(b"audio", language="ja")
+
+        assert result["success"] is True
+        assert result["transcript"] == "こんにちは"
+        assert result["provider"] == "google-fallback"
+        assert result["fallback_used"] is True
+        assert result["original_confidence"] == pytest.approx(0.2)
+
+    @pytest.mark.asyncio
+    async def test_fallback_skipped_on_high_confidence(self):
+        """High Vosk confidence skips fallback"""
+        mock_client = MagicMock(spec=LocalSTTClient)
+        mock_client.transcribe = AsyncMock(
+            return_value=TranscriptionResult(
+                text="こんにちは",
+                confidence=0.9,
+                language="ja",
+                word_confidences=[{"word": "こんにちは", "conf": 0.9}],
+            )
+        )
+
+        mock_fallback = MagicMock()
+        mock_fallback.is_available.return_value = True
+        mock_fallback.transcribe = AsyncMock(return_value="should not be called")
+
+        agent = STTAgent(
+            stt_provider="vosk",
+            stt_client=mock_client,
+            language_processor=None,
+            fallback_client=mock_fallback,
+            confidence_threshold=0.4,
+        )
+        result = await agent.speech_to_text(b"audio", language="ja")
+
+        assert result["success"] is True
+        assert result["transcript"] == "こんにちは"
+        assert result["provider"] == "vosk"
+        assert result.get("fallback_used") is None
+        mock_fallback.transcribe.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_fallback_google_failure_returns_vosk_result(self):
+        """Google STT fails → Vosk result returned"""
+        mock_client = MagicMock(spec=LocalSTTClient)
+        mock_client.transcribe = AsyncMock(
+            return_value=TranscriptionResult(
+                text="あ",
+                confidence=0.2,
+                language="ja",
+                word_confidences=[{"word": "あ", "conf": 0.2}],
+            )
+        )
+
+        mock_fallback = MagicMock()
+        mock_fallback.is_available.return_value = True
+        mock_fallback.transcribe = AsyncMock(side_effect=RuntimeError("Google API error"))
+
+        agent = STTAgent(
+            stt_provider="vosk",
+            stt_client=mock_client,
+            language_processor=None,
+            fallback_client=mock_fallback,
+            confidence_threshold=0.4,
+        )
+        result = await agent.speech_to_text(b"audio", language="ja")
+
+        assert result["success"] is True
+        assert result["transcript"] == "あ"
+        assert result["provider"] == "vosk"
+
+    @pytest.mark.asyncio
+    async def test_fallback_no_credentials_skips(self):
+        """No Google credentials → fallback skipped"""
+        mock_client = MagicMock(spec=LocalSTTClient)
+        mock_client.transcribe = AsyncMock(
+            return_value=TranscriptionResult(
+                text="あ",
+                confidence=0.2,
+                language="ja",
+                word_confidences=[{"word": "あ", "conf": 0.2}],
+            )
+        )
+
+        mock_fallback = MagicMock()
+        mock_fallback.is_available.return_value = False
+
+        agent = STTAgent(
+            stt_provider="vosk",
+            stt_client=mock_client,
+            language_processor=None,
+            fallback_client=mock_fallback,
+            confidence_threshold=0.4,
+        )
+        result = await agent.speech_to_text(b"audio", language="ja")
+
+        assert result["success"] is True
+        assert result["transcript"] == "あ"
+        assert result["provider"] == "vosk"
+
+    @pytest.mark.asyncio
+    async def test_fallback_none_client_skips(self):
+        """fallback_client=None → no fallback attempted"""
+        mock_client = MagicMock(spec=LocalSTTClient)
+        mock_client.transcribe = AsyncMock(
+            return_value=TranscriptionResult(
+                text="あ",
+                confidence=0.2,
+                language="ja",
+                word_confidences=[{"word": "あ", "conf": 0.2}],
+            )
+        )
+
+        agent = STTAgent(
+            stt_provider="vosk",
+            stt_client=mock_client,
+            language_processor=None,
+            fallback_client=None,
+            confidence_threshold=0.4,
+        )
+        result = await agent.speech_to_text(b"audio", language="ja")
+
+        assert result["success"] is True
+        assert result["transcript"] == "あ"
 
 
 if __name__ == "__main__":

--- a/backend/tests/api/test_stt_vocabulary_api.py
+++ b/backend/tests/api/test_stt_vocabulary_api.py
@@ -1,0 +1,311 @@
+"""STT Custom Vocabulary API Tests"""
+
+import base64
+import io
+import wave
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+pytest.importorskip("fastapi", reason="fastapi not installed")
+
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from api.stt_vocabulary import router as stt_vocabulary_router
+
+_test_app = FastAPI()
+_test_app.include_router(stt_vocabulary_router, prefix="/api")
+client = TestClient(_test_app)
+
+
+# =============================================================================
+# Fixtures / helpers
+# =============================================================================
+
+SAMPLE_VOCABULARY = [
+    {
+        "id": "a1b2c3d4-0001-0000-0000-000000000001",
+        "word": "エンジニアカフェ",
+        "reading": "えんじにあかふぇ",
+        "category": "facility",
+        "priority": 10,
+        "created_at": "2026-02-19T00:00:00Z",
+        "updated_at": "2026-02-19T00:00:00Z",
+    },
+    {
+        "id": "a1b2c3d4-0001-0000-0000-000000000002",
+        "word": "博多",
+        "reading": "はかた",
+        "category": "location",
+        "priority": 8,
+        "created_at": "2026-02-19T00:00:00Z",
+        "updated_at": "2026-02-19T00:00:00Z",
+    },
+]
+
+
+def _make_wav_base64() -> str:
+    """テスト用のダミーWAVをbase64エンコードして返す（無音16kHz）"""
+    buf = io.BytesIO()
+    with wave.open(buf, "wb") as wf:
+        wf.setnchannels(1)
+        wf.setsampwidth(2)
+        wf.setframerate(16000)
+        wf.writeframes(b"\x00\x00" * 1600)  # 0.1秒分の無音
+    return base64.b64encode(buf.getvalue()).decode()
+
+
+# =============================================================================
+# GET /api/stt/vocabulary
+# =============================================================================
+
+
+@patch("api.stt_vocabulary._load_vocabulary")
+def test_list_vocabulary_all(mock_load):
+    mock_load.return_value = SAMPLE_VOCABULARY
+    resp = client.get("/api/stt/vocabulary")
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["success"] is True
+    assert body["total"] == 2
+    assert len(body["data"]) == 2
+
+
+@patch("api.stt_vocabulary._load_vocabulary")
+def test_list_vocabulary_filter_by_category(mock_load):
+    mock_load.return_value = SAMPLE_VOCABULARY
+    resp = client.get("/api/stt/vocabulary?category=facility")
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["total"] == 1
+    assert body["data"][0]["word"] == "エンジニアカフェ"
+
+
+@patch("api.stt_vocabulary._load_vocabulary")
+def test_list_vocabulary_invalid_category(mock_load):
+    mock_load.return_value = SAMPLE_VOCABULARY
+    resp = client.get("/api/stt/vocabulary?category=invalid")
+    assert resp.status_code == 422
+
+
+# =============================================================================
+# POST /api/stt/vocabulary
+# =============================================================================
+
+
+@patch("api.stt_vocabulary._save_vocabulary")
+@patch("api.stt_vocabulary._load_vocabulary")
+def test_create_vocabulary(mock_load, mock_save):
+    mock_load.return_value = []
+    mock_save.return_value = None
+
+    resp = client.post(
+        "/api/stt/vocabulary",
+        json={
+            "word": "コワーキング",
+            "reading": "こわーきんぐ",
+            "category": "service",
+            "priority": 7,
+        },
+    )
+    assert resp.status_code == 201
+    body = resp.json()
+    assert body["success"] is True
+    assert body["data"]["word"] == "コワーキング"
+    assert body["data"]["category"] == "service"
+    assert "id" in body["data"]
+    mock_save.assert_called_once()
+
+
+@patch("api.stt_vocabulary._load_vocabulary")
+def test_create_vocabulary_duplicate(mock_load):
+    mock_load.return_value = SAMPLE_VOCABULARY
+    resp = client.post(
+        "/api/stt/vocabulary",
+        json={
+            "word": "エンジニアカフェ",
+            "reading": "えんじにあかふぇ",
+            "category": "facility",
+        },
+    )
+    assert resp.status_code == 409
+
+
+@patch("api.stt_vocabulary._load_vocabulary")
+def test_create_vocabulary_missing_fields(mock_load):
+    mock_load.return_value = []
+    resp = client.post(
+        "/api/stt/vocabulary",
+        json={"word": "テスト"},  # reading, category が欠落
+    )
+    assert resp.status_code == 422
+
+
+# =============================================================================
+# PUT /api/stt/vocabulary/{id}
+# =============================================================================
+
+
+@patch("api.stt_vocabulary._save_vocabulary")
+@patch("api.stt_vocabulary._load_vocabulary")
+def test_update_vocabulary(mock_load, mock_save):
+    mock_load.return_value = [dict(SAMPLE_VOCABULARY[0])]
+    mock_save.return_value = None
+
+    target_id = SAMPLE_VOCABULARY[0]["id"]
+    resp = client.put(
+        f"/api/stt/vocabulary/{target_id}",
+        json={"priority": 5},
+    )
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["success"] is True
+    assert body["data"]["priority"] == 5
+    mock_save.assert_called_once()
+
+
+@patch("api.stt_vocabulary._load_vocabulary")
+def test_update_vocabulary_not_found(mock_load):
+    mock_load.return_value = SAMPLE_VOCABULARY
+    resp = client.put(
+        "/api/stt/vocabulary/nonexistent-id",
+        json={"priority": 5},
+    )
+    assert resp.status_code == 404
+
+
+@patch("api.stt_vocabulary._save_vocabulary")
+@patch("api.stt_vocabulary._load_vocabulary")
+def test_update_vocabulary_duplicate_word(mock_load, mock_save):
+    mock_load.return_value = list(SAMPLE_VOCABULARY)
+    target_id = SAMPLE_VOCABULARY[0]["id"]
+    resp = client.put(
+        f"/api/stt/vocabulary/{target_id}",
+        json={"word": "博多"},  # 既存の別エントリと重複
+    )
+    assert resp.status_code == 409
+
+
+# =============================================================================
+# DELETE /api/stt/vocabulary/{id}
+# =============================================================================
+
+
+@patch("api.stt_vocabulary._save_vocabulary")
+@patch("api.stt_vocabulary._load_vocabulary")
+def test_delete_vocabulary(mock_load, mock_save):
+    mock_load.return_value = [dict(SAMPLE_VOCABULARY[0])]
+    mock_save.return_value = None
+
+    target_id = SAMPLE_VOCABULARY[0]["id"]
+    resp = client.delete(f"/api/stt/vocabulary/{target_id}")
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["success"] is True
+    assert body["data"]["id"] == target_id
+    mock_save.assert_called_once()
+
+
+@patch("api.stt_vocabulary._load_vocabulary")
+def test_delete_vocabulary_not_found(mock_load):
+    mock_load.return_value = SAMPLE_VOCABULARY
+    resp = client.delete("/api/stt/vocabulary/nonexistent-id")
+    assert resp.status_code == 404
+
+
+# =============================================================================
+# POST /api/stt/vocabulary/test
+# =============================================================================
+
+
+@patch("api.stt_vocabulary._load_vocabulary")
+def test_test_vocabulary_invalid_base64(mock_load):
+    mock_load.return_value = SAMPLE_VOCABULARY
+    resp = client.post(
+        "/api/stt/vocabulary/test",
+        json={"audio_base64": "!!!not-valid-base64!!!"},
+    )
+    assert resp.status_code == 400
+
+
+@patch("api.stt_vocabulary._load_vocabulary")
+def test_test_vocabulary_stt_error_returns_success_false(mock_load):
+    mock_load.return_value = SAMPLE_VOCABULARY
+    wav_b64 = _make_wav_base64()
+
+    with patch("api.stt_vocabulary.LocalSTTClient") as MockClient:
+        instance = MagicMock()
+        instance.transcribe = AsyncMock(side_effect=RuntimeError("Vosk model not found"))
+        MockClient.return_value = instance
+
+        resp = client.post(
+            "/api/stt/vocabulary/test",
+            json={"audio_base64": wav_b64, "language": "ja"},
+        )
+
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["success"] is False
+    assert "error" in body
+    assert "[unk]" in body["grammar_words"]
+
+
+@patch("api.stt_vocabulary._load_vocabulary")
+def test_test_vocabulary_success(mock_load):
+    mock_load.return_value = SAMPLE_VOCABULARY
+    wav_b64 = _make_wav_base64()
+
+    mock_result = MagicMock()
+    mock_result.text = "エンジニアカフェ"
+
+    with patch("api.stt_vocabulary.LocalSTTClient") as MockClient:
+        instance = MagicMock()
+        instance.transcribe = AsyncMock(return_value=mock_result)
+        MockClient.return_value = instance
+
+        resp = client.post(
+            "/api/stt/vocabulary/test",
+            json={"audio_base64": wav_b64, "language": "ja", "category": "facility"},
+        )
+
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["success"] is True
+    assert body["transcript"] == "エンジニアカフェ"
+    assert "エンジニアカフェ" in body["grammar_words"]
+    assert "[unk]" in body["grammar_words"]
+
+
+# =============================================================================
+# build_grammar_words helper
+# =============================================================================
+
+
+def test_build_grammar_words_all():
+    from api.stt_vocabulary import build_grammar_words
+
+    words = build_grammar_words(SAMPLE_VOCABULARY)
+    assert "エンジニアカフェ" in words
+    assert "博多" in words
+    assert "[unk]" in words
+    assert words[-1] == "[unk]"
+
+
+def test_build_grammar_words_with_category():
+    from api.stt_vocabulary import build_grammar_words
+
+    words = build_grammar_words(SAMPLE_VOCABULARY, category="facility")
+    assert "エンジニアカフェ" in words
+    assert "博多" not in words
+    assert "[unk]" in words
+
+
+def test_build_grammar_words_priority_order():
+    from api.stt_vocabulary import build_grammar_words
+
+    words = build_grammar_words(SAMPLE_VOCABULARY)
+    # priority=10 のエンジニアカフェが priority=8 の博多より前
+    idx_ec = words.index("エンジニアカフェ")
+    idx_hk = words.index("博多")
+    assert idx_ec < idx_hk

--- a/backend/tests/api/test_voice_api.py
+++ b/backend/tests/api/test_voice_api.py
@@ -1,0 +1,450 @@
+"""Voice API endpoint tests (/api/voice)
+
+main.py のインポートはテスト環境のモジュールパス問題を避けるため行わず、
+test_knowledge_api.py と同様にテスト用 FastAPI アプリを構成してエンドポイントを再現する。
+"""
+
+import base64
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from fastapi import FastAPI, HTTPException
+from fastapi.testclient import TestClient
+from pydantic import BaseModel
+from typing import Optional
+
+# =============================================================================
+# Voice API Models (main.py から複製)
+# =============================================================================
+
+
+class VoiceRequest(BaseModel):
+    action: str
+    audioData: Optional[str] = None
+    sessionId: Optional[str] = None
+    language: Optional[str] = "ja"
+    text: Optional[str] = None
+    streaming: Optional[bool] = False
+    conversationStage: Optional[str] = None
+
+
+class VoiceResponse(BaseModel):
+    success: bool
+    transcript: Optional[str] = None
+    response: Optional[str] = None
+    audioResponse: Optional[str] = None
+    emotion: Optional[str] = None
+    sessionId: Optional[str] = None
+    error: Optional[str] = None
+    detectedLanguage: Optional[str] = None
+    confidence: Optional[float] = None
+
+
+# =============================================================================
+# Test app setup
+# =============================================================================
+
+# main.py の voice_api エンドポイントロジックを再現するテスト用アプリ。
+# voice_agent / stt_agent はモックで注入する。
+
+mock_voice_agent = MagicMock()
+mock_stt_agent = MagicMock()
+
+_test_app = FastAPI()
+
+
+@_test_app.post("/api/voice", response_model=VoiceResponse)
+async def voice_api(request: VoiceRequest):
+    try:
+        if request.action == "text_to_speech":
+            if not request.text or not request.text.strip():
+                raise HTTPException(status_code=400, detail="Missing text for text_to_speech")
+
+            result = await mock_voice_agent.text_to_speech(
+                text=request.text,
+                language=request.language or "ja",
+                emotion=None,
+            )
+            if not result.get("success"):
+                return VoiceResponse(
+                    success=False,
+                    error=result.get("error", "TTS failed"),
+                    emotion=result.get("emotion"),
+                    sessionId=request.sessionId,
+                )
+
+            return VoiceResponse(
+                success=True,
+                audioResponse=result.get("audioResponse"),
+                emotion=result.get("emotion"),
+                sessionId=request.sessionId,
+            )
+
+        elif request.action == "process_voice":
+            if not request.audioData:
+                raise HTTPException(status_code=400, detail="Missing audioData for process_voice")
+
+            audio_bytes = base64.b64decode(request.audioData)
+
+            stt_result = await mock_stt_agent.speech_to_text(
+                audio_bytes,
+                language=request.language,
+                conversation_stage=request.conversationStage,
+            )
+
+            if not stt_result["success"]:
+                return VoiceResponse(
+                    success=False,
+                    error=stt_result.get("error", "STT failed"),
+                    sessionId=request.sessionId,
+                )
+
+            return VoiceResponse(
+                success=True,
+                transcript=stt_result["transcript"],
+                emotion="neutral",
+                detectedLanguage=stt_result.get("language"),
+                confidence=stt_result.get("confidence"),
+                sessionId=request.sessionId,
+            )
+
+        else:
+            raise HTTPException(status_code=400, detail=f"Unknown action: {request.action}")
+
+    except HTTPException:
+        raise
+    except Exception as e:
+        raise HTTPException(status_code=500, detail=str(e))
+
+
+client = TestClient(_test_app)
+
+
+# =============================================================================
+# Helpers
+# =============================================================================
+
+SAMPLE_SESSION_ID = "test-session-001"
+
+
+def _fake_wav_b64() -> str:
+    """最小限のダミー WAV の base64 文字列"""
+    return base64.b64encode(b"\x00" * 100).decode()
+
+
+@pytest.fixture(autouse=True)
+def _reset_mocks():
+    """各テスト前にモックをリセット"""
+    mock_voice_agent.reset_mock()
+    mock_stt_agent.reset_mock()
+
+
+# =============================================================================
+# text_to_speech
+# =============================================================================
+
+
+class TestTextToSpeech:
+    """POST /api/voice  action=text_to_speech"""
+
+    def test_tts_success(self):
+        """TTS 成功時に audioResponse を返す"""
+        mock_voice_agent.text_to_speech = AsyncMock(
+            return_value={
+                "success": True,
+                "audioResponse": "base64audio==",
+                "emotion": "happy",
+            }
+        )
+
+        resp = client.post(
+            "/api/voice",
+            json={
+                "action": "text_to_speech",
+                "text": "こんにちは",
+                "language": "ja",
+                "sessionId": SAMPLE_SESSION_ID,
+            },
+        )
+
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["success"] is True
+        assert body["audioResponse"] == "base64audio=="
+        assert body["emotion"] == "happy"
+        assert body["sessionId"] == SAMPLE_SESSION_ID
+
+    def test_tts_missing_text_returns_400(self):
+        """text が空の場合は 400 エラー"""
+        resp = client.post(
+            "/api/voice",
+            json={
+                "action": "text_to_speech",
+                "text": "",
+                "sessionId": SAMPLE_SESSION_ID,
+            },
+        )
+        assert resp.status_code == 400
+
+    def test_tts_null_text_returns_400(self):
+        """text が null の場合は 400 エラー"""
+        resp = client.post(
+            "/api/voice",
+            json={
+                "action": "text_to_speech",
+                "text": None,
+                "sessionId": SAMPLE_SESSION_ID,
+            },
+        )
+        assert resp.status_code == 400
+
+    def test_tts_whitespace_only_returns_400(self):
+        """text が空白のみの場合は 400 エラー"""
+        resp = client.post(
+            "/api/voice",
+            json={
+                "action": "text_to_speech",
+                "text": "   ",
+                "sessionId": SAMPLE_SESSION_ID,
+            },
+        )
+        assert resp.status_code == 400
+
+    def test_tts_failure_returns_error(self):
+        """TTS 失敗時に success=False + error を返す"""
+        mock_voice_agent.text_to_speech = AsyncMock(
+            return_value={
+                "success": False,
+                "error": "Google TTS unavailable",
+                "emotion": "neutral",
+            }
+        )
+
+        resp = client.post(
+            "/api/voice",
+            json={
+                "action": "text_to_speech",
+                "text": "テスト",
+                "sessionId": SAMPLE_SESSION_ID,
+            },
+        )
+
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["success"] is False
+        assert "unavailable" in body["error"]
+
+    def test_tts_exception_returns_500(self):
+        """TTS が例外を投げた場合は 500 エラー"""
+        mock_voice_agent.text_to_speech = AsyncMock(side_effect=RuntimeError("unexpected"))
+
+        resp = client.post(
+            "/api/voice",
+            json={
+                "action": "text_to_speech",
+                "text": "テスト",
+                "sessionId": SAMPLE_SESSION_ID,
+            },
+        )
+
+        assert resp.status_code == 500
+
+
+# =============================================================================
+# process_voice
+# =============================================================================
+
+
+class TestProcessVoice:
+    """POST /api/voice  action=process_voice"""
+
+    def test_stt_success(self):
+        """STT 成功時に transcript を返す"""
+        mock_stt_agent.speech_to_text = AsyncMock(
+            return_value={
+                "success": True,
+                "transcript": "こんにちは",
+                "confidence": 0.92,
+                "language": "ja",
+                "provider": "vosk",
+            }
+        )
+
+        resp = client.post(
+            "/api/voice",
+            json={
+                "action": "process_voice",
+                "audioData": _fake_wav_b64(),
+                "language": "ja",
+                "sessionId": SAMPLE_SESSION_ID,
+            },
+        )
+
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["success"] is True
+        assert body["transcript"] == "こんにちは"
+        assert body["confidence"] == pytest.approx(0.92)
+        assert body["detectedLanguage"] == "ja"
+        assert body["sessionId"] == SAMPLE_SESSION_ID
+
+    def test_stt_missing_audio_returns_400(self):
+        """audioData がない場合は 400 エラー"""
+        resp = client.post(
+            "/api/voice",
+            json={
+                "action": "process_voice",
+                "audioData": None,
+                "sessionId": SAMPLE_SESSION_ID,
+            },
+        )
+        assert resp.status_code == 400
+
+    def test_stt_failure_returns_error(self):
+        """STT 失敗時に success=False + error を返す"""
+        mock_stt_agent.speech_to_text = AsyncMock(
+            return_value={
+                "success": False,
+                "transcript": "",
+                "confidence": 0.0,
+                "language": "unknown",
+                "provider": "vosk",
+                "error": "Vosk returned empty recognition result",
+            }
+        )
+
+        resp = client.post(
+            "/api/voice",
+            json={
+                "action": "process_voice",
+                "audioData": _fake_wav_b64(),
+                "language": "ja",
+                "sessionId": SAMPLE_SESSION_ID,
+            },
+        )
+
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["success"] is False
+        assert "empty" in body["error"].lower()
+
+    def test_stt_exception_returns_500(self):
+        """STT が例外を投げた場合は 500 エラー"""
+        mock_stt_agent.speech_to_text = AsyncMock(side_effect=RuntimeError("Vosk crashed"))
+
+        resp = client.post(
+            "/api/voice",
+            json={
+                "action": "process_voice",
+                "audioData": _fake_wav_b64(),
+                "sessionId": SAMPLE_SESSION_ID,
+            },
+        )
+
+        assert resp.status_code == 500
+
+
+# =============================================================================
+# Unknown action
+# =============================================================================
+
+
+class TestUnknownAction:
+    """POST /api/voice  未知の action"""
+
+    def test_unknown_action_returns_400(self):
+        """不明な action は 400 エラー"""
+        resp = client.post(
+            "/api/voice",
+            json={
+                "action": "unknown_action",
+                "sessionId": SAMPLE_SESSION_ID,
+            },
+        )
+        assert resp.status_code == 400
+        assert "Unknown action" in resp.json()["detail"]
+
+
+# =============================================================================
+# Language parameter
+# =============================================================================
+
+
+class TestLanguageParam:
+    """language パラメータの挙動"""
+
+    def test_tts_default_language_ja(self):
+        """language 未指定時はデフォルト ja"""
+        mock_voice_agent.text_to_speech = AsyncMock(
+            return_value={
+                "success": True,
+                "audioResponse": "audio==",
+                "emotion": "neutral",
+            }
+        )
+
+        client.post(
+            "/api/voice",
+            json={
+                "action": "text_to_speech",
+                "text": "テスト",
+            },
+        )
+
+        call_kwargs = mock_voice_agent.text_to_speech.call_args.kwargs
+        assert call_kwargs["language"] == "ja"
+
+    def test_stt_passes_language_to_agent(self):
+        """process_voice は language を stt_agent に渡す"""
+        mock_stt_agent.speech_to_text = AsyncMock(
+            return_value={
+                "success": True,
+                "transcript": "hello",
+                "confidence": 0.9,
+                "language": "en",
+                "provider": "vosk",
+            }
+        )
+
+        client.post(
+            "/api/voice",
+            json={
+                "action": "process_voice",
+                "audioData": _fake_wav_b64(),
+                "language": "en",
+            },
+        )
+
+        call_kwargs = mock_stt_agent.speech_to_text.call_args.kwargs
+        assert call_kwargs["language"] == "en"
+
+    def test_process_voice_with_conversation_stage(self):
+        """process_voice は conversationStage を stt_agent に渡す"""
+        mock_stt_agent.speech_to_text = AsyncMock(
+            return_value={
+                "success": True,
+                "transcript": "こんにちは",
+                "confidence": 0.95,
+                "language": "ja",
+                "provider": "vosk",
+            }
+        )
+
+        resp = client.post(
+            "/api/voice",
+            json={
+                "action": "process_voice",
+                "audioData": _fake_wav_b64(),
+                "language": "ja",
+                "sessionId": SAMPLE_SESSION_ID,
+                "conversationStage": "greeting",
+            },
+        )
+
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["success"] is True
+        assert body["transcript"] == "こんにちは"
+
+        call_kwargs = mock_stt_agent.speech_to_text.call_args.kwargs
+        assert call_kwargs["conversation_stage"] == "greeting"


### PR DESCRIPTION
## Summary

<!-- PRの概要を1-3行で説明してください -->

## Changes

---

## 1. エンジニアカフェ用語の認識精度向上

### `backend/agents/stt_agent.py` — STTAgent を大幅拡張

**構造変更**

- 返却型を `str` から `TranscriptionResult` dataclass に変更（`text` / `confidence` / `language` / `word_confidences` を保持）
- `LocalSTTClient` のモデル管理を `model_path_ja` / `model_path_en` 個別変数から `model_paths: Dict` に統合
- `STTAgent.__init__` に `use_grammar` / `language_processor` / `confidence_threshold` / `fallback_client` パラメータを追加

**新機能**

| 機能 | Phase | 実装箇所 | 概要 |
| --- | --- | --- | --- |
| 単語レベル信頼度取得 | 1 | `stt_agent.py:288` | `rec.SetWords(True)` を有効化し、各単語の confidence を抽出・平均値を返却 |
| ドメイン固有 Grammar | 1 | `ENGINEER_CAFE_GRAMMAR`（ja 22語 / en 21語） | `_sync_transcribe()` に `grammar` パラメータを追加し、指定時は制限語彙モードで `KaldiRecognizer` を生成 |
| 言語自動検出 | 0 | `stt_agent.py:347-394` `transcribe_auto_detect()` | ja / en 両モデルを `asyncio.gather` で並列実行し、confidence が高い方を返却。`language=None` 時に自動発動 |
| LanguageProcessor 後検証 | 0 | `stt_agent.py:501-548` `_validate_language()` | Vosk 認識後のテキストを `LanguageProcessor.detect_language()` で検証し、言語不一致なら別モデルで再認識 |
| 会話ステージ別 Grammar 切替 | 2 | `STAGE_GRAMMARS`（greeting / service_selection / confirmation） | `_resolve_grammar()` でステージ指定語彙と `ENGINEER_CAFE_GRAMMAR` をマージして解決 |
| 低信頼度フォールバック | 2 | `_try_fallback()`（confidence &lt; 0.4） | `GoogleSTTClient.is_available()` で認証情報を事前チェック。閾値未満なら Google STT へフォールバック、失敗時は Vosk 結果をそのまま返却 |

### `backend/main.py` — Voice API エンドポイントの STT 実装

- `VoiceRequest` に `conversationStage` フィールドを追加
- `VoiceResponse` に `detectedLanguage` / `confidence` フィールドを追加
- `process_voice` アクションを実装（プレースホルダーから audioData デコード → STT 実行 → レスポンス構築へ）
- `audioData` 未指定時の 400 エラーハンドリングを追加

### テストカバレッジ

| テストファイル | テスト数 | 対象 |
| --- | --- | --- |
| `tests/agents/test_stt_agent.py` | 951行相当 | Phase 0〜2 の全機能（信頼度・Grammar・自動検出・LP検証・ステージ切替・フォールバック） |
| `tests/api/test_voice_api.py` | 450行相当 | `/api/voice` TTS / STT / 言語パラメータ / エラー系 |

### 未実装（スコープ外）

Phase 3（ドメイン特化コーパス作成・言語モデル再コンパイル・WER評価）は高工数のため今フェーズ対象外。

---

## 2. カスタム語彙管理 API

### `backend/api/stt_vocabulary.py`（新規）

**エンドポイント — 全て実装済み**

| エンドポイント | 実装関数 | 補足 |
| --- | --- | --- |
| `GET /api/stt/vocabulary` | `list_vocabulary()` | カテゴリフィルタ対応 |
| `POST /api/stt/vocabulary` | `create_vocabulary()` | 重複チェック（409） / バリデーション（422） |
| `PUT /api/stt/vocabulary/{id}` | `update_vocabulary()` | 部分更新 / word 重複チェック |
| `DELETE /api/stt/vocabulary/{id}` | `delete_vocabulary()` | 404 ハンドリングあり |
| `POST /api/stt/vocabulary/test` | `test_vocabulary()` | base64 WAV 受付 / カテゴリ絞り込みあり |

**データモデル — `VocabularyItem`（L41）— 全フィールド実装済み**

`id`（UUID）/ `word` / `reading` / `category`（facility / location / service / event）/ `priority`（1〜10）/ `created_at` / `updated_at`

**辞書の使われ方**

| 要件 | 実装箇所 |
| --- | --- |
| JSON Grammar 形式（`[unk]` 付き）への変換 | `build_grammar_words()`（L134）priority 降順ソート |
| `KaldiRecognizer` 初期化時に Grammar として渡す | `_sync_transcribe()` 内で第3引数に渡す |
| 会話ステージに応じた Grammar の動的切替 | `_resolve_grammar()` でステージ語彙 + JSON 語彙をマージ |

**初期登録データ — `backend/data/stt_vocabulary.json`**

エンジニアカフェ / 博多 / 天神 / コワーキングスペース / ミートアップ / Wi-Fi — 計6件収録

### テストカバレッジ

| テストファイル | テスト数 | 対象 |
| --- | --- | --- |
| `tests/api/test_stt_vocabulary_api.py` | 311行相当 | 語彙 API 全エンドポイント + `build_grammar_words()` |

---

## CI 結果

| チェック | 結果 |
| --- | --- |
| ruff | All checks passed |
| black | 全ファイル unchanged |
| pytest | 68 passed / 0 failed |

---

## Related Issues

<!-- 関連するIssueがあればリンクしてください -->
<!-- Closes #123 / Fixes #123 / Resolves #123 -->

## Test Plan

<!-- テスト方法を記載してください -->

- [ ] ローカルで動作確認済み
- [ ] 既存機能への影響がないことを確認済み

## Checklist

- [ ] コードが目的を達成している
- [ ] 不要なコード・コメントを削除した
- [ ] 必要に応じてドキュメントを更新した
- [ ] `pnpm lint` が通る
- [ ] `pnpm typecheck` が通る

## Screenshots (if applicable)

<!-- UIの変更がある場合はスクリーンショットを添付してください -->
