### PR TITLE
feat(frontend): add admin authentication middleware (#122)

### DIFF
--- a/frontend/src/app/(admin)/admin/login/page.tsx
+++ b/frontend/src/app/(admin)/admin/login/page.tsx
@@ -1,0 +1,93 @@
+'use client'
+
+import { Suspense, useState } from 'react'
+import { useRouter, useSearchParams } from 'next/navigation'
+
+function LoginForm() {
+  const [password, setPassword] = useState('')
+  const [error, setError] = useState('')
+  const [loading, setLoading] = useState(false)
+  const router = useRouter()
+  const searchParams = useSearchParams()
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault()
+    setError('')
+    setLoading(true)
+
+    try {
+      const res = await fetch('/api/admin/auth', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ password }),
+      })
+
+      if (res.ok) {
+        const redirectTo = searchParams.get('from') || '/admin/knowledge'
+        router.push(redirectTo)
+        router.refresh()
+      } else {
+        const data = await res.json()
+        setError(data.error || 'Authentication failed')
+      }
+    } catch {
+      setError('Network error. Please try again.')
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  return (
+    <form className="mt-8 space-y-6" onSubmit={handleSubmit}>
+      {error && (
+        <div className="rounded-md bg-red-50 p-4">
+          <p className="text-sm text-red-700">{error}</p>
+        </div>
+      )}
+      <div>
+        <label htmlFor="password" className="sr-only">
+          Password
+        </label>
+        <input
+          id="password"
+          name="password"
+          type="password"
+          required
+          className="appearance-none rounded-md relative block w-full px-3 py-2 border border-gray-300 placeholder-gray-500 text-gray-900 focus:outline-none focus:ring-blue-500 focus:border-blue-500 focus:z-10 sm:text-sm"
+          placeholder="Admin password"
+          value={password}
+          onChange={(e) => setPassword(e.target.value)}
+        />
+      </div>
+      <div>
+        <button
+          type="submit"
+          disabled={loading}
+          className="group relative w-full flex justify-center py-2 px-4 border border-transparent text-sm font-medium rounded-md text-white bg-blue-600 hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500 disabled:opacity-50 disabled:cursor-not-allowed"
+        >
+          {loading ? 'Signing in...' : 'Sign in'}
+        </button>
+      </div>
+    </form>
+  )
+}
+
+export default function AdminLoginPage() {
+  return (
+    <div className="min-h-screen flex items-center justify-center bg-gray-50">
+      <div className="max-w-md w-full space-y-8 p-8 bg-white rounded-lg shadow">
+        <div>
+          <h2 className="text-center text-2xl font-bold text-gray-900">
+            Admin Login
+          </h2>
+          <p className="mt-2 text-center text-sm text-gray-600">
+            Engineer Cafe Navigator
+          </p>
+        </div>
+        <Suspense fallback={<div className="mt-8 text-center text-gray-500">Loading...</div>}>
+          <LoginForm />
+        </Suspense>
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/app/api/admin/auth/route.ts
+++ b/frontend/src/app/api/admin/auth/route.ts
@@ -1,0 +1,40 @@
+import { NextResponse } from 'next/server'
+import { cookies } from 'next/headers'
+
+export async function POST(request: Request) {
+  const adminSecret = process.env.ADMIN_SECRET_KEY
+
+  if (!adminSecret) {
+    return NextResponse.json(
+      { error: 'ADMIN_SECRET_KEY not configured' },
+      { status: 500 }
+    )
+  }
+
+  const body = await request.json()
+  const { password } = body
+
+  if (!password || password !== adminSecret) {
+    return NextResponse.json(
+      { error: 'Invalid password' },
+      { status: 401 }
+    )
+  }
+
+  const cookieStore = await cookies()
+  cookieStore.set('admin-token', adminSecret, {
+    httpOnly: true,
+    secure: process.env.NODE_ENV === 'production',
+    sameSite: 'lax',
+    path: '/',
+    maxAge: 60 * 60 * 24, // 24 hours
+  })
+
+  return NextResponse.json({ success: true })
+}
+
+export async function DELETE() {
+  const cookieStore = await cookies()
+  cookieStore.delete('admin-token')
+  return NextResponse.json({ success: true })
+}

--- a/frontend/src/middleware.ts
+++ b/frontend/src/middleware.ts
@@ -1,0 +1,44 @@
+import { NextResponse } from 'next/server'
+import type { NextRequest } from 'next/server'
+
+export function middleware(request: NextRequest) {
+  const adminSecret = process.env.ADMIN_SECRET_KEY
+
+  // If ADMIN_SECRET_KEY is not set, allow all access (development mode)
+  if (!adminSecret) {
+    return NextResponse.next()
+  }
+
+  const { pathname } = request.nextUrl
+
+  // Skip login page and auth API
+  if (pathname === '/admin/login' || pathname.startsWith('/api/admin/auth')) {
+    return NextResponse.next()
+  }
+
+  const token = request.cookies.get('admin-token')?.value
+
+  // API routes: return 401 JSON
+  if (pathname.startsWith('/api/admin')) {
+    if (!token || token !== adminSecret) {
+      return NextResponse.json(
+        { error: 'Unauthorized' },
+        { status: 401 }
+      )
+    }
+    return NextResponse.next()
+  }
+
+  // Admin pages: redirect to login
+  if (!token || token !== adminSecret) {
+    const loginUrl = new URL('/admin/login', request.url)
+    loginUrl.searchParams.set('from', pathname)
+    return NextResponse.redirect(loginUrl)
+  }
+
+  return NextResponse.next()
+}
+
+export const config = {
+  matcher: ['/admin/:path*', '/api/admin/:path*'],
+}


### PR DESCRIPTION
## Summary
- Add Next.js middleware (`middleware.ts`) to protect `/admin/*` routes and `/api/admin/*` endpoints with cookie-based authentication
- Add admin login page at `/admin/login` with password form and Suspense boundary for `useSearchParams`
- Add auth API endpoint (`/api/admin/auth`) with POST (login) and DELETE (logout) supporting httpOnly secure cookies

## Details
- When `ADMIN_SECRET_KEY` env var is not set, all access is allowed (development mode)
- Admin pages redirect to `/admin/login?from=<path>` when unauthenticated
- Admin API routes return 401 JSON when unauthenticated
- Login page and auth API are excluded from middleware protection
- Cookie is httpOnly, secure in production, sameSite=lax, 24-hour expiry

## Test plan
- [ ] Verify middleware redirects unauthenticated users to login page
- [ ] Verify login page submits password and redirects on success
- [ ] Verify auth API sets httpOnly cookie on valid password
- [ ] Verify auth API returns 401 on invalid password
- [ ] Verify DELETE endpoint clears the cookie
- [ ] Verify dev mode (no ADMIN_SECRET_KEY) allows all access
- [ ] Run `pnpm lint`, `pnpm typecheck`, `pnpm build` successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)