### PR TITLE
feat(ci): add Cloud Run staging deploy for backend (#154)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -259,6 +259,63 @@ jobs:
           path: backend/reports/
           retention-days: 30
 
+  # Backend: Deploy to Cloud Run (staging)
+  # Only runs on push to develop after backend tests pass
+  # NOTE: This is an optional deploy job - not included in ci-success gate
+  #
+  # Deployment strategy:
+  #   - develop branch -> staging (Cloud Run, asia-northeast1)
+  #   - main branch -> production (separate environment, not yet configured)
+  #
+  # TTS services (VoiceVox, Kokoro) are NOT available on Cloud Run.
+  # They require dedicated GPU/CPU instances or external API alternatives.
+  # The backend will start without TTS; voice endpoints will fail gracefully
+  # when TTS_PROVIDER is set to an unsupported value or TTS service is unreachable.
+  backend-deploy-staging:
+    needs: [changes, backend-test]
+    if: needs.changes.outputs.backend == 'true' && github.event_name == 'push' && github.ref == 'refs/heads/develop'
+    runs-on: ubuntu-latest
+    environment: staging
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Authenticate to Google Cloud
+        uses: google-github-actions/auth@v2
+        with:
+          credentials_json: ${{ secrets.GCP_SA_KEY }}
+
+      - name: Set up Cloud SDK
+        uses: google-github-actions/setup-gcloud@v2
+
+      - name: Configure Docker for Artifact Registry
+        run: gcloud auth configure-docker asia-northeast1-docker.pkg.dev
+
+      - name: Build and push Docker image
+        run: |
+          docker build \
+            -t asia-northeast1-docker.pkg.dev/aipartner-426616/cloud-run-source-deploy/engineer-cafe-backend:${{ github.sha }} \
+            -t asia-northeast1-docker.pkg.dev/aipartner-426616/cloud-run-source-deploy/engineer-cafe-backend:latest \
+            --target production \
+            -f backend/Dockerfile \
+            backend/
+          docker push asia-northeast1-docker.pkg.dev/aipartner-426616/cloud-run-source-deploy/engineer-cafe-backend:${{ github.sha }}
+          docker push asia-northeast1-docker.pkg.dev/aipartner-426616/cloud-run-source-deploy/engineer-cafe-backend:latest
+
+      - name: Deploy to Cloud Run
+        run: |
+          gcloud run deploy engineer-cafe-backend \
+            --image asia-northeast1-docker.pkg.dev/aipartner-426616/cloud-run-source-deploy/engineer-cafe-backend:${{ github.sha }} \
+            --region asia-northeast1 \
+            --platform managed \
+            --allow-unauthenticated \
+            --port 8000 \
+            --memory 2Gi \
+            --cpu 2 \
+            --min-instances 0 \
+            --max-instances 3 \
+            --set-env-vars "ENVIRONMENT=staging" \
+            --set-secrets "OPENROUTER_API_KEY=OPENROUTER_API_KEY:latest,SUPABASE_URL=SUPABASE_URL:latest,SUPABASE_KEY=SUPABASE_KEY:latest,SUPABASE_DB_URI=SUPABASE_DB_URI:latest"
+
   # Frontend: Deploy to Cloudflare Workers (staging)
   # Only runs on push to develop when CLOUDFLARE_API_TOKEN is available
   frontend-deploy-staging:

--- a/backend/.env.staging.example
+++ b/backend/.env.staging.example
@@ -1,0 +1,65 @@
+# ===========================================
+# Engineer Cafe Navigator Backend - Staging (Cloud Run)
+# ===========================================
+# This file documents the environment variables needed for the
+# Cloud Run staging deployment. Most secrets are managed via
+# GCP Secret Manager and injected at deploy time (see ci.yml).
+#
+# Variables set directly as env vars on Cloud Run:
+#   ENVIRONMENT=staging
+#
+# Variables injected from GCP Secret Manager (--set-secrets):
+#   OPENROUTER_API_KEY  -> Secret Manager: OPENROUTER_API_KEY:latest
+#   SUPABASE_URL        -> Secret Manager: SUPABASE_URL:latest
+#   SUPABASE_KEY        -> Secret Manager: SUPABASE_KEY:latest
+#   SUPABASE_DB_URI     -> Secret Manager: SUPABASE_DB_URI:latest
+
+# ===========================================
+# Environment
+# ===========================================
+ENVIRONMENT=staging
+
+# ===========================================
+# OpenRouter API (Required - via Secret Manager)
+# ===========================================
+# Managed in GCP Secret Manager, not set here directly.
+# OPENROUTER_API_KEY=
+
+# ===========================================
+# Supabase Configuration (Required - via Secret Manager)
+# ===========================================
+# Managed in GCP Secret Manager, not set here directly.
+# SUPABASE_URL=https://smdmvpnsfmdspzzaisia.supabase.co
+# SUPABASE_KEY=
+# SUPABASE_DB_URI=
+
+# ===========================================
+# TTS Configuration
+# ===========================================
+# TTS services (VoiceVox, Kokoro) are NOT available on Cloud Run.
+# They run as separate Docker containers and require dedicated instances.
+#
+# Options for Cloud Run:
+#   1. Set TTS_PROVIDER=google and provide Google Cloud TTS credentials
+#   2. Do not set TTS_PROVIDER (voice endpoints will fail gracefully)
+#   3. Deploy VoiceVox/Kokoro as separate Cloud Run services and set URLs
+#
+# If deploying TTS as separate services:
+# VOICEVOX_API_URL=https://voicevox-service-xxxxx.run.app
+# KOKORO_API_URL=https://kokoro-tts-service-xxxxx.run.app
+# TTS_PROVIDER=voicevox
+
+# ===========================================
+# Optional APIs
+# ===========================================
+# OPENAI_API_KEY=           # For LLM Judge / Embeddings (via Secret Manager if needed)
+# TAVILY_API_KEY=           # For web search
+# GOOGLE_CALENDAR_ICAL_URL= # Public ICS feed URL
+# CONNPASS_API_KEY=         # Connpass event integration
+
+# ===========================================
+# Application Settings
+# ===========================================
+PORT=8000
+# APP_URL=https://engineer-cafe-backend-xxxxx.run.app
+# ALLOWED_ORIGINS=https://your-frontend-domain.com


### PR DESCRIPTION
## Summary
develop ブランチへの push 時にバックエンドを GCP Cloud Run (aipartner-426616) に自動デプロイするCI/CDジョブを追加。

## Changes
- `.github/workflows/ci.yml`: `backend-deploy-staging` ジョブ追加
  - backend 変更 + develop push + backend-test パス後にトリガー
  - Artifact Registry にイメージ push → Cloud Run デプロイ
  - 2 vCPU / 2Gi memory / 0-3 instances
- `backend/.env.staging.example`: staging 環境変数テンプレート

## Environment strategy
- **develop** → staging 自動デプロイ（本PR）
- **main** → production は別環境を別途用意（未設定）

## TTS limitation
VoiceVox / Kokoro TTS は Cloud Run 単体では非対応。音声機能は staging では制限あり。

## Required setup
1. GitHub Secret: `GCP_SA_KEY` (SA JSON)
2. GCP Secret Manager: `OPENROUTER_API_KEY`, `SUPABASE_URL`, `SUPABASE_KEY`, `SUPABASE_DB_URI`

## Test plan
- [x] YAML syntax validation
- [x] 既存 CI ジョブ 11件 保持確認
- [ ] GCP Secrets 設定後に develop push で自動デプロイ確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>