### PR TITLE
feat(deploy): add production Docker Compose for self-hosted deployment

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,6 +39,7 @@ backend/.venv/
 .env.production.local
 frontend/.env.local
 backend/.env
+backend/.env.production
 
 # Log files
 npm-debug.log*

--- a/backend/.env.production.example
+++ b/backend/.env.production.example
@@ -1,0 +1,84 @@
+# ===========================================
+# Engineer Cafe Navigator Backend - Production
+# ===========================================
+# Copy this file to .env.production and fill in the actual values.
+# NEVER commit .env.production to version control.
+
+# ===========================================
+# Environment
+# ===========================================
+ENVIRONMENT=production
+
+# API Secret Key (Required in production)
+# Generate with: openssl rand -hex 32
+API_SECRET_KEY=
+
+# Allowed CORS Origins (comma-separated)
+# Example: https://your-app.vercel.app,https://your-domain.com
+ALLOWED_ORIGINS=
+
+# ===========================================
+# OpenRouter API (Primary - Required)
+# ===========================================
+# Get your key at: https://openrouter.ai/keys
+OPENROUTER_API_KEY=
+
+# OpenAI API (LLM Judge / Embeddings)
+# https://platform.openai.com/api-keys
+OPENAI_API_KEY=
+
+# ===========================================
+# Tavily (Web Search - Required for web search)
+# ===========================================
+# Get your key at: https://tavily.com
+TAVILY_API_KEY=
+
+# ===========================================
+# Google Calendar (ICS format)
+# ===========================================
+# Public ICS feed URL (no API key required)
+# https://calendar.google.com/calendar/ical/CALENDAR_ID/public/basic.ics
+GOOGLE_CALENDAR_ICAL_URL=
+
+# ===========================================
+# Connpass API (Optional)
+# ===========================================
+# CONNPASS_API_KEY=
+
+# ===========================================
+# Supabase Configuration (Cloud)
+# ===========================================
+# Get these from your Supabase project dashboard
+SUPABASE_URL=
+SUPABASE_KEY=
+
+# PostgreSQL connection URI for LangGraph Checkpointer
+# Supabase Cloud: Settings → Database → Connection string (URI)
+SUPABASE_DB_URI=
+
+# ===========================================
+# TTS Configuration
+# ===========================================
+# TTS provider: "voicevox" (default), "google", "kokoro"
+TTS_PROVIDER=voicevox
+
+# Docker service URLs (do not change unless you modify docker-compose)
+VOICEVOX_API_URL=http://voicevox:50021
+KOKORO_API_URL=http://kokoro-tts:8880
+
+# ===========================================
+# LangSmith (Optional - Tracing)
+# ===========================================
+# LANGSMITH_API_KEY=
+# LANGSMITH_PROJECT=engineer-cafe-navigator
+
+# ===========================================
+# Discord Webhook (Optional - Alerts)
+# ===========================================
+# DISCORD_WEBHOOK_URL=
+
+# ===========================================
+# Application Settings
+# ===========================================
+PORT=8000
+APP_URL=https://your-domain.com

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -62,7 +62,7 @@ FROM base AS production
 # Copy application code
 COPY . .
 
-# Note: In production, mount Vosk models via volume:
+# Note: In production, mount models (Vosk STT + Helsinki-NLP translation) via volume:
 #   volumes:
 #     - ./models:/app/models
 

--- a/backend/main.py
+++ b/backend/main.py
@@ -425,7 +425,8 @@ def _get_voice_agent():
     if _voice_agent is None:
         from backend.agents.voice_agent import VoiceAgent
 
-        _voice_agent = VoiceAgent()
+        tts_provider = os.getenv("TTS_PROVIDER", "voicevox")
+        _voice_agent = VoiceAgent(tts_provider=tts_provider)
     return _voice_agent
 
 

--- a/backend/main.py
+++ b/backend/main.py
@@ -111,7 +111,7 @@ async def lifespan(app: FastAPI):
         logger.error("起動時バリデーション失敗。環境変数を確認してください。")
         raise
 
