### PR TITLE
feat(backend): add CTranslate2 + opus-mt query translation service

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -39,6 +39,13 @@ COPY . .
 # Download Vosk STT models (small versions: ~88MB total)
 RUN bash scripts/download_vosk_models.sh models
 
+# Download translation models (Helsinki-NLP/opus-mt, CTranslate2 int8: ~300MB total)
+# Requires build-time deps: pip install torch transformers
+RUN pip install --no-cache-dir torch transformers \
+    && bash scripts/download_translation_models.sh models/translation \
+    && pip uninstall -y torch transformers \
+    && pip cache purge
+
 # Set ownership and switch to non-root user
 RUN chown -R appuser:appuser /app
 USER appuser

--- a/backend/agents/business_info_agent.py
+++ b/backend/agents/business_info_agent.py
@@ -148,22 +148,6 @@ class BusinessInfoAgent:
             # コンテキスト取得
             context = rag_result.get("data", {}).get("context", "")
 
-        # 英語フォールバック: キャッシュ/直接検索どちらでもコンテキストが空の場合、
-        # "Engineer Cafe" コンテキストを付加してgeneral検索（英語概要エントリを拾う）
-        if not context and language == "en":
-            enriched_query = f"Engineer Cafe {query}"
-            logger.info("English fallback: retrying with enriched query '%s'", enriched_query[:60])
-            fallback_result = await self.enhanced_rag.search(
-                query=enriched_query,
-                category="general",
-                language=language,
-                include_advice=True,
-                max_results=10,
-                context_signals=context_signals,
-            )
-            if fallback_result.get("success"):
-                context = fallback_result.get("data", {}).get("context", "")
-
         if not context:
             return self._get_default_response(language, request_type)
 

--- a/backend/agents/facility_agent.py
+++ b/backend/agents/facility_agent.py
@@ -157,22 +157,6 @@ class FacilityAgent:
             # コンテキスト取得
             context = rag_result.get("data", {}).get("context", "")
 
-        # 英語フォールバック: キャッシュ/直接検索どちらでもコンテキストが空の場合、
-        # "Engineer Cafe" コンテキストを付加してgeneral検索（英語概要エントリを拾う）
-        if not context and language == "en":
-            enriched_query = f"Engineer Cafe {query}"
-            logger.info("English fallback: retrying with enriched query '%s'", enriched_query[:60])
-            fallback_result = await self.enhanced_rag.search(
-                query=enriched_query,
-                category="general",
-                language=language,
-                include_advice=True,
-                max_results=10,
-                context_signals=context_signals,
-            )
-            if fallback_result.get("success"):
-                context = fallback_result.get("data", {}).get("context", "")
-
         if not context:
             return self._get_default_response(language, request_type)
 

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -26,6 +26,10 @@ psycopg[binary]>=3.1.0
 vosk>=0.3.45
 soundfile>=0.12.1
 
+# Translation (CTranslate2 + Helsinki-NLP/opus-mt)
+ctranslate2>=4.0.0
+sentencepiece>=0.2.0
+
 # Testing dependencies
 pytest>=8.0.0
 pytest-asyncio>=0.23.0

