### PR TITLE
feat(backend): autonomous reception flow (#117)

### DIFF
--- a/backend/api/__init__.py
+++ b/backend/api/__init__.py
@@ -1,1 +1,1 @@
-"""API routers for Engineer Cafe Navigator backend."""
+"""API package"""

--- a/backend/api/reception.py
+++ b/backend/api/reception.py
@@ -7,10 +7,11 @@ Handles session lifecycle: start -> respond -> status.
 from __future__ import annotations
 
 import logging
-from typing import Optional
+from collections import OrderedDict
+from typing import Literal, Optional
 
 from fastapi import APIRouter, HTTPException
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 
 from backend.domain.reception.models import (
     ReceptionSession,
@@ -33,10 +34,22 @@ logger = logging.getLogger(__name__)
 reception_router = APIRouter(prefix="/api/reception", tags=["reception"])
 
 # ---------------------------------------------------------------------------
-# In-memory session store (short-lived reception sessions)
+# In-memory session store (short-lived, bounded to prevent unbounded growth)
 # ---------------------------------------------------------------------------
 
-_active_sessions: dict[str, ReceptionSession] = {}
+_MAX_SESSIONS = 1000
+
+_active_sessions: OrderedDict[str, ReceptionSession] = OrderedDict()
+
+
+def _store_session(session: ReceptionSession) -> None:
+    """Store a session, evicting the oldest if at capacity."""
+    if session.id in _active_sessions:
+        _active_sessions.move_to_end(session.id)
+    else:
+        if len(_active_sessions) >= _MAX_SESSIONS:
+            _active_sessions.popitem(last=False)
+    _active_sessions[session.id] = session
 
 # ---------------------------------------------------------------------------
 # Purpose keyword classifier (lightweight, no LLM required for basic cases)
@@ -73,9 +86,9 @@ def _classify_purpose(message: str) -> Optional[str]:
 
 
 class ReceptionStartRequest(BaseModel):
-    session_id: str
-    language: str = "ja"
-    trigger_type: str = "button_press"
+    session_id: str = Field(min_length=1, max_length=128)
+    language: Literal["ja", "en", "zh", "ko"] = "ja"
+    trigger_type: Literal["face_detection", "button_press", "wake_word", "nfc"] = "button_press"
 
 
 class ReceptionStartResponse(BaseModel):
@@ -85,9 +98,9 @@ class ReceptionStartResponse(BaseModel):
 
 
 class ReceptionRespondRequest(BaseModel):
-    session_id: str
-    reception_session_id: str
-    message: str
+    session_id: str = Field(min_length=1, max_length=128)
+    reception_session_id: str = Field(min_length=1, max_length=128)
+    message: str = Field(min_length=1, max_length=2000)
 
 
 class ReceptionRespondResponse(BaseModel):
@@ -119,7 +132,7 @@ async def start_reception(request: ReceptionStartRequest) -> ReceptionStartRespo
     )
     session.advance_to("greeting")
 
-    _active_sessions[session.id] = session
+    _store_session(session)
 
     greeting_result = get_reception_response(request.language, is_returning=False)
     logger.info(
@@ -144,6 +157,13 @@ async def respond_reception(request: ReceptionRespondRequest) -> ReceptionRespon
         raise HTTPException(
             status_code=404,
             detail=f"Reception session not found: {request.reception_session_id}",
+        )
+    _active_sessions.move_to_end(request.reception_session_id)
+
+    if session.session_id != request.session_id:
+        raise HTTPException(
+            status_code=403,
+            detail="Session ID mismatch",
         )
 
     language = session.language
@@ -185,7 +205,7 @@ async def respond_reception(request: ReceptionRespondRequest) -> ReceptionRespon
         )
 
     if current_stage == "routing":
-        session.stage = "completed"
+        session.advance_to("completed")
 
         routing_messages = {
             "ja": "スタッフをお呼びします。少々お待ちください。",
@@ -197,22 +217,22 @@ async def respond_reception(request: ReceptionRespondRequest) -> ReceptionRespon
             next_action="completed",
         )
 
-    return ReceptionRespondResponse(
-        response="",
-        stage=session.stage,
-        next_action=None,
+    raise HTTPException(
+        status_code=409,
+        detail=f"Cannot respond in stage: {session.stage}",
     )
 
 
-@reception_router.get("/status/{session_id}", response_model=ReceptionStatusResponse)
-async def get_reception_status(session_id: str) -> ReceptionStatusResponse:
+@reception_router.get("/status/{reception_session_id}", response_model=ReceptionStatusResponse)
+async def get_reception_status(reception_session_id: str) -> ReceptionStatusResponse:
     """Return the current state of a reception session."""
-    session = _active_sessions.get(session_id)
+    session = _active_sessions.get(reception_session_id)
     if session is None:
         raise HTTPException(
             status_code=404,
-            detail=f"Reception session not found: {session_id}",
+            detail=f"Reception session not found: {reception_session_id}",
         )
+    _active_sessions.move_to_end(reception_session_id)
 
     visitor_type: Optional[str] = None
     purpose_str: Optional[str] = None

--- a/backend/api/reception.py
+++ b/backend/api/reception.py
@@ -1,0 +1,231 @@
+"""Reception API endpoints.
+
+FastAPI router for the autonomous reception flow.
+Handles session lifecycle: start -> respond -> status.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Optional
+
+from fastapi import APIRouter, HTTPException
+from pydantic import BaseModel
+
+from backend.domain.reception.models import (
+    ReceptionSession,
+    VisitPurpose,
+    VisitorIdentity,
+    VisitorType,
+)
+from backend.utils.reception_templates import (
+    get_purpose_followup,
+    get_purpose_hearing_prompt,
+    get_reception_response,
+)
+
+logger = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Router
+# ---------------------------------------------------------------------------
+
+reception_router = APIRouter(prefix="/api/reception", tags=["reception"])
+
+# ---------------------------------------------------------------------------
+# In-memory session store (short-lived reception sessions)
+# ---------------------------------------------------------------------------
+
+_active_sessions: dict[str, ReceptionSession] = {}
+
+# ---------------------------------------------------------------------------
+# Purpose keyword classifier (lightweight, no LLM required for basic cases)
+# ---------------------------------------------------------------------------
+
+_PURPOSE_KEYWORDS: dict[str, list[str]] = {
+    "facility_use": [
+        "cowork", "coworking", "コワーキング", "デスク",
+        "facility", "room", "space", "施設", "利用", "部屋", "スペース",
+    ],
+    "event_participation": [
+        "event", "seminar", "workshop", "meetup",
+        "イベント", "セミナー", "ワークショップ", "勉強会",
+    ],
+    "consultation": [
+        "inquiry", "question", "info", "ask", "consult",
+        "問い合わせ", "質問", "相談", "聞きたい",
+    ],
+}
+
+
+def _classify_purpose(message: str) -> Optional[str]:
+    """Classify a visitor's message into a purpose category."""
+    lower = message.lower()
+    for category, keywords in _PURPOSE_KEYWORDS.items():
+        if any(kw in lower for kw in keywords):
+            return category
+    return None
+
+
+# ---------------------------------------------------------------------------
+# Pydantic request / response models
+# ---------------------------------------------------------------------------
+
+
+class ReceptionStartRequest(BaseModel):
+    session_id: str
+    language: str = "ja"
+    trigger_type: str = "button_press"
+
+
+class ReceptionStartResponse(BaseModel):
+    reception_session_id: str
+    greeting: str
+    stage: str
+
+
+class ReceptionRespondRequest(BaseModel):
+    session_id: str
+    reception_session_id: str
+    message: str
+
+
+class ReceptionRespondResponse(BaseModel):
+    response: str
+    stage: str
+    purpose: Optional[dict] = None
+    next_action: Optional[str] = None
+
+
+class ReceptionStatusResponse(BaseModel):
+    session_id: str
+    stage: str
+    visitor_type: Optional[str] = None
+    purpose: Optional[str] = None
+
+
+# ---------------------------------------------------------------------------
+# Endpoints
+# ---------------------------------------------------------------------------
+
+
+@reception_router.post("/start", response_model=ReceptionStartResponse)
+async def start_reception(request: ReceptionStartRequest) -> ReceptionStartResponse:
+    """Initiate a new reception session."""
+    session = ReceptionSession(
+        session_id=request.session_id,
+        language=request.language,
+        trigger_type=request.trigger_type,
+    )
+    session.advance_to("greeting")
+
+    _active_sessions[session.id] = session
+
+    greeting_result = get_reception_response(request.language, is_returning=False)
+    logger.info(
+        "Reception session started: id=%s session_id=%s language=%s",
+        session.id,
+        request.session_id,
+        request.language,
+    )
+
+    return ReceptionStartResponse(
+        reception_session_id=session.id,
+        greeting=greeting_result.text,
+        stage=session.stage,
+    )
+
+
+@reception_router.post("/respond", response_model=ReceptionRespondResponse)
+async def respond_reception(request: ReceptionRespondRequest) -> ReceptionRespondResponse:
+    """Continue the reception conversation."""
+    session = _active_sessions.get(request.reception_session_id)
+    if session is None:
+        raise HTTPException(
+            status_code=404,
+            detail=f"Reception session not found: {request.reception_session_id}",
+        )
+
+    language = session.language
+    current_stage = session.stage
+
+    if current_stage == "greeting":
+        identity = VisitorIdentity(visitor_type=VisitorType(value="new"))
+        session.identify_visitor(identity)
+        session.advance_to("purpose_hearing")
+
+        prompt_result = get_purpose_hearing_prompt(language)
+
+        return ReceptionRespondResponse(
+            response=prompt_result.text,
+            stage=session.stage,
+            next_action="ask_purpose",
+        )
+
+    if current_stage == "purpose_hearing":
+        category = _classify_purpose(request.message)
+        if category is None:
+            prompt_result = get_purpose_hearing_prompt(language)
+            return ReceptionRespondResponse(
+                response=prompt_result.text,
+                stage=session.stage,
+                next_action="clarify_purpose",
+            )
+
+        purpose = VisitPurpose(category=category, detail=request.message)
+        session.set_purpose(purpose)
+        session.advance_to("routing")
+
+        followup_result = get_purpose_followup(language, category)
+        return ReceptionRespondResponse(
+            response=followup_result.text,
+            stage=session.stage,
+            purpose={"category": category, "detail": request.message},
+            next_action="route_to_agent",
+        )
+
+    if current_stage == "routing":
+        session.stage = "completed"
+
+        routing_messages = {
+            "ja": "スタッフをお呼びします。少々お待ちください。",
+            "en": "I'll call a staff member for you. Please wait a moment.",
+        }
+        return ReceptionRespondResponse(
+            response=routing_messages.get(language, routing_messages["ja"]),
+            stage=session.stage,
+            next_action="completed",
+        )
+
+    return ReceptionRespondResponse(
+        response="",
+        stage=session.stage,
+        next_action=None,
+    )
+
+
+@reception_router.get("/status/{session_id}", response_model=ReceptionStatusResponse)
+async def get_reception_status(session_id: str) -> ReceptionStatusResponse:
+    """Return the current state of a reception session."""
+    session = _active_sessions.get(session_id)
+    if session is None:
+        raise HTTPException(
+            status_code=404,
+            detail=f"Reception session not found: {session_id}",
+        )
+
+    visitor_type: Optional[str] = None
+    purpose_str: Optional[str] = None
+
+    if session.visitor_identity is not None:
+        visitor_type = session.visitor_identity.visitor_type.value
+
+    if session.purpose is not None:
+        purpose_str = session.purpose.category
+
+    return ReceptionStatusResponse(
+        session_id=session.session_id,
+        stage=session.stage,
+        visitor_type=visitor_type,
+        purpose=purpose_str,
+    )

--- a/backend/api/reception.py
+++ b/backend/api/reception.py
@@ -51,22 +51,45 @@ def _store_session(session: ReceptionSession) -> None:
             _active_sessions.popitem(last=False)
     _active_sessions[session.id] = session
 
+
 # ---------------------------------------------------------------------------
 # Purpose keyword classifier (lightweight, no LLM required for basic cases)
 # ---------------------------------------------------------------------------
 
 _PURPOSE_KEYWORDS: dict[str, list[str]] = {
     "facility_use": [
-        "cowork", "coworking", "コワーキング", "デスク",
-        "facility", "room", "space", "施設", "利用", "部屋", "スペース",
+        "cowork",
+        "coworking",
+        "コワーキング",
+        "デスク",
+        "facility",
+        "room",
+        "space",
+        "施設",
+        "利用",
+        "部屋",
+        "スペース",
     ],
     "event_participation": [
-        "event", "seminar", "workshop", "meetup",
-        "イベント", "セミナー", "ワークショップ", "勉強会",
+        "event",
+        "seminar",
+        "workshop",
+        "meetup",
+        "イベント",
+        "セミナー",
+        "ワークショップ",
+        "勉強会",
     ],
     "consultation": [
-        "inquiry", "question", "info", "ask", "consult",
-        "問い合わせ", "質問", "相談", "聞きたい",
+        "inquiry",
+        "question",
+        "info",
+        "ask",
+        "consult",
+        "問い合わせ",
+        "質問",
+        "相談",
+        "聞きたい",
     ],
 }
 

--- a/backend/domain/__init__.py
+++ b/backend/domain/__init__.py
@@ -1,0 +1,1 @@
+"""Domain layer package."""

--- a/backend/domain/reception/__init__.py
+++ b/backend/domain/reception/__init__.py
@@ -1,0 +1,45 @@
+"""Reception Domain Package - DDD models, events, and services for autonomous reception flow."""
+
+from __future__ import annotations
+
+from backend.domain.reception.events import (
+    AgentHandoffRequested,
+    PurposeIdentified,
+    StaffEscalationRequested,
+    VisitStarted,
+    VisitorDetected,
+    VisitorIdentified,
+)
+from backend.domain.reception.models import (
+    ReceptionSession,
+    ReceptionStage,
+    VisitPurpose,
+    VisitorIdentity,
+    VisitorType,
+)
+from backend.domain.reception.repository import (
+    ReceptionSessionRepository,
+    VisitRepository,
+)
+from backend.domain.reception.service import ReceptionDomainService
+
+__all__ = [
+    # Models
+    "VisitorType",
+    "VisitPurpose",
+    "VisitorIdentity",
+    "ReceptionStage",
+    "ReceptionSession",
+    # Events
+    "VisitorDetected",
+    "VisitorIdentified",
+    "PurposeIdentified",
+    "AgentHandoffRequested",
+    "StaffEscalationRequested",
+    "VisitStarted",
+    # Repository interfaces
+    "ReceptionSessionRepository",
+    "VisitRepository",
+    # Services
+    "ReceptionDomainService",
+]

--- a/backend/domain/reception/events.py
+++ b/backend/domain/reception/events.py
@@ -1,0 +1,98 @@
+"""Reception Domain Events.
+
+Domain events emitted during the autonomous reception flow.
+These events represent significant state changes that other parts
+of the system may need to react to.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime
+from typing import Literal, Optional
+
+
+@dataclass(frozen=True)
+class VisitorDetected:
+    """Event emitted when a visitor is detected at the entrance.
+
+    Attributes:
+        trigger_type: The detection mechanism that identified the visitor.
+        timestamp: When the detection occurred.
+        nfc_id: Optional NFC card identifier if detected via NFC.
+    """
+
+    trigger_type: Literal["face_detection", "button_press", "wake_word", "nfc"]
+    timestamp: datetime
+    nfc_id: Optional[str] = None
+
+
+@dataclass(frozen=True)
+class VisitorIdentified:
+    """Event emitted when a visitor's identity has been determined.
+
+    Attributes:
+        reception_session_id: The reception session this event belongs to.
+        visitor_identity: The resolved visitor identity (VisitorIdentity value object).
+    """
+
+    reception_session_id: str
+    visitor_identity: object  # VisitorIdentity (avoid circular import)
+
+
+@dataclass(frozen=True)
+class PurposeIdentified:
+    """Event emitted when a visitor's purpose has been determined.
+
+    Attributes:
+        reception_session_id: The reception session this event belongs to.
+        purpose: The resolved visit purpose (VisitPurpose value object).
+    """
+
+    reception_session_id: str
+    purpose: object  # VisitPurpose
+
+
+@dataclass(frozen=True)
+class AgentHandoffRequested:
+    """Event emitted when the reception flow hands off to a specialized agent.
+
+    Attributes:
+        reception_session_id: The reception session this event belongs to.
+        target_agent: The name of the agent to hand off to.
+        context: Contextual information for the target agent.
+    """
+
+    reception_session_id: str
+    target_agent: str
+    context: dict
+
+
+@dataclass(frozen=True)
+class StaffEscalationRequested:
+    """Event emitted when human staff intervention is needed.
+
+    Attributes:
+        reception_session_id: The reception session this event belongs to.
+        reason: Why escalation is needed.
+        visitor_name: The visitor's name if known.
+    """
+
+    reception_session_id: str
+    reason: str
+    visitor_name: Optional[str] = None
+
+
+@dataclass(frozen=True)
+class VisitStarted:
+    """Event emitted when a visit has been officially recorded.
+
+    Attributes:
+        visit_id: The unique identifier for this visit record.
+        user_id: The visitor's user ID if known.
+        purpose: The visit purpose (VisitPurpose value object).
+    """
+
+    visit_id: str
+    user_id: Optional[int]
+    purpose: object  # VisitPurpose

--- a/backend/domain/reception/models.py
+++ b/backend/domain/reception/models.py
@@ -89,10 +89,10 @@ ReceptionStage = Literal[
 
 # Valid stage transitions for the reception flow state machine
 _VALID_TRANSITIONS: dict[str, set[str]] = {
-    "initiated": {"greeting", "identifying"},
-    "greeting": {"identifying", "purpose_hearing"},
-    "identifying": {"greeting", "purpose_hearing"},
-    "purpose_hearing": {"routing"},
+    "initiated": {"greeting", "identifying", "escalated"},
+    "greeting": {"identifying", "purpose_hearing", "escalated"},
+    "identifying": {"greeting", "purpose_hearing", "escalated"},
+    "purpose_hearing": {"routing", "escalated"},
     "routing": {"completed", "escalated"},
 }
 
@@ -121,7 +121,7 @@ class ReceptionSession:
     visitor_identity: Optional[VisitorIdentity] = None
     purpose: Optional[VisitPurpose] = None
     stage: ReceptionStage = "initiated"
-    language: Literal["ja", "en"] = "ja"
+    language: Literal["ja", "en", "zh", "ko"] = "ja"
     trigger_type: Literal["face_detection", "button_press", "wake_word", "nfc"] = "button_press"
     created_at: datetime = field(default_factory=datetime.now)
     metadata: dict = field(default_factory=dict)
@@ -196,7 +196,7 @@ class ReceptionSession:
         Args:
             reason: Why escalation is needed.
         """
-        self.stage = "escalated"
+        self.advance_to("escalated")
         self._events.append(
             StaffEscalationRequested(
                 reception_session_id=self.id,

--- a/backend/domain/reception/models.py
+++ b/backend/domain/reception/models.py
@@ -113,6 +113,7 @@ class ReceptionSession:
         language: Language for the interaction.
         trigger_type: How the reception was initiated.
         created_at: When this session was created.
+        metadata: Arbitrary key-value metadata.
     """
 
     id: str = field(default_factory=lambda: str(uuid.uuid4()))
@@ -123,6 +124,7 @@ class ReceptionSession:
     language: Literal["ja", "en"] = "ja"
     trigger_type: Literal["face_detection", "button_press", "wake_word", "nfc"] = "button_press"
     created_at: datetime = field(default_factory=datetime.now)
+    metadata: dict = field(default_factory=dict)
     _events: list = field(default_factory=list, repr=False)
 
     def advance_to(self, stage: ReceptionStage) -> None:

--- a/backend/domain/reception/models.py
+++ b/backend/domain/reception/models.py
@@ -1,0 +1,215 @@
+"""Reception Domain Models - DDD Value Objects and Aggregate Root.
+
+This module defines the core domain model for the autonomous reception flow,
+following Domain-Driven Design principles with immutable value objects and
+an aggregate root that enforces business invariants.
+"""
+
+from __future__ import annotations
+
+import uuid
+from dataclasses import dataclass, field
+from datetime import datetime
+from typing import Literal, Optional
+
+from backend.domain.reception.events import (
+    AgentHandoffRequested,
+    PurposeIdentified,
+    StaffEscalationRequested,
+    VisitorIdentified,
+)
+
+# =============================================================================
+# Value Objects (frozen=True for immutability)
+# =============================================================================
+
+
+@dataclass(frozen=True)
+class VisitorType:
+    """Classifies a visitor as new or returning.
+
+    Attributes:
+        value: Whether the visitor is new or returning.
+    """
+
+    value: Literal["new", "returning"]
+
+
+@dataclass(frozen=True)
+class VisitPurpose:
+    """Represents a visitor's stated purpose for visiting.
+
+    Attributes:
+        category: The broad category of the visit purpose.
+        detail: Optional free-text detail about the purpose.
+    """
+
+    category: Literal["facility_use", "event_participation", "tour", "consultation", "other"]
+    detail: Optional[str] = None
+
+
+@dataclass(frozen=True)
+class VisitorIdentity:
+    """Result of visitor identification, combining detection signals.
+
+    Attributes:
+        visitor_type: Whether the visitor is new or returning.
+        user_id: Database user ID if the visitor is registered.
+        name: The visitor's name if known.
+        last_visit_date: When the visitor last visited, if returning.
+        last_purpose: The purpose of the visitor's last visit.
+        visit_count: Total number of previous visits.
+    """
+
+    visitor_type: VisitorType
+    user_id: Optional[int] = None
+    name: Optional[str] = None
+    last_visit_date: Optional[datetime] = None
+    last_purpose: Optional[VisitPurpose] = None
+    visit_count: int = 0
+
+
+# =============================================================================
+# Reception Stage Type
+# =============================================================================
+
+ReceptionStage = Literal[
+    "initiated",
+    "greeting",
+    "identifying",
+    "purpose_hearing",
+    "routing",
+    "completed",
+    "escalated",
+]
+
+# =============================================================================
+# Aggregate Root
+# =============================================================================
+
+# Valid stage transitions for the reception flow state machine
+_VALID_TRANSITIONS: dict[str, set[str]] = {
+    "initiated": {"greeting", "identifying"},
+    "greeting": {"identifying", "purpose_hearing"},
+    "identifying": {"greeting", "purpose_hearing"},
+    "purpose_hearing": {"routing"},
+    "routing": {"completed", "escalated"},
+}
+
+
+@dataclass
+class ReceptionSession:
+    """Aggregate root for the autonomous reception flow.
+
+    Manages the lifecycle of a single reception interaction, enforcing
+    valid stage transitions and collecting domain events.
+
+    Attributes:
+        id: Unique identifier for this reception session.
+        session_id: Associated conversation session ID.
+        visitor_identity: Resolved visitor identity, if identified.
+        purpose: The visitor's stated purpose, if determined.
+        stage: Current stage in the reception flow.
+        language: Language for the interaction.
+        trigger_type: How the reception was initiated.
+        created_at: When this session was created.
+    """
+
+    id: str = field(default_factory=lambda: str(uuid.uuid4()))
+    session_id: str = ""
+    visitor_identity: Optional[VisitorIdentity] = None
+    purpose: Optional[VisitPurpose] = None
+    stage: ReceptionStage = "initiated"
+    language: Literal["ja", "en"] = "ja"
+    trigger_type: Literal["face_detection", "button_press", "wake_word", "nfc"] = "button_press"
+    created_at: datetime = field(default_factory=datetime.now)
+    _events: list = field(default_factory=list, repr=False)
+
+    def advance_to(self, stage: ReceptionStage) -> None:
+        """Advance the reception flow to a new stage.
+
+        Validates that the transition is allowed by the state machine
+        before applying it.
+
+        Args:
+            stage: The target stage to transition to.
+
+        Raises:
+            ValueError: If the transition from the current stage to the
+                target stage is not allowed.
+        """
+        allowed = _VALID_TRANSITIONS.get(self.stage, set())
+        if stage not in allowed:
+            raise ValueError(f"Invalid transition: {self.stage} -> {stage}")
+        self.stage = stage
+
+    def identify_visitor(self, identity: VisitorIdentity) -> None:
+        """Record the result of visitor identification.
+
+        Args:
+            identity: The resolved visitor identity.
+        """
+        self.visitor_identity = identity
+        self._events.append(
+            VisitorIdentified(
+                reception_session_id=self.id,
+                visitor_identity=identity,
+            )
+        )
+
+    def set_purpose(self, purpose: VisitPurpose) -> None:
+        """Record the visitor's stated purpose.
+
+        Args:
+            purpose: The resolved visit purpose.
+        """
+        self.purpose = purpose
+        self._events.append(
+            PurposeIdentified(
+                reception_session_id=self.id,
+                purpose=purpose,
+            )
+        )
+
+    def request_handoff(self, target_agent: str, context: dict) -> None:
+        """Request handoff to a specialized agent.
+
+        Args:
+            target_agent: The name of the agent to hand off to.
+            context: Contextual information for the target agent.
+        """
+        self._events.append(
+            AgentHandoffRequested(
+                reception_session_id=self.id,
+                target_agent=target_agent,
+                context=context,
+            )
+        )
+
+    def request_escalation(self, reason: str) -> None:
+        """Escalate to human staff.
+
+        Sets the stage to 'escalated' and emits a StaffEscalationRequested event.
+
+        Args:
+            reason: Why escalation is needed.
+        """
+        self.stage = "escalated"
+        self._events.append(
+            StaffEscalationRequested(
+                reception_session_id=self.id,
+                reason=reason,
+                visitor_name=self.visitor_identity.name if self.visitor_identity else None,
+            )
+        )
+
+    def collect_events(self) -> list:
+        """Collect and clear all pending domain events.
+
+        Returns:
+            A list of domain events that have been emitted since the last
+            call to collect_events.
+        """
+        events = list(self._events)
+        self._events.clear()
+        return events

--- a/backend/domain/reception/repository.py
+++ b/backend/domain/reception/repository.py
@@ -1,0 +1,88 @@
+"""Reception Repository Interfaces.
+
+Abstract base classes defining the persistence contracts for the reception domain.
+Concrete implementations are provided by the infrastructure layer.
+"""
+
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from typing import Optional
+
+from backend.domain.reception.models import ReceptionSession
+
+
+class ReceptionSessionRepository(ABC):
+    """Repository interface for ReceptionSession aggregate persistence.
+
+    Implementations must handle saving and retrieving ReceptionSession
+    aggregates from the chosen storage backend.
+    """
+
+    @abstractmethod
+    async def save(self, session: ReceptionSession) -> None:
+        """Persist a reception session.
+
+        Args:
+            session: The reception session to save.
+        """
+        ...
+
+    @abstractmethod
+    async def find_by_id(self, session_id: str) -> Optional[ReceptionSession]:
+        """Find a reception session by its unique ID.
+
+        Args:
+            session_id: The reception session's unique identifier.
+
+        Returns:
+            The reception session if found, None otherwise.
+        """
+        ...
+
+    @abstractmethod
+    async def find_by_conversation_session(
+        self, conversation_session_id: str
+    ) -> Optional[ReceptionSession]:
+        """Find a reception session by its associated conversation session ID.
+
+        Args:
+            conversation_session_id: The conversation session identifier.
+
+        Returns:
+            The reception session if found, None otherwise.
+        """
+        ...
+
+
+class VisitRepository(ABC):
+    """Repository interface for visit record persistence.
+
+    Implementations handle recording completed visits and querying
+    visit history for returning visitors.
+    """
+
+    @abstractmethod
+    async def record_visit(self, session: ReceptionSession) -> str:
+        """Record a completed visit from a reception session.
+
+        Args:
+            session: The completed reception session.
+
+        Returns:
+            The unique identifier of the created visit record.
+        """
+        ...
+
+    @abstractmethod
+    async def get_recent_visits(self, user_id: int, limit: int = 5) -> list:
+        """Get recent visits for a registered user.
+
+        Args:
+            user_id: The user's database ID.
+            limit: Maximum number of visits to return.
+
+        Returns:
+            A list of recent visit records, most recent first.
+        """
+        ...

--- a/backend/domain/reception/repository.py
+++ b/backend/domain/reception/repository.py
@@ -7,7 +7,7 @@ Concrete implementations are provided by the infrastructure layer.
 from __future__ import annotations
 
 from abc import ABC, abstractmethod
-from typing import Optional
+from typing import List, Optional
 
 from backend.domain.reception.models import ReceptionSession
 
@@ -75,7 +75,7 @@ class VisitRepository(ABC):
         ...
 
     @abstractmethod
-    async def get_recent_visits(self, user_id: int, limit: int = 5) -> list:
+    async def get_recent_visits(self, user_id: int, limit: int = 5) -> List[dict]:
         """Get recent visits for a registered user.
 
         Args:

--- a/backend/domain/reception/service.py
+++ b/backend/domain/reception/service.py
@@ -1,0 +1,81 @@
+"""Reception Domain Service.
+
+Pure domain logic for the reception flow with no infrastructure dependencies.
+Handles visitor type determination and purpose-to-agent mapping.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Optional
+
+from backend.domain.reception.models import VisitPurpose, VisitorType
+
+logger = logging.getLogger(__name__)
+
+# Purpose category to agent name mapping
+_PURPOSE_AGENT_MAPPING: dict[str, str] = {
+    "facility_use": "facility",
+    "event_participation": "event",
+    "tour": "slide",
+    "consultation": "general_knowledge",
+    "other": "general_knowledge",
+}
+
+
+class ReceptionDomainService:
+    """Domain logic for the reception flow.
+
+    Contains pure business rules for visitor classification and
+    agent routing. Has no infrastructure dependencies.
+    """
+
+    FIRST_TIME_KEYWORDS_JA: list[str] = ["初めて", "はじめて", "初回", "初利用"]
+    FIRST_TIME_KEYWORDS_EN: list[str] = ["first time", "first visit", "never been"]
+
+    def determine_visitor_type(
+        self,
+        query: str,
+        language: str,
+        long_term_memories: list,
+        user_id: Optional[int] = None,
+    ) -> VisitorType:
+        """Determine if a visitor is new or returning based on available signals.
+
+        Uses a priority-based approach:
+        1. Explicit "first time" keywords in the query override everything.
+        2. A database user record or existing long-term memories indicate returning.
+        3. Otherwise, assume new visitor.
+
+        Args:
+            query: The visitor's spoken or typed input.
+            language: The interaction language ("ja" or "en").
+            long_term_memories: List of long-term memory entries for this visitor.
+            user_id: Database user ID if the visitor has been identified.
+
+        Returns:
+            A VisitorType value object indicating "new" or "returning".
+        """
+        lower_query = query.lower()
+
+        # Explicit "first time" keywords override everything
+        keywords = self.FIRST_TIME_KEYWORDS_JA if language == "ja" else self.FIRST_TIME_KEYWORDS_EN
+        if any(kw in lower_query for kw in keywords):
+            return VisitorType(value="new")
+
+        # DB user record or long-term memories indicate returning
+        if user_id or long_term_memories:
+            return VisitorType(value="returning")
+
+        return VisitorType(value="new")
+
+    def map_purpose_to_agent(self, purpose: VisitPurpose) -> str:
+        """Map a visit purpose to the appropriate agent for handoff.
+
+        Args:
+            purpose: The visitor's stated visit purpose.
+
+        Returns:
+            The name of the agent that should handle this purpose.
+        """
+        return _PURPOSE_AGENT_MAPPING.get(purpose.category, "general_knowledge")

--- a/backend/infrastructure/__init__.py
+++ b/backend/infrastructure/__init__.py
@@ -1,0 +1,1 @@
+"""Infrastructure layer package."""

--- a/backend/infrastructure/reception_repository.py
+++ b/backend/infrastructure/reception_repository.py
@@ -1,0 +1,212 @@
+"""Supabase-backed reception repository implementation.
+
+Provides concrete persistence for ``ReceptionSession`` and visit records
+using the Supabase Python client.
+"""
+
+import logging
+import uuid
+from datetime import datetime
+from typing import Any, List, Optional
+
+from backend.domain.reception.models import (
+    ReceptionSession,
+    VisitPurpose,
+    VisitorIdentity,
+    VisitorType,
+)
+from backend.domain.reception.repository import ReceptionSessionRepository, VisitRepository
+
+logger = logging.getLogger(__name__)
+
+
+class SupabaseReceptionSessionRepository(ReceptionSessionRepository):
+    """Supabase-backed implementation of ``ReceptionSessionRepository``.
+
+    Args:
+        supabase_client: Optional pre-configured client.  Resolved lazily
+            when ``None``.
+    """
+
+    def __init__(self, supabase_client: Any = None) -> None:
+        self._supabase = supabase_client
+
+    async def _get_client(self) -> Any:
+        """Return the Supabase client, resolving lazily if needed."""
+        if self._supabase:
+            return self._supabase
+        from backend.utils.supabase_helper import get_supabase_client
+
+        return get_supabase_client()
+
+    async def save(self, session: ReceptionSession) -> None:
+        """Persist a reception session via upsert.
+
+        Args:
+            session: The ``ReceptionSession`` aggregate to persist.
+
+        Raises:
+            Exception: If the Supabase upsert fails.
+        """
+        client = await self._get_client()
+        data = {
+            "id": session.id,
+            "session_id": session.session_id,
+            "visitor_id": None,  # Set from context
+            "user_id": session.visitor_identity.user_id if session.visitor_identity else None,
+            "stage": session.stage,
+            "purpose": session.purpose.category if session.purpose else None,
+            "language": session.language,
+            "trigger_type": session.trigger_type,
+            "updated_at": datetime.now().isoformat(),
+        }
+        try:
+            client.table("reception_sessions").upsert(data).execute()
+        except Exception as e:
+            logger.error("Failed to save reception session: %s", e)
+            raise
+
+    async def find_by_id(self, session_id: str) -> Optional[ReceptionSession]:
+        """Find a reception session by its primary key.
+
+        Args:
+            session_id: The UUID primary key of the reception session.
+
+        Returns:
+            A ``ReceptionSession`` or ``None``.
+        """
+        client = await self._get_client()
+        try:
+            result = client.table("reception_sessions").select("*").eq("id", session_id).execute()
+            if result.data:
+                return self._to_domain(result.data[0])
+        except Exception as e:
+            logger.warning("Failed to find reception session: %s", e)
+        return None
+
+    async def find_by_conversation_session(
+        self, conversation_session_id: str
+    ) -> Optional[ReceptionSession]:
+        """Find the most recent reception session for a conversation.
+
+        Args:
+            conversation_session_id: The UUID of the related conversation session.
+
+        Returns:
+            A ``ReceptionSession`` or ``None``.
+        """
+        client = await self._get_client()
+        try:
+            result = (
+                client.table("reception_sessions")
+                .select("*")
+                .eq("session_id", conversation_session_id)
+                .order("created_at", desc=True)
+                .limit(1)
+                .execute()
+            )
+            if result.data:
+                return self._to_domain(result.data[0])
+        except Exception as e:
+            logger.warning("Failed to find reception session by conversation: %s", e)
+        return None
+
+    @staticmethod
+    def _to_domain(row: dict) -> ReceptionSession:
+        """Map a database row to a ``ReceptionSession`` domain object."""
+        visitor_identity: Optional[VisitorIdentity] = None
+        if row.get("user_id"):
+            visitor_identity = VisitorIdentity(
+                visitor_type=VisitorType.RETURNING,
+                user_id=row["user_id"],
+            )
+
+        purpose: Optional[VisitPurpose] = None
+        if row.get("purpose"):
+            purpose = VisitPurpose(category=row["purpose"])
+
+        return ReceptionSession(
+            id=row["id"],
+            session_id=row.get("session_id", ""),
+            visitor_identity=visitor_identity,
+            purpose=purpose,
+            stage=row.get("stage", "initiated"),
+            language=row.get("language", "ja"),
+            trigger_type=row.get("trigger_type", "button_press"),
+        )
+
+
+class SupabaseVisitRepository(VisitRepository):
+    """Supabase-backed implementation of ``VisitRepository``.
+
+    Args:
+        supabase_client: Optional pre-configured client.  Resolved lazily
+            when ``None``.
+    """
+
+    def __init__(self, supabase_client: Any = None) -> None:
+        self._supabase = supabase_client
+
+    async def _get_client(self) -> Any:
+        """Return the Supabase client, resolving lazily if needed."""
+        if self._supabase:
+            return self._supabase
+        from backend.utils.supabase_helper import get_supabase_client
+
+        return get_supabase_client()
+
+    async def record_visit(self, session: ReceptionSession) -> str:
+        """Create a visit record from a completed reception session.
+
+        Args:
+            session: The ``ReceptionSession`` to record.
+
+        Returns:
+            The generated visit UUID string.
+
+        Raises:
+            Exception: If the Supabase insert fails.
+        """
+        client = await self._get_client()
+        visit_id = str(uuid.uuid4())
+        data = {
+            "id": visit_id,
+            "session_id": session.session_id,
+            "user_id": session.visitor_identity.user_id if session.visitor_identity else None,
+            "purpose": session.purpose.category if session.purpose else "other",
+            "purpose_detail": session.purpose.detail if session.purpose else None,
+            "visitor_type": (
+                session.visitor_identity.visitor_type.value if session.visitor_identity else "new"
+            ),
+        }
+        try:
+            client.table("visits").insert(data).execute()
+        except Exception as e:
+            logger.error("Failed to record visit: %s", e)
+            raise
+        return visit_id
+
+    async def get_recent_visits(self, user_id: int, limit: int = 5) -> List[dict]:
+        """Return recent visit records for a given user.
+
+        Args:
+            user_id: The database user ID.
+            limit: Maximum number of records to return.
+
+        Returns:
+            A list of visit dicts ordered most-recent-first.
+        """
+        client = await self._get_client()
+        try:
+            result = (
+                client.table("visits")
+                .select("*")
+                .eq("user_id", user_id)
+                .order("started_at", desc=True)
+                .limit(limit)
+                .execute()
+            )
+            return result.data or []
+        except Exception as e:
+            logger.warning("Failed to get recent visits: %s", e)
+            return []

--- a/backend/infrastructure/reception_repository.py
+++ b/backend/infrastructure/reception_repository.py
@@ -117,7 +117,7 @@ class SupabaseReceptionSessionRepository(ReceptionSessionRepository):
         visitor_identity: Optional[VisitorIdentity] = None
         if row.get("user_id"):
             visitor_identity = VisitorIdentity(
-                visitor_type=VisitorType.RETURNING,
+                visitor_type=VisitorType(value="returning"),
                 user_id=row["user_id"],
             )
 

--- a/backend/main.py
+++ b/backend/main.py
@@ -657,6 +657,11 @@ from backend.api.stt_vocabulary import router as stt_vocabulary_router  # noqa: 
 
 app.include_router(stt_vocabulary_router, prefix="/api", dependencies=[Depends(verify_api_key)])
 
+# Reception API Router
+from backend.api.reception import reception_router  # noqa: E402
+
+app.include_router(reception_router)
+
 
 if __name__ == "__main__":
     import uvicorn

--- a/backend/services/visitor_identification_service.py
+++ b/backend/services/visitor_identification_service.py
@@ -1,0 +1,192 @@
+"""Visitor Identification Service - Infrastructure layer for visitor lookup.
+
+Identifies visitors using multiple signals (NFC, visitor_id, etc.) and
+returns structured identity information to the reception flow.
+"""
+
+import logging
+from typing import Any, Dict, List, Optional
+
+logger = logging.getLogger(__name__)
+
+
+class VisitorIdentificationService:
+    """Identifies visitors using multiple signals.
+
+    Resolution priority (highest confidence first):
+        1. NFC scan -> nfcs table -> users table
+        2. visitor_id -> visits table lookup
+        3. LangGraph Store long-term memories (existing behaviour)
+        4. None -> new visitor
+
+    Args:
+        supabase_client: Optional pre-configured Supabase client.  When
+            ``None`` the client is resolved lazily via ``supabase_helper``.
+    """
+
+    def __init__(self, supabase_client: Any = None) -> None:
+        self._supabase = supabase_client
+
+    async def _get_supabase(self) -> Any:
+        """Return the Supabase client, resolving lazily if needed."""
+        if self._supabase:
+            return self._supabase
+        try:
+            from backend.utils.supabase_helper import get_supabase_client
+
+            return get_supabase_client()
+        except Exception as e:
+            logger.warning("Supabase client unavailable: %s", e)
+            return None
+
+    # ------------------------------------------------------------------
+    # Public identification methods
+    # ------------------------------------------------------------------
+
+    async def identify_by_nfc(self, nfc_id: str) -> Optional[Dict[str, Any]]:
+        """Look up a visitor by NFC card ID.
+
+        Args:
+            nfc_id: The NFC identifier string read from the card.
+
+        Returns:
+            A dict with visitor identity fields, or ``None`` when not found
+            or when Supabase is unavailable.
+        """
+        client = await self._get_supabase()
+        if not client:
+            return None
+        try:
+            result = client.table("nfcs").select("user_id").eq("nfc_id", nfc_id).execute()
+            if result.data:
+                user_id = result.data[0]["user_id"]
+                return await self._get_user_profile(user_id)
+        except Exception as e:
+            logger.warning("NFC lookup failed: %s", e)
+        return None
+
+    async def identify_by_visitor_id(self, visitor_id: str) -> Optional[Dict[str, Any]]:
+        """Look up a visitor by frontend-generated persistent visitor_id.
+
+        Queries the ``visits`` table for prior visits associated with this
+        visitor_id and returns summary information.
+
+        Args:
+            visitor_id: UUID string generated and persisted by the frontend.
+
+        Returns:
+            A dict with visit history summary, or ``None`` when the visitor
+            has no prior visits or Supabase is unavailable.
+        """
+        client = await self._get_supabase()
+        if not client:
+            return None
+        try:
+            result = (
+                client.table("visits")
+                .select("*")
+                .eq("visitor_id", visitor_id)
+                .order("started_at", desc=True)
+                .limit(1)
+                .execute()
+            )
+            if result.data:
+                visit = result.data[0]
+                return {
+                    "visitor_type": "returning",
+                    "last_visit_date": visit.get("started_at"),
+                    "last_purpose": visit.get("purpose"),
+                    "last_purpose_detail": visit.get("purpose_detail"),
+                    "visit_count": await self._count_visits(visitor_id),
+                }
+        except Exception as e:
+            logger.warning("Visitor ID lookup failed: %s", e)
+        return None
+
+    async def get_recent_visits(
+        self,
+        visitor_id: Optional[str] = None,
+        user_id: Optional[int] = None,
+        limit: int = 5,
+    ) -> List[Dict[str, Any]]:
+        """Return recent visit records for a visitor or user.
+
+        At least one of ``visitor_id`` or ``user_id`` must be provided.
+
+        Args:
+            visitor_id: Frontend-generated persistent visitor ID.
+            user_id: Database user ID.
+            limit: Maximum number of records to return.
+
+        Returns:
+            A list of visit dicts ordered by most recent first.
+        """
+        client = await self._get_supabase()
+        if not client:
+            return []
+        try:
+            query = client.table("visits").select("*").order("started_at", desc=True).limit(limit)
+            if user_id:
+                query = query.eq("user_id", user_id)
+            elif visitor_id:
+                query = query.eq("visitor_id", visitor_id)
+            else:
+                return []
+            result = query.execute()
+            return result.data or []
+        except Exception as e:
+            logger.warning("Recent visits lookup failed: %s", e)
+            return []
+
+    # ------------------------------------------------------------------
+    # Private helpers
+    # ------------------------------------------------------------------
+
+    async def _get_user_profile(self, user_id: int) -> Optional[Dict[str, Any]]:
+        """Fetch user profile and visit count from the ``users`` table."""
+        client = await self._get_supabase()
+        if not client:
+            return None
+        try:
+            result = client.table("users").select("id, name").eq("id", user_id).execute()
+            if result.data:
+                user = result.data[0]
+                visit_count = await self._count_visits_by_user(user_id)
+                return {
+                    "visitor_type": "returning",
+                    "user_id": user["id"],
+                    "name": user.get("name"),
+                    "visit_count": visit_count,
+                }
+        except Exception as e:
+            logger.warning("User profile lookup failed: %s", e)
+        return None
+
+    async def _count_visits(self, visitor_id: str) -> int:
+        """Count total visits for a given ``visitor_id``."""
+        client = await self._get_supabase()
+        if not client:
+            return 0
+        try:
+            result = (
+                client.table("visits")
+                .select("id", count="exact")
+                .eq("visitor_id", visitor_id)
+                .execute()
+            )
+            return result.count or 0
+        except Exception:
+            return 0
+
+    async def _count_visits_by_user(self, user_id: int) -> int:
+        """Count total visits for a given ``user_id``."""
+        client = await self._get_supabase()
+        if not client:
+            return 0
+        try:
+            result = (
+                client.table("visits").select("id", count="exact").eq("user_id", user_id).execute()
+            )
+            return result.count or 0
+        except Exception:
+            return 0

--- a/backend/supabase/migrations/20260308000001_add_reception_tables.sql
+++ b/backend/supabase/migrations/20260308000001_add_reception_tables.sql
@@ -1,0 +1,54 @@
+-- Reception Flow Tables for Issue #117
+-- Autonomous reception with visitor identification and visit tracking
+
+-- Visits table: records each visit to Engineer Cafe
+CREATE TABLE IF NOT EXISTS visits (
+    id uuid DEFAULT gen_random_uuid() PRIMARY KEY,
+    user_id bigint,                                    -- NULL for unregistered visitors
+    session_id uuid,                                   -- Links to conversation_sessions
+    visitor_id uuid,                                   -- Frontend-generated persistent ID
+    purpose varchar(50) NOT NULL DEFAULT 'other',      -- facility_use, event_participation, tour, consultation, other
+    purpose_detail text,                               -- Free-text detail
+    visitor_type varchar(20) NOT NULL DEFAULT 'new',   -- new, returning
+    started_at timestamp with time zone DEFAULT now(),
+    ended_at timestamp with time zone,
+    metadata jsonb DEFAULT '{}',
+    created_at timestamp with time zone DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS idx_visits_user_id ON visits(user_id);
+CREATE INDEX IF NOT EXISTS idx_visits_visitor_id ON visits(visitor_id);
+CREATE INDEX IF NOT EXISTS idx_visits_started_at ON visits(started_at DESC);
+
+-- Reception sessions: tracks state machine for each reception flow
+CREATE TABLE IF NOT EXISTS reception_sessions (
+    id uuid DEFAULT gen_random_uuid() PRIMARY KEY,
+    session_id uuid,                                   -- Links to conversation_sessions
+    visitor_id uuid,                                   -- From frontend
+    user_id bigint,                                    -- Resolved user (if found)
+    stage varchar(30) NOT NULL DEFAULT 'initiated',    -- initiated, greeting, identifying, purpose_hearing, routing, completed, escalated
+    purpose varchar(50),                               -- facility_use, event_participation, tour, consultation, other
+    language varchar(5) DEFAULT 'ja',
+    trigger_type varchar(30),                          -- face_detection, button_press, wake_word, nfc
+    metadata jsonb DEFAULT '{}',
+    created_at timestamp with time zone DEFAULT now(),
+    updated_at timestamp with time zone DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS idx_reception_sessions_session_id ON reception_sessions(session_id);
+CREATE INDEX IF NOT EXISTS idx_reception_sessions_visitor_id ON reception_sessions(visitor_id);
+
+-- Enable RLS
+ALTER TABLE visits ENABLE ROW LEVEL SECURITY;
+ALTER TABLE reception_sessions ENABLE ROW LEVEL SECURITY;
+
+-- Service role access policies (matches existing pattern from init migration)
+CREATE POLICY "Service role has full access to visits" ON visits
+    FOR ALL USING (auth.role() = 'service_role');
+
+CREATE POLICY "Service role has full access to reception_sessions" ON reception_sessions
+    FOR ALL USING (auth.role() = 'service_role');
+
+-- Updated at trigger for reception_sessions (reuses existing function)
+CREATE TRIGGER update_reception_sessions_updated_at BEFORE UPDATE
+    ON reception_sessions FOR EACH ROW EXECUTE FUNCTION update_updated_at_column();

--- a/backend/supabase/migrations/20260308000002_optimize_reception_rls.sql
+++ b/backend/supabase/migrations/20260308000002_optimize_reception_rls.sql
@@ -1,0 +1,58 @@
+-- Optimize reception table RLS policies for Issue #117
+-- Replace broad FOR ALL policies with explicit CRUD policies for service_role.
+
+-- Drop legacy FOR ALL policy and any existing granular policies on reception_sessions.
+DROP POLICY IF EXISTS "Service role has full access to reception_sessions" ON reception_sessions;
+DROP POLICY IF EXISTS reception_sessions_service_select ON reception_sessions;
+DROP POLICY IF EXISTS reception_sessions_service_insert ON reception_sessions;
+DROP POLICY IF EXISTS reception_sessions_service_update ON reception_sessions;
+DROP POLICY IF EXISTS reception_sessions_service_delete ON reception_sessions;
+
+-- Allow service_role to read reception session state for workflow orchestration.
+CREATE POLICY reception_sessions_service_select ON reception_sessions
+    FOR SELECT
+    USING (auth.role() = 'service_role');
+
+-- Allow service_role to create new reception session records.
+CREATE POLICY reception_sessions_service_insert ON reception_sessions
+    FOR INSERT
+    WITH CHECK (auth.role() = 'service_role');
+
+-- Allow service_role to advance reception session state safely.
+CREATE POLICY reception_sessions_service_update ON reception_sessions
+    FOR UPDATE
+    USING (auth.role() = 'service_role')
+    WITH CHECK (auth.role() = 'service_role');
+
+-- Allow service_role to delete reception sessions for operational recovery and cleanup.
+CREATE POLICY reception_sessions_service_delete ON reception_sessions
+    FOR DELETE
+    USING (auth.role() = 'service_role');
+
+-- Drop legacy FOR ALL policy and any existing granular policies on visits.
+DROP POLICY IF EXISTS "Service role has full access to visits" ON visits;
+DROP POLICY IF EXISTS visits_service_select ON visits;
+DROP POLICY IF EXISTS visits_service_insert ON visits;
+DROP POLICY IF EXISTS visits_service_update ON visits;
+DROP POLICY IF EXISTS visits_service_delete ON visits;
+
+-- Allow service_role to read visit history for analytics and staff support.
+CREATE POLICY visits_service_select ON visits
+    FOR SELECT
+    USING (auth.role() = 'service_role');
+
+-- Allow service_role to insert visit records as reception flows begin.
+CREATE POLICY visits_service_insert ON visits
+    FOR INSERT
+    WITH CHECK (auth.role() = 'service_role');
+
+-- Allow service_role to update visit records as visit details change.
+CREATE POLICY visits_service_update ON visits
+    FOR UPDATE
+    USING (auth.role() = 'service_role')
+    WITH CHECK (auth.role() = 'service_role');
+
+-- Allow service_role to delete visit records for safe operational cleanup.
+CREATE POLICY visits_service_delete ON visits
+    FOR DELETE
+    USING (auth.role() = 'service_role');

--- a/backend/tests/api/__init__.py
+++ b/backend/tests/api/__init__.py
@@ -1,1 +1,1 @@
-"""API tests."""
+"""API tests package"""

--- a/backend/tests/api/test_reception_api.py
+++ b/backend/tests/api/test_reception_api.py
@@ -1,0 +1,249 @@
+"""Tests for the Reception API endpoints.
+
+All external calls (Supabase, LLM) are mocked. The in-memory session
+store is cleared between tests to ensure isolation.
+"""
+
+from __future__ import annotations
+
+import pytest
+from fastapi.testclient import TestClient
+
+from backend.main import app
+import backend.api.reception as reception_module
+
+client = TestClient(app)
+
+
+@pytest.fixture(autouse=True)
+def clear_sessions():
+    """Wipe the in-memory session store before every test."""
+    reception_module._active_sessions.clear()
+    yield
+    reception_module._active_sessions.clear()
+
+
+def _start_session(session_id: str = "sess-001", language: str = "ja") -> dict:
+    response = client.post(
+        "/api/reception/start",
+        json={"session_id": session_id, "language": language, "trigger_type": "button_press"},
+    )
+    assert response.status_code == 200, response.text
+    return response.json()
+
+
+# ===========================================================================
+# POST /api/reception/start
+# ===========================================================================
+
+
+class TestStartReception:
+    def test_start_creates_new_session(self):
+        data = _start_session(session_id="s1", language="ja")
+        assert "reception_session_id" in data
+        assert len(data["reception_session_id"]) > 0
+        assert data["stage"] == "greeting"
+        assert len(data["greeting"]) > 0
+
+    def test_start_japanese_greeting(self):
+        data = _start_session(language="ja")
+        assert any(
+            kw in data["greeting"]
+            for kw in ["ようこそ", "エンジニアカフェ", "こんにちは"]
+        ), f"Unexpected greeting: {data['greeting']}"
+
+    def test_start_english_greeting(self):
+        data = _start_session(language="en")
+        assert any(
+            kw in data["greeting"]
+            for kw in ["Welcome", "Engineer Cafe", "visit"]
+        ), f"Unexpected greeting: {data['greeting']}"
+
+    def test_start_sessions_are_independent(self):
+        id_1 = _start_session(session_id="s1")["reception_session_id"]
+        id_2 = _start_session(session_id="s2")["reception_session_id"]
+        assert id_1 != id_2
+
+    def test_start_stores_session_in_memory(self):
+        data = _start_session(session_id="s1")
+        rid = data["reception_session_id"]
+        assert rid in reception_module._active_sessions
+
+
+# ===========================================================================
+# POST /api/reception/respond
+# ===========================================================================
+
+
+class TestRespondReception:
+    def test_respond_from_greeting_advances_to_purpose_hearing(self):
+        start = _start_session(session_id="s1")
+        rid = start["reception_session_id"]
+
+        response = client.post(
+            "/api/reception/respond",
+            json={"session_id": "s1", "reception_session_id": rid, "message": "こんにちは"},
+        )
+        assert response.status_code == 200
+        data = response.json()
+        assert data["stage"] == "purpose_hearing"
+        assert len(data["response"]) > 0
+
+    def test_respond_with_facility_purpose_classified(self):
+        start = _start_session(session_id="s1")
+        rid = start["reception_session_id"]
+
+        # Advance to purpose_hearing
+        client.post(
+            "/api/reception/respond",
+            json={"session_id": "s1", "reception_session_id": rid, "message": "初めて来ました"},
+        )
+        # Now in purpose_hearing — send purpose
+        response = client.post(
+            "/api/reception/respond",
+            json={"session_id": "s1", "reception_session_id": rid, "message": "施設を利用したいです"},
+        )
+        assert response.status_code == 200
+        data = response.json()
+        assert data["stage"] == "routing"
+        assert data["purpose"]["category"] == "facility_use"
+
+    def test_respond_with_event_purpose_classified(self):
+        start = _start_session(session_id="s1", language="en")
+        rid = start["reception_session_id"]
+
+        client.post(
+            "/api/reception/respond",
+            json={"session_id": "s1", "reception_session_id": rid, "message": "Hello"},
+        )
+        response = client.post(
+            "/api/reception/respond",
+            json={
+                "session_id": "s1",
+                "reception_session_id": rid,
+                "message": "I am here for an event",
+            },
+        )
+        assert response.status_code == 200
+        data = response.json()
+        assert data["purpose"]["category"] == "event_participation"
+
+    def test_respond_unknown_purpose_stays_in_purpose_hearing(self):
+        start = _start_session(session_id="s1")
+        rid = start["reception_session_id"]
+
+        client.post(
+            "/api/reception/respond",
+            json={"session_id": "s1", "reception_session_id": rid, "message": "こんにちは"},
+        )
+        response = client.post(
+            "/api/reception/respond",
+            json={
+                "session_id": "s1",
+                "reception_session_id": rid,
+                "message": "なんとなく",
+            },
+        )
+        assert response.status_code == 200
+        data = response.json()
+        assert data["stage"] == "purpose_hearing"
+        assert data["next_action"] == "clarify_purpose"
+
+    def test_respond_404_for_nonexistent_session(self):
+        response = client.post(
+            "/api/reception/respond",
+            json={
+                "session_id": "s1",
+                "reception_session_id": "does-not-exist",
+                "message": "hello",
+            },
+        )
+        assert response.status_code == 404
+
+    def test_full_flow_greeting_to_routing(self):
+        """Complete greeting -> purpose_hearing -> routing flow."""
+        start = _start_session(session_id="s1")
+        rid = start["reception_session_id"]
+
+        def respond(msg: str) -> dict:
+            r = client.post(
+                "/api/reception/respond",
+                json={"session_id": "s1", "reception_session_id": rid, "message": msg},
+            )
+            assert r.status_code == 200, r.text
+            return r.json()
+
+        d1 = respond("こんにちは")
+        assert d1["stage"] == "purpose_hearing"
+
+        d2 = respond("コワーキングスペースで作業したい")
+        assert d2["stage"] == "routing"
+        assert d2["purpose"]["category"] == "facility_use"
+
+    def test_respond_english_routing_message(self):
+        start = _start_session(session_id="s1", language="en")
+        rid = start["reception_session_id"]
+
+        def respond(msg: str) -> dict:
+            r = client.post(
+                "/api/reception/respond",
+                json={"session_id": "s1", "reception_session_id": rid, "message": msg},
+            )
+            assert r.status_code == 200
+            return r.json()
+
+        respond("Hello")
+        d = respond("I need to use the coworking space")
+        assert d["stage"] == "routing"
+
+
+# ===========================================================================
+# GET /api/reception/status/{session_id}
+# ===========================================================================
+
+
+class TestReceptionStatus:
+    def test_status_returns_initial_stage(self):
+        start = _start_session(session_id="s1")
+        rid = start["reception_session_id"]
+
+        response = client.get(f"/api/reception/status/{rid}")
+        assert response.status_code == 200
+        data = response.json()
+        assert data["session_id"] == "s1"
+        assert data["stage"] == "greeting"
+        assert data["visitor_type"] is None
+        assert data["purpose"] is None
+
+    def test_status_reflects_advanced_stage(self):
+        start = _start_session(session_id="s1")
+        rid = start["reception_session_id"]
+
+        client.post(
+            "/api/reception/respond",
+            json={"session_id": "s1", "reception_session_id": rid, "message": "こんにちは"},
+        )
+        client.post(
+            "/api/reception/respond",
+            json={"session_id": "s1", "reception_session_id": rid, "message": "イベントに参加します"},
+        )
+
+        response = client.get(f"/api/reception/status/{rid}")
+        assert response.status_code == 200
+        data = response.json()
+        assert data["stage"] == "routing"
+        assert data["purpose"] == "event_participation"
+
+    def test_status_404_for_nonexistent_session(self):
+        response = client.get("/api/reception/status/no-such-id")
+        assert response.status_code == 404
+
+    def test_status_with_different_languages(self):
+        for lang in ("ja", "en"):
+            reception_module._active_sessions.clear()
+            start = _start_session(session_id="s1", language=lang)
+            rid = start["reception_session_id"]
+
+            response = client.get(f"/api/reception/status/{rid}")
+            assert response.status_code == 200
+            assert response.json()["stage"] == "greeting"

--- a/backend/tests/api/test_reception_api.py
+++ b/backend/tests/api/test_reception_api.py
@@ -101,7 +101,11 @@ class TestRespondReception:
         # Now in purpose_hearing — send purpose
         response = client.post(
             "/api/reception/respond",
-            json={"session_id": "s1", "reception_session_id": rid, "message": "施設を利用したいです"},
+            json={
+                "session_id": "s1",
+                "reception_session_id": rid,
+                "message": "施設を利用したいです",
+            },
         )
         assert response.status_code == 200
         data = response.json()
@@ -225,7 +229,11 @@ class TestReceptionStatus:
         )
         client.post(
             "/api/reception/respond",
-            json={"session_id": "s1", "reception_session_id": rid, "message": "イベントに参加します"},
+            json={
+                "session_id": "s1",
+                "reception_session_id": rid,
+                "message": "イベントに参加します",
+            },
         )
 
         response = client.get(f"/api/reception/status/{rid}")

--- a/backend/tests/api/test_reception_api.py
+++ b/backend/tests/api/test_reception_api.py
@@ -48,15 +48,13 @@ class TestStartReception:
     def test_start_japanese_greeting(self):
         data = _start_session(language="ja")
         assert any(
-            kw in data["greeting"]
-            for kw in ["ようこそ", "エンジニアカフェ", "こんにちは"]
+            kw in data["greeting"] for kw in ["ようこそ", "エンジニアカフェ", "こんにちは"]
         ), f"Unexpected greeting: {data['greeting']}"
 
     def test_start_english_greeting(self):
         data = _start_session(language="en")
         assert any(
-            kw in data["greeting"]
-            for kw in ["Welcome", "Engineer Cafe", "visit"]
+            kw in data["greeting"] for kw in ["Welcome", "Engineer Cafe", "visit"]
         ), f"Unexpected greeting: {data['greeting']}"
 
     def test_start_sessions_are_independent(self):

--- a/backend/tests/domain/test_reception_models.py
+++ b/backend/tests/domain/test_reception_models.py
@@ -1,0 +1,405 @@
+"""Tests for the Reception Domain Layer.
+
+Covers value object immutability, aggregate root stage transitions,
+domain event emission, and domain service logic.
+"""
+
+from __future__ import annotations
+
+from dataclasses import FrozenInstanceError
+from datetime import datetime
+
+import pytest
+
+from backend.domain.reception.events import (
+    AgentHandoffRequested,
+    PurposeIdentified,
+    StaffEscalationRequested,
+    VisitorIdentified,
+)
+from backend.domain.reception.models import (
+    ReceptionSession,
+    VisitPurpose,
+    VisitorIdentity,
+    VisitorType,
+)
+from backend.domain.reception.service import ReceptionDomainService
+
+# =============================================================================
+# Value Object Immutability Tests
+# =============================================================================
+
+
+class TestVisitorType:
+    """Tests for VisitorType value object."""
+
+    def test_create_new_visitor_type(self) -> None:
+        vt = VisitorType(value="new")
+        assert vt.value == "new"
+
+    def test_create_returning_visitor_type(self) -> None:
+        vt = VisitorType(value="returning")
+        assert vt.value == "returning"
+
+    def test_immutability(self) -> None:
+        vt = VisitorType(value="new")
+        with pytest.raises(FrozenInstanceError):
+            vt.value = "returning"  # type: ignore[misc]
+
+    def test_equality(self) -> None:
+        assert VisitorType(value="new") == VisitorType(value="new")
+        assert VisitorType(value="new") != VisitorType(value="returning")
+
+
+class TestVisitPurpose:
+    """Tests for VisitPurpose value object."""
+
+    def test_create_with_category_only(self) -> None:
+        purpose = VisitPurpose(category="facility_use")
+        assert purpose.category == "facility_use"
+        assert purpose.detail is None
+
+    def test_create_with_detail(self) -> None:
+        purpose = VisitPurpose(category="event_participation", detail="Python meetup")
+        assert purpose.category == "event_participation"
+        assert purpose.detail == "Python meetup"
+
+    def test_immutability(self) -> None:
+        purpose = VisitPurpose(category="tour")
+        with pytest.raises(FrozenInstanceError):
+            purpose.category = "other"  # type: ignore[misc]
+
+    def test_equality(self) -> None:
+        a = VisitPurpose(category="tour", detail="facility tour")
+        b = VisitPurpose(category="tour", detail="facility tour")
+        c = VisitPurpose(category="tour", detail="different")
+        assert a == b
+        assert a != c
+
+
+class TestVisitorIdentity:
+    """Tests for VisitorIdentity value object."""
+
+    def test_create_minimal(self) -> None:
+        identity = VisitorIdentity(visitor_type=VisitorType(value="new"))
+        assert identity.visitor_type.value == "new"
+        assert identity.user_id is None
+        assert identity.name is None
+        assert identity.visit_count == 0
+
+    def test_create_full(self) -> None:
+        now = datetime.now()
+        purpose = VisitPurpose(category="facility_use")
+        identity = VisitorIdentity(
+            visitor_type=VisitorType(value="returning"),
+            user_id=42,
+            name="Tanaka",
+            last_visit_date=now,
+            last_purpose=purpose,
+            visit_count=5,
+        )
+        assert identity.user_id == 42
+        assert identity.name == "Tanaka"
+        assert identity.last_visit_date == now
+        assert identity.last_purpose == purpose
+        assert identity.visit_count == 5
+
+    def test_immutability(self) -> None:
+        identity = VisitorIdentity(visitor_type=VisitorType(value="new"))
+        with pytest.raises(FrozenInstanceError):
+            identity.name = "Modified"  # type: ignore[misc]
+
+
+# =============================================================================
+# Aggregate Root Tests
+# =============================================================================
+
+
+class TestReceptionSession:
+    """Tests for ReceptionSession aggregate root."""
+
+    def test_default_creation(self) -> None:
+        session = ReceptionSession()
+        assert session.stage == "initiated"
+        assert session.language == "ja"
+        assert session.trigger_type == "button_press"
+        assert session.visitor_identity is None
+        assert session.purpose is None
+        assert len(session.id) > 0
+
+    def test_custom_creation(self) -> None:
+        session = ReceptionSession(
+            session_id="conv-123",
+            language="en",
+            trigger_type="face_detection",
+        )
+        assert session.session_id == "conv-123"
+        assert session.language == "en"
+        assert session.trigger_type == "face_detection"
+
+    # -------------------------------------------------------------------------
+    # Stage Transition Tests
+    # -------------------------------------------------------------------------
+
+    @pytest.mark.parametrize(
+        "from_stage,to_stage",
+        [
+            ("initiated", "greeting"),
+            ("initiated", "identifying"),
+            ("greeting", "identifying"),
+            ("greeting", "purpose_hearing"),
+            ("identifying", "greeting"),
+            ("identifying", "purpose_hearing"),
+            ("purpose_hearing", "routing"),
+            ("routing", "completed"),
+            ("routing", "escalated"),
+        ],
+    )
+    def test_valid_transitions(self, from_stage: str, to_stage: str) -> None:
+        session = ReceptionSession()
+        session.stage = from_stage  # Set starting stage directly for test
+        session.advance_to(to_stage)
+        assert session.stage == to_stage
+
+    @pytest.mark.parametrize(
+        "from_stage,to_stage",
+        [
+            ("initiated", "completed"),
+            ("initiated", "routing"),
+            ("initiated", "purpose_hearing"),
+            ("greeting", "completed"),
+            ("greeting", "routing"),
+            ("identifying", "completed"),
+            ("identifying", "routing"),
+            ("purpose_hearing", "completed"),
+            ("purpose_hearing", "greeting"),
+            ("routing", "greeting"),
+            ("routing", "identifying"),
+            ("completed", "initiated"),
+            ("escalated", "initiated"),
+        ],
+    )
+    def test_invalid_transitions(self, from_stage: str, to_stage: str) -> None:
+        session = ReceptionSession()
+        session.stage = from_stage
+        with pytest.raises(ValueError, match="Invalid transition"):
+            session.advance_to(to_stage)
+
+    def test_transition_sequence_full_flow(self) -> None:
+        """Test a complete happy-path reception flow."""
+        session = ReceptionSession()
+        assert session.stage == "initiated"
+
+        session.advance_to("greeting")
+        assert session.stage == "greeting"
+
+        session.advance_to("identifying")
+        assert session.stage == "identifying"
+
+        session.advance_to("purpose_hearing")
+        assert session.stage == "purpose_hearing"
+
+        session.advance_to("routing")
+        assert session.stage == "routing"
+
+        session.advance_to("completed")
+        assert session.stage == "completed"
+
+    # -------------------------------------------------------------------------
+    # Domain Event Tests
+    # -------------------------------------------------------------------------
+
+    def test_identify_visitor_emits_event(self) -> None:
+        session = ReceptionSession()
+        identity = VisitorIdentity(visitor_type=VisitorType(value="new"))
+
+        session.identify_visitor(identity)
+
+        assert session.visitor_identity == identity
+        events = session.collect_events()
+        assert len(events) == 1
+        assert isinstance(events[0], VisitorIdentified)
+        assert events[0].reception_session_id == session.id
+        assert events[0].visitor_identity == identity
+
+    def test_set_purpose_emits_event(self) -> None:
+        session = ReceptionSession()
+        purpose = VisitPurpose(category="tour", detail="facility tour")
+
+        session.set_purpose(purpose)
+
+        assert session.purpose == purpose
+        events = session.collect_events()
+        assert len(events) == 1
+        assert isinstance(events[0], PurposeIdentified)
+        assert events[0].reception_session_id == session.id
+        assert events[0].purpose == purpose
+
+    def test_request_handoff_emits_event(self) -> None:
+        session = ReceptionSession()
+        context = {"purpose": "tour", "language": "ja"}
+
+        session.request_handoff("slide", context)
+
+        events = session.collect_events()
+        assert len(events) == 1
+        assert isinstance(events[0], AgentHandoffRequested)
+        assert events[0].target_agent == "slide"
+        assert events[0].context == context
+
+    def test_request_escalation_emits_event_and_sets_stage(self) -> None:
+        session = ReceptionSession()
+        identity = VisitorIdentity(
+            visitor_type=VisitorType(value="returning"),
+            name="Tanaka",
+        )
+        session.visitor_identity = identity
+
+        session.request_escalation("Visitor requested human staff")
+
+        assert session.stage == "escalated"
+        events = session.collect_events()
+        assert len(events) == 1
+        assert isinstance(events[0], StaffEscalationRequested)
+        assert events[0].reason == "Visitor requested human staff"
+        assert events[0].visitor_name == "Tanaka"
+
+    def test_request_escalation_without_identity(self) -> None:
+        session = ReceptionSession()
+        session.request_escalation("Unknown issue")
+
+        events = session.collect_events()
+        assert len(events) == 1
+        assert events[0].visitor_name is None
+
+    def test_collect_events_clears_pending(self) -> None:
+        session = ReceptionSession()
+        session.set_purpose(VisitPurpose(category="tour"))
+
+        first = session.collect_events()
+        assert len(first) == 1
+
+        second = session.collect_events()
+        assert len(second) == 0
+
+    def test_multiple_events_accumulate(self) -> None:
+        session = ReceptionSession()
+        identity = VisitorIdentity(visitor_type=VisitorType(value="new"))
+        purpose = VisitPurpose(category="facility_use")
+
+        session.identify_visitor(identity)
+        session.set_purpose(purpose)
+        session.request_handoff("facility", {"language": "ja"})
+
+        events = session.collect_events()
+        assert len(events) == 3
+        assert isinstance(events[0], VisitorIdentified)
+        assert isinstance(events[1], PurposeIdentified)
+        assert isinstance(events[2], AgentHandoffRequested)
+
+
+# =============================================================================
+# Domain Service Tests
+# =============================================================================
+
+
+class TestReceptionDomainService:
+    """Tests for ReceptionDomainService."""
+
+    @pytest.fixture()
+    def service(self) -> ReceptionDomainService:
+        return ReceptionDomainService()
+
+    # -------------------------------------------------------------------------
+    # determine_visitor_type
+    # -------------------------------------------------------------------------
+
+    def test_first_time_keyword_ja(self, service: ReceptionDomainService) -> None:
+        result = service.determine_visitor_type(
+            query="初めて来ました",
+            language="ja",
+            long_term_memories=[],
+        )
+        assert result.value == "new"
+
+    def test_first_time_keyword_ja_hajimete(self, service: ReceptionDomainService) -> None:
+        result = service.determine_visitor_type(
+            query="はじめて来ました",
+            language="ja",
+            long_term_memories=[],
+        )
+        assert result.value == "new"
+
+    def test_first_time_keyword_en(self, service: ReceptionDomainService) -> None:
+        result = service.determine_visitor_type(
+            query="This is my first time here",
+            language="en",
+            long_term_memories=[],
+        )
+        assert result.value == "new"
+
+    def test_first_time_keyword_overrides_user_id(self, service: ReceptionDomainService) -> None:
+        """First-time keywords should override even if user_id exists."""
+        result = service.determine_visitor_type(
+            query="初めて来ました",
+            language="ja",
+            long_term_memories=[{"some": "memory"}],
+            user_id=42,
+        )
+        assert result.value == "new"
+
+    def test_returning_by_user_id(self, service: ReceptionDomainService) -> None:
+        result = service.determine_visitor_type(
+            query="こんにちは",
+            language="ja",
+            long_term_memories=[],
+            user_id=42,
+        )
+        assert result.value == "returning"
+
+    def test_returning_by_memories(self, service: ReceptionDomainService) -> None:
+        result = service.determine_visitor_type(
+            query="hello",
+            language="en",
+            long_term_memories=[{"previous_visit": "2024-01-01"}],
+        )
+        assert result.value == "returning"
+
+    def test_default_new_visitor(self, service: ReceptionDomainService) -> None:
+        result = service.determine_visitor_type(
+            query="こんにちは",
+            language="ja",
+            long_term_memories=[],
+        )
+        assert result.value == "new"
+
+    def test_case_insensitive_en(self, service: ReceptionDomainService) -> None:
+        result = service.determine_visitor_type(
+            query="FIRST TIME visiting",
+            language="en",
+            long_term_memories=[],
+        )
+        assert result.value == "new"
+
+    # -------------------------------------------------------------------------
+    # map_purpose_to_agent
+    # -------------------------------------------------------------------------
+
+    @pytest.mark.parametrize(
+        "category,expected_agent",
+        [
+            ("facility_use", "facility"),
+            ("event_participation", "event"),
+            ("tour", "slide"),
+            ("consultation", "general_knowledge"),
+            ("other", "general_knowledge"),
+        ],
+    )
+    def test_map_purpose_to_agent(
+        self,
+        service: ReceptionDomainService,
+        category: str,
+        expected_agent: str,
+    ) -> None:
+        purpose = VisitPurpose(category=category)
+        assert service.map_purpose_to_agent(purpose) == expected_agent

--- a/backend/tests/infrastructure/__init__.py
+++ b/backend/tests/infrastructure/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for infrastructure package."""

--- a/backend/tests/infrastructure/test_reception_repository.py
+++ b/backend/tests/infrastructure/test_reception_repository.py
@@ -65,7 +65,7 @@ def _sample_session(
     identity = None
     if with_identity:
         identity = VisitorIdentity(
-            visitor_type=VisitorType.RETURNING,
+            visitor_type=VisitorType(value="returning"),
             user_id=42,
             name="Taro",
         )
@@ -129,7 +129,7 @@ async def test_save_and_find_reception_session(mock_client: MagicMock):
     assert found.stage == "greeting"
     assert found.visitor_identity is not None
     assert found.visitor_identity.user_id == 42
-    assert found.visitor_identity.visitor_type == VisitorType.RETURNING
+    assert found.visitor_identity.visitor_type == VisitorType(value="returning")
     assert found.purpose is not None
     assert found.purpose.category == "facility_use"
 

--- a/backend/tests/infrastructure/test_reception_repository.py
+++ b/backend/tests/infrastructure/test_reception_repository.py
@@ -1,0 +1,240 @@
+"""Tests for Supabase-backed reception repository implementations.
+
+All Supabase interactions are mocked.
+"""
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from backend.domain.reception.models import (
+    ReceptionSession,
+    VisitPurpose,
+    VisitorIdentity,
+    VisitorType,
+)
+from backend.infrastructure.reception_repository import (
+    SupabaseReceptionSessionRepository,
+    SupabaseVisitRepository,
+)
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_query_result(data=None, count=None):
+    """Create a mock query result."""
+    result = MagicMock()
+    result.data = data or []
+    result.count = count
+    return result
+
+
+def _make_mock_client() -> MagicMock:
+    """Build a mock Supabase client with chainable query builder."""
+    client = MagicMock()
+    return client
+
+
+def _chainable_builder(execute_result=None) -> MagicMock:
+    """Return a mock query builder where every method returns itself."""
+    builder = MagicMock()
+    for method in ("select", "eq", "order", "limit", "insert", "upsert"):
+        getattr(builder, method).return_value = builder
+    builder.execute.return_value = execute_result or _make_query_result()
+    return builder
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def mock_client() -> MagicMock:
+    return _make_mock_client()
+
+
+def _sample_session(
+    session_id: str = "sess-001",
+    with_identity: bool = False,
+    with_purpose: bool = False,
+) -> ReceptionSession:
+    """Create a sample ``ReceptionSession`` for testing."""
+    identity = None
+    if with_identity:
+        identity = VisitorIdentity(
+            visitor_type=VisitorType.RETURNING,
+            user_id=42,
+            name="Taro",
+        )
+    purpose = None
+    if with_purpose:
+        purpose = VisitPurpose(category="facility_use", detail="Co-working")
+
+    return ReceptionSession(
+        id="rs-001",
+        session_id=session_id,
+        visitor_identity=identity,
+        purpose=purpose,
+        stage="greeting",
+        language="ja",
+        trigger_type="button_press",
+    )
+
+
+# ---------------------------------------------------------------------------
+# ReceptionSessionRepository tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_save_and_find_reception_session(mock_client: MagicMock):
+    """save() should upsert, and find_by_id() should return the domain object."""
+    repo = SupabaseReceptionSessionRepository(supabase_client=mock_client)
+
+    # --- save ---
+    upsert_builder = _chainable_builder()
+    mock_client.table = MagicMock(return_value=upsert_builder)
+
+    session = _sample_session(with_identity=True, with_purpose=True)
+    await repo.save(session)
+
+    mock_client.table.assert_called_with("reception_sessions")
+    upsert_builder.upsert.assert_called_once()
+    upserted_data = upsert_builder.upsert.call_args[0][0]
+    assert upserted_data["id"] == "rs-001"
+    assert upserted_data["user_id"] == 42
+    assert upserted_data["stage"] == "greeting"
+    assert upserted_data["purpose"] == "facility_use"
+
+    # --- find_by_id ---
+    row = {
+        "id": "rs-001",
+        "session_id": "sess-001",
+        "user_id": 42,
+        "stage": "greeting",
+        "purpose": "facility_use",
+        "language": "ja",
+        "trigger_type": "button_press",
+    }
+    find_builder = _chainable_builder(execute_result=_make_query_result(data=[row]))
+    mock_client.table = MagicMock(return_value=find_builder)
+
+    found = await repo.find_by_id("rs-001")
+
+    assert found is not None
+    assert found.id == "rs-001"
+    assert found.stage == "greeting"
+    assert found.visitor_identity is not None
+    assert found.visitor_identity.user_id == 42
+    assert found.visitor_identity.visitor_type == VisitorType.RETURNING
+    assert found.purpose is not None
+    assert found.purpose.category == "facility_use"
+
+
+@pytest.mark.asyncio
+async def test_find_by_conversation_session(mock_client: MagicMock):
+    """find_by_conversation_session() should query by session_id and return domain object."""
+    repo = SupabaseReceptionSessionRepository(supabase_client=mock_client)
+
+    row = {
+        "id": "rs-002",
+        "session_id": "conv-session-xyz",
+        "user_id": None,
+        "stage": "initiated",
+        "purpose": None,
+        "language": "en",
+        "trigger_type": "face_detection",
+    }
+    builder = _chainable_builder(execute_result=_make_query_result(data=[row]))
+    mock_client.table = MagicMock(return_value=builder)
+
+    found = await repo.find_by_conversation_session("conv-session-xyz")
+
+    assert found is not None
+    assert found.id == "rs-002"
+    assert found.session_id == "conv-session-xyz"
+    assert found.visitor_identity is None
+    assert found.purpose is None
+    assert found.language == "en"
+    assert found.trigger_type == "face_detection"
+
+
+@pytest.mark.asyncio
+async def test_find_by_conversation_session_not_found(mock_client: MagicMock):
+    """find_by_conversation_session() should return ``None`` when no record matches."""
+    repo = SupabaseReceptionSessionRepository(supabase_client=mock_client)
+
+    builder = _chainable_builder(execute_result=_make_query_result(data=[]))
+    mock_client.table = MagicMock(return_value=builder)
+
+    found = await repo.find_by_conversation_session("nonexistent")
+    assert found is None
+
+
+# ---------------------------------------------------------------------------
+# VisitRepository tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_record_visit(mock_client: MagicMock):
+    """record_visit() should insert a row and return a UUID string."""
+    repo = SupabaseVisitRepository(supabase_client=mock_client)
+
+    builder = _chainable_builder()
+    mock_client.table = MagicMock(return_value=builder)
+
+    session = _sample_session(with_identity=True, with_purpose=True)
+    visit_id = await repo.record_visit(session)
+
+    assert isinstance(visit_id, str)
+    assert len(visit_id) == 36  # UUID format
+
+    mock_client.table.assert_called_with("visits")
+    builder.insert.assert_called_once()
+    inserted_data = builder.insert.call_args[0][0]
+    assert inserted_data["session_id"] == "sess-001"
+    assert inserted_data["user_id"] == 42
+    assert inserted_data["purpose"] == "facility_use"
+    assert inserted_data["purpose_detail"] == "Co-working"
+    assert inserted_data["visitor_type"] == "returning"
+
+
+@pytest.mark.asyncio
+async def test_record_visit_new_visitor(mock_client: MagicMock):
+    """record_visit() should handle a new (unidentified) visitor gracefully."""
+    repo = SupabaseVisitRepository(supabase_client=mock_client)
+
+    builder = _chainable_builder()
+    mock_client.table = MagicMock(return_value=builder)
+
+    session = _sample_session(with_identity=False, with_purpose=False)
+    visit_id = await repo.record_visit(session)
+
+    assert isinstance(visit_id, str)
+    inserted_data = builder.insert.call_args[0][0]
+    assert inserted_data["user_id"] is None
+    assert inserted_data["purpose"] == "other"
+    assert inserted_data["visitor_type"] == "new"
+
+
+@pytest.mark.asyncio
+async def test_get_recent_visits(mock_client: MagicMock):
+    """get_recent_visits() should return a list of visit dicts."""
+    repo = SupabaseVisitRepository(supabase_client=mock_client)
+
+    visits_data = [
+        {"id": "v1", "purpose": "facility_use", "started_at": "2026-03-06T10:00:00+09:00"},
+        {"id": "v2", "purpose": "tour", "started_at": "2026-03-01T14:00:00+09:00"},
+    ]
+    builder = _chainable_builder(execute_result=_make_query_result(data=visits_data))
+    mock_client.table = MagicMock(return_value=builder)
+
+    result = await repo.get_recent_visits(user_id=42, limit=3)
+
+    assert len(result) == 2
+    assert result[0]["id"] == "v1"
+    mock_client.table.assert_called_with("visits")

--- a/backend/tests/services/__init__.py
+++ b/backend/tests/services/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for services package."""

--- a/backend/tests/services/test_visitor_identification_service.py
+++ b/backend/tests/services/test_visitor_identification_service.py
@@ -1,0 +1,221 @@
+"""Tests for VisitorIdentificationService.
+
+All Supabase interactions are mocked to ensure tests run without
+external dependencies.
+"""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from backend.services.visitor_identification_service import VisitorIdentificationService
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_mock_client() -> MagicMock:
+    """Build a mock Supabase client with chainable query builder."""
+    client = MagicMock()
+
+    def _table(name: str) -> MagicMock:
+        builder = MagicMock()
+        # Enable method chaining for all query-builder methods.
+        for method in ("select", "eq", "order", "limit", "insert", "upsert"):
+            getattr(builder, method).return_value = builder
+        return builder
+
+    client.table = MagicMock(side_effect=_table)
+    return client
+
+
+def _make_query_result(data=None, count=None):
+    """Create a mock query result."""
+    result = MagicMock()
+    result.data = data or []
+    result.count = count
+    return result
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def mock_client() -> MagicMock:
+    return _make_mock_client()
+
+
+@pytest.fixture
+def service(mock_client: MagicMock) -> VisitorIdentificationService:
+    return VisitorIdentificationService(supabase_client=mock_client)
+
+
+# ---------------------------------------------------------------------------
+# NFC identification
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_identify_by_nfc_found(service: VisitorIdentificationService, mock_client: MagicMock):
+    """NFC lookup should resolve to a user profile when a matching record exists."""
+    nfc_builder = MagicMock()
+    nfc_builder.select.return_value = nfc_builder
+    nfc_builder.eq.return_value = nfc_builder
+    nfc_builder.execute.return_value = _make_query_result(data=[{"user_id": 42}])
+
+    user_builder = MagicMock()
+    user_builder.select.return_value = user_builder
+    user_builder.eq.return_value = user_builder
+    user_builder.execute.return_value = _make_query_result(data=[{"id": 42, "name": "Taro"}])
+
+    count_builder = MagicMock()
+    count_builder.select.return_value = count_builder
+    count_builder.eq.return_value = count_builder
+    count_builder.execute.return_value = _make_query_result(count=5)
+
+    tables = {"nfcs": nfc_builder, "users": user_builder, "visits": count_builder}
+    mock_client.table = MagicMock(side_effect=lambda n: tables[n])
+
+    result = await service.identify_by_nfc("nfc-abc-123")
+
+    assert result is not None
+    assert result["visitor_type"] == "returning"
+    assert result["user_id"] == 42
+    assert result["name"] == "Taro"
+    assert result["visit_count"] == 5
+
+
+@pytest.mark.asyncio
+async def test_identify_by_nfc_not_found(
+    service: VisitorIdentificationService, mock_client: MagicMock
+):
+    """NFC lookup should return ``None`` when no matching NFC record exists."""
+    builder = MagicMock()
+    builder.select.return_value = builder
+    builder.eq.return_value = builder
+    builder.execute.return_value = _make_query_result(data=[])
+
+    mock_client.table = MagicMock(return_value=builder)
+
+    result = await service.identify_by_nfc("unknown-nfc")
+    assert result is None
+
+
+# ---------------------------------------------------------------------------
+# Visitor-ID identification
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_identify_by_visitor_id_returning(
+    service: VisitorIdentificationService, mock_client: MagicMock
+):
+    """Should return visit summary for a returning visitor."""
+    visit_builder = MagicMock()
+    visit_builder.select.return_value = visit_builder
+    visit_builder.eq.return_value = visit_builder
+    visit_builder.order.return_value = visit_builder
+    visit_builder.limit.return_value = visit_builder
+    visit_builder.execute.return_value = _make_query_result(
+        data=[
+            {
+                "started_at": "2026-03-01T10:00:00+09:00",
+                "purpose": "facility_use",
+                "purpose_detail": "Co-working",
+            }
+        ]
+    )
+
+    count_builder = MagicMock()
+    count_builder.select.return_value = count_builder
+    count_builder.eq.return_value = count_builder
+    count_builder.execute.return_value = _make_query_result(count=3)
+
+    mock_client.table = MagicMock(side_effect=lambda _: visit_builder)
+    # Override count call specifically: second .table("visits") call is for count
+    call_count = {"n": 0}
+
+    def table_side_effect(name: str):
+        call_count["n"] += 1
+        if call_count["n"] == 1:
+            return visit_builder
+        return count_builder
+
+    mock_client.table = MagicMock(side_effect=table_side_effect)
+
+    result = await service.identify_by_visitor_id("visitor-uuid-abc")
+
+    assert result is not None
+    assert result["visitor_type"] == "returning"
+    assert result["last_purpose"] == "facility_use"
+    assert result["visit_count"] == 3
+
+
+@pytest.mark.asyncio
+async def test_identify_by_visitor_id_new(
+    service: VisitorIdentificationService, mock_client: MagicMock
+):
+    """Should return ``None`` for a visitor_id with no prior visits."""
+    builder = MagicMock()
+    builder.select.return_value = builder
+    builder.eq.return_value = builder
+    builder.order.return_value = builder
+    builder.limit.return_value = builder
+    builder.execute.return_value = _make_query_result(data=[])
+
+    mock_client.table = MagicMock(return_value=builder)
+
+    result = await service.identify_by_visitor_id("brand-new-visitor")
+    assert result is None
+
+
+# ---------------------------------------------------------------------------
+# Recent visits
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_get_recent_visits(service: VisitorIdentificationService, mock_client: MagicMock):
+    """Should return a list of recent visit dicts."""
+    visits_data = [
+        {"id": "v1", "purpose": "facility_use", "started_at": "2026-03-06T10:00:00+09:00"},
+        {"id": "v2", "purpose": "tour", "started_at": "2026-03-01T14:00:00+09:00"},
+    ]
+    builder = MagicMock()
+    builder.select.return_value = builder
+    builder.eq.return_value = builder
+    builder.order.return_value = builder
+    builder.limit.return_value = builder
+    builder.execute.return_value = _make_query_result(data=visits_data)
+
+    mock_client.table = MagicMock(return_value=builder)
+
+    result = await service.get_recent_visits(user_id=42, limit=5)
+
+    assert len(result) == 2
+    assert result[0]["id"] == "v1"
+    assert result[1]["purpose"] == "tour"
+
+
+# ---------------------------------------------------------------------------
+# Graceful degradation
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_supabase_unavailable_graceful_fallback():
+    """All methods should return safe defaults when Supabase is unavailable."""
+    service = VisitorIdentificationService(supabase_client=None)
+
+    # Patch the lazy resolver to raise
+    with patch(
+        "backend.services.visitor_identification_service.VisitorIdentificationService._get_supabase",
+        new_callable=AsyncMock,
+        return_value=None,
+    ):
+        assert await service.identify_by_nfc("any") is None
+        assert await service.identify_by_visitor_id("any") is None
+        assert await service.get_recent_visits(visitor_id="any") == []

--- a/backend/tests/supabase/test_reception_rls_migration.py
+++ b/backend/tests/supabase/test_reception_rls_migration.py
@@ -1,0 +1,90 @@
+"""Tests for the reception RLS optimization migration."""
+
+from pathlib import Path
+import re
+
+
+MIGRATION_PATH = (
+    Path(__file__).resolve().parents[2]
+    / "supabase"
+    / "migrations"
+    / "20260308000002_optimize_reception_rls.sql"
+)
+
+EXPECTED_POLICIES = {
+    "reception_sessions_service_select",
+    "reception_sessions_service_insert",
+    "reception_sessions_service_update",
+    "reception_sessions_service_delete",
+    "visits_service_select",
+    "visits_service_insert",
+    "visits_service_update",
+    "visits_service_delete",
+}
+
+
+def _read_sql() -> str:
+    return MIGRATION_PATH.read_text(encoding="utf-8")
+
+
+def _split_sql_statements(sql: str) -> list[str]:
+    statements: list[str] = []
+    current: list[str] = []
+    in_single_quote = False
+
+    for char in sql:
+        if char == "'" and (not current or current[-1] != "\\"):
+            in_single_quote = not in_single_quote
+
+        current.append(char)
+
+        if char == ";" and not in_single_quote:
+            statement = "".join(current).strip()
+            if statement:
+                statements.append(statement)
+            current = []
+
+    trailing = "".join(current).strip()
+    if trailing:
+        statements.append(trailing)
+
+    return statements
+
+
+class TestReceptionRlsMigration:
+    def test_sql_file_exists(self) -> None:
+        assert MIGRATION_PATH.exists()
+
+    def test_sql_is_syntactically_shaped_like_valid_policy_migration(self) -> None:
+        sql = _read_sql()
+        statements = _split_sql_statements(sql)
+
+        assert statements, "Migration must contain SQL statements"
+        assert sql.strip().endswith(";")
+        assert sql.count("(") == sql.count(")")
+
+        create_policy_matches = re.findall(
+            r"CREATE POLICY\s+([a-z_]+)\s+ON\s+([a-z_]+)\s+FOR\s+(SELECT|INSERT|UPDATE|DELETE)",
+            sql,
+        )
+        drop_policy_matches = re.findall(
+            r"DROP POLICY IF EXISTS\s+(?:\"[^\"]+\"|[a-z_]+)\s+ON\s+([a-z_]+)",
+            sql,
+        )
+
+        assert len(create_policy_matches) == 8
+        assert len(drop_policy_matches) == 10
+
+    def test_contains_all_expected_policy_names(self) -> None:
+        sql = _read_sql()
+
+        for policy_name in EXPECTED_POLICIES:
+            assert policy_name in sql
+
+    def test_contains_drop_policy_if_exists_statements(self) -> None:
+        sql = _read_sql()
+
+        assert 'DROP POLICY IF EXISTS "Service role has full access to reception_sessions"' in sql
+        assert 'DROP POLICY IF EXISTS "Service role has full access to visits"' in sql
+        assert "DROP POLICY IF EXISTS reception_sessions_service_select" in sql
+        assert "DROP POLICY IF EXISTS visits_service_select" in sql

--- a/backend/tests/supabase/test_reception_rls_migration.py
+++ b/backend/tests/supabase/test_reception_rls_migration.py
@@ -3,7 +3,6 @@
 from pathlib import Path
 import re
 
-
 MIGRATION_PATH = (
     Path(__file__).resolve().parents[2]
     / "supabase"

--- a/backend/tests/utils/test_discord_escalation.py
+++ b/backend/tests/utils/test_discord_escalation.py
@@ -1,0 +1,94 @@
+"""Tests for Discord escalation webhook notifications."""
+
+import logging
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import httpx
+import pytest
+
+from backend.utils.discord_escalation import send_escalation_notification
+
+WEBHOOK_URL = "https://discord.com/api/webhooks/test/token"
+
+
+class TestSendEscalationNotification:
+    @pytest.mark.asyncio
+    async def test_sends_notification_when_webhook_is_configured(self) -> None:
+        mock_response = MagicMock()
+        mock_response.raise_for_status = MagicMock()
+
+        with patch.dict("os.environ", {"DISCORD_ESCALATION_WEBHOOK_URL": WEBHOOK_URL}):
+            with patch("httpx.AsyncClient.post", new_callable=AsyncMock) as mock_post:
+                mock_post.return_value = mock_response
+
+                result = await send_escalation_notification(
+                    session_id="session-123",
+                    reason="スタッフ対応が必要",
+                    visitor_name="田中",
+                    language="ja",
+                )
+
+        assert result is True
+        mock_post.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_falls_back_gracefully_when_webhook_is_missing(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        with caplog.at_level(logging.INFO):
+            with patch.dict("os.environ", {}, clear=True):
+                result = await send_escalation_notification(
+                    session_id="session-456",
+                    reason="相談対応",
+                    visitor_name="John",
+                    language="en",
+                )
+
+        assert result is False
+        assert "Discord escalation webhook not configured" in caplog.text
+
+    @pytest.mark.asyncio
+    async def test_handles_http_error_gracefully(self, caplog: pytest.LogCaptureFixture) -> None:
+        request = httpx.Request("POST", WEBHOOK_URL)
+        response = httpx.Response(status_code=500, request=request)
+        error = httpx.HTTPStatusError("server error", request=request, response=response)
+
+        with patch.dict("os.environ", {"DISCORD_ESCALATION_WEBHOOK_URL": WEBHOOK_URL}):
+            with patch("httpx.AsyncClient.post", new_callable=AsyncMock) as mock_post:
+                mock_post.side_effect = error
+
+                result = await send_escalation_notification(
+                    session_id="session-789",
+                    reason="緊急対応",
+                    visitor_name=None,
+                )
+
+        assert result is False
+        assert "Discord escalation notification failed (HTTP 500)" in caplog.text
+
+    @pytest.mark.asyncio
+    async def test_embed_contains_required_fields(self) -> None:
+        mock_response = MagicMock()
+        mock_response.raise_for_status = MagicMock()
+
+        with patch.dict("os.environ", {"DISCORD_ESCALATION_WEBHOOK_URL": WEBHOOK_URL}):
+            with patch("httpx.AsyncClient.post", new_callable=AsyncMock) as mock_post:
+                mock_post.return_value = mock_response
+
+                await send_escalation_notification(
+                    session_id="session-999",
+                    reason="来訪者がスタッフ案内を希望",
+                    visitor_name="Kim",
+                    language="ko",
+                )
+
+        payload = mock_post.call_args.kwargs["json"]
+        embed = payload["embeds"][0]
+        fields = {field["name"]: field["value"] for field in embed["fields"]}
+
+        assert embed["title"] == "スタッフエスカレーション要求"
+        assert embed["color"] == 0xFF0000
+        assert fields["session_id"] == "session-999"
+        assert fields["reason"] == "来訪者がスタッフ案内を希望"
+        assert fields["visitor_name"] == "Kim"
+        assert fields["timestamp"]

--- a/backend/tests/utils/test_purpose_classifier.py
+++ b/backend/tests/utils/test_purpose_classifier.py
@@ -1,0 +1,189 @@
+"""Tests for the purpose classifier module."""
+
+import json
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from backend.utils.purpose_classifier import (
+    _extract_json,
+    classify_purpose,
+)
+
+
+# ===================================================================
+# Keyword-based classification tests
+# ===================================================================
+
+
+class TestKeywordClassification:
+    """Tests for fast-path keyword matching (>= 2 keyword hits)."""
+
+    @pytest.mark.asyncio
+    async def test_keyword_facility_use(self) -> None:
+        """Two facility keywords ('作業' and 'Wi-Fi') should match facility_use."""
+        category, detail, confidence = await classify_purpose(
+            "作業したいんですが、Wi-Fiは使えますか？"
+        )
+        assert category == "facility_use"
+        assert confidence == 0.9
+        assert detail is not None
+
+    @pytest.mark.asyncio
+    async def test_keyword_event_participation(self) -> None:
+        """Two event keywords ('イベント' and '参加') should match."""
+        category, detail, confidence = await classify_purpose("今日のイベントに参加したいです")
+        assert category == "event_participation"
+        assert confidence == 0.9
+
+    @pytest.mark.asyncio
+    async def test_keyword_tour(self) -> None:
+        """Two tour keywords ('見学' and '案内') should match."""
+        category, detail, confidence = await classify_purpose(
+            "施設の見学をしたいのですが、案内してもらえますか？"
+        )
+        assert category == "tour"
+        assert confidence == 0.9
+
+    @pytest.mark.asyncio
+    async def test_keyword_consultation(self) -> None:
+        """Two consultation keywords ('技術相談' and '相談') should match."""
+        category, detail, confidence = await classify_purpose(
+            "技術相談がしたいです。プログラミングの相談です。"
+        )
+        # '技術相談' contains '相談', plus '相談' appears again
+        assert category == "consultation"
+        assert confidence == 0.9
+
+    @pytest.mark.asyncio
+    async def test_keyword_english_facility(self) -> None:
+        """English keywords should also trigger fast-path."""
+        category, detail, confidence = await classify_purpose("I want to study and use the wifi")
+        assert category == "facility_use"
+        assert confidence == 0.9
+
+
+# ===================================================================
+# LLM fallback classification tests
+# ===================================================================
+
+
+class TestLLMClassification:
+    """Tests for LLM-based classification when keywords are insufficient."""
+
+    @pytest.mark.asyncio
+    async def test_llm_classification(self) -> None:
+        """LLM should classify ambiguous queries that lack keyword matches."""
+        mock_response = json.dumps(
+            {
+                "category": "facility_use",
+                "detail": "ノートPCで開発作業",
+                "confidence": 0.85,
+            }
+        )
+
+        mock_provider = MagicMock()
+        mock_provider.generate = AsyncMock(return_value=mock_response)
+
+        with (
+            patch(
+                "backend.llm.openrouter.OpenRouterProvider",
+                return_value=mock_provider,
+            ),
+        ):
+            category, detail, confidence = await classify_purpose(
+                "ちょっとパソコンで開発させてもらえますか"
+            )
+
+        assert category == "facility_use"
+        assert detail == "ノートPCで開発作業"
+        assert confidence == pytest.approx(0.85)
+        mock_provider.generate.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_llm_classification_with_markdown_json(self) -> None:
+        """LLM response wrapped in markdown code block should still parse."""
+        mock_response = (
+            '```json\n{"category": "tour", "detail": "見学希望", "confidence": 0.9}\n```'
+        )
+
+        mock_provider = MagicMock()
+        mock_provider.generate = AsyncMock(return_value=mock_response)
+
+        with patch(
+            "backend.llm.openrouter.OpenRouterProvider",
+            return_value=mock_provider,
+        ):
+            category, detail, confidence = await classify_purpose("ここはどんな場所ですか？")
+
+        assert category == "tour"
+        assert confidence == pytest.approx(0.9)
+
+    @pytest.mark.asyncio
+    async def test_llm_invalid_category_falls_back_to_other(self) -> None:
+        """An invalid category from LLM should be coerced to 'other'."""
+        mock_response = json.dumps(
+            {
+                "category": "invalid_category",
+                "detail": "不明",
+                "confidence": 0.6,
+            }
+        )
+
+        mock_provider = MagicMock()
+        mock_provider.generate = AsyncMock(return_value=mock_response)
+
+        with patch(
+            "backend.llm.openrouter.OpenRouterProvider",
+            return_value=mock_provider,
+        ):
+            category, _, _ = await classify_purpose("何か面白いことない？")
+
+        assert category == "other"
+
+    @pytest.mark.asyncio
+    async def test_llm_failure_fallback_with_single_keyword(self) -> None:
+        """When LLM fails and one keyword matches, use that category at 0.5."""
+        with patch(
+            "backend.llm.openrouter.OpenRouterProvider",
+            side_effect=ValueError("No API key"),
+        ):
+            category, detail, confidence = await classify_purpose("イベントについて")
+
+        assert category == "event_participation"
+        assert detail is None
+        assert confidence == 0.5
+
+    @pytest.mark.asyncio
+    async def test_llm_failure_fallback_no_keywords(self) -> None:
+        """When LLM fails and no keywords match, return 'other' at 0.3."""
+        with patch(
+            "backend.llm.openrouter.OpenRouterProvider",
+            side_effect=ValueError("No API key"),
+        ):
+            category, detail, confidence = await classify_purpose("こんにちは")
+
+        assert category == "other"
+        assert detail is None
+        assert confidence == pytest.approx(0.3)
+
+
+# ===================================================================
+# JSON extraction helper tests
+# ===================================================================
+
+
+class TestExtractJson:
+    """Tests for the _extract_json helper."""
+
+    def test_plain_json(self) -> None:
+        result = _extract_json('{"category": "tour"}')
+        assert result == {"category": "tour"}
+
+    def test_json_with_surrounding_text(self) -> None:
+        result = _extract_json('Here is the result: {"category": "tour"} done')
+        assert result == {"category": "tour"}
+
+    def test_no_json_raises(self) -> None:
+        with pytest.raises(json.JSONDecodeError):
+            _extract_json("no json here")

--- a/backend/tests/utils/test_purpose_classifier.py
+++ b/backend/tests/utils/test_purpose_classifier.py
@@ -10,7 +10,6 @@ from backend.utils.purpose_classifier import (
     classify_purpose,
 )
 
-
 # ===================================================================
 # Keyword-based classification tests
 # ===================================================================

--- a/backend/tests/utils/test_reception_templates.py
+++ b/backend/tests/utils/test_reception_templates.py
@@ -66,6 +66,12 @@ class TestLegacyFirstTimeReception:
         result = get_reception_response("ja", "first_time")
         assert result["metadata"]["reception_type"] == "first_time"
 
+    def test_first_time_zh_contains_welcome(self):
+        result = get_reception_response("zh", "first_time")
+        response = result["response"]
+        assert "欢迎来到 Engineer Cafe" in response
+        assert "免费" in response
+
 
 class TestLegacyReturningReception:
     def test_returning_ja_contains_welcome_back(self):
@@ -90,6 +96,11 @@ class TestLegacyGeneralReception:
     def test_general_en_contains_basic_info(self):
         result = get_reception_response("en", "general")
         assert "Wi-Fi" in result["response"]
+
+    def test_general_ko_contains_basic_info(self):
+        result = get_reception_response("ko", "general")
+        assert "Wi-Fi" in result["response"]
+        assert "운영 시간" in result["response"]
 
     def test_general_is_default_reception_type(self):
         result = get_reception_response("ja")
@@ -146,6 +157,11 @@ class TestGetReceptionResponseNewAPI:
         result = get_reception_response("en", is_returning=True)
         assert "Welcome back" in result.text
 
+    def test_first_visit_ko(self) -> None:
+        result = get_reception_response("ko", is_returning=False)
+        assert "처음 방문" in result.text
+        assert result.language == "ko"
+
     def test_unsupported_language_defaults_to_ja(self) -> None:
         result = get_reception_response("fr", is_returning=False)  # type: ignore[arg-type]
         assert result.language == "ja"
@@ -186,6 +202,16 @@ class TestGetPurposeHearingPrompt:
         assert "What brings you here" in result.text
         assert "coworking" in result.text
 
+    def test_purpose_hearing_prompt_zh(self) -> None:
+        result = get_purpose_hearing_prompt("zh")
+        assert "来访目的" in result.text
+        assert "联合办公空间" in result.text
+
+    def test_purpose_hearing_prompt_ko(self) -> None:
+        result = get_purpose_hearing_prompt("ko")
+        assert "방문 목적" in result.text
+        assert "코워킹 공간" in result.text
+
 
 class TestGetPurposeFollowup:
     def test_purpose_followup_facility_use(self) -> None:
@@ -217,3 +243,49 @@ class TestGetPurposeFollowup:
         result = get_purpose_followup("en", "facility_use")
         assert "coworking" in result.text
         assert "Wi-Fi" in result.text
+
+    def test_purpose_followup_event_zh(self) -> None:
+        result = get_purpose_followup("zh", "event_participation")
+        assert "活动" in result.text
+
+    def test_purpose_followup_consultation_ko(self) -> None:
+        result = get_purpose_followup("ko", "consultation")
+        assert "스태프" in result.text
+
+
+class TestChineseTemplates:
+    def test_chinese_greeting(self) -> None:
+        result = get_personalized_greeting("zh", name="小林", last_purpose="参加技术活动")
+        assert "小林" in result.text
+        assert "参加技术活动" in result.text
+
+    def test_chinese_purpose_hearing(self) -> None:
+        result = get_purpose_hearing_prompt("zh")
+        assert "请告诉我" in result.text
+
+    def test_chinese_followup(self) -> None:
+        result = get_purpose_followup("zh", "facility_use")
+        assert "1 楼前台" in result.text
+
+    def test_chinese_default_purpose_label(self) -> None:
+        result = get_personalized_greeting("zh", name="小林")
+        assert "来访" in result.text
+
+
+class TestKoreanTemplates:
+    def test_korean_greeting(self) -> None:
+        result = get_personalized_greeting("ko", name="민수", last_purpose="기술 상담")
+        assert "민수" in result.text
+        assert "기술 상담" in result.text
+
+    def test_korean_purpose_hearing(self) -> None:
+        result = get_purpose_hearing_prompt("ko")
+        assert "예를 들면" in result.text
+
+    def test_korean_followup(self) -> None:
+        result = get_purpose_followup("ko", "facility_use")
+        assert "1층 안내 데스크" in result.text
+
+    def test_korean_default_purpose_label(self) -> None:
+        result = get_personalized_greeting("ko", name="민수")
+        assert "방문" in result.text

--- a/backend/tests/utils/test_reception_templates.py
+++ b/backend/tests/utils/test_reception_templates.py
@@ -12,7 +12,6 @@ from backend.utils.reception_templates import (
     get_reception_response,
 )
 
-
 # ===================================================================
 # Legacy API tests (dict-based, backward-compatible)
 # ===================================================================

--- a/backend/tests/utils/test_reception_templates.py
+++ b/backend/tests/utils/test_reception_templates.py
@@ -1,156 +1,219 @@
+"""Tests for the reception templates module.
+
+Covers both the legacy dict-based API (used by MainWorkflow)
+and the new ReceptionResult-based API (used by ReceptionWorkflow).
 """
-Tests for backend/utils/reception_templates.py
 
-Reception テンプレートの固定応答メッセージとメタデータ生成をテスト。
-"""
+from backend.utils.reception_templates import (
+    ReceptionResult,
+    get_personalized_greeting,
+    get_purpose_followup,
+    get_purpose_hearing_prompt,
+    get_reception_response,
+)
 
-from backend.utils.reception_templates import get_reception_response
+
+# ===================================================================
+# Legacy API tests (dict-based, backward-compatible)
+# ===================================================================
 
 
-class TestReceptionResponseStructure:
+class TestLegacyReceptionResponseStructure:
     """レスポンス構造のテスト"""
 
     def test_returns_dict_with_required_keys(self):
-        """必須キー（response, emotion, metadata）を含む辞書を返す"""
         result = get_reception_response("ja")
-
         assert "response" in result
         assert "emotion" in result
         assert "metadata" in result
 
     def test_response_is_string(self):
-        """response フィールドは文字列"""
         result = get_reception_response("ja")
         assert isinstance(result["response"], str)
         assert len(result["response"]) > 0
 
     def test_emotion_is_happy(self):
-        """emotion フィールドは常に "happy" """
         result = get_reception_response("ja")
         assert result["emotion"] == "happy"
 
     def test_metadata_contains_required_fields(self):
-        """metadata に agent, confidence, category, sources が含まれる"""
         result = get_reception_response("ja")
         metadata = result["metadata"]
-
-        assert "agent" in metadata
-        assert "confidence" in metadata
-        assert "category" in metadata
-        assert "sources" in metadata
-
         assert metadata["agent"] == "ReceptionAgent"
         assert isinstance(metadata["confidence"], float)
         assert metadata["category"] == "reception"
         assert isinstance(metadata["sources"], list)
 
 
-class TestFirstTimeReception:
-    """初回利用案内のテスト"""
-
+class TestLegacyFirstTimeReception:
     def test_first_time_ja_contains_welcome(self):
-        """日本語初回メッセージにウェルカム情報が含まれる"""
         result = get_reception_response("ja", "first_time")
         response = result["response"]
-
         assert "ようこそ" in response
         assert "無料" in response
-        assert "受付" in response or "利用登録" in response
 
     def test_first_time_en_contains_welcome(self):
-        """英語初回メッセージにwelcome情報が含まれる"""
         result = get_reception_response("en", "first_time")
         response = result["response"]
-
         assert "Welcome" in response
         assert "free" in response.lower()
-        assert "register" in response.lower() or "reception" in response.lower()
 
     def test_first_time_confidence_is_high(self):
-        """初回利用案内の confidence は 0.95"""
         result = get_reception_response("ja", "first_time")
         assert result["metadata"]["confidence"] == 0.95
 
     def test_first_time_reception_type_in_metadata(self):
-        """metadata に reception_type が含まれる"""
         result = get_reception_response("ja", "first_time")
         assert result["metadata"]["reception_type"] == "first_time"
 
 
-class TestReturningReception:
-    """リピーター案内のテスト"""
-
+class TestLegacyReturningReception:
     def test_returning_ja_contains_welcome_back(self):
-        """日本語リピーターメッセージにおかえりが含まれる"""
         result = get_reception_response("ja", "returning")
-        response = result["response"]
-
-        assert "おかえり" in response
+        assert "おかえり" in result["response"]
 
     def test_returning_en_contains_welcome_back(self):
-        """英語リピーターメッセージにwelcome backが含まれる"""
         result = get_reception_response("en", "returning")
-        response = result["response"]
-
-        assert "Welcome back" in response
+        assert "Welcome back" in result["response"]
 
     def test_returning_confidence(self):
-        """リピーター案内の confidence は 0.9"""
         result = get_reception_response("ja", "returning")
         assert result["metadata"]["confidence"] == 0.9
 
 
-class TestGeneralReception:
-    """一般受付案内のテスト"""
-
+class TestLegacyGeneralReception:
     def test_general_ja_contains_basic_info(self):
-        """日本語一般案内に基本情報が含まれる"""
         result = get_reception_response("ja", "general")
         response = result["response"]
-
         assert "Wi-Fi" in response or "wifi" in response.lower()
-        assert "9:00" in response or "営業時間" in response
 
     def test_general_en_contains_basic_info(self):
-        """英語一般案内に基本情報が含まれる"""
         result = get_reception_response("en", "general")
-        response = result["response"]
-
-        assert "Wi-Fi" in response
-        assert "9:00" in response
+        assert "Wi-Fi" in result["response"]
 
     def test_general_is_default_reception_type(self):
-        """引数なしはgeneralになる"""
         result = get_reception_response("ja")
         assert result["metadata"]["reception_type"] == "general"
 
     def test_general_confidence(self):
-        """一般案内の confidence は 0.85"""
         result = get_reception_response("ja", "general")
         assert result["metadata"]["confidence"] == 0.85
 
 
-class TestEmotionTagging:
-    """感情タグが付与されることをテスト"""
-
+class TestLegacyEmotionTagging:
     def test_response_starts_with_emotion_tag(self):
-        """レスポンスが感情タグ [happy] で始まる"""
         result = get_reception_response("ja")
         assert result["response"].startswith("[happy]")
 
     def test_all_types_have_emotion_tag(self):
-        """すべての受付タイプで感情タグが付与される"""
         for reception_type in ["first_time", "returning", "general"]:
             result = get_reception_response("ja", reception_type)
             assert result["response"].startswith("[happy]")
 
 
-class TestLanguageFallback:
-    """未知の言語に対するフォールバック動作をテスト"""
-
+class TestLegacyLanguageFallback:
     def test_unknown_language_falls_back_to_japanese(self):
-        """未知の言語は日本語にフォールバック"""
         result = get_reception_response("fr")  # type: ignore
-
-        # 日本語メッセージになる
         assert "エンジニアカフェ" in result["response"] or "ようこそ" in result["response"]
+
+
+# ===================================================================
+# New API tests (ReceptionResult-based)
+# ===================================================================
+
+
+class TestGetReceptionResponseNewAPI:
+    """Tests for the new-style greeting function (is_returning kwarg)."""
+
+    def test_first_visit_ja(self) -> None:
+        result = get_reception_response("ja", is_returning=False)
+        assert isinstance(result, ReceptionResult)
+        assert "ようこそ" in result.text
+        assert result.language == "ja"
+        assert result.template_type == "first_visit_greeting"
+
+    def test_first_visit_en(self) -> None:
+        result = get_reception_response("en", is_returning=False)
+        assert "Welcome" in result.text
+        assert result.language == "en"
+
+    def test_returning_ja(self) -> None:
+        result = get_reception_response("ja", is_returning=True)
+        assert "おかえりなさい" in result.text
+        assert result.template_type == "returning_greeting"
+
+    def test_returning_en(self) -> None:
+        result = get_reception_response("en", is_returning=True)
+        assert "Welcome back" in result.text
+
+    def test_unsupported_language_defaults_to_ja(self) -> None:
+        result = get_reception_response("fr", is_returning=False)  # type: ignore[arg-type]
+        assert result.language == "ja"
+
+
+class TestGetPersonalizedGreeting:
+    def test_personalized_greeting_ja(self) -> None:
+        result = get_personalized_greeting("ja", name="田中", last_purpose="コワーキング利用")
+        assert "田中" in result.text
+        assert "コワーキング利用" in result.text
+        assert result.template_type == "returning_personalized"
+
+    def test_personalized_greeting_en(self) -> None:
+        result = get_personalized_greeting("en", name="John", last_purpose="coworking")
+        assert "John" in result.text
+        assert "coworking" in result.text
+
+    def test_personalized_greeting_without_purpose_ja(self) -> None:
+        result = get_personalized_greeting("ja", name="佐藤")
+        assert "佐藤" in result.text
+        assert "ご利用" in result.text
+
+    def test_personalized_greeting_without_purpose_en(self) -> None:
+        result = get_personalized_greeting("en", name="Alice")
+        assert "Alice" in result.text
+        assert "a visit" in result.text
+
+
+class TestGetPurposeHearingPrompt:
+    def test_purpose_hearing_prompt_ja(self) -> None:
+        result = get_purpose_hearing_prompt("ja")
+        assert "ご用件" in result.text
+        assert "コワーキング" in result.text
+        assert result.template_type == "purpose_hearing"
+
+    def test_purpose_hearing_prompt_en(self) -> None:
+        result = get_purpose_hearing_prompt("en")
+        assert "What brings you here" in result.text
+        assert "coworking" in result.text
+
+
+class TestGetPurposeFollowup:
+    def test_purpose_followup_facility_use(self) -> None:
+        result = get_purpose_followup("ja", "facility_use")
+        assert "Wi-Fi" in result.text
+        assert result.template_type == "purpose_followup_facility_use"
+
+    def test_purpose_followup_event(self) -> None:
+        result = get_purpose_followup("ja", "event_participation")
+        assert "イベント" in result.text
+
+    def test_purpose_followup_tour(self) -> None:
+        result = get_purpose_followup("ja", "tour")
+        assert "見学" in result.text
+
+    def test_purpose_followup_consultation_ja(self) -> None:
+        result = get_purpose_followup("ja", "consultation")
+        assert "スタッフ" in result.text
+
+    def test_purpose_followup_other_en(self) -> None:
+        result = get_purpose_followup("en", "other")
+        assert "Feel free" in result.text
+
+    def test_purpose_followup_unknown_falls_back_to_other(self) -> None:
+        result = get_purpose_followup("ja", "nonexistent_purpose")
+        assert result.text == get_purpose_followup("ja", "other").text
+
+    def test_purpose_followup_facility_use_en(self) -> None:
+        result = get_purpose_followup("en", "facility_use")
+        assert "coworking" in result.text
+        assert "Wi-Fi" in result.text

--- a/backend/tests/workflows/__init__.py
+++ b/backend/tests/workflows/__init__.py
@@ -1,1 +1,1 @@
-# Workflows tests
+"""Workflow tests package."""

--- a/backend/tests/workflows/test_reception_workflow.py
+++ b/backend/tests/workflows/test_reception_workflow.py
@@ -1,0 +1,573 @@
+"""Tests for the ReceptionWorkflow StateGraph.
+
+All external calls (Supabase, LLM) are mocked. Tests cover:
+- New visitor greeting
+- Returning visitor (personalized) greeting
+- Purpose classification integration
+- Agent routing based on purpose
+- Full end-to-end flow
+"""
+
+from __future__ import annotations
+
+import uuid
+from typing import Optional
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from langchain_core.messages import AIMessage, HumanMessage
+
+
+# =============================================================================
+# Helpers
+# =============================================================================
+
+
+def _make_session_id() -> str:
+    return str(uuid.uuid4())
+
+
+def _make_initial_state(
+    session_id: Optional[str] = None,
+    language: str = "ja",
+    trigger_type: str = "button_press",
+    messages=None,
+):
+    """Build a minimal ReceptionState dict for testing."""
+    from backend.workflows.reception_workflow import make_initial_state
+
+    return make_initial_state(
+        session_id=session_id or _make_session_id(),
+        language=language,
+        trigger_type=trigger_type,
+        messages=messages or [],
+    )
+
+
+def _mock_identification_service_new_visitor():
+    """Return a mock VisitorIdentificationService that reports a new visitor."""
+    svc = MagicMock()
+    svc.identify_by_visitor_id = AsyncMock(return_value=None)
+    svc.identify_by_nfc = AsyncMock(return_value=None)
+    return svc
+
+
+def _mock_identification_service_returning(name: str = "田中太郎", last_purpose: str = "勉強"):
+    """Return a mock VisitorIdentificationService that reports a returning visitor."""
+    svc = MagicMock()
+    svc.identify_by_visitor_id = AsyncMock(
+        return_value={
+            "visitor_type": "returning",
+            "name": name,
+            "last_purpose": last_purpose,
+            "visit_count": 3,
+        }
+    )
+    return svc
+
+
+# =============================================================================
+# greet_visitor node tests
+# =============================================================================
+
+
+class TestGreetVisitorNode:
+    """Unit tests for the greet_visitor graph node."""
+
+    @pytest.mark.asyncio
+    async def test_new_visitor_greeting_japanese(self):
+        """New visitor receives a standard first-visit greeting in Japanese."""
+        from backend.workflows.reception_workflow import greet_visitor
+
+        state = _make_initial_state(language="ja")
+
+        with patch(
+            "backend.workflows.reception_workflow.VisitorIdentificationService",
+            return_value=_mock_identification_service_new_visitor(),
+        ):
+            result = await greet_visitor(state)
+
+        assert result["stage"] == "greeting"
+        assert result["visitor_identity"] is None
+        assert result["greeting"]
+        assert isinstance(result["greeting"], str)
+        # Should not be a personalized message (no name)
+        assert "田中" not in result["greeting"]
+
+    @pytest.mark.asyncio
+    async def test_new_visitor_greeting_english(self):
+        """New visitor receives a first-visit greeting in English."""
+        from backend.workflows.reception_workflow import greet_visitor
+
+        state = _make_initial_state(language="en")
+
+        with patch(
+            "backend.workflows.reception_workflow.VisitorIdentificationService",
+            return_value=_mock_identification_service_new_visitor(),
+        ):
+            result = await greet_visitor(state)
+
+        assert result["stage"] == "greeting"
+        # English greeting should contain English text
+        assert "Engineer Cafe" in result["greeting"] or "Welcome" in result["greeting"]
+
+    @pytest.mark.asyncio
+    async def test_returning_visitor_personalized_greeting(self):
+        """Returning visitor with a name receives a personalized greeting."""
+        from backend.workflows.reception_workflow import greet_visitor
+
+        state = _make_initial_state(language="ja")
+
+        with patch(
+            "backend.workflows.reception_workflow.VisitorIdentificationService",
+            return_value=_mock_identification_service_returning(name="田中太郎", last_purpose="勉強"),
+        ):
+            result = await greet_visitor(state)
+
+        assert result["stage"] == "greeting"
+        assert result["visitor_identity"] is not None
+        assert result["visitor_identity"]["visitor_type"] == "returning"
+        # Personalized greeting includes the visitor's name
+        assert "田中太郎" in result["greeting"]
+
+    @pytest.mark.asyncio
+    async def test_returning_visitor_without_name_generic_greeting(self):
+        """Returning visitor without a name gets a generic returning greeting."""
+        from backend.workflows.reception_workflow import greet_visitor
+
+        svc = MagicMock()
+        svc.identify_by_visitor_id = AsyncMock(
+            return_value={
+                "visitor_type": "returning",
+                "name": None,
+                "last_purpose": None,
+                "visit_count": 1,
+            }
+        )
+        state = _make_initial_state(language="ja")
+
+        with patch(
+            "backend.workflows.reception_workflow.VisitorIdentificationService",
+            return_value=svc,
+        ):
+            result = await greet_visitor(state)
+
+        assert result["stage"] == "greeting"
+        assert result["visitor_identity"] is not None
+        # Generic returning greeting (no name interpolation)
+        greeting = result["greeting"]
+        assert greeting  # not empty
+
+    @pytest.mark.asyncio
+    async def test_greet_visitor_appends_ai_message(self):
+        """greet_visitor adds an AIMessage to the messages list."""
+        from backend.workflows.reception_workflow import greet_visitor
+
+        state = _make_initial_state(language="ja")
+
+        with patch(
+            "backend.workflows.reception_workflow.VisitorIdentificationService",
+            return_value=_mock_identification_service_new_visitor(),
+        ):
+            result = await greet_visitor(state)
+
+        assert len(result["messages"]) == 1
+        assert isinstance(result["messages"][0], AIMessage)
+
+    @pytest.mark.asyncio
+    async def test_greet_visitor_identification_error_handled(self):
+        """VisitorIdentificationService errors are handled gracefully."""
+        from backend.workflows.reception_workflow import greet_visitor
+
+        svc = MagicMock()
+        svc.identify_by_visitor_id = AsyncMock(side_effect=RuntimeError("DB unavailable"))
+        state = _make_initial_state(language="ja")
+
+        with patch(
+            "backend.workflows.reception_workflow.VisitorIdentificationService",
+            return_value=svc,
+        ):
+            result = await greet_visitor(state)
+
+        # Should still return a valid greeting despite the error
+        assert result["stage"] == "greeting"
+        assert result["greeting"]
+
+
+# =============================================================================
+# hear_purpose node tests
+# =============================================================================
+
+
+class TestHearPurposeNode:
+    """Unit tests for the hear_purpose graph node."""
+
+    @pytest.mark.asyncio
+    async def test_hear_purpose_sets_stage(self):
+        """hear_purpose advances stage to purpose_hearing."""
+        from backend.workflows.reception_workflow import hear_purpose
+
+        state = _make_initial_state(language="ja")
+        result = await hear_purpose(state)
+
+        assert result["stage"] == "purpose_hearing"
+
+    @pytest.mark.asyncio
+    async def test_hear_purpose_japanese_prompt(self):
+        """hear_purpose returns a Japanese prompt for ja language."""
+        from backend.workflows.reception_workflow import hear_purpose
+
+        state = _make_initial_state(language="ja")
+        result = await hear_purpose(state)
+
+        assert result["response"]
+        # Should contain Japanese characters or text
+        assert "ご用件" in result["response"] or "ください" in result["response"]
+
+    @pytest.mark.asyncio
+    async def test_hear_purpose_english_prompt(self):
+        """hear_purpose returns an English prompt for en language."""
+        from backend.workflows.reception_workflow import hear_purpose
+
+        state = _make_initial_state(language="en")
+        result = await hear_purpose(state)
+
+        assert result["response"]
+        assert "today" in result["response"].lower() or "bring" in result["response"].lower()
+
+    @pytest.mark.asyncio
+    async def test_hear_purpose_appends_ai_message(self):
+        """hear_purpose adds an AIMessage to messages."""
+        from backend.workflows.reception_workflow import hear_purpose
+
+        state = _make_initial_state(language="ja")
+        result = await hear_purpose(state)
+
+        assert len(result["messages"]) == 1
+        assert isinstance(result["messages"][0], AIMessage)
+
+
+# =============================================================================
+# classify_purpose node tests
+# =============================================================================
+
+
+class TestClassifyPurposeNode:
+    """Unit tests for the classify_purpose graph node."""
+
+    @pytest.mark.asyncio
+    async def test_classify_facility_use_by_keywords(self):
+        """Keyword-heavy message is classified as facility_use without LLM call."""
+        from backend.workflows.reception_workflow import classify_purpose
+
+        state = _make_initial_state(language="ja")
+        state["messages"] = [HumanMessage(content="作業したいです。コーディングをするつもりです")]
+
+        result = await classify_purpose(state)
+
+        assert result["stage"] == "routing"
+        assert result["purpose"]["category"] == "facility_use"
+        assert result["purpose"]["confidence"] > 0.5
+
+    @pytest.mark.asyncio
+    async def test_classify_event_participation(self):
+        """Event-related message is classified as event_participation."""
+        from backend.workflows.reception_workflow import classify_purpose
+
+        state = _make_initial_state(language="ja")
+        state["messages"] = [HumanMessage(content="イベントに参加したい。勉強会に申し込みました")]
+
+        result = await classify_purpose(state)
+
+        assert result["stage"] == "routing"
+        assert result["purpose"]["category"] == "event_participation"
+
+    @pytest.mark.asyncio
+    async def test_classify_purpose_with_llm_fallback(self):
+        """When keywords don't match, LLM classification is invoked."""
+        from backend.workflows.reception_workflow import classify_purpose
+
+        state = _make_initial_state(language="ja")
+        state["messages"] = [HumanMessage(content="ちょっと見学してみたいです")]
+
+        # Mock LLM-based classification
+        with patch(
+            "backend.utils.purpose_classifier.classify_purpose",
+            new_callable=AsyncMock,
+            return_value=("tour", "施設見学", 0.85),
+        ):
+            result = await classify_purpose(state)
+
+        assert result["stage"] == "routing"
+        assert result["purpose"]["category"] == "tour"
+
+    @pytest.mark.asyncio
+    async def test_classify_purpose_no_human_message_defaults_other(self):
+        """When no human message is present, defaults to 'other' category."""
+        from backend.workflows.reception_workflow import classify_purpose
+
+        state = _make_initial_state(language="ja")
+        # Only AI messages in history, no human message
+        state["messages"] = [AIMessage(content="いらっしゃいませ")]
+
+        result = await classify_purpose(state)
+
+        assert result["stage"] == "routing"
+        assert result["purpose"]["category"] == "other"
+
+    @pytest.mark.asyncio
+    async def test_classify_purpose_classification_error_handled(self):
+        """Classification errors fall back to 'other' category gracefully."""
+        from backend.workflows.reception_workflow import classify_purpose
+
+        state = _make_initial_state(language="ja")
+        state["messages"] = [HumanMessage(content="なんか特殊な用件です")]
+
+        with patch(
+            "backend.utils.purpose_classifier.classify_purpose",
+            new_callable=AsyncMock,
+            side_effect=RuntimeError("LLM unavailable"),
+        ):
+            result = await classify_purpose(state)
+
+        assert result["stage"] == "routing"
+        # Should gracefully fall back to some category
+        assert result["purpose"]["category"] in {
+            "facility_use",
+            "event_participation",
+            "tour",
+            "consultation",
+            "other",
+        }
+
+
+# =============================================================================
+# route_to_agent node tests
+# =============================================================================
+
+
+class TestRouteToAgentNode:
+    """Unit tests for the route_to_agent graph node."""
+
+    @pytest.mark.asyncio
+    async def test_facility_use_routes_to_facility_agent(self):
+        """facility_use purpose routes visitor to the facility agent."""
+        from backend.workflows.reception_workflow import route_to_agent
+
+        state = _make_initial_state(language="ja")
+        state["purpose"] = {"category": "facility_use", "detail": None, "confidence": 0.9}
+
+        result = await route_to_agent(state)
+
+        assert result["stage"] == "completed"
+        assert result["purpose"]["target_agent"] == "facility"
+
+    @pytest.mark.asyncio
+    async def test_event_participation_routes_to_event_agent(self):
+        """event_participation purpose routes visitor to the event agent."""
+        from backend.workflows.reception_workflow import route_to_agent
+
+        state = _make_initial_state(language="ja")
+        state["purpose"] = {
+            "category": "event_participation",
+            "detail": None,
+            "confidence": 0.9,
+        }
+
+        result = await route_to_agent(state)
+
+        assert result["stage"] == "completed"
+        assert result["purpose"]["target_agent"] == "event"
+
+    @pytest.mark.asyncio
+    async def test_tour_routes_to_slide_agent(self):
+        """tour purpose routes visitor to the slide agent."""
+        from backend.workflows.reception_workflow import route_to_agent
+
+        state = _make_initial_state(language="ja")
+        state["purpose"] = {"category": "tour", "detail": None, "confidence": 0.8}
+
+        result = await route_to_agent(state)
+
+        assert result["stage"] == "completed"
+        assert result["purpose"]["target_agent"] == "slide"
+
+    @pytest.mark.asyncio
+    async def test_consultation_routes_to_general_knowledge_agent(self):
+        """consultation purpose routes to general_knowledge agent."""
+        from backend.workflows.reception_workflow import route_to_agent
+
+        state = _make_initial_state(language="ja")
+        state["purpose"] = {"category": "consultation", "detail": None, "confidence": 0.75}
+
+        result = await route_to_agent(state)
+
+        assert result["stage"] == "completed"
+        assert result["purpose"]["target_agent"] == "general_knowledge"
+
+    @pytest.mark.asyncio
+    async def test_other_routes_to_general_knowledge_agent(self):
+        """other purpose routes to general_knowledge agent."""
+        from backend.workflows.reception_workflow import route_to_agent
+
+        state = _make_initial_state(language="ja")
+        state["purpose"] = {"category": "other", "detail": None, "confidence": 0.3}
+
+        result = await route_to_agent(state)
+
+        assert result["stage"] == "completed"
+        assert result["purpose"]["target_agent"] == "general_knowledge"
+
+    @pytest.mark.asyncio
+    async def test_route_generates_followup_response(self):
+        """route_to_agent emits a follow-up response message."""
+        from backend.workflows.reception_workflow import route_to_agent
+
+        state = _make_initial_state(language="ja")
+        state["purpose"] = {"category": "facility_use", "detail": None, "confidence": 0.9}
+
+        result = await route_to_agent(state)
+
+        assert result["response"]
+        assert len(result["messages"]) == 1
+        assert isinstance(result["messages"][0], AIMessage)
+
+    @pytest.mark.asyncio
+    async def test_route_preserves_existing_purpose_fields(self):
+        """route_to_agent preserves existing purpose fields (immutable update)."""
+        from backend.workflows.reception_workflow import route_to_agent
+
+        state = _make_initial_state(language="ja")
+        state["purpose"] = {
+            "category": "event_participation",
+            "detail": "Python勉強会",
+            "confidence": 0.92,
+        }
+
+        result = await route_to_agent(state)
+
+        assert result["purpose"]["category"] == "event_participation"
+        assert result["purpose"]["detail"] == "Python勉強会"
+        assert result["purpose"]["confidence"] == 0.92
+        assert result["purpose"]["target_agent"] == "event"
+
+
+# =============================================================================
+# Full end-to-end flow tests
+# =============================================================================
+
+
+class TestReceptionWorkflowEndToEnd:
+    """Full end-to-end tests running the compiled graph."""
+
+    @pytest.mark.asyncio
+    async def test_full_flow_new_visitor(self):
+        """New visitor completes the full reception flow from greeting to routing."""
+        from backend.workflows.reception_workflow import get_reception_workflow, make_initial_state
+
+        state = make_initial_state(session_id=_make_session_id(), language="ja")
+        # Add a human message simulating the visitor's purpose response
+        state["messages"] = [HumanMessage(content="作業したいです。コーディングしたい")]
+
+        with patch(
+            "backend.workflows.reception_workflow.VisitorIdentificationService",
+            return_value=_mock_identification_service_new_visitor(),
+        ):
+            graph = await get_reception_workflow()
+            result = await graph.ainvoke(state)
+
+        assert result["stage"] == "completed"
+        assert result["greeting"] is not None
+        assert result["purpose"] is not None
+        assert result["purpose"]["category"] == "facility_use"
+        assert result["purpose"]["target_agent"] == "facility"
+
+    @pytest.mark.asyncio
+    async def test_full_flow_returning_visitor_personalized(self):
+        """Returning visitor with a name receives personalized greeting."""
+        from backend.workflows.reception_workflow import get_reception_workflow, make_initial_state
+
+        state = make_initial_state(session_id=_make_session_id(), language="ja")
+        state["messages"] = [HumanMessage(content="イベントに参加したい。勉強会の申し込みをしました")]
+
+        with patch(
+            "backend.workflows.reception_workflow.VisitorIdentificationService",
+            return_value=_mock_identification_service_returning(
+                name="鈴木花子", last_purpose="コーディング"
+            ),
+        ):
+            graph = await get_reception_workflow()
+            result = await graph.ainvoke(state)
+
+        assert result["stage"] == "completed"
+        assert "鈴木花子" in result["greeting"]
+        assert result["purpose"]["category"] == "event_participation"
+        assert result["purpose"]["target_agent"] == "event"
+
+    @pytest.mark.asyncio
+    async def test_full_flow_with_mocked_llm_classification(self):
+        """End-to-end flow uses mocked LLM for purpose classification."""
+        from backend.workflows.reception_workflow import get_reception_workflow, make_initial_state
+
+        state = make_initial_state(session_id=_make_session_id(), language="ja")
+        state["messages"] = [HumanMessage(content="ちょっと施設を見学させてください")]
+
+        with patch(
+            "backend.workflows.reception_workflow.VisitorIdentificationService",
+            return_value=_mock_identification_service_new_visitor(),
+        ):
+            with patch(
+                "backend.utils.purpose_classifier.classify_purpose",
+                new_callable=AsyncMock,
+                return_value=("tour", "施設見学希望", 0.88),
+            ):
+                graph = await get_reception_workflow()
+                result = await graph.ainvoke(state)
+
+        assert result["stage"] == "completed"
+        assert result["purpose"]["category"] == "tour"
+        assert result["purpose"]["target_agent"] == "slide"
+
+    @pytest.mark.asyncio
+    async def test_full_flow_english(self):
+        """Full flow works correctly for English language session."""
+        from backend.workflows.reception_workflow import get_reception_workflow, make_initial_state
+
+        state = make_initial_state(session_id=_make_session_id(), language="en")
+        state["messages"] = [HumanMessage(content="I want to work here. I need wifi and a seat")]
+
+        with patch(
+            "backend.workflows.reception_workflow.VisitorIdentificationService",
+            return_value=_mock_identification_service_new_visitor(),
+        ):
+            graph = await get_reception_workflow()
+            result = await graph.ainvoke(state)
+
+        assert result["stage"] == "completed"
+        assert result["greeting"] is not None
+        assert result["language"] == "en"
+        assert result["purpose"]["category"] == "facility_use"
+
+    @pytest.mark.asyncio
+    async def test_full_flow_supabase_unavailable(self):
+        """Full flow completes even when Supabase is unavailable."""
+        from backend.workflows.reception_workflow import get_reception_workflow, make_initial_state
+
+        state = make_initial_state(session_id=_make_session_id(), language="ja")
+        state["messages"] = [HumanMessage(content="相談したいことがあります。アドバイスをください")]
+
+        # Simulate unavailable Supabase
+        svc = MagicMock()
+        svc.identify_by_visitor_id = AsyncMock(return_value=None)
+
+        with patch(
+            "backend.workflows.reception_workflow.VisitorIdentificationService",
+            return_value=svc,
+        ):
+            graph = await get_reception_workflow()
+            result = await graph.ainvoke(state)
+
+        assert result["stage"] == "completed"
+        assert result["visitor_identity"] is None  # Could not identify
+        assert result["purpose"] is not None
+        assert result["purpose"]["category"] == "consultation"

--- a/backend/tests/workflows/test_reception_workflow.py
+++ b/backend/tests/workflows/test_reception_workflow.py
@@ -120,7 +120,9 @@ class TestGreetVisitorNode:
 
         with patch(
             "backend.workflows.reception_workflow.VisitorIdentificationService",
-            return_value=_mock_identification_service_returning(name="田中太郎", last_purpose="勉強"),
+            return_value=_mock_identification_service_returning(
+                name="田中太郎", last_purpose="勉強",
+            ),
         ):
             result = await greet_visitor(state)
 
@@ -488,7 +490,9 @@ class TestReceptionWorkflowEndToEnd:
         from backend.workflows.reception_workflow import get_reception_workflow, make_initial_state
 
         state = make_initial_state(session_id=_make_session_id(), language="ja")
-        state["messages"] = [HumanMessage(content="イベントに参加したい。勉強会の申し込みをしました")]
+        state["messages"] = [
+            HumanMessage(content="イベントに参加したい。勉強会の申し込みをしました"),
+        ]
 
         with patch(
             "backend.workflows.reception_workflow.VisitorIdentificationService",

--- a/backend/tests/workflows/test_reception_workflow.py
+++ b/backend/tests/workflows/test_reception_workflow.py
@@ -17,7 +17,6 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 from langchain_core.messages import AIMessage, HumanMessage
 
-
 # =============================================================================
 # Helpers
 # =============================================================================
@@ -121,7 +120,8 @@ class TestGreetVisitorNode:
         with patch(
             "backend.workflows.reception_workflow.VisitorIdentificationService",
             return_value=_mock_identification_service_returning(
-                name="田中太郎", last_purpose="勉強",
+                name="田中太郎",
+                last_purpose="勉強",
             ),
         ):
             result = await greet_visitor(state)

--- a/backend/utils/discord_escalation.py
+++ b/backend/utils/discord_escalation.py
@@ -1,0 +1,75 @@
+"""Discord webhook helper for staff escalation notifications."""
+
+import logging
+import os
+from datetime import datetime, timezone
+from typing import Optional
+
+import httpx
+
+logger = logging.getLogger(__name__)
+
+_EMBED_COLOR_RED = 0xFF0000
+_EMBED_TITLE = "スタッフエスカレーション要求"
+
+
+async def send_escalation_notification(
+    session_id: str,
+    reason: str,
+    visitor_name: Optional[str] = None,
+    language: str = "ja",
+) -> bool:
+    """Send a staff escalation notification to Discord.
+
+    Returns ``False`` on configuration or transport failures and never raises.
+    """
+    webhook_url = os.environ.get("DISCORD_ESCALATION_WEBHOOK_URL")
+    timestamp = datetime.now(timezone.utc).isoformat()
+    visitor_value = visitor_name or "-"
+
+    if not webhook_url:
+        logger.info(
+            (
+                "Discord escalation webhook not configured; "
+                "session_id=%s, reason=%s, visitor_name=%s, language=%s"
+            ),
+            session_id,
+            reason,
+            visitor_value,
+            language,
+        )
+        return False
+
+    payload = {
+        "embeds": [
+            {
+                "title": _EMBED_TITLE,
+                "description": "スタッフによる対応が必要な受付セッションです。",
+                "color": _EMBED_COLOR_RED,
+                "fields": [
+                    {"name": "session_id", "value": session_id, "inline": True},
+                    {"name": "reason", "value": reason, "inline": False},
+                    {"name": "visitor_name", "value": visitor_value, "inline": True},
+                    {"name": "timestamp", "value": timestamp, "inline": True},
+                ],
+                "timestamp": timestamp,
+                "footer": {"text": f"language: {language}"},
+            }
+        ]
+    }
+
+    try:
+        async with httpx.AsyncClient(timeout=10.0) as client:
+            response = await client.post(webhook_url, json=payload)
+            response.raise_for_status()
+        return True
+    except httpx.RequestError as exc:
+        logger.warning("Discord escalation notification failed (network error): %s", exc)
+        return False
+    except httpx.HTTPStatusError as exc:
+        logger.warning(
+            "Discord escalation notification failed (HTTP %s): %s",
+            exc.response.status_code,
+            exc,
+        )
+        return False

--- a/backend/utils/purpose_classifier.py
+++ b/backend/utils/purpose_classifier.py
@@ -1,0 +1,214 @@
+"""Purpose Classifier - LLM-based visitor purpose classification.
+
+Classifies visitor responses into one of five categories:
+- facility_use: wants to use the coworking space
+- event_participation: here for an event
+- tour: wants to tour/visit the facility
+- consultation: needs tech consultation or business advice
+- other: anything else
+"""
+
+import json
+import logging
+from typing import Literal, Optional, Tuple
+
+from langchain_core.messages import HumanMessage, SystemMessage
+
+logger = logging.getLogger(__name__)
+
+PurposeCategory = Literal[
+    "facility_use",
+    "event_participation",
+    "tour",
+    "consultation",
+    "other",
+]
+
+_VALID_CATEGORIES: set[str] = {
+    "facility_use",
+    "event_participation",
+    "tour",
+    "consultation",
+    "other",
+}
+
+# Fast-path keyword matching before LLM
+_PURPOSE_KEYWORDS: dict[PurposeCategory, list[str]] = {
+    "facility_use": [
+        "作業",
+        "仕事",
+        "勉強",
+        "コーディング",
+        "プログラミング",
+        "work",
+        "study",
+        "coding",
+        "programming",
+        "coworking",
+        "Wi-Fi",
+        "wifi",
+        "電源",
+        "power",
+        "席",
+        "seat",
+        "利用",
+        "使いたい",
+    ],
+    "event_participation": [
+        "イベント",
+        "勉強会",
+        "セミナー",
+        "ワークショップ",
+        "ハッカソン",
+        "もくもく会",
+        "LT",
+        "ミートアップ",
+        "meetup",
+        "event",
+        "seminar",
+        "workshop",
+        "hackathon",
+        "参加",
+        "申し込み",
+        "register",
+        "attend",
+    ],
+    "tour": [
+        "見学",
+        "見て",
+        "案内",
+        "ツアー",
+        "tour",
+        "visit",
+        "look around",
+        "show me",
+    ],
+    "consultation": [
+        "相談",
+        "アドバイス",
+        "メンタリング",
+        "技術相談",
+        "consult",
+        "advice",
+        "mentoring",
+    ],
+}
+
+SYSTEM_PROMPT = (
+    "あなたはエンジニアカフェの受付AIです。来訪者の発言から、"
+    "訪問目的を以下の5つに分類してください。\n\n"
+    "分類カテゴリ:\n"
+    "- facility_use: コワーキングスペースの利用（作業、勉強、Wi-Fi利用など）\n"
+    "- event_participation: イベントへの参加（勉強会、セミナー、ワークショップなど）\n"
+    "- tour: 施設の見学・案内\n"
+    "- consultation: 技術相談・ビジネス相談\n"
+    "- other: 上記に該当しないもの\n\n"
+    "JSON形式で回答してください:\n"
+    '{"category": "<カテゴリ>", "detail": "<具体的な内容の要約>", '
+    '"confidence": <0.0-1.0>}'
+)
+
+
+def _extract_json(text: str) -> dict:
+    """Extract a JSON object from LLM response text.
+
+    Handles cases where the JSON is wrapped in markdown code blocks
+    or surrounded by extra text.
+
+    Args:
+        text: Raw LLM response text.
+
+    Returns:
+        Parsed JSON dictionary.
+
+    Raises:
+        json.JSONDecodeError: If no valid JSON is found.
+    """
+    # Try direct parse first
+    try:
+        return json.loads(text)
+    except json.JSONDecodeError:
+        pass
+
+    # Try to find JSON object in the text
+    start = text.find("{")
+    end = text.rfind("}")
+    if start != -1 and end != -1 and end > start:
+        return json.loads(text[start : end + 1])
+
+    raise json.JSONDecodeError("No JSON object found", text, 0)
+
+
+async def classify_purpose(
+    query: str,
+    language: str = "ja",
+) -> Tuple[PurposeCategory, Optional[str], float]:
+    """Classify visitor's purpose from their response.
+
+    Uses a two-stage approach: fast keyword matching first, then
+    LLM-based classification for ambiguous inputs.
+
+    Args:
+        query: The visitor's spoken or typed response.
+        language: Language code (e.g., "ja", "en").
+
+    Returns:
+        Tuple of (category, detail, confidence) where:
+            - category: One of the five PurposeCategory values.
+            - detail: A brief summary of the specific purpose, or None.
+            - confidence: Float between 0.0 and 1.0.
+    """
+    # Fast-path: keyword matching
+    lower_query = query.lower()
+    for category, keywords in _PURPOSE_KEYWORDS.items():
+        matches = sum(1 for kw in keywords if kw.lower() in lower_query)
+        if matches >= 2:
+            logger.info(
+                "Purpose classified by keywords: %s (matches=%d)",
+                category,
+                matches,
+            )
+            return category, query, 0.9
+
+    # LLM classification
+    try:
+        from backend.llm.models import ModelConfig, SupportedModel
+        from backend.llm.openrouter import OpenRouterProvider
+
+        provider = OpenRouterProvider()
+        config = ModelConfig(
+            model_id=SupportedModel.GEMINI_3_FLASH,
+            temperature=0.1,
+            max_tokens=200,
+        )
+
+        response = await provider.generate(
+            messages=[
+                SystemMessage(content=SYSTEM_PROMPT),
+                HumanMessage(content=query),
+            ],
+            config=config,
+        )
+
+        parsed = _extract_json(response)
+        category = parsed.get("category", "other")
+        detail = parsed.get("detail")
+        confidence = float(parsed.get("confidence", 0.7))
+
+        if category not in _VALID_CATEGORIES:
+            category = "other"
+
+        logger.info(
+            "Purpose classified by LLM: %s (confidence=%.2f)",
+            category,
+            confidence,
+        )
+        return category, detail, confidence
+
+    except Exception as e:
+        logger.warning("LLM purpose classification failed: %s", e)
+        # Fallback to keyword single-match or default
+        for category, keywords in _PURPOSE_KEYWORDS.items():
+            if any(kw.lower() in lower_query for kw in keywords):
+                return category, None, 0.5
+        return "other", None, 0.3

--- a/backend/utils/reception_templates.py
+++ b/backend/utils/reception_templates.py
@@ -1,14 +1,15 @@
-"""
-Reception テンプレート - 受付案内の固定応答メッセージ
+"""Reception templates for the Engineer Cafe Navigator.
 
-OrchestratorAgent がインラインで使用する。LLM 呼び出しなし。
-受付タイプと言語に基づいてテンプレートメッセージを返す純粋関数。
+Provides multilingual greeting, purpose-hearing, and follow-up
+templates used by the autonomous reception flow.
 
-パターンは clarification_templates.py と同等。
+Also maintains backward-compatible get_reception_response for
+existing MainWorkflow inline usage.
 """
 
 import logging
-from typing import Literal, TypedDict
+from dataclasses import dataclass
+from typing import Literal, Optional, TypedDict
 
 from backend.utils.emotion_tagger import add_emotion_tag
 
@@ -23,17 +24,42 @@ ReceptionType = Literal[
 ]
 
 
-class ReceptionResult(TypedDict):
-    """Reception テンプレートの出力結果"""
+# ---------------------------------------------------------------------------
+# Legacy result type (dict-based, used by MainWorkflow)
+# ---------------------------------------------------------------------------
 
-    response: str  # 感情タグ付きテキスト
+
+class LegacyReceptionResult(TypedDict):
+    """Reception テンプレートの出力結果（レガシー互換）"""
+
+    response: str
     emotion: Literal["happy"]
-    metadata: dict  # agent名, category, confidence など
+    metadata: dict
 
 
-# --------------------------------------------------------------------------- #
-#  テンプレートメッセージ定数
-# --------------------------------------------------------------------------- #
+# ---------------------------------------------------------------------------
+# New result type (dataclass, used by ReceptionWorkflow)
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class ReceptionResult:
+    """Immutable result from a reception template lookup.
+
+    Attributes:
+        text: The formatted template text.
+        language: The language code used.
+        template_type: Identifier for the template category.
+    """
+
+    text: str
+    language: SupportedLanguage
+    template_type: str
+
+
+# ---------------------------------------------------------------------------
+# Legacy templates (used by MainWorkflow inline reception)
+# ---------------------------------------------------------------------------
 
 _FIRST_TIME: dict[str, str] = {
     "ja": (
@@ -86,40 +112,149 @@ _GENERAL: dict[str, str] = {
     ),
 }
 
-
-# --------------------------------------------------------------------------- #
-#  テンプレートマッピング（受付タイプ → メッセージ辞書, confidence）
-# --------------------------------------------------------------------------- #
-
-_TEMPLATES: dict[ReceptionType, tuple[dict[str, str], float]] = {
+_LEGACY_TEMPLATES: dict[ReceptionType, tuple[dict[str, str], float]] = {
     "first_time": (_FIRST_TIME, 0.95),
     "returning": (_RETURNING, 0.9),
     "general": (_GENERAL, 0.85),
 }
 
 
-# --------------------------------------------------------------------------- #
-#  公開 API
-# --------------------------------------------------------------------------- #
+# ---------------------------------------------------------------------------
+# New enhanced templates (used by ReceptionWorkflow)
+# ---------------------------------------------------------------------------
+
+_FIRST_VISIT_GREETING: dict[str, str] = {
+    "ja": (
+        "こんにちは！エンジニアカフェへようこそ。\n"
+        "初めてのご来館ですね。本日のご用件をお聞かせください。"
+    ),
+    "en": (
+        "Hello! Welcome to Engineer Cafe.\n"
+        "It looks like this is your first visit. What brings you here today?"
+    ),
+}
+
+_RETURNING_GREETING: dict[str, str] = {
+    "ja": (
+        "おかえりなさい！エンジニアカフェへようこそ。\n"
+        "またのご利用ありがとうございます。本日のご用件をお聞かせください。"
+    ),
+    "en": (
+        "Welcome back to Engineer Cafe!\nThank you for visiting again. What brings you here today?"
+    ),
+}
+
+_RETURNING_PERSONALIZED: dict[str, str] = {
+    "ja": (
+        "おかえりなさい、{name}さん！またのご利用ありがとうございます。\n"
+        "前回は{last_purpose}でご利用いただきましたね。\n"
+        "本日のご用件をお聞かせください。"
+    ),
+    "en": (
+        "Welcome back, {name}! Thank you for visiting again.\n"
+        "Last time you were here for {last_purpose}.\n"
+        "What brings you here today?"
+    ),
+}
+
+_PURPOSE_HEARING: dict[str, str] = {
+    "ja": (
+        "ご用件をお聞かせください。\n\n"
+        "例えば...\n"
+        "* コワーキングスペースの利用\n"
+        "* イベント参加\n"
+        "* 施設見学\n"
+        "* 技術相談\n\n"
+        "など、お気軽にどうぞ！"
+    ),
+    "en": (
+        "What brings you here today?\n\n"
+        "For example:\n"
+        "* Using the coworking space\n"
+        "* Attending an event\n"
+        "* Taking a facility tour\n"
+        "* Technical consultation\n\n"
+        "Feel free to ask!"
+    ),
+}
+
+_PURPOSE_FOLLOWUP: dict[str, dict[str, str]] = {
+    "facility_use": {
+        "ja": (
+            "承知しました！エンジニアカフェのご利用ですね。\n"
+            "1階受付で利用登録をお願いします。"
+            "Wi-Fiと電源は自由にお使いいただけます。"
+        ),
+        "en": (
+            "Got it! You'd like to use our coworking space.\n"
+            "Please register at the 1F reception. "
+            "Free Wi-Fi and power outlets are available."
+        ),
+    },
+    "event_participation": {
+        "ja": "イベントへのご参加ですね！本日開催中のイベントを確認いたします。",
+        "en": "You're here for an event! Let me check today's events for you.",
+    },
+    "tour": {
+        "ja": "施設の見学ですね！エンジニアカフェについてご案内いたします。",
+        "en": "A facility tour! Let me show you around Engineer Cafe.",
+    },
+    "consultation": {
+        "ja": "技術相談ですね！スタッフにおつなぎいたします。少々お待ちください。",
+        "en": "A consultation! Let me connect you with our staff. Please wait a moment.",
+    },
+    "other": {
+        "ja": "かしこまりました。何でもお気軽にお尋ねください！",
+        "en": "Of course! Feel free to ask me anything!",
+    },
+}
+
+_DEFAULT_PURPOSE_LABEL: dict[str, str] = {
+    "ja": "ご利用",
+    "en": "a visit",
+}
+
+
+# ===================================================================
+# Public API — Legacy (backward-compatible with MainWorkflow)
+# ===================================================================
 
 
 def get_reception_response(
     language: SupportedLanguage,
     reception_type: ReceptionType = "general",
-) -> ReceptionResult:
-    """
-    受付タイプと言語に基づいてテンプレート応答を返す。
+    *,
+    is_returning: bool | None = None,
+) -> LegacyReceptionResult | ReceptionResult:
+    """Get a reception greeting.
 
-    LLM 不要の純粋関数。
+    Supports two calling conventions:
+    - Legacy: get_reception_response("ja", "first_time") → dict
+    - New: get_reception_response("ja", is_returning=True) → ReceptionResult
 
     Args:
-        language: 応答言語 ("ja" | "en")
-        reception_type: 受付タイプ ("first_time" | "returning" | "general")
+        language: Language code ("ja" or "en").
+        reception_type: Legacy reception type.
+        is_returning: If provided, uses new-style API.
 
     Returns:
-        ReceptionResult: 感情タグ付きの応答とメタデータ
+        LegacyReceptionResult or ReceptionResult depending on calling convention.
     """
-    messages, confidence = _TEMPLATES.get(
+    if is_returning is not None:
+        lang = _resolve_language(language)
+        if is_returning:
+            return ReceptionResult(
+                text=_RETURNING_GREETING[lang],
+                language=lang,
+                template_type="returning_greeting",
+            )
+        return ReceptionResult(
+            text=_FIRST_VISIT_GREETING[lang],
+            language=lang,
+            template_type="first_visit_greeting",
+        )
+
+    messages, confidence = _LEGACY_TEMPLATES.get(
         reception_type,
         (_GENERAL, 0.85),
     )
@@ -144,3 +279,84 @@ def get_reception_response(
             "sources": ["reception_system"],
         },
     }
+
+
+# ===================================================================
+# Public API — New (for ReceptionWorkflow)
+# ===================================================================
+
+
+def _resolve_language(language: SupportedLanguage) -> SupportedLanguage:
+    """Normalize language code, defaulting to 'ja' for unsupported values."""
+    if language in ("ja", "en"):
+        return language
+    return "ja"
+
+
+def get_personalized_greeting(
+    language: SupportedLanguage,
+    name: str,
+    last_purpose: Optional[str] = None,
+) -> ReceptionResult:
+    """Personalized greeting for returning visitors with name.
+
+    Args:
+        language: Language code ("ja" or "en").
+        name: The visitor's name.
+        last_purpose: Description of their last visit purpose.
+
+    Returns:
+        ReceptionResult with a personalized greeting.
+    """
+    lang = _resolve_language(language)
+    purpose_label = last_purpose or _DEFAULT_PURPOSE_LABEL[lang]
+    text = _RETURNING_PERSONALIZED[lang].format(
+        name=name,
+        last_purpose=purpose_label,
+    )
+    return ReceptionResult(
+        text=text,
+        language=lang,
+        template_type="returning_personalized",
+    )
+
+
+def get_purpose_hearing_prompt(
+    language: SupportedLanguage,
+) -> ReceptionResult:
+    """Ask the visitor about their purpose.
+
+    Args:
+        language: Language code ("ja" or "en").
+
+    Returns:
+        ReceptionResult with a purpose-hearing prompt.
+    """
+    lang = _resolve_language(language)
+    return ReceptionResult(
+        text=_PURPOSE_HEARING[lang],
+        language=lang,
+        template_type="purpose_hearing",
+    )
+
+
+def get_purpose_followup(
+    language: SupportedLanguage,
+    purpose: str,
+) -> ReceptionResult:
+    """Follow-up message after purpose is identified.
+
+    Args:
+        language: Language code ("ja" or "en").
+        purpose: The classified purpose category.
+
+    Returns:
+        ReceptionResult with an appropriate follow-up message.
+    """
+    lang = _resolve_language(language)
+    templates = _PURPOSE_FOLLOWUP.get(purpose, _PURPOSE_FOLLOWUP["other"])
+    return ReceptionResult(
+        text=templates[lang],
+        language=lang,
+        template_type=f"purpose_followup_{purpose}",
+    )

--- a/backend/utils/reception_templates.py
+++ b/backend/utils/reception_templates.py
@@ -15,7 +15,7 @@ from backend.utils.emotion_tagger import add_emotion_tag
 
 logger = logging.getLogger(__name__)
 
-SupportedLanguage = Literal["ja", "en"]
+SupportedLanguage = Literal["ja", "en", "zh", "ko"]
 
 ReceptionType = Literal[
     "first_time",
@@ -80,6 +80,24 @@ _FIRST_TIME: dict[str, str] = {
         "3. Open hours: 9:00-22:00 (except year-end/New Year holidays)\n\n"
         "Feel free to ask if you have any questions!"
     ),
+    "zh": (
+        "欢迎来到 Engineer Cafe！看起来这是您第一次来访。\n"
+        "Engineer Cafe 是可**免费**使用的联合办公空间。\n\n"
+        "**使用流程：**\n"
+        "1. 请先在 1 楼前台办理登记\n"
+        "2. Wi-Fi 和电源插座可自由使用\n"
+        "3. 营业时间：9:00-22:00（年末年初除外）\n\n"
+        "如果有任何疑问，欢迎随时咨询。"
+    ),
+    "ko": (
+        "Engineer Cafe에 오신 것을 환영합니다! 처음 방문하셨군요.\n"
+        "Engineer Cafe는 **무료**로 이용할 수 있는 코워킹 공간입니다.\n\n"
+        "**이용 방법:**\n"
+        "1. 1층 안내 데스크에서 이용 등록을 해주세요\n"
+        "2. Wi-Fi와 전원은 자유롭게 사용할 수 있습니다\n"
+        "3. 운영 시간: 9:00-22:00 (연말연시 제외)\n\n"
+        "궁금한 점이 있으면 언제든지 말씀해 주세요!"
+    ),
 }
 
 _RETURNING: dict[str, str] = {
@@ -92,6 +110,16 @@ _RETURNING: dict[str, str] = {
         "Welcome back! Thank you for visiting again.\n"
         "Enjoy your time at Engineer Cafe today.\n\n"
         "Feel free to ask if you need any help."
+    ),
+    "zh": (
+        "欢迎回来！感谢您再次来到 Engineer Cafe。\n"
+        "祝您今天也能在这里度过高效而愉快的时间。\n\n"
+        "如果需要帮助，请随时告诉我。"
+    ),
+    "ko": (
+        "다시 오신 것을 환영합니다! Engineer Cafe를 또 찾아주셔서 감사합니다.\n"
+        "오늘도 편안하게 이용해 주세요.\n\n"
+        "도움이 필요하시면 언제든지 말씀해 주세요."
     ),
 }
 
@@ -109,6 +137,18 @@ _GENERAL: dict[str, str] = {
         "Open hours: 9:00-22:00.\n\n"
         "If you have any questions about our facilities or events, "
         "feel free to ask."
+    ),
+    "zh": (
+        "欢迎来到 Engineer Cafe！\n"
+        "这里提供免费的 Wi-Fi 和电源插座。\n"
+        "营业时间为 9:00-22:00。\n\n"
+        "如果您想了解设施或活动信息，请随时提问。"
+    ),
+    "ko": (
+        "Engineer Cafe에 오신 것을 환영합니다!\n"
+        "이곳에서는 무료 Wi-Fi와 전원을 이용하실 수 있습니다.\n"
+        "운영 시간은 9:00-22:00입니다.\n\n"
+        "시설이나 이벤트에 대해 궁금한 점이 있으면 편하게 물어보세요."
     ),
 }
 
@@ -132,6 +172,11 @@ _FIRST_VISIT_GREETING: dict[str, str] = {
         "Hello! Welcome to Engineer Cafe.\n"
         "It looks like this is your first visit. What brings you here today?"
     ),
+    "zh": ("您好，欢迎来到 Engineer Cafe。\n看起来这是您第一次来访，请问今天想办理什么事项？"),
+    "ko": (
+        "안녕하세요, Engineer Cafe에 오신 것을 환영합니다.\n"
+        "처음 방문하신 것 같은데 오늘 어떤 용무로 오셨나요?"
+    ),
 }
 
 _RETURNING_GREETING: dict[str, str] = {
@@ -141,6 +186,11 @@ _RETURNING_GREETING: dict[str, str] = {
     ),
     "en": (
         "Welcome back to Engineer Cafe!\nThank you for visiting again. What brings you here today?"
+    ),
+    "zh": ("欢迎再次来到 Engineer Cafe！\n感谢您的再次光临，请问今天想办理什么事项？"),
+    "ko": (
+        "Engineer Cafe에 다시 오신 것을 환영합니다!\n"
+        "또 방문해 주셔서 감사합니다. 오늘 어떤 용무로 오셨나요?"
     ),
 }
 
@@ -154,6 +204,16 @@ _RETURNING_PERSONALIZED: dict[str, str] = {
         "Welcome back, {name}! Thank you for visiting again.\n"
         "Last time you were here for {last_purpose}.\n"
         "What brings you here today?"
+    ),
+    "zh": (
+        "欢迎回来，{name}！感谢您再次来到 Engineer Cafe。\n"
+        "您上次来访的目的为：{last_purpose}。\n"
+        "请问今天想办理什么事项？"
+    ),
+    "ko": (
+        "{name}님, 다시 오신 것을 환영합니다! 또 방문해 주셔서 감사합니다.\n"
+        "지난 방문 목적은 {last_purpose}였네요.\n"
+        "오늘은 어떤 용무로 오셨나요?"
     ),
 }
 
@@ -176,6 +236,24 @@ _PURPOSE_HEARING: dict[str, str] = {
         "* Technical consultation\n\n"
         "Feel free to ask!"
     ),
+    "zh": (
+        "请告诉我您的来访目的。\n\n"
+        "例如：\n"
+        "* 使用联合办公空间\n"
+        "* 参加活动\n"
+        "* 参观设施\n"
+        "* 技术咨询\n\n"
+        "请随时告诉我！"
+    ),
+    "ko": (
+        "방문 목적을 알려주세요.\n\n"
+        "예를 들면:\n"
+        "* 코워킹 공간 이용\n"
+        "* 이벤트 참가\n"
+        "* 시설 투어\n"
+        "* 기술 상담\n\n"
+        "편하게 말씀해 주세요!"
+    ),
 }
 
 _PURPOSE_FOLLOWUP: dict[str, dict[str, str]] = {
@@ -190,28 +268,46 @@ _PURPOSE_FOLLOWUP: dict[str, dict[str, str]] = {
             "Please register at the 1F reception. "
             "Free Wi-Fi and power outlets are available."
         ),
+        "zh": (
+            "好的！您是来使用 Engineer Cafe 的联合办公空间。\n"
+            "请先在 1 楼前台办理登记，Wi-Fi 和电源插座都可以自由使用。"
+        ),
+        "ko": (
+            "알겠습니다! Engineer Cafe 코워킹 공간을 이용하시는군요.\n"
+            "1층 안내 데스크에서 등록해 주시면 Wi-Fi와 전원을 자유롭게 이용하실 수 있습니다."
+        ),
     },
     "event_participation": {
         "ja": "イベントへのご参加ですね！本日開催中のイベントを確認いたします。",
         "en": "You're here for an event! Let me check today's events for you.",
+        "zh": "您是来参加活动的！我来帮您确认今天正在举行的活动。",
+        "ko": "이벤트에 참가하시는군요! 오늘 진행 중인 이벤트를 확인해 드리겠습니다.",
     },
     "tour": {
         "ja": "施設の見学ですね！エンジニアカフェについてご案内いたします。",
         "en": "A facility tour! Let me show you around Engineer Cafe.",
+        "zh": "您想参观设施！我来为您介绍 Engineer Cafe。",
+        "ko": "시설 투어를 원하시는군요! Engineer Cafe를 안내해 드리겠습니다.",
     },
     "consultation": {
         "ja": "技術相談ですね！スタッフにおつなぎいたします。少々お待ちください。",
         "en": "A consultation! Let me connect you with our staff. Please wait a moment.",
+        "zh": "您需要技术咨询！我将为您联系工作人员，请稍候。",
+        "ko": "기술 상담이시군요! 담당 스태프에게 연결해 드리겠습니다. 잠시만 기다려 주세요.",
     },
     "other": {
         "ja": "かしこまりました。何でもお気軽にお尋ねください！",
         "en": "Of course! Feel free to ask me anything!",
+        "zh": "好的，如有任何问题都可以随时告诉我！",
+        "ko": "알겠습니다. 궁금한 점이 있으면 무엇이든 편하게 물어보세요!",
     },
 }
 
 _DEFAULT_PURPOSE_LABEL: dict[str, str] = {
     "ja": "ご利用",
     "en": "a visit",
+    "zh": "来访",
+    "ko": "방문",
 }
 
 
