### PR TITLE
fix(backend): load .env.local in RAGAS evaluation runner

### DIFF
--- a/backend/tests/evaluation/run_ragas_evaluation.py
+++ b/backend/tests/evaluation/run_ragas_evaluation.py
@@ -35,6 +35,16 @@ _project_root = str(Path(__file__).parent.parent.parent.parent)
 sys.path.insert(0, _project_root)
 sys.path.insert(0, _backend_dir)
 
+# .env.local から環境変数を読み込む（dotenv が利用可能な場合）
+_env_local = Path(_backend_dir) / ".env.local"
+try:
+    from dotenv import load_dotenv
+
+    if _env_local.exists():
+        load_dotenv(_env_local)
+except ImportError:
+    pass
+
 from backend.tests.fixtures.dataset_loader import DatasetLoader, GroundTruthCase  # noqa: E402
 
 logging.basicConfig(level=logging.INFO, format="%(asctime)s [%(levelname)s] %(message)s")


### PR DESCRIPTION
## Summary
- `run_ragas_evaluation.py` が `.env.local` を読み込んでいなかったため、`--mode live` 実行時に `supabase_url is required` エラーで全件スキップされていた
- `dotenv.load_dotenv()` を追加（dotenv 未インストール時は graceful に無視）

## Test plan
- [x] `ruff check .` エラーゼロ
- [x] `black --check .` フォーマット問題なし
- [x] `python -m tests.evaluation.run_ragas_evaluation --mode live --max-cases 10` で 10/10 件の評価成功を確認済み

Generated with [Claude Code](https://claude.com/claude-code)