--- a/backend/scripts/download_translation_models.sh
+++ b/backend/scripts/download_translation_models.sh
@@ -1,0 +1,81 @@
+#!/bin/bash
+# Download and convert Helsinki-NLP/opus-mt translation models for CTranslate2.
+#
+# Creates int8-quantized CTranslate2 models + SentencePiece tokenizer files.
+#
+# Models:
+#   opus-mt-en-jap  (EN -> JA)  ~150 MB int8
+#   opus-mt-ja-en   (JA -> EN)  ~150 MB int8
+#
+# Requirements (build-time only):
+#   pip install ctranslate2 transformers torch sentencepiece
+#
+# Usage:
+#   bash scripts/download_translation_models.sh              # default: models/translation
+#   bash scripts/download_translation_models.sh /custom/dir  # custom directory
+
+set -e
+
+MODEL_DIR="${1:-models/translation}"
+mkdir -p "$MODEL_DIR"
+
+HF_BASE="https://huggingface.co/Helsinki-NLP"
+
+# ──────────────────────────────────────────────────────────
+# Helper: convert one model
+# ──────────────────────────────────────────────────────────
+convert_model() {
+    local hf_name="$1"   # e.g. opus-mt-en-jap
+    local label="$2"     # e.g. "EN -> JA"
+    local target="$MODEL_DIR/$hf_name"
+
+    if [ -f "$target/model.bin" ] && [ -f "$target/source.spm" ] && [ -f "$target/target.spm" ]; then
+        echo "[skip] $label model already exists at $target"
+        return
+    fi
+
+    echo ""
+    echo "============================================"
+    echo " Converting $label ($hf_name)"
+    echo "============================================"
+
+    # Step 1: CTranslate2 conversion (needs torch + transformers)
+    echo "[1/2] Converting Helsinki-NLP/$hf_name to CTranslate2 int8 ..."
+    ct2-transformers-converter \
+        --model "Helsinki-NLP/$hf_name" \
+        --quantization int8 \
+        --output_dir "$target" \
+        --force
+
+    # Step 2: Download SentencePiece tokenizer files from HuggingFace
+    echo "[2/2] Downloading SentencePiece tokenizer files ..."
+    for spm_file in source.spm target.spm; do
+        if [ ! -f "$target/$spm_file" ]; then
+            curl -sL -o "$target/$spm_file" \
+                "$HF_BASE/$hf_name/resolve/main/$spm_file"
+            echo "  -> $spm_file downloaded"
+        else
+            echo "  -> $spm_file already present"
+        fi
+    done
+
+    echo "[done] $label model ready at $target"
+}
+
+# ──────────────────────────────────────────────────────────
+# Main
+# ──────────────────────────────────────────────────────────
+
+# Check for required tools
+if ! command -v ct2-transformers-converter &> /dev/null; then
+    echo "ERROR: ct2-transformers-converter not found."
+    echo "Install with: pip install ctranslate2 transformers torch sentencepiece"
+    exit 1
+fi
+
+convert_model "opus-mt-en-jap" "EN -> JA"
+convert_model "opus-mt-ja-en"  "JA -> EN"
+
+echo ""
+echo "Translation models ready:"
+ls -ld "$MODEL_DIR"/opus-mt-*/

