### PR TITLE
feat(backend): barge-in interrupt mechanism (#127)

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -236,6 +236,21 @@ class ChatResponse(BaseModel):
     vrm_control: Optional[Dict[str, Any]] = None
 
 
+class InterruptRequest(BaseModel):
+    session_id: str
+
+
+@app.post("/api/interrupt", dependencies=[Depends(verify_api_key)])
+@_rate_limit("60/minute")
+async def interrupt_session(request: Request, body: InterruptRequest):
+    """フロントエンドからの割り込みシグナルを受信"""
+    from backend.utils.interrupt_manager import get_interrupt_manager
+
+    manager = get_interrupt_manager()
+    manager.request_interrupt(body.session_id)
+    return {"status": "interrupted", "session_id": body.session_id}
+
+
 @app.get("/health")
 @_rate_limit("60/minute")
 async def health_check(request: Request):
@@ -279,6 +294,10 @@ async def chat(request: Request, body: ChatRequest):
     チャットエンドポイント
     LangGraphエージェントを使用してクエリを処理します
     """
+    from backend.utils.interrupt_manager import get_interrupt_manager
+
+    get_interrupt_manager().clear_interrupt(body.session_id)
+
     try:
         from backend.workflows.main_workflow import get_workflow
 
@@ -331,6 +350,10 @@ async def chat_stream(request: Request, body: ChatRequest):
     SSEストリーミングチャットエンドポイント
     Server-Sent Events でレスポンスをストリーミング
     """
+    from backend.utils.interrupt_manager import get_interrupt_manager
+
+    interrupt_mgr = get_interrupt_manager()
+    interrupt_mgr.clear_interrupt(body.session_id)
 
     async def event_generator():
         try:
@@ -348,6 +371,9 @@ async def chat_stream(request: Request, body: ChatRequest):
                     "visitor_id": body.visitor_id,
                 }
             ):
+                if interrupt_mgr.is_interrupted(body.session_id):
+                    yield f'data: {json.dumps({"type": "interrupted"})}\n\n'
+                    break
                 if isinstance(event, dict):
                     yield f"data: {json.dumps(event, ensure_ascii=False)}\n\n"
 
@@ -373,6 +399,10 @@ async def invoke_agent(request: Request, body: ChatRequest):
     """
     LangGraphエージェントの直接実行エンドポイント
     """
+    from backend.utils.interrupt_manager import get_interrupt_manager
+
+    get_interrupt_manager().clear_interrupt(body.session_id)
+
     try:
         from backend.workflows.main_workflow import get_workflow
 

--- a/backend/tests/test_interrupt_api.py
+++ b/backend/tests/test_interrupt_api.py
@@ -1,0 +1,70 @@
+import json
+from unittest.mock import AsyncMock, patch
+
+from fastapi.testclient import TestClient
+
+from backend.utils.interrupt_manager import get_interrupt_manager
+
+
+def test_interrupt_endpoint():
+    from backend.main import app
+
+    manager = get_interrupt_manager()
+    manager.clear_interrupt("s1")
+
+    client = TestClient(app)
+    response = client.post("/api/interrupt", json={"session_id": "s1"})
+
+    assert response.status_code == 200
+    assert response.json() == {"status": "interrupted", "session_id": "s1"}
+    assert manager.is_interrupted("s1")
+
+    manager.clear_interrupt("s1")
+
+
+def test_interrupt_requires_session_id():
+    from backend.main import app
+
+    client = TestClient(app)
+    response = client.post("/api/interrupt", json={})
+
+    assert response.status_code == 422
+
+
+def test_chat_stream_emits_interrupted_event():
+    from backend.main import app
+
+    manager = get_interrupt_manager()
+    manager.clear_interrupt("stream-session")
+
+    async def mock_stream(_input_data):
+        yield {"type": "token", "content": "first"}
+        manager.request_interrupt("stream-session")
+        yield {"type": "token", "content": "ignored"}
+
+    mock_workflow = AsyncMock()
+    mock_workflow.astream = mock_stream
+
+    with patch(
+        "backend.workflows.main_workflow.get_workflow",
+        new_callable=AsyncMock,
+        return_value=mock_workflow,
+    ):
+        client = TestClient(app)
+        with client.stream(
+            "POST",
+            "/api/chat/stream",
+            json={"query": "hello", "session_id": "stream-session"},
+        ) as response:
+            lines = [line for line in response.iter_lines() if line]
+
+    payloads = [json.loads(line.removeprefix("data: ")) for line in lines if line != "data: [DONE]"]
+
+    assert response.status_code == 200
+    assert payloads == [
+        {"type": "token", "content": "first"},
+        {"type": "interrupted"},
+    ]
+    assert lines[-1] == "data: [DONE]"
+
+    manager.clear_interrupt("stream-session")

