### PR TITLE
fix(backend): add set_language and speech_to_text voice API handlers (#119)

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -434,6 +434,38 @@ def _get_slide_agent():
     return _slide_agent
 
 
+async def _handle_stt(body: VoiceRequest) -> VoiceResponse:
+    """Shared STT processing for process_voice and speech_to_text actions."""
+    if not body.audioData:
+        raise HTTPException(status_code=400, detail="Missing audioData")
+
+    import base64
+
+    audio_bytes = base64.b64decode(body.audioData)
+
+    stt_result = await _get_stt_agent().speech_to_text(
+        audio_bytes,
+        language=body.language,
+        conversation_stage=body.conversationStage,
+    )
+
+    if not stt_result["success"]:
+        return VoiceResponse(
+            success=False,
+            error=stt_result.get("error", "STT failed"),
+            sessionId=body.sessionId,
+        )
+
+    return VoiceResponse(
+        success=True,
+        transcript=stt_result["transcript"],
+        emotion="neutral",
+        detectedLanguage=stt_result.get("language"),
+        confidence=stt_result.get("confidence"),
+        sessionId=body.sessionId,
+    )
+
+
 @app.post("/api/voice", response_model=VoiceResponse, dependencies=[Depends(verify_api_key)])
 @_rate_limit("20/minute")
 async def voice_api(request: Request, body: VoiceRequest):
@@ -463,34 +495,13 @@ async def voice_api(request: Request, body: VoiceRequest):
             )
 
         elif body.action == "process_voice":
-            if not body.audioData:
-                raise HTTPException(status_code=400, detail="Missing audioData for process_voice")
+            return await _handle_stt(body)
 
-            import base64
+        elif body.action == "set_language":
+            return VoiceResponse(success=True, sessionId=body.sessionId)
 
-            audio_bytes = base64.b64decode(body.audioData)
-
-            stt_result = await _get_stt_agent().speech_to_text(
-                audio_bytes,
-                language=body.language,
-                conversation_stage=body.conversationStage,
-            )
-
-            if not stt_result["success"]:
-                return VoiceResponse(
-                    success=False,
-                    error=stt_result.get("error", "STT failed"),
-                    sessionId=body.sessionId,
-                )
-
-            return VoiceResponse(
-                success=True,
-                transcript=stt_result["transcript"],
-                emotion="neutral",
-                detectedLanguage=stt_result.get("language"),
-                confidence=stt_result.get("confidence"),
-                sessionId=body.sessionId,
-            )
+        elif body.action == "speech_to_text":
+            return await _handle_stt(body)
 
         else:
             raise HTTPException(status_code=400, detail=f"Unknown action: {body.action}")

--- a/backend/tests/api/test_voice_api.py
+++ b/backend/tests/api/test_voice_api.py
@@ -53,6 +53,36 @@ mock_stt_agent = MagicMock()
 _test_app = FastAPI()
 
 
+async def _handle_stt_test(request: VoiceRequest) -> VoiceResponse:
+    """Shared STT processing for process_voice and speech_to_text actions (test version)."""
+    if not request.audioData:
+        raise HTTPException(status_code=400, detail="Missing audioData")
+
+    audio_bytes = base64.b64decode(request.audioData)
+
+    stt_result = await mock_stt_agent.speech_to_text(
+        audio_bytes,
+        language=request.language,
+        conversation_stage=request.conversationStage,
+    )
+
+    if not stt_result["success"]:
+        return VoiceResponse(
+            success=False,
+            error=stt_result.get("error", "STT failed"),
+            sessionId=request.sessionId,
+        )
+
+    return VoiceResponse(
+        success=True,
+        transcript=stt_result["transcript"],
+        emotion="neutral",
+        detectedLanguage=stt_result.get("language"),
+        confidence=stt_result.get("confidence"),
+        sessionId=request.sessionId,
+    )
+
+
 @_test_app.post("/api/voice", response_model=VoiceResponse)
 async def voice_api(request: VoiceRequest):
     try:
@@ -81,32 +111,13 @@ async def voice_api(request: VoiceRequest):
             )
 
         elif request.action == "process_voice":
-            if not request.audioData:
-                raise HTTPException(status_code=400, detail="Missing audioData for process_voice")
+            return await _handle_stt_test(request)
 
-            audio_bytes = base64.b64decode(request.audioData)
+        elif request.action == "set_language":
+            return VoiceResponse(success=True, sessionId=request.sessionId)
 
