### PR TITLE
feat(backend): add response translation (JA→EN) in format_response_node

### DIFF
--- a/backend/tests/workflows/test_main_workflow.py
+++ b/backend/tests/workflows/test_main_workflow.py
@@ -421,6 +421,165 @@ class TestStoreMessageIntegration:
             assert len(result_format["messages"]) == 2
 
 
+class TestResponseTranslation:
+    """レスポンス翻訳（JA→EN）のテスト"""
+
+    @pytest.mark.asyncio
+    @patch("backend.workflows.main_workflow.OrchestratorAgent")
+    async def test_format_response_translates_ja_to_en(self, mock_orchestrator_class):
+        """language='en' の場合、日本語回答が英語に翻訳されることを確認"""
+        from backend.workflows.main_workflow import MainWorkflow
+
+        mock_orchestrator_class.return_value = AsyncMock()
+
+        with (
+            patch("backend.utils.memory_helper.get_memory_helper") as mock_get_helper,
+            patch("backend.services.translation_service.get_translation_service") as mock_get_ts,
+        ):
+            mock_helper = AsyncMock()
+            mock_helper.store_message = AsyncMock()
+            mock_get_helper.return_value = mock_helper
+
+            mock_ts = AsyncMock()
+            mock_ts.translate = AsyncMock(return_value="It is from 9am to 10pm.")
+            mock_get_ts.return_value = mock_ts
+
+            workflow = MainWorkflow()
+
+            state = {
+                "query": "What are the hours?",
+                "answer": "9時から22時です。",
+                "session_id": "test-session",
+                "language": "en",
+            }
+
+            result = await workflow._format_response_node(state, _mock_runtime())
+
+            mock_ts.translate.assert_called_once_with("9時から22時です。", "ja_to_en")
+            assert result["messages"][-1].content == "It is from 9am to 10pm."
+
+    @pytest.mark.asyncio
+    @patch("backend.workflows.main_workflow.OrchestratorAgent")
+    async def test_format_response_skips_translation_for_ja(self, mock_orchestrator_class):
+        """language='ja' の場合、翻訳をスキップすることを確認"""
+        from backend.workflows.main_workflow import MainWorkflow
+
+        mock_orchestrator_class.return_value = AsyncMock()
+
+        with patch("backend.utils.memory_helper.get_memory_helper") as mock_get_helper:
+            mock_helper = AsyncMock()
+            mock_helper.store_message = AsyncMock()
+            mock_get_helper.return_value = mock_helper
+
+            workflow = MainWorkflow()
+
+            state = {
+                "query": "営業時間は？",
+                "answer": "9時から22時です。",
+                "session_id": "test-session",
+                "language": "ja",
+            }
+
+            result = await workflow._format_response_node(state, _mock_runtime())
+
+            assert result["messages"][-1].content == "9時から22時です。"
+
+    @pytest.mark.asyncio
+    @patch("backend.workflows.main_workflow.OrchestratorAgent")
+    async def test_format_response_translation_failure_fallback(self, mock_orchestrator_class):
+        """翻訳失敗時、元の日本語回答がそのまま使用されることを確認"""
+        from backend.workflows.main_workflow import MainWorkflow
+
+        mock_orchestrator_class.return_value = AsyncMock()
+
+        with (
+            patch("backend.utils.memory_helper.get_memory_helper") as mock_get_helper,
+            patch("backend.services.translation_service.get_translation_service") as mock_get_ts,
+        ):
+            mock_helper = AsyncMock()
+            mock_helper.store_message = AsyncMock()
+            mock_get_helper.return_value = mock_helper
+
+            mock_ts = AsyncMock()
+            mock_ts.translate = AsyncMock(side_effect=RuntimeError("Model not found"))
+            mock_get_ts.return_value = mock_ts
+
+            workflow = MainWorkflow()
+
+            state = {
+                "query": "What are the hours?",
+                "answer": "9時から22時です。",
+                "session_id": "test-session",
+                "language": "en",
+            }
+
+            result = await workflow._format_response_node(state, _mock_runtime())
+
+            assert result["messages"][-1].content == "9時から22時です。"
+
+    @pytest.mark.asyncio
+    @patch("backend.workflows.main_workflow.OrchestratorAgent")
+    async def test_format_response_stores_translated_in_memory(self, mock_orchestrator_class):
+        """翻訳後の英語回答がメモリに保存されることを確認"""
+        from backend.workflows.main_workflow import MainWorkflow
+
+        mock_orchestrator_class.return_value = AsyncMock()
+
+        with (
+            patch("backend.utils.memory_helper.get_memory_helper") as mock_get_helper,
+            patch("backend.services.translation_service.get_translation_service") as mock_get_ts,
+        ):
+            mock_helper = AsyncMock()
+            mock_helper.store_message = AsyncMock()
+            mock_get_helper.return_value = mock_helper
+
+            mock_ts = AsyncMock()
+            mock_ts.translate = AsyncMock(return_value="It is from 9am to 10pm.")
+            mock_get_ts.return_value = mock_ts
+
+            workflow = MainWorkflow()
+
+            state = {
+                "query": "What are the hours?",
+                "answer": "9時から22時です。",
+                "session_id": "test-session",
+                "language": "en",
+            }
+
+            await workflow._format_response_node(state, _mock_runtime())
+
+            mock_helper.store_message.assert_called_once_with(
+                session_id="test-session",
+                role="assistant",
+                content="It is from 9am to 10pm.",
+            )
+
+    @pytest.mark.asyncio
+    @patch("backend.workflows.main_workflow.OrchestratorAgent")
+    async def test_format_response_default_language_ja(self, mock_orchestrator_class):
+        """language未指定時のデフォルト'ja'で翻訳がスキップされることを確認"""
+        from backend.workflows.main_workflow import MainWorkflow
+
+        mock_orchestrator_class.return_value = AsyncMock()
+
+        with patch("backend.utils.memory_helper.get_memory_helper") as mock_get_helper:
+            mock_helper = AsyncMock()
+            mock_helper.store_message = AsyncMock()
+            mock_get_helper.return_value = mock_helper
+
+            workflow = MainWorkflow()
+
+            state = {
+                "query": "営業時間は？",
+                "answer": "9時から22時です。",
+                "session_id": "test-session",
+            }
+
+            result = await workflow._format_response_node(state, _mock_runtime())
+
+            assert result["messages"][-1].content == "9時から22時です。"
+
+
 class TestRetryPolicy:
     """RetryPolicy 設定テスト"""
 