--- a/backend/tests/utils/test_interrupt_manager.py
+++ b/backend/tests/utils/test_interrupt_manager.py
@@ -1,0 +1,60 @@
+import asyncio
+
+import pytest
+
+from backend.utils.interrupt_manager import InterruptManager
+
+
+class TestInterruptManager:
+    def test_request_and_check_interrupt(self):
+        mgr = InterruptManager()
+
+        assert not mgr.is_interrupted("s1")
+
+        mgr.request_interrupt("s1")
+
+        assert mgr.is_interrupted("s1")
+
+    def test_clear_interrupt(self):
+        mgr = InterruptManager()
+
+        mgr.request_interrupt("s1")
+        mgr.clear_interrupt("s1")
+
+        assert not mgr.is_interrupted("s1")
+
+    def test_session_isolation(self):
+        mgr = InterruptManager()
+
+        mgr.request_interrupt("s1")
+
+        assert not mgr.is_interrupted("s2")
+
+    @pytest.mark.asyncio
+    async def test_wait_for_interrupt_timeout(self):
+        mgr = InterruptManager()
+
+        result = await mgr.wait_for_interrupt("s1", timeout=0.1)
+
+        assert not result
+
+    @pytest.mark.asyncio
+    async def test_wait_for_interrupt_signaled(self):
+        mgr = InterruptManager()
+
+        async def signal_later():
+            await asyncio.sleep(0.05)
+            mgr.request_interrupt("s1")
+
+        asyncio.create_task(signal_later())
+        result = await mgr.wait_for_interrupt("s1", timeout=1.0)
+
+        assert result
+
+    def test_stale_session_cleanup(self):
+        mgr = InterruptManager()
+
+        mgr.request_interrupt("old_session")
+        mgr.cleanup_stale_sessions(max_age_seconds=0)
+
+        assert not mgr.is_interrupted("old_session")

--- a/backend/utils/interrupt_manager.py
+++ b/backend/utils/interrupt_manager.py
@@ -1,0 +1,72 @@
+"""Session-scoped interrupt signal management."""
+
+from __future__ import annotations
+
+import asyncio
+import time
+from dataclasses import dataclass, field
+
+
+@dataclass
+class InterruptState:
+    event: asyncio.Event = field(default_factory=asyncio.Event)
+    timestamp: float = field(default_factory=time.time)
+
+
+class InterruptManager:
+    """Manage session-scoped interrupt signals outside LangGraph state."""
+
+    def __init__(self):
+        self._sessions: dict[str, InterruptState] = {}
+
+    def _get_or_create_state(self, session_id: str) -> InterruptState:
+        state = self._sessions.get(session_id)
+        if state is None:
+            state = InterruptState()
+            self._sessions[session_id] = state
+        return state
+
+    def request_interrupt(self, session_id: str) -> None:
+        """Request interruption for a session."""
+        state = self._get_or_create_state(session_id)
+        state.timestamp = time.time()
+        state.event.set()
+
+    def is_interrupted(self, session_id: str) -> bool:
+        """Return whether a session currently has a pending interrupt."""
+        state = self._sessions.get(session_id)
+        return bool(state and state.event.is_set())
+
+    def clear_interrupt(self, session_id: str) -> None:
+        """Clear interrupt state for a session."""
+        self._sessions.pop(session_id, None)
+
+    async def wait_for_interrupt(self, session_id: str, timeout: float | None = None) -> bool:
+        """Wait asynchronously for an interrupt signal."""
+        state = self._get_or_create_state(session_id)
+        if state.event.is_set():
+            return True
+
+        try:
+            await asyncio.wait_for(state.event.wait(), timeout=timeout)
+            return True
+        except asyncio.TimeoutError:
+            return False
+
+    def cleanup_stale_sessions(self, max_age_seconds: float) -> None:
+        """Remove interrupt state older than the configured age."""
+        now = time.time()
+        stale_session_ids = [
+            session_id
+            for session_id, state in self._sessions.items()
+            if now - state.timestamp >= max_age_seconds
+        ]
+        for session_id in stale_session_ids:
+            self._sessions.pop(session_id, None)
+
+
+_manager = InterruptManager()
+
+
+def get_interrupt_manager() -> InterruptManager:
+    return _manager


### PR DESCRIPTION
## Summary

- `InterruptManager`: セッション単位の割り込み状態管理（asyncio.Event ベース）
- `POST /api/interrupt`: フロントエンドVADからの割り込みシグナル受信
- SSEストリーミング割り込み: `{"type": "interrupted"}` 送信後に停止
- `/api/chat`, `/api/chat/stream`, `/api/agent/invoke` 開始時に割り込み状態クリア

## Design Decision

LangGraph の内部状態（checkpointer/Store）には触れず、外部マネージャーで管理。
- LangGraph の `astream()` = トークンストリーミング
- LangGraph の HITL `interrupt` = グラフ再開機構（永続化前提）
- 本実装の interrupt = リアルタイム音声割り込み（一時的なシグナル）

これらは別物であり、混在させない設計。

## Files Changed

| File | Change |
|------|--------|
| `backend/utils/interrupt_manager.py` | NEW: InterruptManager + singleton |
| `backend/main.py` | InterruptRequest model, POST /api/interrupt, clear/check in chat/stream/invoke |
| `backend/tests/utils/test_interrupt_manager.py` | NEW: 6 unit tests |
| `backend/tests/test_interrupt_api.py` | NEW: 3 API integration tests |

## Test Plan

- [x] `pytest tests/utils/test_interrupt_manager.py` — 6 passed
- [x] `pytest tests/test_interrupt_api.py` — 3 passed (incl. SSE interrupted event test)
- [x] `pytest tests/test_main_endpoints.py` — 10 passed (既存テスト破壊なし)
- [x] `black --check` pass
- [x] `ruff check` pass

Closes #127

🤖 Generated with [Claude Code](https://claude.com/claude-code)