--- a/backend/services/translation_service.py
+++ b/backend/services/translation_service.py
@@ -1,0 +1,247 @@
+"""
+CTranslate2 + Helsinki-NLP/opus-mt translation service.
+
+Provides bidirectional EN<->JA translation for the query translation pipeline.
+Japanese knowledge base is searched with translated queries, enabling
+English users to access the same knowledge.
+
+Uses:
+- CTranslate2 for fast CPU inference with int8 quantization
+- sentencepiece for tokenization (source.spm / target.spm)
+- Helsinki-NLP/opus-mt-en-jap for EN->JA
+- Helsinki-NLP/opus-mt-ja-en for JA->EN
+
+Runtime dependencies: ctranslate2, sentencepiece (no torch/transformers needed).
+"""
+
+import asyncio
+import logging
+import os
+import re
+from typing import Literal, Optional
+
+logger = logging.getLogger(__name__)
+
+TranslationDirection = Literal["en_to_ja", "ja_to_en"]
+
+# Japanese character detection (Hiragana, Katakana, CJK)
+_JAPANESE_CHAR_RE = re.compile(r"[\u3040-\u309f\u30a0-\u30ff\u4e00-\u9faf]")
+# Latin-only text (ASCII letters, digits, punctuation, whitespace)
+_LATIN_ONLY_RE = re.compile(r"^[a-zA-Z0-9\s\W]+$")
+
+# Model sub-directory names (under model_dir)
+_MODEL_NAMES: dict[TranslationDirection, str] = {
+    "en_to_ja": "opus-mt-en-jap",
+    "ja_to_en": "opus-mt-ja-en",
+}
+
+# Default model directory (relative to backend/)
+_DEFAULT_MODEL_DIR = os.path.join(
+    os.path.dirname(os.path.dirname(os.path.abspath(__file__))),
+    "models",
+    "translation",
+)
+
+
+class TranslationService:
+    """
+    Bidirectional EN<->JA translation service using CTranslate2.
+
+    Models are loaded lazily on first use to avoid startup overhead.
+    Use get_translation_service() for singleton access.
+
+    CTranslate2 best-practice settings (from official docs):
+    - compute_type="int8" for ~6-10x speedup with minimal quality loss
+    - beam_size=1 for lowest latency on short queries
+    - return_scores=False to skip score computation
+    - inter_threads=2, intra_threads=1 for CPU parallelism
+    """
+
+    def __init__(self, model_dir: Optional[str] = None):
+        self._model_dir = model_dir or _DEFAULT_MODEL_DIR
+        self._translators: dict[str, object] = {}
+        self._source_sps: dict[str, object] = {}
+        self._target_sps: dict[str, object] = {}
+        logger.info("TranslationService initialized (lazy load): %s", self._model_dir)
+
+    # ------------------------------------------------------------------
+    # Model loading (lazy, following stt_agent.py pattern)
+    # ------------------------------------------------------------------
+
+    def _load_model(self, direction: TranslationDirection) -> None:
+        """Load CTranslate2 translator + SentencePiece tokenizers."""
+        if direction in self._translators:
+            return
+
+        try:
+            import ctranslate2
+            import sentencepiece as spm
+        except ImportError as exc:
+            raise RuntimeError(
+                f"Missing dependency: {exc}. " "Install with: pip install ctranslate2 sentencepiece"
+            ) from exc
+
+        model_name = _MODEL_NAMES[direction]
+        model_path = os.path.join(self._model_dir, model_name)
+
+        if not os.path.isdir(model_path):
+            raise RuntimeError(
+                f"Translation model not found: {model_path}. "
+                "Run: bash scripts/download_translation_models.sh"
+            )
+
+        source_spm_path = os.path.join(model_path, "source.spm")
+        target_spm_path = os.path.join(model_path, "target.spm")
+
+        for spm_path in (source_spm_path, target_spm_path):
+            if not os.path.isfile(spm_path):
+                raise RuntimeError(
+                    f"SentencePiece model not found: {spm_path}. "
+                    "Re-run: bash scripts/download_translation_models.sh"
+                )
+
+        self._translators[direction] = ctranslate2.Translator(
+            model_path,
+            compute_type="int8",
+            inter_threads=2,
+            intra_threads=1,
+        )
+
+        source_sp = spm.SentencePieceProcessor()
+        source_sp.Load(source_spm_path)
+        self._source_sps[direction] = source_sp
+
+        target_sp = spm.SentencePieceProcessor()
+        target_sp.Load(target_spm_path)
+        self._target_sps[direction] = target_sp
+
+        logger.info("Loaded translation model: %s (%s)", direction, model_path)
+
+    # ------------------------------------------------------------------
+    # Language detection helpers
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def is_japanese(text: str) -> bool:
+        """Return True if *text* contains any Japanese characters."""
+        return bool(_JAPANESE_CHAR_RE.search(text))
+
+    @staticmethod
+    def is_latin_only(text: str) -> bool:
+        """Return True if *text* consists entirely of Latin/ASCII chars."""
+        return bool(_LATIN_ONLY_RE.match(text))
+
+    # ------------------------------------------------------------------
+    # Core translation (synchronous, CPU-bound)
+    # ------------------------------------------------------------------
+
+    def _translate_sync(self, text: str, direction: TranslationDirection) -> str:
+        """Synchronous translation — runs in thread pool via translate()."""
+        self._load_model(direction)
+
+        source_sp = self._source_sps[direction]
+        target_sp = self._target_sps[direction]
+        translator = self._translators[direction]
+
+        # SentencePiece encode -> list[str]
+        tokens: list[str] = source_sp.Encode(text, out_type=str)
+
+        # CTranslate2 translate (beam=1, no scores for speed)
+        results = translator.translate_batch(
+            [tokens],
+            beam_size=1,
+            return_scores=False,
+        )
+
+        output_tokens: list[str] = results[0].hypotheses[0]
+
+        # Strip EOS token if present
+        if output_tokens and output_tokens[-1] == "</s>":
+            output_tokens = output_tokens[:-1]
+
+        # SentencePiece decode -> str
+        translated: str = target_sp.Decode(output_tokens)
+        return translated
+
+    # ------------------------------------------------------------------
+    # Public async API
+    # ------------------------------------------------------------------
+
+    async def translate(
+        self,
+        text: str,
+        direction: TranslationDirection,
+    ) -> str:
+        """
+        Translate text between English and Japanese.
+
+        Skips translation when text is already in the target language.
+
+        Args:
+            text: Source text.
+            direction: ``"en_to_ja"`` or ``"ja_to_en"``.
+
+        Returns:
+            Translated text, or the original if already in the target language
+            or if translation fails.
+        """
+        if not text or not text.strip():
+            return text
+
+        # Skip when already in target language
+        if direction == "en_to_ja" and self.is_japanese(text):
+            logger.debug("Skip EN->JA: text already contains Japanese")
+            return text
+        if direction == "ja_to_en" and self.is_latin_only(text):
+            logger.debug("Skip JA->EN: text is already Latin-only")
+            return text
+
+        try:
+            loop = asyncio.get_running_loop()
+            translated = await loop.run_in_executor(None, self._translate_sync, text, direction)
+            logger.debug(
+                "Translated [%s]: '%s' -> '%s'",
+                direction,
+                text[:60],
+                translated[:60],
+            )
+            return translated
+        except Exception:
+            logger.warning(
+                "Translation failed [%s], returning original text.",
+                direction,
+                exc_info=True,
+            )
+            return text
+
+    async def translate_batch(
+        self,
+        texts: list[str],
+        direction: TranslationDirection,
+    ) -> list[str]:
+        """Translate multiple texts. Currently sequential; batch CTranslate2 possible later."""
+        if not texts:
+            return []
+        return [await self.translate(t, direction) for t in texts]
+
+
+# ======================================================================
+# Singleton access
+# ======================================================================
+
+_translation_service: Optional[TranslationService] = None
+
+
+def get_translation_service(
+    model_dir: Optional[str] = None,
+) -> TranslationService:
+    """
+    Return the singleton :class:`TranslationService`.
+
+    Args:
+        model_dir: Override model directory (only effective on first call).
+    """
+    global _translation_service  # noqa: PLW0603
+    if _translation_service is None:
+        _translation_service = TranslationService(model_dir=model_dir)
+    return _translation_service