--- a/backend/workflows/main_workflow.py
+++ b/backend/workflows/main_workflow.py
@@ -610,6 +610,30 @@ class MainWorkflow:
         except Exception:
             pass  # Non-critical — API層でもスキャンするため
 
+        # Response translation: translate JA response to EN for non-Japanese users
+        language = state.get("language", "ja")
+        if language != "ja":
+            try:
+                from backend.services.translation_service import (
+                    get_translation_service,
+                )
+
+                ts = get_translation_service()
+                translated_answer = await ts.translate(answer, "ja_to_en")
+                if translated_answer != answer:
+                    logger.info(
+                        "Translated response for lang=%s: '%s' -> '%s'",
+                        language,
+                        answer[:40],
+                        translated_answer[:40],
+                    )
+                answer = translated_answer
+            except Exception as trans_err:
+                logger.warning(
+                    "Response translation failed, using original: %s",
+                    trans_err,
+                )
+
         # アシスタント応答を保存
         try:
             memory_helper = get_memory_helper()


### PR DESCRIPTION
## Summary
- `_format_response_node` にレスポンス翻訳（JA→EN）を追加。英語ユーザーに対して、RAGベースの日本語応答を自動的に英語に翻訳する
- PR #91 で実装したクエリ翻訳（EN→JA）と対になる機能。これにより翻訳パイプラインが完成する
- 5件の新規テスト（`TestResponseTranslation` クラス）を追加

## Background
PR #91 でクエリ翻訳（EN→JA）を実装したが、調査の結果レスポンス翻訳（JA→EN）が未実装であることが判明。

**問題:**
- 英語ユーザーのクエリは日本語に翻訳されRAG検索に使用される ✅
- しかしAgentの応答（日本語RAGコンテキストベース）は英語に翻訳されない ❌
- 日本語テキストがKokoro TTS（英語モデル）に渡され音声出力が破綻する

## Changes
### `backend/workflows/main_workflow.py`
- `_format_response_node` にレスポンス翻訳ブロックを追加
- 処理順序: emotion tag strip → PII masking → **レスポンス翻訳** → メモリ保存
- 翻訳失敗時はgraceful degradation（元の応答をそのまま使用）

### `backend/tests/workflows/test_main_workflow.py`
- `TestResponseTranslation` クラス追加（5テスト）:
  1. EN言語でJA→EN翻訳が実行される
  2. JA言語で翻訳がスキップされる
  3. 翻訳失敗時のフォールバック
  4. 翻訳後の英語がメモリに保存される
  5. language未指定時のデフォルト動作（ja）

## Test plan
- [x] `ruff check`: passed
- [x] `black --check`: passed
- [x] `pytest test_main_workflow.py`: 27/27 PASSED (22 existing + 5 new)
- [x] `pytest test_translation_service.py`: 23/23 PASSED (regression)

🤖 Generated with [Claude Code](https://claude.com/claude-code)