-    if os.getenv("ENV", "development") == "production":
+    if os.getenv("ENVIRONMENT", "development") == "production":
         setup_structured_logging()
 
     try:
@@ -185,7 +185,7 @@ app.add_middleware(TokenTrackerMiddleware)
 # Optional API key authentication
 _API_SECRET_KEY = os.getenv("API_SECRET_KEY")
 
-if os.getenv("ENV", "development") == "production" and not _API_SECRET_KEY:
+if os.getenv("ENVIRONMENT", "development") == "production" and not _API_SECRET_KEY:
     logger.warning(
         "API_SECRET_KEY not set in production. " "All endpoints are unprotected — this is insecure."
     )
@@ -202,7 +202,7 @@ async def verify_api_key(request: Request) -> None:
 
 # CORS設定
 _default_origins = ["http://localhost:3000", "http://localhost:3001"]
-_env = os.getenv("ENV", "development")
+_env = os.getenv("ENVIRONMENT", "development")
 _configured_origins = [o.strip() for o in os.getenv("ALLOWED_ORIGINS", "").split(",") if o.strip()]
 
 if _env == "production" and not _configured_origins:

--- a/backend/scripts/setup_production_models.sh
+++ b/backend/scripts/setup_production_models.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+# ===========================================
+# Production Model Setup Script
+# ===========================================
+# Downloads all required models for the backend:
+#   - Vosk STT models (Japanese + English, ~88 MB)
+#   - Helsinki-NLP translation models (CTranslate2 int8, ~300 MB)
+#
+# Usage (recommended — runs inside Docker with all dependencies):
+#   docker compose -f docker-compose.production.yml --profile setup run --rm model-setup
+#
+# Or run directly on host (requires curl, unzip, python3 with torch/transformers):
+#   bash backend/scripts/setup_production_models.sh
+# ===========================================
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+MODEL_DIR="${1:-/app/models}"
+
+echo "=== Engineer Cafe Navigator: Model Setup ==="
+echo "Model directory: ${MODEL_DIR}"
+echo ""
+
+# --- 1. Vosk STT Models ---
+echo "--- [1/2] Downloading Vosk STT models ---"
+if [ -f "${SCRIPT_DIR}/download_vosk_models.sh" ]; then
+    bash "${SCRIPT_DIR}/download_vosk_models.sh" "${MODEL_DIR}"
+    echo "Vosk models: OK"
+else
+    echo "WARNING: download_vosk_models.sh not found at ${SCRIPT_DIR}. Skipping."
+fi
+
+echo ""
+
+# --- 2. Translation Models ---
+echo "--- [2/2] Downloading translation models ---"
+TRANSLATION_DIR="${MODEL_DIR}/translation"
+if [ -f "${SCRIPT_DIR}/download_translation_models.sh" ]; then
+    bash "${SCRIPT_DIR}/download_translation_models.sh" "${TRANSLATION_DIR}"
+    echo "Translation models: OK"
+else
+    echo "WARNING: download_translation_models.sh not found at ${SCRIPT_DIR}. Skipping."
+fi
+
+echo ""
+echo "=== Model setup complete ==="
+echo "Models are stored in: ${MODEL_DIR}"
+ls -lh "${MODEL_DIR}" 2>/dev/null || true