--- a/backend/tests/test_translation_service.py
+++ b/backend/tests/test_translation_service.py
@@ -13,7 +13,6 @@ from backend.services.translation_service import (
     get_translation_service,
 )
 
-
 # =====================================================================
 # Fixtures
 # =====================================================================

--- a/backend/tests/test_translation_service.py
+++ b/backend/tests/test_translation_service.py
@@ -1,0 +1,289 @@
+"""
+Tests for CTranslate2 translation service.
+
+All tests use mocks so they run without actual models installed.
+"""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from backend.services.translation_service import (
+    TranslationService,
+    get_translation_service,
+)
+
+
+# =====================================================================
+# Fixtures
+# =====================================================================
+
+
+@pytest.fixture()
+def mock_ctranslate2():
+    """Mock ctranslate2.Translator for unit tests."""
+    mock_translator = MagicMock()
+    # Simulate translate_batch returning a result with hypotheses
+    hypothesis = MagicMock()
+    hypothesis.hypotheses = [["translated", "token", "</s>"]]
+    mock_translator.translate_batch.return_value = [hypothesis]
+
+    mock_module = MagicMock()
+    mock_module.Translator.return_value = mock_translator
+    return mock_module, mock_translator
+
+
+@pytest.fixture()
+def mock_sentencepiece():
+    """Mock sentencepiece.SentencePieceProcessor."""
+    mock_sp = MagicMock()
+    mock_sp.Encode.return_value = ["hello", "world"]
+    mock_sp.Decode.return_value = "翻訳されたテキスト"
+
+    mock_module = MagicMock()
+    mock_module.SentencePieceProcessor.return_value = mock_sp
+    return mock_module, mock_sp
+
+
+@pytest.fixture()
+def translation_service(tmp_path, mock_ctranslate2, mock_sentencepiece):
+    """Create a TranslationService with mocked dependencies."""
+    # Create fake model directories with required files
+    for model_name in ("opus-mt-en-jap", "opus-mt-ja-en"):
+        model_dir = tmp_path / model_name
+        model_dir.mkdir()
+        (model_dir / "model.bin").write_text("fake")
+        (model_dir / "source.spm").write_text("fake")
+        (model_dir / "target.spm").write_text("fake")
+
+    ct2_mod, _ = mock_ctranslate2
+    sp_mod, _ = mock_sentencepiece
+
+    with (
+        patch.dict("sys.modules", {"ctranslate2": ct2_mod, "sentencepiece": sp_mod}),
+        patch(
+            "importlib.import_module",
+            side_effect=lambda name: ct2_mod if "ctranslate2" in name else sp_mod,
+        ),
+    ):
+        svc = TranslationService(model_dir=str(tmp_path))
+        # Manually inject mocks since _load_model uses import
+        for direction in ("en_to_ja", "ja_to_en"):
+            svc._translators[direction] = ct2_mod.Translator.return_value
+            svc._source_sps[direction] = sp_mod.SentencePieceProcessor.return_value
+            svc._target_sps[direction] = sp_mod.SentencePieceProcessor.return_value
+        yield svc
+
+
+# =====================================================================
+# Language detection tests
+# =====================================================================
+
+
+class TestLanguageDetection:
+    """Tests for is_japanese / is_latin_only static methods."""
+
+    def test_is_japanese_hiragana(self):
+        assert TranslationService.is_japanese("こんにちは") is True
+
+    def test_is_japanese_katakana(self):
+        assert TranslationService.is_japanese("カフェ") is True
+
+    def test_is_japanese_kanji(self):
+        assert TranslationService.is_japanese("営業時間") is True
+
+    def test_is_japanese_english(self):
+        assert TranslationService.is_japanese("Hello world") is False
+
+    def test_is_japanese_mixed(self):
+        assert TranslationService.is_japanese("Hello こんにちは") is True
+
+    def test_is_latin_only_english(self):
+        assert TranslationService.is_latin_only("Hello world!") is True
+
+    def test_is_latin_only_digits(self):
+        assert TranslationService.is_latin_only("Room 101, 2nd floor") is True
+
+    def test_is_latin_only_japanese(self):
+        assert TranslationService.is_latin_only("こんにちは") is False
+
+    def test_is_latin_only_mixed(self):
+        assert TranslationService.is_latin_only("Hello こんにちは") is False
+
+
+# =====================================================================
+# Translation tests (mocked)
+# =====================================================================
+
+
+class TestTranslation:
+    """Tests for translate() async method with mocked CTranslate2."""
+
+    @pytest.mark.asyncio
+    async def test_en_to_ja_translation(self, translation_service, mock_sentencepiece):
+        """English query should be translated to Japanese."""
+        _, mock_sp = mock_sentencepiece
+        mock_sp.Decode.return_value = "営業時間は何時ですか"
+
+        result = await translation_service.translate("What are the opening hours?", "en_to_ja")
+        assert result == "営業時間は何時ですか"
+
+    @pytest.mark.asyncio
+    async def test_ja_to_en_translation(self, translation_service, mock_sentencepiece):
+        """Japanese text should be translated to English."""
+        _, mock_sp = mock_sentencepiece
+        mock_sp.Decode.return_value = "The opening hours are 9am to 10pm"
+
+        result = await translation_service.translate("営業時間は9時から22時です", "ja_to_en")
+        assert result == "The opening hours are 9am to 10pm"
+
+    @pytest.mark.asyncio
+    async def test_japanese_query_passthrough_en_to_ja(self, translation_service):
+        """Japanese text should be returned as-is for en_to_ja direction."""
+        result = await translation_service.translate("営業時間は？", "en_to_ja")
+        assert result == "営業時間は？"
+
+    @pytest.mark.asyncio
+    async def test_english_query_passthrough_ja_to_en(self, translation_service):
+        """English text should be returned as-is for ja_to_en direction."""
+        result = await translation_service.translate("What are the hours?", "ja_to_en")
+        assert result == "What are the hours?"
+
+    @pytest.mark.asyncio
+    async def test_empty_input(self, translation_service):
+        """Empty input should be returned as-is."""
+        result = await translation_service.translate("", "en_to_ja")
+        assert result == ""
+
+    @pytest.mark.asyncio
+    async def test_whitespace_only_input(self, translation_service):
+        """Whitespace-only input should be returned as-is."""
+        result = await translation_service.translate("   ", "en_to_ja")
+        assert result == "   "
+
+    @pytest.mark.asyncio
+    async def test_translation_error_returns_original(self, translation_service):
+        """Translation error should return the original text (graceful fallback)."""
+        # Force an error in the sync translation
+        translation_service._translators["en_to_ja"].translate_batch.side_effect = RuntimeError(
+            "Model error"
+        )
+
+        result = await translation_service.translate("What are the hours?", "en_to_ja")
+        assert result == "What are the hours?"
+
+
+# =====================================================================
+# Batch translation tests
+# =====================================================================
+
+
+class TestBatchTranslation:
+    """Tests for translate_batch() method."""
+
+    @pytest.mark.asyncio
+    async def test_batch_translation(self, translation_service, mock_sentencepiece):
+        """Multiple texts should be translated."""
+        _, mock_sp = mock_sentencepiece
+        mock_sp.Decode.return_value = "翻訳結果"
+
+        results = await translation_service.translate_batch(["Hello", "World"], "en_to_ja")
+        assert len(results) == 2
+
+    @pytest.mark.asyncio
+    async def test_empty_batch(self, translation_service):
+        """Empty batch should return empty list."""
+        results = await translation_service.translate_batch([], "en_to_ja")
+        assert results == []
+
+
+# =====================================================================
+# Singleton pattern tests
+# =====================================================================
+
+
+class TestSingleton:
+    """Tests for get_translation_service() singleton."""
+
+    def test_singleton_returns_same_instance(self):
+        """get_translation_service() should return the same instance."""
+        # Reset singleton
+        import backend.services.translation_service as mod
+
+        mod._translation_service = None
+
+        svc1 = get_translation_service()
+        svc2 = get_translation_service()
+        assert svc1 is svc2
+
+        # Clean up
+        mod._translation_service = None
+
+    def test_singleton_custom_model_dir(self):
+        """First call with model_dir should set the directory."""
+        import backend.services.translation_service as mod
+
+        mod._translation_service = None
+
+        svc = get_translation_service(model_dir="/custom/path")
+        assert svc._model_dir == "/custom/path"
+
+        # Clean up
+        mod._translation_service = None
+
+
+# =====================================================================
+# Model loading error tests
+# =====================================================================
+
+
+class TestModelLoading:
+    """Tests for model loading error handling."""
+
+    def test_model_not_found_error(self, tmp_path, mock_ctranslate2, mock_sentencepiece):
+        """Missing model directory should raise RuntimeError."""
+        ct2_mod, _ = mock_ctranslate2
+        sp_mod, _ = mock_sentencepiece
+
+        with patch.dict("sys.modules", {"ctranslate2": ct2_mod, "sentencepiece": sp_mod}):
+            svc = TranslationService(model_dir=str(tmp_path))
+            with pytest.raises(RuntimeError, match="Translation model not found"):
+                svc._load_model("en_to_ja")
+
+    def test_missing_spm_files_error(self, tmp_path, mock_ctranslate2, mock_sentencepiece):
+        """Missing .spm files should raise RuntimeError."""
+        model_dir = tmp_path / "opus-mt-en-jap"
+        model_dir.mkdir()
+        # Create model.bin but NOT .spm files
+        (model_dir / "model.bin").write_text("fake")
+
+        ct2_mod, _ = mock_ctranslate2
+        sp_mod, _ = mock_sentencepiece
+
+        with patch.dict("sys.modules", {"ctranslate2": ct2_mod, "sentencepiece": sp_mod}):
+            svc = TranslationService(model_dir=str(tmp_path))
+            with pytest.raises(RuntimeError, match="SentencePiece model not found"):
+                svc._load_model("en_to_ja")
+
+
+# =====================================================================
+# EOS token stripping test
+# =====================================================================
+
+
+class TestEosTokenStripping:
+    """Tests for </s> EOS token removal in _translate_sync."""
+
+    def test_eos_token_stripped(self, translation_service, mock_ctranslate2):
+        """</s> token at the end should be stripped before decode."""
+        ct2_mod, mock_translator = mock_ctranslate2
+        hypothesis = MagicMock()
+        hypothesis.hypotheses = [["hello", "world", "</s>"]]
+        mock_translator.translate_batch.return_value = [hypothesis]
+
+        # Call sync directly to check token handling
+        translation_service._translate_sync("test", "en_to_ja")
+        # Decode should be called with tokens WITHOUT </s>
+        sp = translation_service._target_sps["en_to_ja"]
+        call_args = sp.Decode.call_args[0][0]
+        assert "</s>" not in call_args

