### PR TITLE
feat(backend): AI reception feature enhancements (#95-#99)

### DIFF
--- a/backend/agents/event_agent.py
+++ b/backend/agents/event_agent.py
@@ -357,3 +357,43 @@ class EventAgent:
         events.sort(key=lambda e: e.get("start", "") or "")
 
         return events
+
+    async def get_today_events(self, language: str = "ja") -> Dict:
+        """本日のイベント情報を取得
+
+        Google CalendarとConnpassから本日のイベントを検索し、統合して返す。
+        受付案内や自動イベント紹介に使用。
+
+        Args:
+            language: 応答言語 ("ja" | "en")
+
+        Returns:
+            Dict with keys:
+                - events (List[Dict]): イベントリスト
+                - count (int): イベント数
+                - formatted_text (str): 整形済みテキスト
+                - has_events (bool): イベントがあるかどうか
+        """
+        try:
+            calendar_result, connpass_result = await asyncio.gather(
+                self.calendar_service.search_events("today"),
+                self.connpass_service.search_events("today"),
+            )
+
+            events = self._merge_events(calendar_result, connpass_result)
+            formatted_text = self._format_calendar_events(events, language)
+
+            return {
+                "events": events,
+                "count": len(events),
+                "formatted_text": formatted_text,
+                "has_events": len(events) > 0,
+            }
+        except Exception as e:
+            logger.warning("Failed to get today's events: %s", e)
+            return {
+                "events": [],
+                "count": 0,
+                "formatted_text": "",
+                "has_events": False,
+            }

--- a/backend/agents/facility_agent.py
+++ b/backend/agents/facility_agent.py
@@ -323,6 +323,125 @@ class FacilityAgent:
 
         return "helpful"
 
+    async def get_accessibility_summary(self, language: str = "ja") -> Dict:
+        """アクセシビリティ情報のサマリーを取得
+
+        RAG検索でアクセシビリティ関連情報を集約し、LLMでサマリーを生成。
+        RAG失敗時はデフォルトのアクセシビリティ情報を返す。
+
+        Args:
+            language: 応答言語 ("ja" | "en")
+
+        Returns:
+            Dict with keys:
+                - summary (str): アクセシビリティサマリーテキスト
+                - details (Dict): 詳細情報
+                - has_info (bool): RAG情報が取得できたか
+        """
+        default_info = self._get_default_accessibility_info(language)
+
+        try:
+            rag_result = await self.enhanced_rag.search(
+                query=(
+                    "バリアフリー 車椅子 アクセシビリティ エレベーター 段差"
+                    if language == "ja"
+                    else "accessibility wheelchair elevator barrier-free ramp"
+                ),
+                category="facility-info",
+                language=language,
+                max_results=10,
+            )
+
+            if not rag_result.get("success"):
+                return {
+                    "summary": default_info["summary"],
+                    "details": default_info,
+                    "has_info": False,
+                }
+
+            context = rag_result.get("data", {}).get("context", "")
+            if not context:
+                return {
+                    "summary": default_info["summary"],
+                    "details": default_info,
+                    "has_info": False,
+                }
+
+            # LLMでサマリー生成
+            if language == "en":
+                prompt = (
+                    "Summarize the accessibility information for Engineer Cafe "
+                    "based on the following data. Include wheelchair access, "
+                    "elevator availability, and any limitations.\n\n"
+                    f"Information: {context}\n\n"
+                    "Provide a concise 2-3 sentence summary."
+                )
+            else:
+                prompt = (
+                    "以下の情報からエンジニアカフェのアクセシビリティ情報を"
+                    "まとめてください。車椅子アクセス、エレベーターの有無、"
+                    "制限事項を含めてください。\n\n"
+                    f"情報: {context}\n\n"
+                    "簡潔に2-3文でまとめてください。"
+                )
+
+            summary = await self.llm_provider.generate(
+                messages=[HumanMessage(content=prompt)],
+                config=get_model_config("facility_info"),
+            )
+
+            return {
+                "summary": summary,
+                "details": {"raw_context": context},
+                "has_info": True,
+            }
+
+        except Exception as e:
+            logger.warning("Accessibility summary generation failed: %s", e)
+            return {
+                "summary": default_info["summary"],
+                "details": default_info,
+                "has_info": False,
+            }
+
+    @staticmethod
+    def _get_default_accessibility_info(language: str) -> Dict:
+        """デフォルトのアクセシビリティ情報を返す
+
+        RAG検索が失敗した場合のフォールバック。
+        1909年築の歴史的建造物としての制約を含む。
+
+        Args:
+            language: 応答言語 ("ja" | "en")
+
+        Returns:
+            Dict: デフォルトアクセシビリティ情報
+        """
+        if language == "en":
+            return {
+                "summary": (
+                    "Engineer Cafe is located in a historic building built in 1909. "
+                    "The 1st floor is wheelchair accessible. "
+                    "The basement (B1) and upper floors have limited accessibility "
+                    "due to the building's historic structure. "
+                    "Please contact staff for assistance."
+                ),
+                "wheelchair": "1F accessible, B1/upper floors limited",
+                "elevator": "Not available (historic building)",
+                "building_note": "Built in 1909, Important Cultural Property",
+            }
+        return {
+            "summary": (
+                "エンジニアカフェは1909年築の歴史的建造物（重要文化財）内にあります。"
+                "1階は車椅子でご利用いただけます。"
+                "地下1階や上階は建物の構造上、アクセスに制限がございます。"
+                "お困りの際はスタッフまでお声がけください。"
+            ),
+            "wheelchair": "1階は利用可、地下・上階は制限あり",
+            "elevator": "なし（歴史的建造物のため）",
+            "building_note": "1909年築、重要文化財",
+        }
+
     def _get_default_response(self, language: str, request_type: Optional[str]) -> Dict:
         """デフォルト応答を返す
 

--- a/backend/agents/orchestrator_agent.py
+++ b/backend/agents/orchestrator_agent.py
@@ -36,6 +36,7 @@ from backend.config.routing_constants import (
     CHILDREN_NOISE_KEYWORDS,
     COMMUNITY_KEYWORDS,
     CONSULTATION_KEYWORDS,
+    EMERGENCY_KEYWORDS,
     EXCLUSIVE_RENTAL_KEYWORDS,
     EVENT_KEYWORDS,
     FACILITY_EQUIPMENT_KEYWORDS,
@@ -365,6 +366,15 @@ class OrchestratorAgent:
     def _try_fast_routing(self, query: str) -> Optional[dict]:
         """キーワードベースの高速ルーティング"""
         lower_query = query.lower()
+
+        # 緊急キーワード → facility（最優先）
+        if match_keywords(lower_query, EMERGENCY_KEYWORDS):
+            return {
+                "agent": "facility",
+                "category": "emergency",
+                "request_type": "emergency",
+                "reasoning": "Emergency keyword detected",
+            }
 
         # カフェ曖昧性: "カフェ" + "どっち/どちら/which" → clarification
         # (orchestrator_node がcategory基準でインライン処理する)

--- a/backend/config/prompts/facility_prompts.py
+++ b/backend/config/prompts/facility_prompts.py
@@ -64,6 +64,10 @@ FACILITY_ENHANCEMENT_KEYWORDS: Dict[str, Dict[str, str]] = {
         "ja": "トイレ お手洗い 化粧室 テラス 場所 行き方",
         "en": "toilet restroom bathroom location terrace directions",
     },
+    "emergency": {
+        "ja": "緊急 AED 避難経路 非常口 救急 地震対応 防災",
+        "en": "emergency AED evacuation exit first aid earthquake safety",
+    },
 }
 
 # requestTypeに応じたプロンプト文言
@@ -87,6 +91,10 @@ FACILITY_REQUEST_TYPE_PROMPTS: Dict[str, Dict[str, str]] = {
     "toilet": {
         "en": "toilet and restroom location information",
         "ja": "トイレ・お手洗いの場所情報",
+    },
+    "emergency": {
+        "en": "emergency and safety information",
+        "ja": "緊急・安全情報",
     },
 }
 

--- a/backend/config/routing_constants.py
+++ b/backend/config/routing_constants.py
@@ -245,6 +245,27 @@ RECEPTION_KEYWORDS = [
     "はじめて",
 ]
 
+EMERGENCY_KEYWORDS = [
+    "緊急",
+    "地震",
+    "火事",
+    "火災",
+    "避難",
+    "AED",
+    "救急",
+    "警察",
+    "救命",
+    "emergency",
+    "earthquake",
+    "fire",
+    "evacuate",
+    "evacuation",
+    "ambulance",
+    "police",
+    "first aid",
+    "defibrillator",
+]
+
 FLOOR_LAYOUT_KEYWORDS = [
     "フロア構成",
     "フロアマップ",
@@ -461,6 +482,8 @@ CATEGORY_TO_AGENT_MAP: Dict[str, AgentNodeName] = {
     "community": "business_info",
     "cafe-clarification-needed": "general_knowledge",
     "meeting-room-clarification-needed": "general_knowledge",
+    "event-clarification-needed": "general_knowledge",
+    "space-clarification-needed": "general_knowledge",
     # query_classifier._detect_specific_category が返すカテゴリ
     "pricing": "business_info",
     "facilities": "facility",
@@ -471,6 +494,7 @@ CATEGORY_TO_AGENT_MAP: Dict[str, AgentNodeName] = {
     "smoking": "facility",
     "food_drink": "facility",
     "policy": "facility",
+    "emergency": "facility",
     "reception": "business_info",
     "floor_layout": "facility",
 }
@@ -484,7 +508,7 @@ CATEGORY_TO_AGENT_MAP: Dict[str, AgentNodeName] = {
 def match_keywords(text: str, keywords: List[str]) -> bool:
     """テキストにキーワードリストのいずれかが含まれているか判定"""
     lower_text = text.lower()
-    return any(kw in lower_text for kw in keywords)
+    return any(kw.lower() in lower_text for kw in keywords)
 
 
 LOCATION_KEYWORDS = ["場所", "どこ", "アクセス", "住所", "location", "where", "address"]
@@ -505,6 +529,8 @@ def extract_request_type(query: str) -> Optional[str]:
     """
     lower_query = query.lower()
 
+    if match_keywords(lower_query, EMERGENCY_KEYWORDS):
+        return "emergency"
     if match_keywords(lower_query, WIFI_KEYWORDS):
         return "wifi"
     if match_keywords(lower_query, BUSINESS_HOURS_KEYWORDS):

--- a/backend/tests/agents/test_event_agent.py
+++ b/backend/tests/agents/test_event_agent.py
@@ -2,6 +2,10 @@
 EventAgent のユニットテスト
 """
 
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
 from backend.agents.event_agent import EventAgent
 
 
@@ -164,3 +168,143 @@ class TestEventDeduplication:
         titles = [e["title"] for e in events]
         assert "Python Workshop" in titles
         assert "React Meetup" in titles
+
+
+class TestGetTodayEvents:
+    """get_today_events() のテスト"""
+
+    def setup_method(self):
+        self.agent = EventAgent()
+
+    @pytest.mark.asyncio
+    async def test_returns_events_when_available(self):
+        """イベントがある場合に正しく返すこと"""
+        with (
+            patch.object(
+                self.agent.calendar_service,
+                "search_events",
+                new_callable=AsyncMock,
+            ) as mock_cal,
+            patch.object(
+                self.agent.connpass_service,
+                "search_events",
+                new_callable=AsyncMock,
+            ) as mock_conn,
+        ):
+            mock_cal.return_value = {
+                "success": True,
+                "data": {
+                    "events": [
+                        {
+                            "title": "Today's Workshop",
+                            "start": "2026-02-28T14:00:00Z",
+                            "description": "A workshop",
+                        }
+                    ]
+                },
+            }
+            mock_conn.return_value = {"success": True, "data": {"events": []}}
+
+            result = await self.agent.get_today_events("ja")
+
+            assert result["has_events"] is True
+            assert result["count"] == 1
+            assert len(result["events"]) == 1
+            assert result["events"][0]["title"] == "Today's Workshop"
+            assert len(result["formatted_text"]) > 0
+            mock_cal.assert_called_once_with("today")
+
+    @pytest.mark.asyncio
+    async def test_returns_empty_when_no_events(self):
+        """イベントがない場合に空を返すこと"""
+        with (
+            patch.object(
+                self.agent.calendar_service,
+                "search_events",
+                new_callable=AsyncMock,
+            ) as mock_cal,
+            patch.object(
+                self.agent.connpass_service,
+                "search_events",
+                new_callable=AsyncMock,
+            ) as mock_conn,
+        ):
+            mock_cal.return_value = {"success": True, "data": {"events": []}}
+            mock_conn.return_value = {"success": True, "data": {"events": []}}
+
+            result = await self.agent.get_today_events("ja")
+
+            assert result["has_events"] is False
+            assert result["count"] == 0
+            assert result["formatted_text"] == ""
+
+    @pytest.mark.asyncio
+    async def test_merges_calendar_and_connpass(self):
+        """CalendarとConnpassのイベントを統合すること"""
+        with (
+            patch.object(
+                self.agent.calendar_service,
+                "search_events",
+                new_callable=AsyncMock,
+            ) as mock_cal,
+            patch.object(
+                self.agent.connpass_service,
+                "search_events",
+                new_callable=AsyncMock,
+            ) as mock_conn,
+        ):
+            mock_cal.return_value = {
+                "success": True,
+                "data": {
+                    "events": [
+                        {
+                            "title": "Cal Event",
+                            "start": "2026-02-28T10:00:00Z",
+                            "description": "",
+                        }
+                    ]
+                },
+            }
+            mock_conn.return_value = {
+                "success": True,
+                "data": {
+                    "events": [
+                        {
+                            "title": "Connpass Event",
+                            "start": "2026-02-28T15:00:00Z",
+                            "description": "",
+                            "source": "connpass",
+                        }
+                    ]
+                },
+            }
+
+            result = await self.agent.get_today_events("ja")
+
+            assert result["count"] == 2
+            titles = [e["title"] for e in result["events"]]
+            assert "Cal Event" in titles
+            assert "Connpass Event" in titles
+
+    @pytest.mark.asyncio
+    async def test_handles_api_error_gracefully(self):
+        """API失敗時にエラーなく空結果を返すこと"""
+        with (
+            patch.object(
+                self.agent.calendar_service,
+                "search_events",
+                new_callable=AsyncMock,
+            ) as mock_cal,
+            patch.object(
+                self.agent.connpass_service,
+                "search_events",
+                new_callable=AsyncMock,
+            ) as mock_conn,
+        ):
+            mock_cal.side_effect = Exception("API error")
+            mock_conn.side_effect = Exception("API error")
+
+            result = await self.agent.get_today_events("ja")
+
+            assert result["has_events"] is False
+            assert result["count"] == 0

--- a/backend/tests/agents/test_facility_agent.py
+++ b/backend/tests/agents/test_facility_agent.py
@@ -366,3 +366,75 @@ class TestFacilityAgent:
 
                 assert result["answer"] is not None
                 assert result["metadata"]["request_type"] == request_type
+
+
+class TestAccessibilitySummary:
+    """get_accessibility_summary() のテスト"""
+
+    def test_default_accessibility_info_japanese(self):
+        """日本語デフォルトアクセシビリティ情報"""
+        info = FacilityAgent._get_default_accessibility_info("ja")
+
+        assert "1909" in info["summary"]
+        assert "車椅子" in info["summary"] or "1階" in info["summary"]
+        assert "wheelchair" in info or "車椅子" in info.get("wheelchair", "")
+        assert info["building_note"] is not None
+
+    def test_default_accessibility_info_english(self):
+        """英語デフォルトアクセシビリティ情報"""
+        info = FacilityAgent._get_default_accessibility_info("en")
+
+        assert "1909" in info["summary"]
+        assert "wheelchair" in info["summary"].lower()
+        assert info["elevator"] is not None
+
+    @pytest.mark.asyncio
+    async def test_returns_rag_based_summary(self):
+        """RAG成功時にLLMサマリーを返すこと"""
+        agent = FacilityAgent()
+
+        with (
+            patch.object(agent.enhanced_rag, "search", new_callable=AsyncMock) as mock_rag,
+            patch.object(agent.llm_provider, "generate", new_callable=AsyncMock) as mock_llm,
+        ):
+            mock_rag.return_value = {
+                "success": True,
+                "data": {
+                    "context": "1階は車椅子対応。地下はアクセス制限あり。",
+                    "results": [],
+                },
+            }
+            mock_llm.return_value = "1階は車椅子でご利用可能です。地下は制限があります。"
+
+            result = await agent.get_accessibility_summary("ja")
+
+            assert result["has_info"] is True
+            assert "車椅子" in result["summary"]
+            assert result["details"]["raw_context"] is not None
+
+    @pytest.mark.asyncio
+    async def test_returns_default_on_rag_failure(self):
+        """RAG失敗時にデフォルト情報を返すこと"""
+        agent = FacilityAgent()
+
+        with patch.object(agent.enhanced_rag, "search", new_callable=AsyncMock) as mock_rag:
+            mock_rag.return_value = {"success": False, "error": "search failed"}
+
+            result = await agent.get_accessibility_summary("ja")
+
+            assert result["has_info"] is False
+            assert "1909" in result["summary"]
+
+    @pytest.mark.asyncio
+    async def test_returns_default_on_exception(self):
+        """例外発生時にデフォルト情報を返すこと"""
+        agent = FacilityAgent()
+
+        with patch.object(agent.enhanced_rag, "search", new_callable=AsyncMock) as mock_rag:
+            mock_rag.side_effect = Exception("connection error")
+
+            result = await agent.get_accessibility_summary("en")
+
+            assert result["has_info"] is False
+            assert "1909" in result["summary"]
+            assert "wheelchair" in result["summary"].lower()

--- a/backend/tests/config/test_emergency_keywords.py
+++ b/backend/tests/config/test_emergency_keywords.py
@@ -1,0 +1,77 @@
+"""
+緊急キーワードテスト - Issue #97
+"""
+
+import pytest
+
+from backend.config.routing_constants import (
+    EMERGENCY_KEYWORDS,
+    CATEGORY_TO_AGENT_MAP,
+    extract_request_type,
+)
+
+
+class TestEmergencyKeywords:
+    """緊急キーワード定義のテスト"""
+
+    def test_emergency_keywords_exist(self):
+        """EMERGENCY_KEYWORDSが定義されていること"""
+        assert len(EMERGENCY_KEYWORDS) > 0
+
+    def test_emergency_keywords_contain_japanese(self):
+        """日本語キーワードが含まれること"""
+        ja_keywords = ["緊急", "地震", "火事", "避難", "AED"]
+        for kw in ja_keywords:
+            assert kw in EMERGENCY_KEYWORDS, f"{kw} not in EMERGENCY_KEYWORDS"
+
+    def test_emergency_keywords_contain_english(self):
+        """英語キーワードが含まれること"""
+        en_keywords = ["emergency", "earthquake", "fire", "evacuate"]
+        for kw in en_keywords:
+            assert kw in EMERGENCY_KEYWORDS, f"{kw} not in EMERGENCY_KEYWORDS"
+
+    def test_emergency_maps_to_facility_agent(self):
+        """emergencyカテゴリがfacilityエージェントにマッピングされること"""
+        assert CATEGORY_TO_AGENT_MAP["emergency"] == "facility"
+
+
+class TestEmergencyRouting:
+    """extract_request_typeでの緊急キーワードルーティングテスト"""
+
+    @pytest.mark.parametrize(
+        "query",
+        [
+            "AEDはどこですか？",
+            "地震です！",
+            "火事だ！",
+            "避難経路を教えて",
+            "緊急です",
+        ],
+    )
+    def test_japanese_emergency_queries(self, query):
+        """日本語の緊急クエリがemergencyにルーティングされること"""
+        assert extract_request_type(query) == "emergency"
+
+    @pytest.mark.parametrize(
+        "query",
+        [
+            "Where is the AED?",
+            "Emergency!",
+            "There is a fire!",
+            "How do I evacuate?",
+        ],
+    )
+    def test_english_emergency_queries(self, query):
+        """英語の緊急クエリがemergencyにルーティングされること"""
+        assert extract_request_type(query) == "emergency"
+
+    def test_emergency_detected_before_reception(self):
+        """emergencyがreceptionより優先されること"""
+        # "初めて" is a reception keyword, but "緊急" should take priority
+        result = extract_request_type("緊急で初めて来ました")
+        assert result == "emergency"
+
+    def test_non_emergency_query_not_affected(self):
+        """非緊急クエリが影響を受けないこと"""
+        assert extract_request_type("Wi-Fiはありますか？") == "wifi"
+        assert extract_request_type("営業時間は？") == "hours"

--- a/backend/tests/config/test_routing_constants.py
+++ b/backend/tests/config/test_routing_constants.py
@@ -4,7 +4,10 @@ routing_constants のユニットテスト - 新規キーワードルーティ�
 
 import pytest
 
-from backend.config.routing_constants import extract_request_type
+from backend.config.routing_constants import (
+    CATEGORY_TO_AGENT_MAP,
+    extract_request_type,
+)
 
 
 class TestNewRoutingKeywords:
@@ -58,3 +61,37 @@ class TestNewRoutingKeywords:
     def test_food_drink_keywords(self, query, expected):
         """飲食キーワードがfood_drinkにルーティングされることを確認"""
         assert extract_request_type(query) == expected
+
+
+class TestReceptionRouting:
+    """受付キーワードルーティングテスト"""
+
+    @pytest.mark.parametrize(
+        "query,expected",
+        [
+            ("初めて来ました", "reception"),
+            ("利用方法を教えてください", "reception"),
+            ("チェックインしたいです", "reception"),
+            ("How do I check-in?", "reception"),
+        ],
+    )
+    def test_reception_keywords(self, query, expected):
+        """受付キーワードがreceptionにルーティングされることを確認"""
+        assert extract_request_type(query) == expected
+
+    def test_reception_maps_to_business_info(self):
+        """receptionカテゴリがbusiness_infoにマッピングされることを確認"""
+        assert CATEGORY_TO_AGENT_MAP["reception"] == "business_info"
+
+
+class TestEmergencyRoutingIntegration:
+    """緊急キーワードルーティング統合テスト"""
+
+    def test_emergency_maps_to_facility(self):
+        """emergencyカテゴリがfacilityにマッピングされることを確認"""
+        assert CATEGORY_TO_AGENT_MAP["emergency"] == "facility"
+
+    def test_emergency_priority_over_other_keywords(self):
+        """emergencyは他のキーワードより優先される"""
+        # "場所" is a location keyword but "AED" is emergency
+        assert extract_request_type("AEDの場所はどこ？") == "emergency"

--- a/backend/tests/e2e/test_reception_enhancement_e2e.py
+++ b/backend/tests/e2e/test_reception_enhancement_e2e.py
@@ -15,7 +15,6 @@ import pytest
 
 from backend.tests.e2e.conftest import assert_keywords, is_routing_failure
 
-
 # =============================================================================
 # Issue #97: 緊急情報対応テスト
 # =============================================================================
@@ -398,9 +397,7 @@ class TestReceptionEdgeCasesE2E:
 
     async def test_negative_sentiment_query(self, invoke_workflow):
         """ネガティブな感情のクエリ"""
-        result = await invoke_workflow(
-            "Wi-Fiが繋がらないんですけど、どうすればいいですか？"
-        )
+        result = await invoke_workflow("Wi-Fiが繋がらないんですけど、どうすればいいですか？")
         assert result["answer"], "ネガティブクエリへの回答が空です"
 
     async def test_ambiguous_cafe_reference(self, invoke_workflow):

--- a/backend/tests/e2e/test_reception_enhancement_e2e.py
+++ b/backend/tests/e2e/test_reception_enhancement_e2e.py
@@ -1,0 +1,478 @@
+"""
+受付機能強化 E2Eテスト - Issues #95-#99
+
+AI受付エージェントとしての全機能を網羅的にテスト。
+緊急情報、受付案内、イベント曖昧性、スペース曖昧性、
+アクセシビリティを含む包括的シナリオ。
+
+実行方法:
+    pytest backend/tests/e2e/test_reception_enhancement_e2e.py --run-e2e -v
+"""
+
+import uuid
+
+import pytest
+
+from backend.tests.e2e.conftest import assert_keywords, is_routing_failure
+
+
+# =============================================================================
+# Issue #97: 緊急情報対応テスト
+# =============================================================================
+
+
+@pytest.mark.e2e
+class TestEmergencyResponseE2E:
+    """緊急キーワード検出とFacilityAgentルーティングのE2Eテスト"""
+
+    async def test_aed_location_japanese(self, invoke_workflow):
+        """AED場所の質問 → FacilityAgentが応答"""
+        result = await invoke_workflow("AEDはどこですか？")
+        assert result["answer"], "回答が空です"
+        # AED/emergency系の応答であることを確認
+        metadata = result.get("metadata", {})
+        # FacilityAgentまたはorchestrator_inline経由で応答
+        agent = metadata.get("agent", "")
+        assert agent in (
+            "FacilityAgent",
+            "orchestrator_inline",
+            "",
+        ), f"Unexpected agent: {agent}"
+
+    async def test_aed_location_english(self, invoke_workflow):
+        """AED location query in English → FacilityAgent responds"""
+        result = await invoke_workflow("Where is the AED?", language="en")
+        assert result["answer"], "Answer is empty"
+
+    async def test_earthquake_response_japanese(self, invoke_workflow):
+        """地震の質問 → 安全情報を提供"""
+        result = await invoke_workflow("地震です！どうすればいいですか？")
+        assert result["answer"], "回答が空です"
+
+    async def test_fire_emergency_japanese(self, invoke_workflow):
+        """火事の質問 → 避難情報を提供"""
+        result = await invoke_workflow("火事だ！避難経路を教えて！")
+        assert result["answer"], "回答が空です"
+
+    async def test_evacuation_route_english(self, invoke_workflow):
+        """Evacuation query in English"""
+        result = await invoke_workflow(
+            "How do I evacuate? Where is the emergency exit?",
+            language="en",
+        )
+        assert result["answer"], "Answer is empty"
+
+    async def test_emergency_priority_over_location(self, invoke_workflow):
+        """緊急が場所キーワードより優先される"""
+        result = await invoke_workflow("AEDの場所はどこにありますか？")
+        assert result["answer"], "回答が空です"
+        # 回答にAEDまたは緊急系の情報が含まれるべき
+        # （"場所"キーワードに引きずられずemergencyルーティングされるか確認）
+
+    async def test_first_aid_query(self, invoke_workflow):
+        """救急に関する質問"""
+        result = await invoke_workflow("救急箱はありますか？けがをしました")
+        assert result["answer"], "回答が空です"
+
+
+# =============================================================================
+# Issue #96: 受付案内テスト
+# =============================================================================
+
+
+@pytest.mark.e2e
+class TestReceptionE2E:
+    """受付テンプレート応答のE2Eテスト"""
+
+    async def test_first_time_visitor_japanese(self, invoke_workflow):
+        """初回利用者の質問 → first_time テンプレート"""
+        result = await invoke_workflow("初めて来ました。利用方法を教えてください。")
+        assert result["answer"], "回答が空です"
+        # reception template or business_info agent
+        if not is_routing_failure(result["answer"]):
+            assert_keywords(
+                result["answer"],
+                ["ようこそ", "受付", "登録", "無料", "Wi-Fi", "エンジニアカフェ"],
+                threshold=0.2,
+                msg="初回利用者案内",
+            )
+
+    async def test_first_time_visitor_english(self, invoke_workflow):
+        """First-time visitor in English → first_time template"""
+        result = await invoke_workflow(
+            "This is my first visit. How do I use the space?",
+            language="en",
+        )
+        assert result["answer"], "Answer is empty"
+        if not is_routing_failure(result["answer"]):
+            assert_keywords(
+                result["answer"],
+                ["welcome", "free", "Wi-Fi", "register", "reception"],
+                threshold=0.2,
+                msg="First-time visitor guidance",
+            )
+
+    async def test_check_in_query(self, invoke_workflow):
+        """チェックイン方法の質問"""
+        result = await invoke_workflow("チェックインはどうすればいいですか？")
+        assert result["answer"], "回答が空です"
+
+    async def test_registration_query(self, invoke_workflow):
+        """利用登録の質問"""
+        result = await invoke_workflow("初回利用登録はどこでできますか？")
+        assert result["answer"], "回答が空です"
+
+    async def test_general_welcome(self, invoke_workflow):
+        """一般的な受付案内"""
+        result = await invoke_workflow("利用方法を教えてください")
+        assert result["answer"], "回答が空です"
+
+
+# =============================================================================
+# Issue #95: Clarification テンプレート新カテゴリテスト
+# =============================================================================
+
+
+@pytest.mark.e2e
+class TestEventClarificationE2E:
+    """イベント曖昧性質問のE2Eテスト"""
+
+    async def test_vague_event_query_japanese(self, invoke_workflow):
+        """曖昧なイベント質問 → clarification テンプレート"""
+        result = await invoke_workflow("イベントについて教えてください")
+        assert result["answer"], "回答が空です"
+        # イベント情報またはclarificationが返る
+        if not is_routing_failure(result["answer"]):
+            assert_keywords(
+                result["answer"],
+                ["イベント", "参加", "開催", "スケジュール", "予定"],
+                threshold=0.2,
+                msg="イベント曖昧性テスト",
+            )
+
+    async def test_vague_event_query_english(self, invoke_workflow):
+        """Vague event query in English"""
+        result = await invoke_workflow(
+            "Tell me about events",
+            language="en",
+        )
+        assert result["answer"], "Answer is empty"
+
+    async def test_specific_event_query(self, invoke_workflow):
+        """具体的なイベント質問 → EventAgentで直接応答"""
+        result = await invoke_workflow("今週のイベントは何がありますか？")
+        assert result["answer"], "回答が空です"
+
+
+@pytest.mark.e2e
+class TestSpaceClarificationE2E:
+    """スペース曖昧性質問のE2Eテスト"""
+
+    async def test_vague_space_query_japanese(self, invoke_workflow):
+        """曖昧なスペース質問 → clarification テンプレート or detailed info"""
+        result = await invoke_workflow("どのスペースが使えますか？")
+        assert result["answer"], "回答が空です"
+        if not is_routing_failure(result["answer"]):
+            assert_keywords(
+                result["answer"],
+                [
+                    "メインホール",
+                    "集中スペース",
+                    "MTG",
+                    "MAKER",
+                    "スペース",
+                    "1階",
+                    "地下",
+                ],
+                threshold=0.15,
+                msg="スペース案内",
+            )
+
+    async def test_vague_space_query_english(self, invoke_workflow):
+        """Vague space query in English"""
+        result = await invoke_workflow(
+            "What spaces are available?",
+            language="en",
+        )
+        assert result["answer"], "Answer is empty"
+
+    async def test_specific_space_query(self, invoke_workflow):
+        """具体的なスペース質問 → FacilityAgentで直接応答"""
+        result = await invoke_workflow("地下のMTGスペースの利用方法を教えて")
+        assert result["answer"], "回答が空です"
+
+
+# =============================================================================
+# Issue #98: EventAgent.get_today_events() テスト
+# =============================================================================
+
+
+@pytest.mark.e2e
+class TestTodayEventsE2E:
+    """本日のイベント情報取得のE2Eテスト"""
+
+    async def test_today_events_japanese(self, invoke_workflow):
+        """今日のイベント情報を聞く"""
+        result = await invoke_workflow("今日のイベントはありますか？")
+        assert result["answer"], "回答が空です"
+        # イベントがあってもなくても適切な応答であること
+        metadata = result.get("metadata", {})
+        agent = metadata.get("agent", "")
+        assert agent in ("EventAgent", "orchestrator_inline", ""), f"Unexpected agent: {agent}"
+
+    async def test_today_events_english(self, invoke_workflow):
+        """Today's events query in English"""
+        result = await invoke_workflow("What events are happening today?", language="en")
+        assert result["answer"], "Answer is empty"
+
+    async def test_today_schedule(self, invoke_workflow):
+        """本日のスケジュール確認"""
+        result = await invoke_workflow("本日のスケジュールを教えて")
+        assert result["answer"], "回答が空です"
+
+
+# =============================================================================
+# Issue #99: アクセシビリティ情報テスト
+# =============================================================================
+
+
+@pytest.mark.e2e
+class TestAccessibilityE2E:
+    """アクセシビリティ情報のE2Eテスト"""
+
+    async def test_wheelchair_access_japanese(self, invoke_workflow):
+        """車椅子利用可否の質問"""
+        result = await invoke_workflow("車椅子で利用できますか？")
+        assert result["answer"], "回答が空です"
+        if not is_routing_failure(result["answer"]):
+            assert_keywords(
+                result["answer"],
+                ["車椅子", "1階", "地下", "バリアフリー", "スタッフ", "エレベーター"],
+                threshold=0.15,
+                msg="車椅子アクセス情報",
+            )
+
+    async def test_wheelchair_access_english(self, invoke_workflow):
+        """Wheelchair accessibility query in English"""
+        result = await invoke_workflow(
+            "Is the cafe wheelchair accessible?",
+            language="en",
+        )
+        assert result["answer"], "Answer is empty"
+
+    async def test_elevator_availability(self, invoke_workflow):
+        """エレベーターの有無"""
+        result = await invoke_workflow("エレベーターはありますか？")
+        assert result["answer"], "回答が空です"
+
+    async def test_barrier_free_info(self, invoke_workflow):
+        """バリアフリー情報の質問"""
+        result = await invoke_workflow("バリアフリー対応について教えてください")
+        assert result["answer"], "回答が空です"
+
+    async def test_stair_ramp_info(self, invoke_workflow):
+        """段差・スロープの質問"""
+        result = await invoke_workflow("段差はありますか？スロープはありますか？")
+        assert result["answer"], "回答が空です"
+
+
+# =============================================================================
+# 複合シナリオテスト（受付エージェントとしての統合テスト）
+# =============================================================================
+
+
+@pytest.mark.e2e
+class TestReceptionScenarioE2E:
+    """受付エージェントとしての統合シナリオテスト"""
+
+    async def test_first_visit_full_scenario(self, invoke_workflow):
+        """初回訪問者の完全フロー: 受付 → 施設案内 → Wi-Fi → イベント"""
+        sid = f"e2e-first-visit-{uuid.uuid4().hex[:8]}"
+
+        # Step 1: 初回訪問
+        r1 = await invoke_workflow("初めて来ました", session_id=sid)
+        assert r1["answer"], "Step 1: 受付案内が空です"
+
+        # Step 2: スペースについて聞く
+        r2 = await invoke_workflow("どんなスペースがありますか？", session_id=sid)
+        assert r2["answer"], "Step 2: スペース案内が空です"
+
+        # Step 3: Wi-Fiについて聞く
+        r3 = await invoke_workflow("Wi-Fiは使えますか？", session_id=sid)
+        assert r3["answer"], "Step 3: Wi-Fi案内が空です"
+
+        # Step 4: イベントについて聞く
+        r4 = await invoke_workflow("今日のイベントはありますか？", session_id=sid)
+        assert r4["answer"], "Step 4: イベント情報が空です"
+
+    async def test_emergency_during_visit(self, invoke_workflow):
+        """通常利用中の緊急事態シナリオ"""
+        sid = f"e2e-emergency-{uuid.uuid4().hex[:8]}"
+
+        # Step 1: 通常の質問
+        r1 = await invoke_workflow("Wi-Fiのパスワードを教えて", session_id=sid)
+        assert r1["answer"], "Step 1: Wi-Fi情報が空です"
+
+        # Step 2: 突然の緊急事態
+        r2 = await invoke_workflow("AEDはどこですか？急いでいます！", session_id=sid)
+        assert r2["answer"], "Step 2: AED情報が空です"
+
+    async def test_multilingual_reception(self, invoke_workflow):
+        """多言語受付シナリオ"""
+        sid = f"e2e-multilingual-{uuid.uuid4().hex[:8]}"
+
+        # 英語での初回訪問
+        r1 = await invoke_workflow(
+            "Hello, this is my first time here. How do I use this place?",
+            language="en",
+            session_id=sid,
+        )
+        assert r1["answer"], "Step 1: English welcome is empty"
+
+        # 英語でWi-Fi質問
+        r2 = await invoke_workflow(
+            "Is there free Wi-Fi?",
+            language="en",
+            session_id=sid,
+        )
+        assert r2["answer"], "Step 2: Wi-Fi info is empty"
+
+    async def test_accessibility_focused_visit(self, invoke_workflow):
+        """アクセシビリティ重視の訪問シナリオ"""
+        sid = f"e2e-accessibility-{uuid.uuid4().hex[:8]}"
+
+        # Step 1: 車椅子利用可否
+        r1 = await invoke_workflow("車椅子で利用できますか？", session_id=sid)
+        assert r1["answer"], "Step 1: 車椅子情報が空です"
+
+        # Step 2: 地下施設へのアクセス
+        r2 = await invoke_workflow(
+            "地下のスペースは車椅子で行けますか？",
+            session_id=sid,
+        )
+        assert r2["answer"], "Step 2: 地下アクセス情報が空です"
+
+
+# =============================================================================
+# ストレステスト・エッジケース
+# =============================================================================
+
+
+@pytest.mark.e2e
+class TestReceptionEdgeCasesE2E:
+    """エッジケース・ストレステスト"""
+
+    async def test_empty_query(self, invoke_workflow):
+        """空のクエリに対する応答"""
+        result = await invoke_workflow("")
+        # 空クエリでもクラッシュしないこと
+        assert isinstance(result.get("answer", ""), str)
+
+    async def test_very_long_query(self, invoke_workflow):
+        """非常に長いクエリ"""
+        long_query = "エンジニアカフェについて教えてください。" * 20
+        result = await invoke_workflow(long_query)
+        assert result["answer"], "長いクエリへの回答が空です"
+
+    async def test_mixed_language_query(self, invoke_workflow):
+        """日英混在クエリ"""
+        result = await invoke_workflow("Wi-Fiのpasswordを教えて。Where can I find it?")
+        assert result["answer"], "混在クエリへの回答が空です"
+
+    async def test_emoji_in_query(self, invoke_workflow):
+        """絵文字を含むクエリ"""
+        result = await invoke_workflow("Wi-Fiは使えますか？🤔")
+        assert result["answer"], "絵文字クエリへの回答が空です"
+
+    async def test_special_characters_query(self, invoke_workflow):
+        """特殊文字を含むクエリ"""
+        result = await invoke_workflow("Wi-Fi（ワイファイ）の<<パスワード>>は？")
+        assert result["answer"], "特殊文字クエリへの回答が空です"
+
+    async def test_multiple_topics_in_one_query(self, invoke_workflow):
+        """複数トピックを含む質問"""
+        result = await invoke_workflow(
+            "Wi-Fiの使い方と、今日のイベント情報と、トイレの場所を教えてください"
+        )
+        assert result["answer"], "複合質問への回答が空です"
+
+    async def test_negative_sentiment_query(self, invoke_workflow):
+        """ネガティブな感情のクエリ"""
+        result = await invoke_workflow(
+            "Wi-Fiが繋がらないんですけど、どうすればいいですか？"
+        )
+        assert result["answer"], "ネガティブクエリへの回答が空です"
+
+    async def test_ambiguous_cafe_reference(self, invoke_workflow):
+        """カフェの曖昧参照（エンジニアカフェ vs サイノカフェ）"""
+        result = await invoke_workflow("カフェのメニューを見たいんですが")
+        assert result["answer"], "カフェ曖昧参照への回答が空です"
+
+    async def test_greeting_only(self, invoke_workflow):
+        """挨拶のみのクエリ"""
+        result = await invoke_workflow("こんにちは！")
+        assert result["answer"], "挨拶への応答が空です"
+
+
+# =============================================================================
+# ルーティング精度検証テスト
+# =============================================================================
+
+
+@pytest.mark.e2e
+class TestRoutingAccuracyE2E:
+    """新しいルーティングの精度検証"""
+
+    async def test_emergency_routes_to_facility(self, invoke_workflow):
+        """緊急クエリが正しくルーティングされること"""
+        queries = [
+            "AEDはどこですか？",
+            "地震の時はどうする？",
+            "火事です！",
+        ]
+        for query in queries:
+            result = await invoke_workflow(query)
+            assert result["answer"], f"'{query}' の回答が空です"
+            # FacilityAgentにルーティングされることを確認
+            agent = result.get("metadata", {}).get("agent", "")
+            if agent:  # agentメタデータがある場合のみチェック
+                assert agent in (
+                    "FacilityAgent",
+                    "facility",
+                    "orchestrator_inline",
+                ), f"'{query}' が {agent} にルーティングされました（facility期待）"
+
+    async def test_reception_routes_correctly(self, invoke_workflow):
+        """受付クエリが正しくルーティングされること"""
+        queries = [
+            "初めて来ました",
+            "利用方法を教えてください",
+            "チェックインしたい",
+        ]
+        for query in queries:
+            result = await invoke_workflow(query)
+            assert result["answer"], f"'{query}' の回答が空です"
+
+    async def test_event_query_routes_to_event_agent(self, invoke_workflow):
+        """イベントクエリがEventAgentにルーティングされること"""
+        result = await invoke_workflow("今週の勉強会は何がありますか？")
+        assert result["answer"], "イベントクエリの回答が空です"
+        agent = result.get("metadata", {}).get("agent", "")
+        if agent:
+            assert agent in (
+                "EventAgent",
+                "event",
+                "orchestrator_inline",
+            ), f"イベントクエリが {agent} にルーティング（event期待）"
+
+    async def test_accessibility_routes_to_facility(self, invoke_workflow):
+        """アクセシビリティクエリがFacilityAgentにルーティングされること"""
+        result = await invoke_workflow("車椅子で利用できますか？")
+        assert result["answer"], "アクセシビリティクエリの回答が空です"
+        agent = result.get("metadata", {}).get("agent", "")
+        if agent:
+            assert agent in (
+                "FacilityAgent",
+                "facility",
+                "orchestrator_inline",
+            ), f"アクセシビリティが {agent} にルーティング（facility期待）"

--- a/backend/tests/utils/test_clarification_templates.py
+++ b/backend/tests/utils/test_clarification_templates.py
@@ -95,6 +95,59 @@ class TestMeetingRoomClarificationMessages:
         assert result["metadata"]["confidence"] == 0.9
 
 
+class TestEventClarificationMessages:
+    """イベント曖昧性のテンプレートメッセージをテスト"""
+
+    def test_event_clarification_ja_contains_options(self):
+        """日本語メッセージにイベント選択肢が含まれる"""
+        result = get_clarification_response("event-clarification-needed", "ja")
+        response = result["response"]
+
+        assert "参加" in response
+        assert "開催" in response
+        assert "スケジュール" in response or "本日" in response
+
+    def test_event_clarification_en_contains_options(self):
+        """英語メッセージにイベント選択肢が含まれる"""
+        result = get_clarification_response("event-clarification-needed", "en")
+        response = result["response"]
+
+        assert "Attend" in response or "attend" in response
+        assert "Host" in response or "host" in response
+
+    def test_event_clarification_confidence_is_high(self):
+        """イベント曖昧性の confidence は 0.9"""
+        result = get_clarification_response("event-clarification-needed", "ja")
+        assert result["metadata"]["confidence"] == 0.9
+
+
+class TestSpaceClarificationMessages:
+    """スペース曖昧性のテンプレートメッセージをテスト"""
+
+    def test_space_clarification_ja_contains_spaces(self):
+        """日本語メッセージに各スペース名が含まれる"""
+        result = get_clarification_response("space-clarification-needed", "ja")
+        response = result["response"]
+
+        assert "メインホール" in response
+        assert "集中スペース" in response
+        assert "MTGスペース" in response
+
+    def test_space_clarification_en_contains_spaces(self):
+        """英語メッセージに各スペース名が含まれる"""
+        result = get_clarification_response("space-clarification-needed", "en")
+        response = result["response"]
+
+        assert "Main Hall" in response
+        assert "Focus Space" in response
+        assert "MTG Space" in response
+
+    def test_space_clarification_confidence_is_high(self):
+        """スペース曖昧性の confidence は 0.9"""
+        result = get_clarification_response("space-clarification-needed", "ja")
+        assert result["metadata"]["confidence"] == 0.9
+
+
 class TestGeneralClarificationMessages:
     """一般的な曖昧性のテンプレートメッセージをテスト"""
 
@@ -157,6 +210,8 @@ class TestEmotionTagging:
         categories = [
             "cafe-clarification-needed",
             "meeting-room-clarification-needed",
+            "event-clarification-needed",
+            "space-clarification-needed",
             "general-clarification-needed",
         ]
 

--- a/backend/tests/utils/test_reception_templates.py
+++ b/backend/tests/utils/test_reception_templates.py
@@ -1,0 +1,156 @@
+"""
+Tests for backend/utils/reception_templates.py
+
+Reception テンプレートの固定応答メッセージとメタデータ生成をテスト。
+"""
+
+from backend.utils.reception_templates import get_reception_response
+
+
+class TestReceptionResponseStructure:
+    """レスポンス構造のテスト"""
+
+    def test_returns_dict_with_required_keys(self):
+        """必須キー（response, emotion, metadata）を含む辞書を返す"""
+        result = get_reception_response("ja")
+
+        assert "response" in result
+        assert "emotion" in result
+        assert "metadata" in result
+
+    def test_response_is_string(self):
+        """response フィールドは文字列"""
+        result = get_reception_response("ja")
+        assert isinstance(result["response"], str)
+        assert len(result["response"]) > 0
+
+    def test_emotion_is_happy(self):
+        """emotion フィールドは常に "happy" """
+        result = get_reception_response("ja")
+        assert result["emotion"] == "happy"
+
+    def test_metadata_contains_required_fields(self):
+        """metadata に agent, confidence, category, sources が含まれる"""
+        result = get_reception_response("ja")
+        metadata = result["metadata"]
+
+        assert "agent" in metadata
+        assert "confidence" in metadata
+        assert "category" in metadata
+        assert "sources" in metadata
+
+        assert metadata["agent"] == "ReceptionAgent"
+        assert isinstance(metadata["confidence"], float)
+        assert metadata["category"] == "reception"
+        assert isinstance(metadata["sources"], list)
+
+
+class TestFirstTimeReception:
+    """初回利用案内のテスト"""
+
+    def test_first_time_ja_contains_welcome(self):
+        """日本語初回メッセージにウェルカム情報が含まれる"""
+        result = get_reception_response("ja", "first_time")
+        response = result["response"]
+
+        assert "ようこそ" in response
+        assert "無料" in response
+        assert "受付" in response or "利用登録" in response
+
+    def test_first_time_en_contains_welcome(self):
+        """英語初回メッセージにwelcome情報が含まれる"""
+        result = get_reception_response("en", "first_time")
+        response = result["response"]
+
+        assert "Welcome" in response
+        assert "free" in response.lower()
+        assert "register" in response.lower() or "reception" in response.lower()
+
+    def test_first_time_confidence_is_high(self):
+        """初回利用案内の confidence は 0.95"""
+        result = get_reception_response("ja", "first_time")
+        assert result["metadata"]["confidence"] == 0.95
+
+    def test_first_time_reception_type_in_metadata(self):
+        """metadata に reception_type が含まれる"""
+        result = get_reception_response("ja", "first_time")
+        assert result["metadata"]["reception_type"] == "first_time"
+
+
+class TestReturningReception:
+    """リピーター案内のテスト"""
+
+    def test_returning_ja_contains_welcome_back(self):
+        """日本語リピーターメッセージにおかえりが含まれる"""
+        result = get_reception_response("ja", "returning")
+        response = result["response"]
+
+        assert "おかえり" in response
+
+    def test_returning_en_contains_welcome_back(self):
+        """英語リピーターメッセージにwelcome backが含まれる"""
+        result = get_reception_response("en", "returning")
+        response = result["response"]
+
+        assert "Welcome back" in response
+
+    def test_returning_confidence(self):
+        """リピーター案内の confidence は 0.9"""
+        result = get_reception_response("ja", "returning")
+        assert result["metadata"]["confidence"] == 0.9
+
+
+class TestGeneralReception:
+    """一般受付案内のテスト"""
+
+    def test_general_ja_contains_basic_info(self):
+        """日本語一般案内に基本情報が含まれる"""
+        result = get_reception_response("ja", "general")
+        response = result["response"]
+
+        assert "Wi-Fi" in response or "wifi" in response.lower()
+        assert "9:00" in response or "営業時間" in response
+
+    def test_general_en_contains_basic_info(self):
+        """英語一般案内に基本情報が含まれる"""
+        result = get_reception_response("en", "general")
+        response = result["response"]
+
+        assert "Wi-Fi" in response
+        assert "9:00" in response
+
+    def test_general_is_default_reception_type(self):
+        """引数なしはgeneralになる"""
+        result = get_reception_response("ja")
+        assert result["metadata"]["reception_type"] == "general"
+
+    def test_general_confidence(self):
+        """一般案内の confidence は 0.85"""
+        result = get_reception_response("ja", "general")
+        assert result["metadata"]["confidence"] == 0.85
+
+
+class TestEmotionTagging:
+    """感情タグが付与されることをテスト"""
+
+    def test_response_starts_with_emotion_tag(self):
+        """レスポンスが感情タグ [happy] で始まる"""
+        result = get_reception_response("ja")
+        assert result["response"].startswith("[happy]")
+
+    def test_all_types_have_emotion_tag(self):
+        """すべての受付タイプで感情タグが付与される"""
+        for reception_type in ["first_time", "returning", "general"]:
+            result = get_reception_response("ja", reception_type)
+            assert result["response"].startswith("[happy]")
+
+
+class TestLanguageFallback:
+    """未知の言語に対するフォールバック動作をテスト"""
+
+    def test_unknown_language_falls_back_to_japanese(self):
+        """未知の言語は日本語にフォールバック"""
+        result = get_reception_response("fr")  # type: ignore
+
+        # 日本語メッセージになる
+        assert "エンジニアカフェ" in result["response"] or "ようこそ" in result["response"]

--- a/backend/utils/clarification_templates.py
+++ b/backend/utils/clarification_templates.py
@@ -16,6 +16,8 @@ SupportedLanguage = Literal["ja", "en"]
 ClarificationCategory = Literal[
     "cafe-clarification-needed",
     "meeting-room-clarification-needed",
+    "event-clarification-needed",
+    "space-clarification-needed",
     "general-clarification-needed",
 ]
 
@@ -71,6 +73,48 @@ _MEETING_ROOM_CLARIFICATION: dict[str, str] = {
     ),
 }
 