--- a/caddy/Caddyfile
+++ b/caddy/Caddyfile
@@ -1,0 +1,39 @@
+# Caddyfile for Engineer Cafe Navigator Backend
+#
+# Caddy automatically provisions and renews TLS certificates via Let's Encrypt.
+# Replace "api.your-domain.com" with your actual domain.
+#
+# Alternative: If using Cloudflare Tunnel, you can skip Caddy entirely and
+# point the tunnel directly to backend:8000. In that case, remove the caddy
+# service from docker-compose.production.yml.
+
+api.your-domain.com {
+	# Reverse proxy to FastAPI backend
+	reverse_proxy backend:8000 {
+		# SSE streaming support — flush immediately for /api/chat/stream
+		@sse path /api/chat/stream
+		flush_interval @sse -1
+	}
+
+	# Request size limit (10 MB — accommodates audio uploads)
+	request_body {
+		max_size 10MB
+	}
+
+	# Security headers
+	header {
+		X-Content-Type-Options "nosniff"
+		X-Frame-Options "DENY"
+		X-XSS-Protection "1; mode=block"
+		Referrer-Policy "strict-origin-when-cross-origin"
+		-Server
+	}
+
+	# Access log
+	log {
+		output file /data/access.log {
+			roll_size 50MiB
+			roll_keep 3
+		}
+	}
+}