--- a/backend/workflows/main_workflow.py
+++ b/backend/workflows/main_workflow.py
@@ -258,6 +258,27 @@ class MainWorkflow:
                 from backend.tools.enhanced_rag import EnhancedRAGSearch
                 from backend.utils.query_classifier import QueryClassifier
 
+                # Translate non-Japanese queries for Japanese knowledge base search
+                rag_query = query
+                if language != "ja":
+                    try:
+                        from backend.services.translation_service import (
+                            get_translation_service,
+                        )
+
+                        ts = get_translation_service()
+                        rag_query = await ts.translate(query, "en_to_ja")
+                        logger.info(
+                            "Translated query for RAG: '%s' -> '%s'",
+                            query[:40],
+                            rag_query[:40],
+                        )
+                    except Exception as trans_err:
+                        logger.warning(
+                            "Query translation failed, using original: %s",
+                            trans_err,
+                        )
+
                 classifier = QueryClassifier()
                 classification = await classifier.classify_with_details(query)
                 category = (
@@ -266,7 +287,7 @@ class MainWorkflow:
 
                 rag = EnhancedRAGSearch()
                 rag_result = await rag.search(
-                    query=query, category=category, language=language, max_results=10
+                    query=rag_query, category=category, language=language, max_results=10
                 )
 
                 knowledge_results = {
@@ -275,6 +296,7 @@ class MainWorkflow:
                     "context_string": rag_result.get("data", {}).get("context", ""),
                     "category": category,
                     "query": query,
+                    "translated_query": rag_query if rag_query != query else None,
                 }
             except Exception as e:
                 logger.warning("RAG pre-fetch failed: %s", e)


### PR DESCRIPTION
## Summary
- CTranslate2 + Helsinki-NLP/opus-mt による軽量・高速な双方向 EN<->JA 翻訳サービスを実装
- 英語クエリを RAG 検索前に日本語に翻訳し、日本語ナレッジベースを英語ユーザーからも検索可能に
- `business_info_agent.py` / `facility_agent.py` の英語フォールバックハックを除去

## Changes
- **`backend/services/translation_service.py`** (NEW): CTranslate2ベースの翻訳サービス。シングルトン遅延ロード、int8量子化、beam_size=1
- **`backend/scripts/download_translation_models.sh`** (NEW): HuggingFaceモデルをCT2形式に変換する冪等スクリプト
- **`backend/tests/test_translation_service.py`** (NEW): 23テスト（全モック、モデル不要）
- **`backend/workflows/main_workflow.py`** (MOD): `_memory_loader_node` に EN→JA 翻訳を統合（RAG検索前）
- **`backend/agents/business_info_agent.py`** (MOD): 英語フォールバックハック削除
- **`backend/agents/facility_agent.py`** (MOD): 英語フォールバックハック削除
- **`backend/Dockerfile`** (MOD): 翻訳モデルダウンロードステップ追加
- **`backend/requirements.txt`** (MOD): ctranslate2, sentencepiece 追加

## Architecture
```
English User → "What are the hours?"
       ↓ TranslationService.translate("en_to_ja")
RAG Search → "営業時間は何時ですか" → Japanese knowledge base
       ↓ Results
LLM Agent → Generates English response (Claude/GPT are multilingual)
       ↓
English User ← "Opening hours are 9am-10pm"
```

## Test plan
- [x] ruff check: all passed
- [x] black --check: all passed
- [x] pytest test_translation_service.py: 23/23 passed
- [ ] E2E: English query returns accurate info from Japanese knowledge base
- [ ] E2E: Japanese query continues to work as before (regression)
- [ ] Docker build with translation model download

Closes #89

🤖 Generated with [Claude Code](https://claude.com/claude-code)