### PR TITLE
fix(ci): use pnpm run deploy for Cloudflare staging deployment

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -286,7 +286,7 @@ jobs:
         working-directory: frontend
 
       - name: Build and deploy to Cloudflare Workers
-        run: npx opennextjs-cloudflare build && npx opennextjs-cloudflare deploy
+        run: pnpm run deploy
         working-directory: frontend
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -77,6 +77,13 @@
     "ws": "^8.18.2",
     "zod": "^3.24.4"
   },
+  "pnpm": {
+    "onlyBuiltDependencies": [
+      "esbuild",
+      "sharp",
+      "workerd"
+    ]
+  },
   "devDependencies": {
     "@types/react": "^19.1.4",
     "@types/react-dom": "^19.1.5",


### PR DESCRIPTION
## Summary
- Changed `npx opennextjs-cloudflare build && npx opennextjs-cloudflare deploy` to `pnpm run deploy` in CI workflow to fix `npm error could not determine executable to run` error in pnpm environment
- Added `pnpm.onlyBuiltDependencies` config for `esbuild`, `sharp`, `workerd` to ensure native build scripts execute properly in CI

## Context
PR #148 merged the Cloudflare Workers deployment setup, but the `frontend-deploy-staging` CI job failed because `npx` cannot resolve packages installed via pnpm. Using `pnpm run deploy` (which calls the existing `deploy` script in package.json) fixes this.

## Test plan
- [ ] CI passes (frontend-lint, frontend-typecheck, frontend-build)
- [ ] `frontend-deploy-staging` job succeeds on merge to develop

🤖 Generated with [Claude Code](https://claude.com/claude-code)