--- a/docker-compose.production.yml
+++ b/docker-compose.production.yml
@@ -1,0 +1,162 @@
+# Docker Compose for Engineer Cafe Navigator - Production
+# Optimized for self-hosted deployment (Oracle Cloud Free Tier ARM VM, or any VPS)
+#
+# Usage:
+#   1. Copy backend/.env.production.example to backend/.env.production and fill in values
+#   2. Download models: docker compose -f docker-compose.production.yml --profile setup run --rm model-setup
+#   3. Start services: docker compose -f docker-compose.production.yml up -d
+#
+# Resource target: 4 OCPU (ARM64) / 24 GB RAM (Oracle Cloud Free Tier)
+# Frontend is deployed separately on Vercel.
+
+services:
+  # Reverse proxy + automatic HTTPS (Let's Encrypt)
+  caddy:
+    image: caddy:2-alpine
+    container_name: engineer-cafe-caddy
+    ports:
+      - "80:80"
+      - "443:443"
+      - "443:443/udp"  # HTTP/3
+    volumes:
+      - ./caddy/Caddyfile:/etc/caddy/Caddyfile:ro
+      - caddy-data:/data
+      - caddy-config:/config
+    depends_on:
+      backend:
+        condition: service_healthy
+    networks:
+      - engineer-cafe-network
+    restart: unless-stopped
+    deploy:
+      resources:
+        limits:
+          cpus: "0.25"
+          memory: 256M
+    logging:
+      driver: json-file
+      options:
+        max-size: "10m"
+        max-file: "3"
+
+  # Backend - FastAPI + LangGraph (production build)
+  backend:
+    build:
+      context: ./backend
+      target: production
+    container_name: engineer-cafe-backend
+    # Port is NOT exposed to host; Caddy proxies to it via Docker network
+    expose:
+      - "8000"
+    volumes:
+      # Mount pre-downloaded models (Vosk STT + Helsinki-NLP translation)
+      - ./backend/models:/app/models:ro
+    env_file:
+      - ./backend/.env.production
+    environment:
+      - PYTHONUNBUFFERED=1
+    depends_on:
+      voicevox:
+        condition: service_healthy
+      kokoro-tts:
+        condition: service_healthy
+    healthcheck:
+      test: ["CMD", "python", "scripts/healthcheck.py"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 15s
+    networks:
+      - engineer-cafe-network
+    restart: unless-stopped
+    deploy:
+      resources:
+        limits:
+          cpus: "2.0"
+          memory: 4G
+    logging:
+      driver: json-file
+      options:
+        max-size: "50m"
+        max-file: "5"
+
+  # VoiceVox TTS Engine - Japanese TTS
+  voicevox:
+    image: voicevox/voicevox_engine:latest
+    container_name: engineer-cafe-voicevox
+    # Port is NOT exposed to host; backend connects via Docker network
+    expose:
+      - "50021"
+    environment:
+      - CPU_NUM_THREADS=2
+    volumes:
+      - voicevox-cache:/root/.cache/voicevox_engine
+    networks:
+      - engineer-cafe-network
+    restart: unless-stopped
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:50021/version"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+      start_period: 60s
+    deploy:
+      resources:
+        limits:
+          cpus: "1.0"
+          memory: 4G
+    logging:
+      driver: json-file
+      options:
+        max-size: "50m"
+        max-file: "3"
+
+  # Kokoro TTS Engine - English TTS
+  kokoro-tts:
+    image: ghcr.io/remsky/kokoro-fastapi-cpu:latest
+    container_name: engineer-cafe-kokoro-tts
+    # Port is NOT exposed to host; backend connects via Docker network
+    expose:
+      - "8880"
+    networks:
+      - engineer-cafe-network
+    restart: unless-stopped
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:8880/v1/audio/voices"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+      start_period: 30s
+    deploy:
+      resources:
+        limits:
+          cpus: "0.5"
+          memory: 2G
+    logging:
+      driver: json-file
+      options:
+        max-size: "50m"
+        max-file: "3"
+
+  # One-shot model downloader (run with: docker compose --profile setup run --rm model-setup)
+  model-setup:
+    build:
+      context: ./backend
+      target: development
+    container_name: engineer-cafe-model-setup
+    profiles:
+      - setup
+    volumes:
+      - ./backend/models:/app/models
+    entrypoint: ["bash", "scripts/setup_production_models.sh"]
+    networks:
+      - engineer-cafe-network
+
+networks:
+  engineer-cafe-network:
+    driver: bridge
+
+volumes:
+  caddy-data:
+  caddy-config:
+  voicevox-cache:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -83,6 +83,7 @@ services:
       interval: 10s
       timeout: 5s
       retries: 5
+      start_period: 60s
 
   # Kokoro TTS Engine (Local) - for English TTS
   kokoro-tts:
@@ -98,6 +99,7 @@ services:
       interval: 10s
       timeout: 5s
       retries: 5
+      start_period: 30s
 
 networks:
   engineer-cafe-network:


### PR DESCRIPTION
## Summary

- Add `docker-compose.production.yml` with Caddy reverse proxy (auto HTTPS), resource limits, log rotation, and model setup profile for self-hosted VPS deployment (Oracle Cloud Free Tier ARM VM or any VPS)
- Add `caddy/Caddyfile` with SSE streaming support, security headers, and request size limits
- Add `backend/.env.production.example` as production environment variable template
- Add `backend/scripts/setup_production_models.sh` wrapper for one-command model download
- Fix `TTS_PROVIDER` env var not being read at startup (Closes #142)
- Fix `ENV` vs `ENVIRONMENT` env var inconsistency in `main.py` (Closes #143)
- Fix missing translation model reference in Dockerfile comment (Closes #144)
- Add `start_period` to VoiceVox/Kokoro healthchecks (Closes #146)

## Bug fixes included

| Issue | Description |
|-------|-------------|
| #142 | `TTS_PROVIDER` env var documented but never read — now wired to `VoiceAgent` |
| #143 | `os.getenv("ENV")` used in 3 places instead of `ENVIRONMENT` — unified |
| #144 | Dockerfile production comment missing translation model reference — updated |
| #146 | VoiceVox/Kokoro healthcheck missing `start_period` — added 60s/30s |

## Resource allocation (Oracle ARM 4 OCPU / 24 GB RAM)

| Service | CPU | Memory |
|---------|-----|--------|
| backend | 2.0 | 4 GB |
| voicevox | 1.0 | 4 GB |
| kokoro-tts | 0.5 | 2 GB |
| caddy | 0.25 | 256 MB |
| OS + buffer | 0.25 | ~13.7 GB |

## Test plan

- [x] `docker compose -f docker-compose.production.yml config` validates (with temp `.env.production`)
- [x] `docker compose config` validates (existing dev compose unbroken)
- [x] `ruff check .` — All checks passed
- [x] `pytest` — 2202 passed, 0 failed
- [x] `grep 'os.getenv("ENV"' backend/main.py` — 0 matches (fully unified)
- [ ] Manual: Deploy to ARM VM and verify services start correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)