+_EVENT_CLARIFICATION: dict[str, str] = {
+    "en": (
+        "I'd be happy to help with event information! "
+        "Could you tell me more about what you're looking for?\n"
+        "1. **Attend an event** - Browse upcoming events at Engineer Cafe\n"
+        "2. **Host an event** - Information about hosting your own event\n"
+        "3. **Today's schedule** - Check what's happening today\n\n"
+        "Which one interests you?"
+    ),
+    "ja": (
+        "イベントについてお手伝いします！"
+        "どのような情報をお探しでしょうか？\n"
+        "1. **イベントに参加したい** - エンジニアカフェの今後のイベント一覧\n"
+        "2. **イベントを開催したい** - イベント開催に関する情報\n"
+        "3. **本日のスケジュール** - 今日開催されるイベントの確認\n\n"
+        "どちらについてお知りになりたいですか？"
+    ),
+}
+
+_SPACE_CLARIFICATION: dict[str, str] = {
+    "en": (
+        "We have several spaces available! "
+        "Which one are you interested in?\n"
+        "1. **Main Hall (1F)** - Open coworking area, free to use\n"
+        "2. **Focus Space (B1)** - Quiet area for concentrated work\n"
+        "3. **MTG Space (B1)** - Free meeting space (2h blocks, reservation priority)\n"
+        "4. **MAKER's Space (B1)** - 3D printer, laser cutter available\n"
+        "5. **Under Space (B1)** - Event & presentation space\n\n"
+        "Which space would you like to know about?"
+    ),
+    "ja": (
+        "いくつかのスペースがございます！"
+        "どちらにご興味がありますか？\n"
+        "1. **メインホール（1階）** - オープンコワーキングエリア、無料利用可\n"
+        "2. **集中スペース（地下1階）** - 静かな作業環境\n"
+        "3. **MTGスペース（地下1階）** - 無料会議スペース（2時間区切り、予約優先）\n"
+        "4. **MAKER'sスペース（地下1階）** - 3Dプリンター・レーザーカッター利用可\n"
+        "5. **アンダースペース（地下1階）** - イベント・プレゼンテーション用スペース\n\n"
+        "どのスペースについてお知りになりたいですか？"
+    ),
+}
+
 _GENERAL_CLARIFICATION: dict[str, str] = {
     "en": (
         "I'd be happy to help! Could you please provide "
@@ -87,6 +131,8 @@ _GENERAL_CLARIFICATION: dict[str, str] = {
 _TEMPLATES: dict[ClarificationCategory, tuple[dict[str, str], float]] = {
     "cafe-clarification-needed": (_CAFE_CLARIFICATION, 0.9),
     "meeting-room-clarification-needed": (_MEETING_ROOM_CLARIFICATION, 0.9),
+    "event-clarification-needed": (_EVENT_CLARIFICATION, 0.9),
+    "space-clarification-needed": (_SPACE_CLARIFICATION, 0.9),
     "general-clarification-needed": (_GENERAL_CLARIFICATION, 0.7),
 }
 

--- a/backend/utils/clarification_templates.py
+++ b/backend/utils/clarification_templates.py
@@ -7,9 +7,12 @@ OrchestratorAgent がインラインで使用する。LLM 呼び出しなし。
 元: backend/agents/clarification_agent.py の handle_clarification()
 """
 
+import logging
 from typing import Literal, TypedDict
 
 from backend.utils.emotion_tagger import add_emotion_tag
+
+logger = logging.getLogger(__name__)
 
 SupportedLanguage = Literal["ja", "en"]
 
@@ -165,6 +168,12 @@ def get_clarification_response(
 
     message = messages.get(language, messages["ja"])
     tagged_message = add_emotion_tag(message, "surprised")
+
+    logger.info(
+        "Clarification template: category=%s, language=%s",
+        category,
+        language,
+    )
 
     return {
         "response": tagged_message,

--- a/backend/utils/reception_templates.py
+++ b/backend/utils/reception_templates.py
@@ -1,0 +1,137 @@
+"""
+Reception テンプレート - 受付案内の固定応答メッセージ
+
+OrchestratorAgent がインラインで使用する。LLM 呼び出しなし。
+受付タイプと言語に基づいてテンプレートメッセージを返す純粋関数。
+
+パターンは clarification_templates.py と同等。
+"""
+
+from typing import Literal, TypedDict
+
+from backend.utils.emotion_tagger import add_emotion_tag
+
+SupportedLanguage = Literal["ja", "en"]
+
+ReceptionType = Literal[
+    "first_time",
+    "returning",
+    "general",
+]
+
+
+class ReceptionResult(TypedDict):
+    """Reception テンプレートの出力結果"""
+
+    response: str  # 感情タグ付きテキスト
+    emotion: Literal["happy"]
+    metadata: dict  # agent名, category, confidence など
+
+
+# --------------------------------------------------------------------------- #
+#  テンプレートメッセージ定数
+# --------------------------------------------------------------------------- #
+
+_FIRST_TIME: dict[str, str] = {
+    "ja": (
+        "ようこそエンジニアカフェへ！初めてのご利用ですね。\n"
+        "エンジニアカフェは**無料**でご利用いただけるコワーキングスペースです。\n\n"
+        "**ご利用の流れ:**\n"
+        "1. 1階受付で利用登録をお願いします\n"
+        "2. Wi-Fi・電源は自由にお使いいただけます\n"
+        "3. 営業時間: 9:00-22:00（年末年始を除く）\n\n"
+        "何かご不明な点があれば、お気軽にお尋ねください！"
+    ),
+    "en": (
+        "Welcome to Engineer Cafe! It looks like this is your first visit.\n"
+        "Engineer Cafe is a **free** coworking space.\n\n"
+        "**How to get started:**\n"
+        "1. Please register at the 1F reception\n"
+        "2. Free Wi-Fi and power outlets are available\n"
+        "3. Open hours: 9:00-22:00 (except year-end/New Year holidays)\n\n"
+        "Feel free to ask if you have any questions!"
+    ),
+}
+
+_RETURNING: dict[str, str] = {
+    "ja": (
+        "おかえりなさい！またのご利用ありがとうございます。\n"
+        "本日もエンジニアカフェをお楽しみください。\n\n"
+        "何かお困りのことがあれば、お気軽にお尋ねください。"
+    ),
+    "en": (
+        "Welcome back! Thank you for visiting again.\n"
+        "Enjoy your time at Engineer Cafe today.\n\n"
+        "Feel free to ask if you need any help."
+    ),
+}
+
+_GENERAL: dict[str, str] = {
+    "ja": (
+        "エンジニアカフェへようこそ！\n"
+        "こちらではWi-Fiや電源を無料でご利用いただけます。\n"
+        "営業時間は9:00-22:00です。\n\n"
+        "施設やイベントについてのご質問がございましたら、"
+        "お気軽にお尋ねください。"
+    ),
+    "en": (
+        "Welcome to Engineer Cafe!\n"
+        "We offer free Wi-Fi and power outlets.\n"
+        "Open hours: 9:00-22:00.\n\n"
+        "If you have any questions about our facilities or events, "
+        "feel free to ask."
+    ),
+}
+
+
+# --------------------------------------------------------------------------- #
+#  テンプレートマッピング（受付タイプ → メッセージ辞書, confidence）
+# --------------------------------------------------------------------------- #
+
+_TEMPLATES: dict[ReceptionType, tuple[dict[str, str], float]] = {
+    "first_time": (_FIRST_TIME, 0.95),
+    "returning": (_RETURNING, 0.9),
+    "general": (_GENERAL, 0.85),
+}
+
+
+# --------------------------------------------------------------------------- #
+#  公開 API
+# --------------------------------------------------------------------------- #
+
+
+def get_reception_response(
+    language: SupportedLanguage,
+    reception_type: ReceptionType = "general",
+) -> ReceptionResult:
+    """
+    受付タイプと言語に基づいてテンプレート応答を返す。
+
+    LLM 不要の純粋関数。
+
+    Args:
+        language: 応答言語 ("ja" | "en")
+        reception_type: 受付タイプ ("first_time" | "returning" | "general")
+
+    Returns:
+        ReceptionResult: 感情タグ付きの応答とメタデータ
+    """
+    messages, confidence = _TEMPLATES.get(
+        reception_type,
+        (_GENERAL, 0.85),
+    )
+
+    message = messages.get(language, messages["ja"])
+    tagged_message = add_emotion_tag(message, "happy")
+
+    return {
+        "response": tagged_message,
+        "emotion": "happy",
+        "metadata": {
+            "agent": "ReceptionAgent",
+            "confidence": confidence,
+            "category": "reception",
+            "reception_type": reception_type,
+            "sources": ["reception_system"],
+        },
+    }

--- a/backend/utils/reception_templates.py
+++ b/backend/utils/reception_templates.py
@@ -7,9 +7,12 @@ OrchestratorAgent がインラインで使用する。LLM 呼び出しなし。
 パターンは clarification_templates.py と同等。
 """
 
+import logging
 from typing import Literal, TypedDict
 
 from backend.utils.emotion_tagger import add_emotion_tag
+
+logger = logging.getLogger(__name__)
 
 SupportedLanguage = Literal["ja", "en"]
 
@@ -123,6 +126,12 @@ def get_reception_response(
 
     message = messages.get(language, messages["ja"])
     tagged_message = add_emotion_tag(message, "happy")
+
+    logger.info(
+        "Reception template: type=%s, language=%s",
+        reception_type,
+        language,
+    )
 
     return {
         "response": tagged_message,

--- a/backend/workflows/main_workflow.py
+++ b/backend/workflows/main_workflow.py
@@ -375,6 +375,7 @@ class MainWorkflow:
         format_response に直接ルーティングする。
         """
         from backend.utils.clarification_templates import get_clarification_response
+        from backend.utils.reception_templates import get_reception_response
 
         query = state.get("query", "")
         session_id = state.get("session_id", "")
@@ -390,6 +391,8 @@ class MainWorkflow:
         if decision.category in (
             "cafe-clarification-needed",
             "meeting-room-clarification-needed",
+            "event-clarification-needed",
+            "space-clarification-needed",
             "general-clarification-needed",
         ):
             result = get_clarification_response(
@@ -417,6 +420,50 @@ class MainWorkflow:
                             "clarification_type": decision.category,
                         },
                         "requires_followup": True,
+                    },
+                },
+            )
+
+        # reception カテゴリをインライン処理
+        if decision.request_type == "reception":
+            # first_time / returning / general の判定
+            lower_query = query.lower()
+            first_time_keywords = [
+                "初めて",
+                "はじめて",
+                "初回",
+                "first time",
+                "first visit",
+            ]
+            if any(kw in lower_query for kw in first_time_keywords):
+                reception_type = "first_time"
+            else:
+                reception_type = "general"
+
+            result = get_reception_response(
+                language=decision.language,
+                reception_type=reception_type,
+            )
+            return Command(
+                goto="format_response",
+                update={
+                    "language": decision.language,
+                    "routing": {
+                        "agent": "orchestrator_inline",
+                        "category": "reception",
+                        "request_type": decision.request_type,
+                        "confidence": decision.confidence,
+                        "reasoning": decision.reasoning,
+                        "debug_info": decision.debug_info,
+                    },
+                    "answer": result["response"],
+                    "emotion": result["emotion"],
+                    "metadata": {
+                        **state.get("metadata", {}),
+                        "reception": {
+                            **result["metadata"],
+                            "reception_type": reception_type,
+                        },
                     },
                 },
             )

--- a/backend/workflows/main_workflow.py
+++ b/backend/workflows/main_workflow.py
@@ -395,6 +395,12 @@ class MainWorkflow:
             "space-clarification-needed",
             "general-clarification-needed",
         ):
+            logger.info(
+                "Inline clarification: category=%s, lang=%s, query=%s",
+                decision.category,
+                decision.language,
+                query[:80],
+            )
             result = get_clarification_response(
                 category=decision.category,
                 language=decision.language,
@@ -426,6 +432,11 @@ class MainWorkflow:
 
         # reception カテゴリをインライン処理
         if decision.request_type == "reception":
+            logger.info(
+                "Inline reception: lang=%s, query=%s",
+                decision.language,
+                query[:80],
+            )
             # first_time / returning / general の判定
             lower_query = query.lower()
             first_time_keywords = [


### PR DESCRIPTION
## Summary

AI受付機能の強化PR。5つのIssue (#95-#99) をまとめて対応。

- **#97 緊急情報対応**: `EMERGENCY_KEYWORDS` (18キーワード JA/EN) を追加、最優先でFacilityAgentにルーティング。emergency用RAGプロンプト追加
- **#98 EventAgent自動案内**: `get_today_events()` メソッド追加。Calendar + Connpass を並列検索・統合して本日のイベント情報を返却
- **#99 アクセシビリティまとめ**: `get_accessibility_summary()` メソッド追加。RAG検索 → LLMサマリー生成、失敗時は1909年築建造物の制約を含むデフォルト応答
- **#96 Receptionルーティング修正**: `reception_templates.py` 新規作成（3種: first_time/returning/general）、main_workflow.pyでインライン処理
- **#95 Clarification強化**: `event-clarification-needed`, `space-clarification-needed` 2カテゴリ追加

### 変更ファイル (13)
| ファイル | 変更 |
|---------|------|
| `config/routing_constants.py` | EMERGENCY_KEYWORDS, emergency/event/space clarification マッピング追加 |
| `config/prompts/facility_prompts.py` | emergency用プロンプト追加 |
| `agents/event_agent.py` | `get_today_events()` 追加 |
| `agents/facility_agent.py` | `get_accessibility_summary()`, `_get_default_accessibility_info()` 追加 |
| `utils/reception_templates.py` | **新規** - 受付テンプレート応答 |
| `utils/clarification_templates.py` | event/space 2カテゴリ追加 |
| `workflows/main_workflow.py` | reception/clarification インライン処理追加 |
| `tests/config/test_emergency_keywords.py` | **新規** - 15テスト |
| `tests/utils/test_reception_templates.py` | **新規** - 14テスト |
| `tests/agents/test_event_agent.py` | 4テスト追加 |
| `tests/agents/test_facility_agent.py` | 5テスト追加 |
| `tests/utils/test_clarification_templates.py` | 6テスト追加 |
| `tests/config/test_routing_constants.py` | 5テスト追加 |

## Test plan

- [x] `ruff check .` - All checks passed
- [x] `black --check .` - All files formatted
- [x] `pytest tests/ -m "not e2e and not ragas and not slow"` - 2103 passed, 0 failed
- [ ] Live API テスト: 緊急クエリ "AEDはどこですか？" → FacilityAgent応答
- [ ] Live API テスト: 受付 "初めて来ました" → reception template応答
- [ ] Live API テスト: イベント曖昧 "イベントについて" → clarification応答
- [ ] Live API テスト: スペース曖昧 "どのスペースが使えますか？" → clarification応答

Closes #95, #96, #97, #98, #99

🤖 Generated with [Claude Code](https://claude.com/claude-code)