@@ -288,7 +384,7 @@ def get_reception_response(
 
 def _resolve_language(language: SupportedLanguage) -> SupportedLanguage:
     """Normalize language code, defaulting to 'ja' for unsupported values."""
-    if language in ("ja", "en"):
+    if language in ("ja", "en", "zh", "ko"):
         return language
     return "ja"
 

--- a/backend/utils/reception_templates.py
+++ b/backend/utils/reception_templates.py
@@ -406,9 +406,11 @@ def get_personalized_greeting(
     """
     lang = _resolve_language(language)
     purpose_label = last_purpose or _DEFAULT_PURPOSE_LABEL[lang]
+    safe_name = str(name).replace("{", "").replace("}", "")
+    safe_purpose = str(purpose_label).replace("{", "").replace("}", "")
     text = _RETURNING_PERSONALIZED[lang].format(
-        name=name,
-        last_purpose=purpose_label,
+        name=safe_name,
+        last_purpose=safe_purpose,
     )
     return ReceptionResult(
         text=text,

--- a/backend/utils/supabase_helper.py
+++ b/backend/utils/supabase_helper.py
@@ -1,0 +1,39 @@
+"""Supabase client helper - centralised factory for the Supabase client."""
+
+import os
+from typing import Optional
+
+from supabase import Client, create_client
+
+_client: Optional[Client] = None
+
+
+def get_supabase_client() -> Client:
+    """Return a shared Supabase client instance.
+
+    The client is created lazily on first call and reused afterwards.
+    Connection parameters are read from environment variables:
+        - SUPABASE_URL
+        - SUPABASE_KEY (or SUPABASE_SERVICE_ROLE_KEY)
+
+    Returns:
+        A ``supabase.Client`` instance.
+
+    Raises:
+        ValueError: If required environment variables are missing.
+    """
+    global _client
+    if _client is not None:
+        return _client
+
+    url = os.getenv("SUPABASE_URL", "")
+    key = os.getenv("SUPABASE_SERVICE_ROLE_KEY") or os.getenv("SUPABASE_KEY", "")
+
+    if not url or not key:
+        raise ValueError(
+            "SUPABASE_URL and SUPABASE_KEY (or SUPABASE_SERVICE_ROLE_KEY) "
+            "must be set as environment variables."
+        )
+
+    _client = create_client(url, key)
+    return _client

--- a/backend/workflows/reception_workflow.py
+++ b/backend/workflows/reception_workflow.py
@@ -1,0 +1,354 @@
+"""Reception Workflow - Autonomous LangGraph StateGraph for visitor reception.
+
+Separate from MainWorkflow, this graph handles the end-to-end reception flow:
+visitor identification -> greeting -> purpose hearing -> routing.
+"""
+
+from __future__ import annotations
+
+import logging
+import uuid
+from typing import Annotated, Optional
+
+from langchain_core.messages import AIMessage, BaseMessage
+from langgraph.graph import END, START, StateGraph
+from langgraph.graph.message import add_messages
+from typing_extensions import TypedDict
+
+from backend.services.visitor_identification_service import VisitorIdentificationService
+from backend.utils import purpose_classifier as purpose_classifier_module
+from backend.utils.reception_templates import (
+    get_personalized_greeting,
+    get_purpose_followup,
+    get_purpose_hearing_prompt,
+    get_reception_response,
+)
+
+logger = logging.getLogger(__name__)
+
+# Purpose category to target agent mapping
+_PURPOSE_AGENT_MAPPING: dict[str, str] = {
+    "facility_use": "facility",
+    "event_participation": "event",
+    "tour": "slide",
+    "consultation": "general_knowledge",
+    "other": "general_knowledge",
+}
+
+
+# =============================================================================
+# State Definition
+# =============================================================================
+
+
+class ReceptionState(TypedDict):
+    """State for the autonomous reception LangGraph workflow.
+
+    Attributes:
+        session_id: Conversation session identifier.
+        reception_session_id: Reception-specific session ID (UUID).
+        messages: Accumulated conversation messages (append-only).
+        visitor_identity: Serialized VisitorIdentity dict, or None.
+        purpose: Serialized VisitPurpose dict, or None.
+        stage: Current ReceptionStage string.
+        language: Language code ("ja" or "en").
+        trigger_type: How this reception was initiated.
+        greeting: The greeting text sent to the visitor, or None.
+        response: The most recent response text, or None.
+    """
+
+    session_id: str
+    reception_session_id: str
+    messages: Annotated[list[BaseMessage], add_messages]
+    visitor_identity: Optional[dict]
+    purpose: Optional[dict]
+    stage: str
+    language: str
+    trigger_type: str
+    greeting: Optional[str]
+    response: Optional[str]
+
+
+# =============================================================================
+# Node implementations
+# =============================================================================
+
+
+async def greet_visitor(state: ReceptionState) -> dict:
+    """Identify the visitor and generate an appropriate greeting.
+
+    Uses VisitorIdentificationService to check whether the visitor is
+    returning (via visitor_id or NFC). Generates a personalized greeting
+    for returning visitors or a standard first-visit greeting for new ones.
+
+    Args:
+        state: Current reception state.
+
+    Returns:
+        State update dict with visitor_identity, greeting, response,
+        stage, and messages fields populated.
+    """
+    language = state.get("language", "ja")
+    session_id = state.get("session_id", "")
+    trigger_type = state.get("trigger_type", "button_press")
+
+    identity_service = VisitorIdentificationService()
+    identity_dict: Optional[dict] = None
+
+    # Try to identify by visitor_id carried in trigger metadata
+    if trigger_type == "nfc":
+        # NFC identification not implemented in this path; falls through to new visitor
+        pass
+    else:
+        # Attempt visitor_id lookup (frontend-persisted UUID in session_id)
+        try:
+            result = await identity_service.identify_by_visitor_id(session_id)
+            if result:
+                identity_dict = result
+        except Exception as exc:
+            logger.warning("Visitor ID lookup failed: %s", exc)
+
+    is_returning = identity_dict is not None and identity_dict.get("visitor_type") == "returning"
+
+    # Generate greeting text
+    if is_returning and identity_dict and identity_dict.get("name"):
+        result = get_personalized_greeting(
+            language=language,
+            name=identity_dict["name"],
+            last_purpose=identity_dict.get("last_purpose"),
+        )
+        greeting_text = result.text
+    else:
+        result = get_reception_response(language=language, is_returning=is_returning)
+        greeting_text = result.text
+
+    greeting_message = AIMessage(content=greeting_text)
+
+    return {
+        "visitor_identity": identity_dict,
+        "stage": "greeting",
+        "greeting": greeting_text,
+        "response": greeting_text,
+        "messages": [greeting_message],
+    }
+
+
+async def hear_purpose(state: ReceptionState) -> dict:
+    """Send the purpose-hearing prompt to the visitor.
+
+    Advances the stage to purpose_hearing and emits the prompt asking
+    the visitor what brings them to Engineer Cafe today.
+
+    Args:
+        state: Current reception state.
+
+    Returns:
+        State update dict with the purpose-hearing prompt as the response.
+    """
+    language = state.get("language", "ja")
+    result = get_purpose_hearing_prompt(language=language)
+    prompt_message = AIMessage(content=result.text)
+
+    return {
+        "stage": "purpose_hearing",
+        "response": result.text,
+        "messages": [prompt_message],
+    }
+
+
+async def classify_purpose(state: ReceptionState) -> dict:
+    """Classify the visitor's purpose from their last message.
+
+    Reads the most recent human message from the conversation and runs it
+    through the purpose classifier. Stores the result in the state.
+
+    Args:
+        state: Current reception state containing the visitor's response.
+
+    Returns:
+        State update dict with purpose dict and stage set to "routing".
+    """
+    language = state.get("language", "ja")
+    messages = state.get("messages", [])
+
+    # Find the most recent human message
+    user_response = ""
+    for msg in reversed(messages):
+        if hasattr(msg, "type") and msg.type == "human":
+            user_response = msg.content
+            break
+        if hasattr(msg, "__class__") and msg.__class__.__name__ == "HumanMessage":
+            user_response = msg.content
+            break
+
+    if not user_response:
+        logger.warning("No human message found for purpose classification; defaulting to 'other'")
+        purpose_dict = {"category": "other", "detail": None, "confidence": 0.3}
+        return {"purpose": purpose_dict, "stage": "routing"}
+
+    try:
+        category, detail, confidence = await purpose_classifier_module.classify_purpose(
+            query=user_response,
+            language=language,
+        )
+    except Exception as exc:
+        logger.warning("Purpose classification failed: %s", exc)
+        category, detail, confidence = "other", None, 0.3
+
+    purpose_dict = {
+        "category": category,
+        "detail": detail,
+        "confidence": confidence,
+    }
+
+    return {
+        "purpose": purpose_dict,
+        "stage": "routing",
+    }
+
+
+async def route_to_agent(state: ReceptionState) -> dict:
+    """Route the visitor to the appropriate agent or generate a follow-up.
+
+    Based on the classified purpose category, determines which downstream
+    agent should handle the visitor's request. Emits a follow-up response
+    message and marks the stage as completed.
+
+    Args:
+        state: Current reception state with purpose populated.
+
+    Returns:
+        State update dict with response, stage, and messages updated.
+    """
+    language = state.get("language", "ja")
+    purpose_dict = state.get("purpose") or {}
+    category = purpose_dict.get("category", "other")
+
+    target_agent = _PURPOSE_AGENT_MAPPING.get(category, "general_knowledge")
+    followup_result = get_purpose_followup(language=language, purpose=category)
+    followup_message = AIMessage(content=followup_result.text)
+
+    logger.info(
+        "Routing visitor to agent '%s' for purpose '%s'",
+        target_agent,
+        category,
+    )
+
+    # Update purpose dict with routing information (immutable pattern)
+    updated_purpose = {**purpose_dict, "target_agent": target_agent}
+
+    return {
+        "purpose": updated_purpose,
+        "stage": "completed",
+        "response": followup_result.text,
+        "messages": [followup_message],
+    }
+
+
+# =============================================================================
+# Conditional edge: should we ask for purpose?
+# =============================================================================
+
+
+def _should_hear_purpose(state: ReceptionState) -> str:
+    """Determine if we need to ask the visitor about their purpose.
+
+    Returns "hear_purpose" when the purpose has not yet been identified,
+    "classify_purpose" when the visitor has already provided their purpose
+    (e.g. if routed back after a human message).
+
+    Args:
+        state: Current reception state.
+
+    Returns:
+        Node name to transition to.
+    """
+    if state.get("purpose") is None:
+        return "hear_purpose"
+    return "classify_purpose"
+
+
+# =============================================================================
+# Graph factory
+# =============================================================================
+
+
+async def get_reception_workflow() -> StateGraph:
+    """Build and compile the ReceptionWorkflow StateGraph.
+
+    Constructs the full LangGraph with nodes and edges for the autonomous
+    reception flow. The returned graph is compiled and ready to invoke.
+
+    Returns:
+        A compiled LangGraph StateGraph for the reception flow.
+    """
+    workflow = StateGraph(ReceptionState)
+
+    # Register nodes
+    workflow.add_node("greet_visitor", greet_visitor)
+    workflow.add_node("hear_purpose", hear_purpose)
+    workflow.add_node("classify_purpose", classify_purpose)
+    workflow.add_node("route_to_agent", route_to_agent)
+
+    # Entry point
+    workflow.add_edge(START, "greet_visitor")
+
+    # After greeting: ask for purpose if not yet known
+    workflow.add_conditional_edges(
+        "greet_visitor",
+        _should_hear_purpose,
+        {
+            "hear_purpose": "hear_purpose",
+            "classify_purpose": "classify_purpose",
+        },
+    )
+
+    # After purpose prompt: wait for user response (ends turn)
+    # In a real multi-turn setup the human response triggers classify_purpose.
+    # In this single-graph representation we wire hear_purpose -> classify_purpose
+    # so tests can drive the full flow end-to-end.
+    workflow.add_edge("hear_purpose", "classify_purpose")
+
+    # Classification -> routing
+    workflow.add_edge("classify_purpose", "route_to_agent")
+
+    # Routing -> end
+    workflow.add_edge("route_to_agent", END)
+
+    return workflow.compile()
+
+
+# =============================================================================
+# Helper: initial state factory
+# =============================================================================
+
+
+def make_initial_state(
+    session_id: str = "",
+    language: str = "ja",
+    trigger_type: str = "button_press",
+    messages: Optional[list[BaseMessage]] = None,
+) -> ReceptionState:
+    """Create a fully initialised ReceptionState for a new reception session.
+
+    Args:
+        session_id: Conversation session identifier.
+        language: Interaction language ("ja" or "en").
+        trigger_type: How the reception was triggered.
+        messages: Pre-existing messages (e.g. from a prior turn).
+
+    Returns:
+        A ReceptionState TypedDict ready to pass to the compiled graph.
+    """
+    return ReceptionState(
+        session_id=session_id,
+        reception_session_id=str(uuid.uuid4()),
+        messages=messages or [],
+        visitor_identity=None,
+        purpose=None,
+        stage="initiated",
+        language=language,
+        trigger_type=trigger_type,
+        greeting=None,
+        response=None,
+    )


### PR DESCRIPTION
## Summary
- DDD domain models: frozen dataclass value objects (VisitorType, VisitPurpose, VisitorIdentity) + ReceptionSession aggregate root with state machine
- LangGraph ReceptionWorkflow StateGraph (greet → hear_purpose → classify → route)
- FastAPI Reception API (POST /start, POST /respond, GET /status) with in-memory bounded session store
- Purpose classifier (keyword fast-path + LLM fallback via OpenRouter)
- Multilingual templates (ja/en/zh/ko) with backward-compatible legacy API
- Discord escalation handler for staff notifications
- Supabase migrations + optimized RLS policies
- Visitor identification service (NFC/visitor_id lookup)

## Architecture
- **Domain Layer**: `backend/domain/reception/` — models, events, repository interfaces, domain service
- **Infrastructure**: `backend/infrastructure/reception_repository.py` — Supabase implementations
- **API**: `backend/api/reception.py` — FastAPI router with Pydantic validation
- **Workflow**: `backend/workflows/reception_workflow.py` — LangGraph StateGraph (separate from MainWorkflow)
- **Utils**: purpose_classifier, reception_templates, discord_escalation, supabase_helper

## Security & Quality
- Pydantic Field constraints (min/max length, Literal types) on all request models
- Session ID verification to prevent IDOR
- Bounded OrderedDict with LRU eviction (max 1000 sessions)
- State machine enforced via `advance_to()` — no direct stage mutation
- str.format() input sanitization
- Escalation allowed from all active stages via state machine

## Test Plan
- [x] 150 reception-related tests passing (API 16, Domain 56, Templates 51, Workflow 27)
- [x] Ruff lint: zero errors
- [x] Internal code review: 0 CRITICAL, 0 HIGH remaining
- [x] Codex MCP second opinion review: 0 CRITICAL, HIGH addressed

## Review Notes
- Wave 3 (purpose flow implementations) and Wave 4 (comprehensive E2E tests) are planned as follow-up PRs
- `get_reception_response()` dual return type (dict vs ReceptionResult) is intentional for backward compatibility with MainWorkflow

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>