-            stt_result = await mock_stt_agent.speech_to_text(
-                audio_bytes,
-                language=request.language,
-                conversation_stage=request.conversationStage,
-            )
-
-            if not stt_result["success"]:
-                return VoiceResponse(
-                    success=False,
-                    error=stt_result.get("error", "STT failed"),
-                    sessionId=request.sessionId,
-                )
-
-            return VoiceResponse(
-                success=True,
-                transcript=stt_result["transcript"],
-                emotion="neutral",
-                detectedLanguage=stt_result.get("language"),
-                confidence=stt_result.get("confidence"),
-                sessionId=request.sessionId,
-            )
+        elif request.action == "speech_to_text":
+            return await _handle_stt_test(request)
 
         else:
             raise HTTPException(status_code=400, detail=f"Unknown action: {request.action}")
@@ -336,6 +347,136 @@ class TestProcessVoice:
             "/api/voice",
             json={
                 "action": "process_voice",
+                "audioData": _fake_wav_b64(),
+                "sessionId": SAMPLE_SESSION_ID,
+            },
+        )
+
+        assert resp.status_code == 500
+
+
+# =============================================================================
+# set_language
+# =============================================================================
+
+
+class TestSetLanguage:
+    """POST /api/voice  action=set_language"""
+
+    def test_set_language_returns_success(self):
+        """set_language は即座に success を返す"""
+        resp = client.post(
+            "/api/voice",
+            json={
+                "action": "set_language",
+                "language": "en",
+                "sessionId": SAMPLE_SESSION_ID,
+            },
+        )
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["success"] is True
+        assert body["sessionId"] == SAMPLE_SESSION_ID
+
+    def test_set_language_without_session_id(self):
+        """set_language は sessionId なしでも成功する"""
+        resp = client.post(
+            "/api/voice",
+            json={
+                "action": "set_language",
+                "language": "ja",
+            },
+        )
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["success"] is True
+
+
+# =============================================================================
+# speech_to_text
+# =============================================================================
+
+
+class TestSpeechToText:
+    """POST /api/voice  action=speech_to_text"""
+
+    def test_stt_success(self):
+        """speech_to_text 成功時に transcript を返す"""
+        mock_stt_agent.speech_to_text = AsyncMock(
+            return_value={
+                "success": True,
+                "transcript": "hello world",
+                "confidence": 0.95,
+                "language": "en",
+                "provider": "vosk",
+            }
+        )
+
+        resp = client.post(
+            "/api/voice",
+            json={
+                "action": "speech_to_text",
+                "audioData": _fake_wav_b64(),
+                "language": "en",
+                "sessionId": SAMPLE_SESSION_ID,
+            },
+        )
+
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["success"] is True
+        assert body["transcript"] == "hello world"
+        assert body["confidence"] == pytest.approx(0.95)
+        assert body["detectedLanguage"] == "en"
+        assert body["sessionId"] == SAMPLE_SESSION_ID
+
+    def test_stt_missing_audio_returns_400(self):
+        """audioData がない場合は 400 エラー"""
+        resp = client.post(
+            "/api/voice",
+            json={
+                "action": "speech_to_text",
+                "sessionId": SAMPLE_SESSION_ID,
+            },
+        )
+        assert resp.status_code == 400
+
+    def test_stt_failure_returns_error(self):
+        """STT 失敗時に success=False + error を返す"""
+        mock_stt_agent.speech_to_text = AsyncMock(
+            return_value={
+                "success": False,
+                "transcript": "",
+                "confidence": 0.0,
+                "language": "unknown",
+                "provider": "vosk",
+                "error": "Recognition failed",
+            }
+        )
+
+        resp = client.post(
+            "/api/voice",
+            json={
+                "action": "speech_to_text",
+                "audioData": _fake_wav_b64(),
+                "language": "ja",
+                "sessionId": SAMPLE_SESSION_ID,
+            },
+        )
+
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["success"] is False
+        assert body["error"] is not None
+
+    def test_stt_exception_returns_500(self):
+        """STT が例外を投げた場合は 500 エラー"""
+        mock_stt_agent.speech_to_text = AsyncMock(side_effect=RuntimeError("STT crashed"))
+
+        resp = client.post(
+            "/api/voice",
+            json={
+                "action": "speech_to_text",
                 "audioData": _fake_wav_b64(),
                 "sessionId": SAMPLE_SESSION_ID,
             },


### PR DESCRIPTION
## Summary
- Add `set_language` action handler to `/api/voice` -- returns success immediately since language is per-request
- Add `speech_to_text` action handler to `/api/voice` -- delegates to shared `_handle_stt()` helper
- Extract common STT logic from `process_voice` into `_handle_stt()` helper to keep code DRY

## Test plan
- [x] `ruff check .` passes
- [x] `black --check .` passes
- [x] All 20 tests in `tests/api/test_voice_api.py` pass (6 new tests for the added handlers)
- [ ] Verify `set_language` returns success with valid language
- [ ] Verify `speech_to_text` returns transcript with valid audio data
- [ ] Verify `speech_to_text` returns 400 when audioData is missing
- [ ] Verify unknown actions still return 400

Closes #119

Generated with [Claude Code](https://claude.com/claude-code)