### PR TITLE
fix(frontend): lazy-init Supabase and KnowledgeBaseUtils for build safety (#121)

### DIFF
--- a/frontend/src/lib/knowledge-base-utils.ts
+++ b/frontend/src/lib/knowledge-base-utils.ts
@@ -468,5 +468,19 @@ export class KnowledgeBaseUtils {
   }
 }
 
-// Export a singleton instance
-export const knowledgeBaseUtils = new KnowledgeBaseUtils();
+// Export a lazy-initialized singleton (Proxy defers construction until first use,
+// preventing build-time errors when GOOGLE_GENERATIVE_AI_API_KEY is not set)
+let _knowledgeBaseUtilsInstance: KnowledgeBaseUtils | null = null
+
+function getKnowledgeBaseUtils(): KnowledgeBaseUtils {
+  if (!_knowledgeBaseUtilsInstance) {
+    _knowledgeBaseUtilsInstance = new KnowledgeBaseUtils()
+  }
+  return _knowledgeBaseUtilsInstance
+}
+
+export const knowledgeBaseUtils = new Proxy({} as KnowledgeBaseUtils, {
+  get(_, prop) {
+    return Reflect.get(getKnowledgeBaseUtils(), prop)
+  },
+})

--- a/frontend/src/lib/supabase.ts
+++ b/frontend/src/lib/supabase.ts
@@ -66,17 +66,38 @@ export interface Database {
   }
 }
 
-// Create Supabase client
-const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL!
-const supabaseAnonKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!
-const supabaseServiceKey = process.env.SUPABASE_SERVICE_ROLE_KEY!
+// Create Supabase client (lazy init for build-time safety)
+const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL ?? ''
+const supabaseAnonKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY ?? ''
 
 // Public client (for client-side operations)
-export const supabase = createClient<Database>(supabaseUrl, supabaseAnonKey)
+// When env vars are empty (CI/build), creates a null placeholder that is never called at build time
+export const supabase = supabaseUrl
+  ? createClient<Database>(supabaseUrl, supabaseAnonKey)
+  : (null as unknown as ReturnType<typeof createClient<Database>>)
 
 // Service client (for server-side operations with full access)
-export const supabaseAdmin = createClient<Database>(supabaseUrl, supabaseServiceKey, {
-  auth: {
-    persistSession: false
+// Uses lazy init + Proxy to avoid build-time errors while keeping backward-compatible exports
+let _supabaseAdmin: ReturnType<typeof createClient<Database>> | null = null
+
+export function getSupabaseAdmin(): ReturnType<typeof createClient<Database>> {
+  if (!_supabaseAdmin) {
+    const url = process.env.NEXT_PUBLIC_SUPABASE_URL
+    const key = process.env.SUPABASE_SERVICE_ROLE_KEY
+    if (!url || !key) {
+      throw new Error(
+        'Supabase config missing: NEXT_PUBLIC_SUPABASE_URL and SUPABASE_SERVICE_ROLE_KEY required'
+      )
+    }
+    _supabaseAdmin = createClient<Database>(url, key, {
+      auth: { persistSession: false },
+    })
   }
+  return _supabaseAdmin
+}
+
+export const supabaseAdmin = new Proxy({} as ReturnType<typeof createClient<Database>>, {
+  get(_, prop) {
+    return Reflect.get(getSupabaseAdmin(), prop)
+  },
 })


### PR DESCRIPTION
## Summary
- Replace eager module-level initialization with Proxy-based lazy init in `supabase.ts` and `knowledge-base-utils.ts`
- Prevents build-time crashes when env vars (`NEXT_PUBLIC_SUPABASE_URL`, `GOOGLE_GENERATIVE_AI_API_KEY`) are not set in CI/CD
- Both changes are backward-compatible — no consumer file changes needed (15 files import `supabaseAdmin`, 5 files import `knowledgeBaseUtils`)

## Changes
| File | Change |
|------|--------|
| `frontend/src/lib/supabase.ts` | Public client uses empty-string fallback; Admin client uses Proxy + `getSupabaseAdmin()` |
| `frontend/src/lib/knowledge-base-utils.ts` | Singleton uses Proxy to defer `new KnowledgeBaseUtils()` until first method call |

## Test plan
- [x] `pnpm lint` — warnings only (pre-existing), no new errors
- [x] `pnpm typecheck` — clean
- [x] `pnpm build` — all routes build successfully (was failing before this fix)
- [x] Verified pre-existing build failure without this fix (`supabaseUrl is required`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)