### PR TITLE
feat(backend): reception handoff bridge + completion endpoint (#117)

### DIFF
--- a/backend/api/reception.py
+++ b/backend/api/reception.py
@@ -1,7 +1,7 @@
 """Reception API endpoints.
 
 FastAPI router for the autonomous reception flow.
-Handles session lifecycle: start -> respond -> status.
+Handles session lifecycle: start -> respond -> complete -> status.
 """
 
 from __future__ import annotations
@@ -26,6 +26,23 @@ from backend.utils.reception_templates import (
 )
 
 logger = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Lazy singleton for handoff service
+# ---------------------------------------------------------------------------
+
+_handoff_service: Optional["ReceptionHandoffService"] = None  # noqa: F821
+
+
+def _get_handoff_service() -> "ReceptionHandoffService":  # noqa: F821
+    """Return a module-level singleton, created on first use."""
+    global _handoff_service
+    if _handoff_service is None:
+        from backend.services.reception_handoff_service import ReceptionHandoffService
+
+        _handoff_service = ReceptionHandoffService()
+    return _handoff_service
+
 
 # ---------------------------------------------------------------------------
 # Router
@@ -131,6 +148,20 @@ class ReceptionRespondResponse(BaseModel):
     stage: str
     purpose: Optional[dict] = None
     next_action: Optional[str] = None
+
+
+class ReceptionCompleteRequest(BaseModel):
+    session_id: str = Field(min_length=1, max_length=128)
+    reception_session_id: str = Field(min_length=1, max_length=128)
+
+
+class ReceptionCompleteResponse(BaseModel):
+    response_text: str
+    target_agent: str
+    requires_staff: bool
+    purpose_category: str
+    action_type: str
+    action_data: Optional[dict] = None
 
 
 class ReceptionStatusResponse(BaseModel):
@@ -246,8 +277,70 @@ async def respond_reception(request: ReceptionRespondRequest) -> ReceptionRespon
     )
 
 
+@reception_router.post("/complete", response_model=ReceptionCompleteResponse)
+async def complete_reception(
+    request: ReceptionCompleteRequest,
+) -> ReceptionCompleteResponse:
+    """Complete the reception flow and prepare handoff to MainWorkflow.
+
+    Called when the session is in the 'routing' stage. Runs purpose-specific
+    preprocessing and returns the workflow state for MainWorkflow invocation.
+    """
+    session = _active_sessions.get(request.reception_session_id)
+    if session is None:
+        raise HTTPException(
+            status_code=404,
+            detail=(f"Reception session not found: " f"{request.reception_session_id}"),
+        )
+    _active_sessions.move_to_end(request.reception_session_id)
+
+    if session.session_id != request.session_id:
+        raise HTTPException(
+            status_code=403,
+            detail="Session ID mismatch",
+        )
+
+    if session.stage != "routing":
+        raise HTTPException(
+            status_code=409,
+            detail=(
+                f"Session must be in 'routing' stage to complete, "
+                f"current stage: {session.stage}"
+            ),
+        )
+
+    # Advance stage BEFORE async work to prevent duplicate processing
+    # from concurrent requests (race condition guard).
+    session.advance_to("completed")
+
+    handoff_service = _get_handoff_service()
+    try:
+        result = await handoff_service.prepare_handoff(session)
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+
+    logger.info(
+        "Reception completed: id=%s target=%s requires_staff=%s",
+        session.id,
+        result.target_agent,
+        result.requires_staff,
+    )
+
+    return ReceptionCompleteResponse(
+        response_text=result.purpose_flow.response_text,
+        target_agent=result.target_agent,
+        requires_staff=result.requires_staff,
+        purpose_category=session.purpose.category,
+        action_type=result.purpose_flow.action_type,
+        action_data=result.purpose_flow.action_data,
+    )
+
+
 @reception_router.get("/status/{reception_session_id}", response_model=ReceptionStatusResponse)
-async def get_reception_status(reception_session_id: str) -> ReceptionStatusResponse:
+async def get_reception_status(
+    reception_session_id: str,
+    session_id: str = "",
+) -> ReceptionStatusResponse:
     """Return the current state of a reception session."""
     session = _active_sessions.get(reception_session_id)
     if session is None:
@@ -256,6 +349,12 @@ async def get_reception_status(reception_session_id: str) -> ReceptionStatusResp
             detail=f"Reception session not found: {reception_session_id}",
         )
     _active_sessions.move_to_end(reception_session_id)
+
+    if session_id and session.session_id != session_id:
+        raise HTTPException(
+            status_code=403,
+            detail="Session ID mismatch",
+        )
 
     visitor_type: Optional[str] = None
     purpose_str: Optional[str] = None

--- a/backend/services/purpose_flow_service.py
+++ b/backend/services/purpose_flow_service.py
@@ -1,0 +1,443 @@
+"""Purpose-specific flow handlers for the reception workflow."""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from datetime import date, datetime
+from typing import Any, Awaitable, Callable, Mapping, Optional
+from zoneinfo import ZoneInfo
+
+from backend.domain.reception.models import VisitPurpose, VisitorIdentity
+from backend.domain.reception.service import ReceptionDomainService
+from backend.utils.discord_escalation import send_escalation_notification
+from backend.utils.supabase_helper import get_supabase_client
+
+logger = logging.getLogger(__name__)
+
+SupportedLanguage = str
+EscalationNotifier = Callable[[str, str, Optional[str], str], Awaitable[bool]]
+
+_SUPPORTED_LANGUAGES = {"ja", "en", "zh", "ko"}
+_JST = ZoneInfo("Asia/Tokyo")
+_EVENT_DATE_KEYS = ("event_date", "date", "start_date", "starts_on")
+_EVENT_DATETIME_KEYS = ("start_at", "starts_at", "start_time", "starts_on", "datetime")
+
+_TEXT_TEMPLATES: dict[str, Mapping[str, Mapping[str, str]]] = {
+    "facility_use": {
+        "ja": {
+            "new": (
+                "エンジニアカフェの施設利用ですね。"
+                "利用方法をご案内しますので、そのままお待ちください。"
+            ),
+            "returning": (
+                "本日も施設利用ですね。" "利用方法をご案内しますので、そのままお待ちください。"
+            ),
+        },
+        "en": {
+            "new": (
+                "You're here to use the facility. "
+                "I'll guide you through the usage information shortly."
+            ),
+            "returning": (
+                "You're here to use the facility again today. "
+                "I'll guide you through the usage information shortly."
+            ),
+        },
+        "zh": {
+            "new": "您今天是来使用馆内设施的。我将为您说明使用方法，请稍候。",
+            "returning": "您今天也是来使用馆内设施的。我将为您说明使用方法，请稍候。",
+        },
+        "ko": {
+            "new": (
+                "시설 이용을 원하시는군요. " "이용 방법을 안내해 드릴 테니 잠시만 기다려 주세요."
+            ),
+            "returning": (
+                "오늘도 시설 이용이시군요. " "이용 방법을 안내해 드릴 테니 잠시만 기다려 주세요."
+            ),
+        },
+    },
+    "event_participation": {
+        "ja": {
+            "with_events": "本日のイベント参加ですね。確認できたイベントをご案内します。",
+            "without_events": (
+                "本日のイベント参加ですね。"
+                "受付で確認できるイベント情報がないため、担当案内へおつなぎします。"
+            ),
+            "fallback": "本日のイベント情報を確認できませんでした。担当案内へおつなぎします。",
+        },
+        "en": {
+            "with_events": (
+                "You're here for an event today. " "I'll share the events I found for today."
+            ),
+            "without_events": (
+                "You're here for an event today. "
+                "I couldn't find a confirmed event listing, so I'll hand you over for assistance."
+            ),
+            "fallback": (
+                "I couldn't check today's event listing right now, "
+                "so I'll hand you over for assistance."
+            ),
+        },
+        "zh": {
+            "with_events": "您今天是来参加活动的。我来为您说明今天确认到的活动。",
+            "without_events": (
+                "您今天是来参加活动的。" "目前没有查到可确认的活动信息，我将为您转接进一步协助。"
+            ),
+            "fallback": "我暂时无法确认今天的活动信息，我将为您转接进一步协助。",
+        },
+        "ko": {
+            "with_events": (
+                "오늘 행사 참여로 방문하셨군요. " "확인된 오늘의 행사를 안내해 드리겠습니다."
+            ),
+            "without_events": (
+                "오늘 행사 참여로 방문하셨군요. "
+                "확인된 행사 정보가 없어 추가 안내로 연결하겠습니다."
+            ),
+            "fallback": "현재 오늘 행사 정보를 확인할 수 없어 추가 안내로 연결하겠습니다.",
+        },
+    },
+    "tour": {
+        "ja": {
+            "default": "館内ツアーですね。ツアー案内におつなぎします。",
+        },
+        "en": {
+            "default": "You're here for a tour. I'll hand you over to the tour guidance flow.",
+        },
+        "zh": {
+            "default": "您今天是来参加参观导览的。我将为您转接到导览流程。",
+        },
+        "ko": {
+            "default": "투어 방문이시군요. 투어 안내 흐름으로 연결하겠습니다.",
+        },
+    },
+    "consultation": {
+        "ja": {
+            "notified": "ご相談ですね。スタッフへお知らせしましたので、そのままお待ちください。",
+            "fallback": (
+                "ご相談ですね。" "スタッフ呼び出しを進めていますので、そのままお待ちください。"
+            ),
+        },
+        "en": {
+            "notified": "You'd like a consultation. I've notified the staff, so please wait here.",
+            "fallback": (
+                "You'd like a consultation. "
+                "I'm arranging staff assistance now, so please wait here."
+            ),
+        },
+        "zh": {
+            "notified": "您希望进行咨询。我已通知工作人员，请稍候。",
+            "fallback": "您希望进行咨询。我正在安排工作人员协助，请稍候。",
+        },
+        "ko": {
+            "notified": "상담을 원하시는군요. 직원을 호출했으니 잠시만 기다려 주세요.",
+            "fallback": "상담을 원하시는군요. 직원 연결을 진행하고 있으니 잠시만 기다려 주세요.",
+        },
+    },
+    "other": {
+        "ja": {
+            "default": "ご用件を確認しました。適切な案内へおつなぎします。",
+        },
+        "en": {
+            "default": "I understood your purpose. I'll hand you over to the appropriate guidance.",
+        },
+        "zh": {
+            "default": "我已确认您的来访目的。我将为您转接到合适的服务。",
+        },
+        "ko": {
+            "default": "방문 목적을 확인했습니다. 적절한 안내로 연결하겠습니다.",
+        },
+    },
+}
+
+
+@dataclass(frozen=True)
+class PurposeFlowResult:
+    """Outcome returned by a purpose-specific flow handler."""
+
+    response_text: str
+    target_agent: str
+    action_type: str
+    action_data: Optional[dict[str, Any]]
+    requires_staff: bool
+
+
+class PurposeFlowService:
+    """Resolve visit-purpose specific handling before agent handoff."""
+
+    def __init__(
+        self,
+        domain_service: Optional[ReceptionDomainService] = None,
+        supabase_client: Any = None,
+        escalation_notifier: Optional[EscalationNotifier] = None,
+    ) -> None:
+        self._domain_service = domain_service or ReceptionDomainService()
+        self._supabase = supabase_client
+        self._escalation_notifier = escalation_notifier or send_escalation_notification
+
+    async def resolve(
+        self,
+        purpose: VisitPurpose,
+        language: str,
+        session_id: str,
+        visitor_identity: VisitorIdentity,
+    ) -> PurposeFlowResult:
+        """Dispatch to the appropriate purpose handler."""
+        handlers = {
+            "facility_use": self.handle_facility_use,
+            "event_participation": self.handle_event_participation,
+            "tour": self.handle_tour,
+            "consultation": self.handle_consultation,
+            "other": self.handle_other,
+        }
+        handler = handlers.get(purpose.category, self.handle_other)
+        if purpose.category == "consultation":
+            return await handler(language, session_id, visitor_identity)
+        return await handler(language, visitor_identity)
+
+    async def handle_facility_use(
+        self,
+        language: str,
+        visitor_identity: VisitorIdentity,
+    ) -> PurposeFlowResult:
+        """Handle visitors who want to use the facility."""
+        normalized_language = self._normalize_language(language)
+        visitor_key = self._visitor_key(visitor_identity)
+        target_agent = self._map_target_agent("facility_use")
+        response_text = self._text("facility_use", normalized_language, visitor_key)
+
+        return PurposeFlowResult(
+            response_text=response_text,
+            target_agent=target_agent,
+            action_type="guide",
+            action_data={
+                "purpose_category": "facility_use",
+                "visitor_type": visitor_identity.visitor_type.value,
+            },
+            requires_staff=False,
+        )
+
+    async def handle_event_participation(
+        self,
+        language: str,
+        visitor_identity: VisitorIdentity,
+    ) -> PurposeFlowResult:
+        """Handle visitors attending an event, enriching with today's events."""
+        normalized_language = self._normalize_language(language)
+        target_agent = self._map_target_agent("event_participation")
+
+        try:
+            events = await self._fetch_today_events()
+        except Exception as exc:
+            logger.warning("Failed to fetch today events: %s", exc)
+            return PurposeFlowResult(
+                response_text=self._text("event_participation", normalized_language, "fallback"),
+                target_agent=target_agent,
+                action_type="lookup",
+                action_data={"events": [], "lookup_failed": True},
+                requires_staff=False,
+            )
+
+        if events:
+            return PurposeFlowResult(
+                response_text=self._text("event_participation", normalized_language, "with_events"),
+                target_agent=target_agent,
+                action_type="lookup",
+                action_data={"events": events, "event_count": len(events)},
+                requires_staff=False,
+            )
+
+        return PurposeFlowResult(
+            response_text=self._text("event_participation", normalized_language, "without_events"),
+            target_agent=target_agent,
+            action_type="lookup",
+            action_data={"events": [], "event_count": 0},
+            requires_staff=False,
+        )
+
+    async def handle_tour(
+        self,
+        language: str,
+        visitor_identity: VisitorIdentity,
+    ) -> PurposeFlowResult:
+        """Handle visitors requesting a tour."""
+        normalized_language = self._normalize_language(language)
+        return PurposeFlowResult(
+            response_text=self._text("tour", normalized_language, "default"),
+            target_agent=self._map_target_agent("tour"),
+            action_type="handoff",
+            action_data={"purpose_category": "tour"},
+            requires_staff=False,
+        )
+
+    async def handle_consultation(
+        self,
+        language: str,
+        session_id: str,
+        visitor_identity: VisitorIdentity,
+    ) -> PurposeFlowResult:
+        """Handle consultations by escalating to staff and notifying Discord."""
+        normalized_language = self._normalize_language(language)
+        target_agent = self._map_target_agent("consultation")
+        reason = self._consultation_reason(normalized_language)
+
+        notified = False
+        try:
+            notified = bool(
+                await self._escalation_notifier(
+                    session_id,
+                    reason,
+                    visitor_identity.name,
+                    normalized_language,
+                )
+            )
+        except Exception as exc:
+            logger.warning("Failed to send consultation escalation: %s", exc)
+
+        template_key = "notified" if notified else "fallback"
+        return PurposeFlowResult(
+            response_text=self._text("consultation", normalized_language, template_key),
+            target_agent=target_agent,
+            action_type="escalate",
+            action_data={
+                "reason": reason,
+                "notification_sent": notified,
+                "session_id": session_id,
+            },
+            requires_staff=True,
+        )
+
+    async def handle_other(
+        self,
+        language: str,
+        visitor_identity: VisitorIdentity,
+    ) -> PurposeFlowResult:
+        """Handle uncategorized purposes with general guidance handoff."""
+        normalized_language = self._normalize_language(language)
+        return PurposeFlowResult(
+            response_text=self._text("other", normalized_language, "default"),
+            target_agent=self._map_target_agent("other"),
+            action_type="handoff",
+            action_data={"purpose_category": "other"},
+            requires_staff=False,
+        )
+
+    async def _fetch_today_events(self) -> list[dict[str, Any]]:
+        """Fetch and normalize today's events from Supabase."""
+        client = await self._get_supabase()
+        if not client:
+            return []
+
+        result = client.table("events").select("*").execute()
+        rows = result.data or []
+        today = datetime.now(_JST).date()
+
+        events = [
+            normalized
+            for row in rows
+            if isinstance(row, dict)
+            for normalized in [self._normalize_event(row)]
+            if normalized is not None and self._is_today_event(row, today)
+        ]
+        return sorted(
+            events,
+            key=lambda event: (
+                event["date"],
+                event.get("start_at") or "",
+                event["title"],
+            ),
+        )
+
+    async def _get_supabase(self) -> Any:
+        """Return the Supabase client, resolving lazily if needed."""
+        if self._supabase is not None:
+            return self._supabase
+        try:
+            return get_supabase_client()
+        except Exception as exc:
+            logger.warning("Supabase client unavailable in PurposeFlowService: %s", exc)
+            return None
+
+    def _normalize_language(self, language: str) -> SupportedLanguage:
+        return language if language in _SUPPORTED_LANGUAGES else "ja"
+
+    def _visitor_key(self, visitor_identity: VisitorIdentity) -> str:
+        return "returning" if visitor_identity.visitor_type.value == "returning" else "new"
+
+    def _map_target_agent(self, category: str) -> str:
+        return self._domain_service.map_purpose_to_agent(VisitPurpose(category=category))
+
+    def _text(self, category: str, language: str, key: str) -> str:
+        category_templates = _TEXT_TEMPLATES[category]
+        language_templates = category_templates.get(language, category_templates["ja"])
+        return language_templates[key]
+
+    def _consultation_reason(self, language: str) -> str:
+        reasons = {
+            "ja": "来訪者が相談対応を希望",
+            "en": "Visitor requested consultation support",
+            "zh": "来访者希望获得咨询支持",
+            "ko": "방문자가 상담 지원을 요청함",
+        }
+        return reasons[language]
+
+    def _is_today_event(self, row: Mapping[str, Any], today: date) -> bool:
+        event_date = self._extract_event_date(row)
+        return event_date == today
+
+    def _extract_event_date(self, row: Mapping[str, Any]) -> Optional[date]:
+        for key in _EVENT_DATE_KEYS:
+            value = row.get(key)
+            parsed = self._parse_date_like(value)
+            if parsed is not None:
+                return parsed
+
+        for key in _EVENT_DATETIME_KEYS:
+            value = row.get(key)
+            parsed = self._parse_datetime_like(value)
+            if parsed is not None:
+                return parsed.date()
+
+        return None
+
+    def _parse_date_like(self, value: Any) -> Optional[date]:
+        if isinstance(value, datetime):
+            return value.astimezone(_JST).date() if value.tzinfo else value.date()
+        if isinstance(value, date):
+            return value
+        if not isinstance(value, str) or not value:
+            return None
+
+        candidate = value.strip()
+        try:
+            return date.fromisoformat(candidate[:10])
+        except ValueError:
+            return None
+
+    def _parse_datetime_like(self, value: Any) -> Optional[datetime]:
+        if isinstance(value, datetime):
+            return value.astimezone(_JST) if value.tzinfo else value.replace(tzinfo=_JST)
+        if not isinstance(value, str) or not value:
+            return None
+
+        candidate = value.strip().replace("Z", "+00:00")
+        try:
+            parsed = datetime.fromisoformat(candidate)
+        except ValueError:
+            return None
+
+        return parsed.astimezone(_JST) if parsed.tzinfo else parsed.replace(tzinfo=_JST)
+
+    def _normalize_event(self, row: Mapping[str, Any]) -> Optional[dict[str, Any]]:
+        title = row.get("title") or row.get("name")
+        event_date = self._extract_event_date(row)
+        if not title or event_date is None:
+            return None
+
+        return {
+            "id": row.get("id"),
+            "title": title,
+            "date": event_date.isoformat(),
+            "location": row.get("location") or row.get("venue"),
+            "start_at": row.get("start_at") or row.get("starts_at") or row.get("start_time"),
+        }

--- a/backend/services/purpose_flow_service.py
+++ b/backend/services/purpose_flow_service.py
@@ -191,13 +191,12 @@ class PurposeFlowService:
             "other": self.handle_other,
         }
         handler = handlers.get(purpose.category, self.handle_other)
-        if purpose.category == "consultation":
-            return await handler(language, session_id, visitor_identity)
-        return await handler(language, visitor_identity)
+        return await handler(language, session_id, visitor_identity)
 
     async def handle_facility_use(
         self,
         language: str,
+        session_id: str,
         visitor_identity: VisitorIdentity,
     ) -> PurposeFlowResult:
         """Handle visitors who want to use the facility."""
@@ -220,6 +219,7 @@ class PurposeFlowService:
     async def handle_event_participation(
         self,
         language: str,
+        session_id: str,
         visitor_identity: VisitorIdentity,
     ) -> PurposeFlowResult:
         """Handle visitors attending an event, enriching with today's events."""
@@ -258,6 +258,7 @@ class PurposeFlowService:
     async def handle_tour(
         self,
         language: str,
+        session_id: str,
         visitor_identity: VisitorIdentity,
     ) -> PurposeFlowResult:
         """Handle visitors requesting a tour."""
@@ -310,6 +311,7 @@ class PurposeFlowService:
     async def handle_other(
         self,
         language: str,
+        session_id: str,
         visitor_identity: VisitorIdentity,
     ) -> PurposeFlowResult:
         """Handle uncategorized purposes with general guidance handoff."""
@@ -328,7 +330,7 @@ class PurposeFlowService:
         if not client:
             return []
 
-        result = client.table("events").select("*").execute()
+        result = client.table("events").select("*").limit(200).execute()
         rows = result.data or []
         today = datetime.now(_JST).date()
 
@@ -379,7 +381,7 @@ class PurposeFlowService:
             "zh": "来访者希望获得咨询支持",
             "ko": "방문자가 상담 지원을 요청함",
         }
-        return reasons[language]
+        return reasons.get(language, reasons["ja"])
 
     def _is_today_event(self, row: Mapping[str, Any], today: date) -> bool:
         event_date = self._extract_event_date(row)

--- a/backend/services/reception_handoff_service.py
+++ b/backend/services/reception_handoff_service.py
@@ -1,0 +1,193 @@
+"""Bridge between ReceptionWorkflow and MainWorkflow.
+
+Transforms a completed ReceptionSession into the state dict expected by
+MainWorkflow, optionally enriched by PurposeFlowService preprocessing.
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from typing import Any, Optional
+
+from backend.domain.reception.models import ReceptionSession, VisitPurpose, VisitorIdentity
+from backend.services.purpose_flow_service import PurposeFlowResult, PurposeFlowService
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True)
+class HandoffResult:
+    """Result of preparing a reception-to-main-workflow handoff.
+
+    Attributes:
+        workflow_state: Dict compatible with WorkflowStateDict for MainWorkflow.
+        target_agent: The MainWorkflow agent node to route to.
+        purpose_flow: The PurposeFlowResult from purpose-specific preprocessing.
+        requires_staff: Whether the visitor needs staff escalation.
+    """
+
+    workflow_state: dict[str, Any]
+    target_agent: str
+    purpose_flow: PurposeFlowResult
+    requires_staff: bool
+
+
+class ReceptionHandoffService:
+    """Prepare the handoff from ReceptionWorkflow to MainWorkflow.
+
+    This service is a pure transformer: it takes a completed ReceptionSession,
+    runs purpose-specific preprocessing via PurposeFlowService, and builds
+    the WorkflowStateDict that MainWorkflow expects.
+    """
+
+    def __init__(
+        self,
+        purpose_flow_service: Optional[PurposeFlowService] = None,
+    ) -> None:
+        self._purpose_flow = purpose_flow_service or PurposeFlowService()
+
+    async def prepare_handoff(
+        self,
+        session: ReceptionSession,
+    ) -> HandoffResult:
+        """Transform a completed ReceptionSession into a MainWorkflow state.
+
+        Args:
+            session: A ReceptionSession that has reached the 'routing' or
+                'completed' stage with purpose and visitor_identity set.
+
+        Returns:
+            A HandoffResult containing the workflow state dict and routing info.
+
+        Raises:
+            ValueError: If the session is missing purpose or visitor_identity.
+        """
+        if session.purpose is None:
+            raise ValueError(f"Cannot hand off session {session.id}: purpose not set")
+        if session.visitor_identity is None:
+            raise ValueError(f"Cannot hand off session {session.id}: visitor_identity not set")
+
+        purpose: VisitPurpose = session.purpose
+        identity: VisitorIdentity = session.visitor_identity
+
+        # Run purpose-specific preprocessing
+        purpose_flow_result = await self._purpose_flow.resolve(
+            purpose=purpose,
+            language=session.language,
+            session_id=session.session_id,
+            visitor_identity=identity,
+        )
+
+        # Use the target agent from PurposeFlowService (single source of truth)
+        target_agent = purpose_flow_result.target_agent
+
+        # Build the WorkflowStateDict-compatible state
+        workflow_state = self._build_workflow_state(
+            session=session,
+            purpose=purpose,
+            identity=identity,
+            purpose_flow_result=purpose_flow_result,
+            target_agent=target_agent,
+        )
+
+        logger.info(
+            "Handoff prepared: session=%s purpose=%s target=%s requires_staff=%s",
+            session.id,
+            purpose.category,
+            target_agent,
+            purpose_flow_result.requires_staff,
+        )
+
+        return HandoffResult(
+            workflow_state=workflow_state,
+            target_agent=target_agent,
+            purpose_flow=purpose_flow_result,
+            requires_staff=purpose_flow_result.requires_staff,
+        )
+
+    def _build_workflow_state(
+        self,
+        session: ReceptionSession,
+        purpose: VisitPurpose,
+        identity: VisitorIdentity,
+        purpose_flow_result: PurposeFlowResult,
+        target_agent: str,
+    ) -> dict[str, Any]:
+        """Build a dict compatible with WorkflowStateDict."""
+        # Construct query from purpose detail or a synthetic description
+        query = purpose.detail or self._synthetic_query(purpose, session.language)
+
+        return {
+            "messages": [],
+            "query": query,
+            "session_id": session.session_id,
+            "language": session.language,
+            "routing": {
+                "agent": target_agent,
+                "category": purpose.category,
+                "request_type": purpose_flow_result.action_type,
+                "confidence": 1.0,
+                "reasoning": "Routed from autonomous reception flow",
+                "debug_info": {},
+            },
+            "answer": None,
+            "emotion": None,
+            "metadata": {
+                "reception_session_id": session.id,
+                "reception_handoff": True,
+                "visitor_type": identity.visitor_type.value,
+                "purpose_category": purpose.category,
+                "purpose_detail": purpose.detail,
+                "purpose_flow_action": purpose_flow_result.action_type,
+                "purpose_flow_data": purpose_flow_result.action_data,
+                "requires_staff": purpose_flow_result.requires_staff,
+            },
+            "context": {
+                "reception_context": {
+                    "visitor_name": identity.name,
+                    "visitor_type": identity.visitor_type.value,
+                    "visit_count": identity.visit_count,
+                    "purpose_response_text": purpose_flow_result.response_text,
+                },
+            },
+            "image_data": None,
+            "ocr_result": None,
+        }
+
+    def _synthetic_query(self, purpose: VisitPurpose, language: str) -> str:
+        """Generate a synthetic query when no detail text is available."""
+        queries: dict[str, dict[str, str]] = {
+            "facility_use": {
+                "ja": "施設を利用したいです",
+                "en": "I'd like to use the facility",
+                "zh": "我想使用设施",
+                "ko": "시설을 이용하고 싶습니다",
+            },
+            "event_participation": {
+                "ja": "イベントに参加したいです",
+                "en": "I'd like to attend an event",
+                "zh": "我想参加活动",
+                "ko": "이벤트에 참가하고 싶습니다",
+            },
+            "tour": {
+                "ja": "館内ツアーをお願いします",
+                "en": "I'd like a facility tour",
+                "zh": "我想参观馆内",
+                "ko": "투어를 부탁드립니다",
+            },
+            "consultation": {
+                "ja": "相談したいことがあります",
+                "en": "I'd like to consult about something",
+                "zh": "我想咨询一些事情",
+                "ko": "상담하고 싶은 것이 있습니다",
+            },
+            "other": {
+                "ja": "用件があります",
+                "en": "I have a request",
+                "zh": "我有事要办",
+                "ko": "용건이 있습니다",
+            },
+        }
+        category_queries = queries.get(purpose.category, queries["other"])
+        return category_queries.get(language, category_queries["ja"])

--- a/backend/tests/api/test_reception_api.py
+++ b/backend/tests/api/test_reception_api.py
@@ -6,6 +6,10 @@ store is cleared between tests to ensure isolation.
 
 from __future__ import annotations
 
+from dataclasses import dataclass
+from typing import Any, Optional
+from unittest.mock import AsyncMock, patch
+
 import pytest
 from fastapi.testclient import TestClient
 
@@ -253,3 +257,121 @@ class TestReceptionStatus:
             response = client.get(f"/api/reception/status/{rid}")
             assert response.status_code == 200
             assert response.json()["stage"] == "greeting"
+
+
+# ===========================================================================
+# POST /api/reception/complete
+# ===========================================================================
+
+
+def _advance_to_routing(session_id: str = "sess-001") -> str:
+    """Start a session and advance it to the 'routing' stage.
+
+    Returns the reception_session_id.
+    """
+    start = _start_session(session_id=session_id)
+    rid = start["reception_session_id"]
+
+    # greeting -> purpose_hearing
+    client.post(
+        "/api/reception/respond",
+        json={"session_id": session_id, "reception_session_id": rid, "message": "hello"},
+    )
+    # purpose_hearing -> routing (facility keyword)
+    client.post(
+        "/api/reception/respond",
+        json={
+            "session_id": session_id,
+            "reception_session_id": rid,
+            "message": "I want to use the coworking space",
+        },
+    )
+    return rid
+
+
+@dataclass
+class _FakePurposeFlow:
+    response_text: str = "Welcome to the coworking area."
+    action_type: str = "guide"
+    action_data: Optional[dict[str, Any]] = None
+
+
+@dataclass
+class _FakeHandoffResult:
+    workflow_state: dict[str, Any] = None  # type: ignore[assignment]
+    target_agent: str = "facility_agent"
+    purpose_flow: _FakePurposeFlow = None  # type: ignore[assignment]
+    requires_staff: bool = False
+
+    def __post_init__(self) -> None:
+        if self.workflow_state is None:
+            self.workflow_state = {"step": "routed"}
+        if self.purpose_flow is None:
+            self.purpose_flow = _FakePurposeFlow()
+
+
+class TestCompleteReception:
+    def test_complete_returns_404_for_unknown_session(self):
+        response = client.post(
+            "/api/reception/complete",
+            json={
+                "session_id": "sess-001",
+                "reception_session_id": "does-not-exist",
+            },
+        )
+        assert response.status_code == 404
+
+    def test_complete_returns_403_on_session_id_mismatch(self):
+        rid = _advance_to_routing(session_id="sess-001")
+
+        response = client.post(
+            "/api/reception/complete",
+            json={
+                "session_id": "wrong-session-id",
+                "reception_session_id": rid,
+            },
+        )
+        assert response.status_code == 403
+
+    def test_complete_returns_409_when_not_in_routing_stage(self):
+        start = _start_session(session_id="sess-001")
+        rid = start["reception_session_id"]
+        # Session is in 'greeting' stage, not 'routing'
+
+        response = client.post(
+            "/api/reception/complete",
+            json={
+                "session_id": "sess-001",
+                "reception_session_id": rid,
+            },
+        )
+        assert response.status_code == 409
+
+    def test_complete_success_with_mocked_handoff(self):
+        rid = _advance_to_routing(session_id="sess-001")
+
+        fake_result = _FakeHandoffResult()
+        mock_service = AsyncMock()
+        mock_service.prepare_handoff.return_value = fake_result
+
+        with patch(
+            "backend.api.reception._get_handoff_service",
+            return_value=mock_service,
+        ):
+            response = client.post(
+                "/api/reception/complete",
+                json={
+                    "session_id": "sess-001",
+                    "reception_session_id": rid,
+                },
+            )
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["target_agent"] == "facility_agent"
+        assert data["requires_staff"] is False
+        assert data["response_text"] == "Welcome to the coworking area."
+        assert data["action_type"] == "guide"
+        assert data["purpose_category"] == "facility_use"
+        # workflow_state must NOT be in the response (PII leak fix)
+        assert "workflow_state" not in data

--- a/backend/tests/services/test_purpose_flow_service.py
+++ b/backend/tests/services/test_purpose_flow_service.py
@@ -1,0 +1,253 @@
+"""Tests for PurposeFlowService."""
+
+from __future__ import annotations
+
+from datetime import datetime
+from unittest.mock import AsyncMock, MagicMock, patch
+from zoneinfo import ZoneInfo
+
+import pytest
+
+from backend.domain.reception.models import VisitPurpose, VisitorIdentity, VisitorType
+from backend.services.purpose_flow_service import PurposeFlowResult, PurposeFlowService
+
+_JST = ZoneInfo("Asia/Tokyo")
+
+
+def _make_query_result(data=None) -> MagicMock:
+    result = MagicMock()
+    result.data = data or []
+    return result
+
+
+def _make_identity(visitor_type: str = "new", name: str | None = None) -> VisitorIdentity:
+    return VisitorIdentity(visitor_type=VisitorType(value=visitor_type), name=name)
+
+
+def _make_event_client(rows: list[dict]) -> MagicMock:
+    client = MagicMock()
+    builder = MagicMock()
+    builder.select.return_value = builder
+    builder.execute.return_value = _make_query_result(rows)
+    client.table.return_value = builder
+    return client
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("language", "expected_fragment"),
+    [
+        ("ja", "施設利用"),
+        ("en", "use the facility"),
+    ],
+)
+async def test_handle_facility_use_returns_guide_result(
+    language: str,
+    expected_fragment: str,
+) -> None:
+    service = PurposeFlowService()
+
+    result = await service.handle_facility_use(language, _make_identity())
+
+    assert isinstance(result, PurposeFlowResult)
+    assert expected_fragment in result.response_text
+    assert result.target_agent == "facility"
+    assert result.action_type == "guide"
+    assert result.requires_staff is False
+    assert result.action_data == {"purpose_category": "facility_use", "visitor_type": "new"}
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("language", "expected_fragment"),
+    [
+        ("ja", "確認できたイベント"),
+        ("en", "events I found for today"),
+    ],
+)
+async def test_handle_event_participation_returns_today_events(
+    language: str,
+    expected_fragment: str,
+) -> None:
+    today = datetime.now(_JST).date().isoformat()
+    rows = [
+        {"id": 1, "title": "Morning Meetup", "event_date": today, "location": "Main Hall"},
+        {"id": 2, "title": "Old Event", "event_date": "2026-01-01", "location": "B1"},
+    ]
+    service = PurposeFlowService(supabase_client=_make_event_client(rows))
+
+    result = await service.handle_event_participation(language, _make_identity("returning"))
+
+    assert expected_fragment in result.response_text
+    assert result.target_agent == "event"
+    assert result.action_type == "lookup"
+    assert result.requires_staff is False
+    assert result.action_data == {
+        "events": [
+            {
+                "id": 1,
+                "title": "Morning Meetup",
+                "date": today,
+                "location": "Main Hall",
+                "start_at": None,
+            }
+        ],
+        "event_count": 1,
+    }
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("language", "expected_fragment"),
+    [
+        ("ja", "受付で確認できるイベント情報がない"),
+        ("en", "couldn't find a confirmed event listing"),
+    ],
+)
+async def test_handle_event_participation_without_events_uses_default_message(
+    language: str,
+    expected_fragment: str,
+) -> None:
+    service = PurposeFlowService(supabase_client=_make_event_client([]))
+
+    result = await service.handle_event_participation(language, _make_identity())
+
+    assert expected_fragment in result.response_text
+    assert result.action_data == {"events": [], "event_count": 0}
+
+
+@pytest.mark.asyncio
+async def test_handle_event_participation_falls_back_on_supabase_error() -> None:
+    client = MagicMock()
+    builder = MagicMock()
+    builder.select.return_value = builder
+    builder.execute.side_effect = RuntimeError("supabase unavailable")
+    client.table.return_value = builder
+    service = PurposeFlowService(supabase_client=client)
+
+    result = await service.handle_event_participation("en", _make_identity())
+
+    assert "couldn't check today's event listing right now" in result.response_text
+    assert result.action_data == {"events": [], "lookup_failed": True}
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("language", "expected_fragment"),
+    [
+        ("ja", "ツアー案内"),
+        ("en", "tour guidance flow"),
+    ],
+)
+async def test_handle_tour_returns_handoff_result(
+    language: str,
+    expected_fragment: str,
+) -> None:
+    service = PurposeFlowService()
+
+    result = await service.handle_tour(language, _make_identity())
+
+    assert expected_fragment in result.response_text
+    assert result.target_agent == "slide"
+    assert result.action_type == "handoff"
+    assert result.requires_staff is False
+    assert result.action_data == {"purpose_category": "tour"}
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("language", "expected_fragment"),
+    [
+        ("ja", "スタッフへお知らせしました"),
+        ("en", "notified the staff"),
+    ],
+)
+async def test_handle_consultation_sends_discord_notification(
+    language: str,
+    expected_fragment: str,
+) -> None:
+    notifier = AsyncMock(return_value=True)
+    service = PurposeFlowService(escalation_notifier=notifier)
+    identity = _make_identity("returning", name="Tanaka")
+
+    result = await service.handle_consultation(language, "session-123", identity)
+
+    assert expected_fragment in result.response_text
+    assert result.target_agent == "general_knowledge"
+    assert result.action_type == "escalate"
+    assert result.requires_staff is True
+    assert result.action_data == {
+        "reason": (
+            "来訪者が相談対応を希望"
+            if language == "ja"
+            else "Visitor requested consultation support"
+        ),
+        "notification_sent": True,
+        "session_id": "session-123",
+    }
+    notifier.assert_awaited_once_with(
+        "session-123",
+        "来訪者が相談対応を希望" if language == "ja" else "Visitor requested consultation support",
+        "Tanaka",
+        language,
+    )
+
+
+@pytest.mark.asyncio
+async def test_handle_consultation_falls_back_when_notification_fails() -> None:
+    notifier = AsyncMock(side_effect=RuntimeError("discord failed"))
+    service = PurposeFlowService(escalation_notifier=notifier)
+
+    result = await service.handle_consultation("en", "session-456", _make_identity(name="John"))
+
+    assert "arranging staff assistance now" in result.response_text
+    assert result.requires_staff is True
+    assert result.action_data == {
+        "reason": "Visitor requested consultation support",
+        "notification_sent": False,
+        "session_id": "session-456",
+    }
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("language", "expected_fragment"),
+    [
+        ("ja", "適切な案内"),
+        ("en", "appropriate guidance"),
+    ],
+)
+async def test_handle_other_returns_general_handoff(
+    language: str,
+    expected_fragment: str,
+) -> None:
+    service = PurposeFlowService()
+
+    result = await service.handle_other(language, _make_identity())
+
+    assert expected_fragment in result.response_text
+    assert result.target_agent == "general_knowledge"
+    assert result.action_type == "handoff"
+    assert result.requires_staff is False
+    assert result.action_data == {"purpose_category": "other"}
+
+
+@pytest.mark.asyncio
+async def test_resolve_dispatches_to_matching_handler() -> None:
+    service = PurposeFlowService()
+    purpose = VisitPurpose(category="consultation")
+
+    with patch.object(service, "handle_consultation", new=AsyncMock()) as mock_handler:
+        sentinel = PurposeFlowResult(
+            response_text="ok",
+            target_agent="general_knowledge",
+            action_type="escalate",
+            action_data=None,
+            requires_staff=True,
+        )
+        mock_handler.return_value = sentinel
+
+        result = await service.resolve(purpose, "ja", "session-789", _make_identity())
+
+    assert result is sentinel
+    mock_handler.assert_awaited_once()

--- a/backend/tests/services/test_purpose_flow_service.py
+++ b/backend/tests/services/test_purpose_flow_service.py
@@ -28,6 +28,7 @@ def _make_event_client(rows: list[dict]) -> MagicMock:
     client = MagicMock()
     builder = MagicMock()
     builder.select.return_value = builder
+    builder.limit.return_value = builder
     builder.execute.return_value = _make_query_result(rows)
     client.table.return_value = builder
     return client
@@ -47,7 +48,7 @@ async def test_handle_facility_use_returns_guide_result(
 ) -> None:
     service = PurposeFlowService()
 
-    result = await service.handle_facility_use(language, _make_identity())
+    result = await service.handle_facility_use(language, "session-test", _make_identity())
 
     assert isinstance(result, PurposeFlowResult)
     assert expected_fragment in result.response_text
@@ -76,7 +77,9 @@ async def test_handle_event_participation_returns_today_events(
     ]
     service = PurposeFlowService(supabase_client=_make_event_client(rows))
 
-    result = await service.handle_event_participation(language, _make_identity("returning"))
+    result = await service.handle_event_participation(
+        language, "session-test", _make_identity("returning")
+    )
 
     assert expected_fragment in result.response_text
     assert result.target_agent == "event"
@@ -110,7 +113,7 @@ async def test_handle_event_participation_without_events_uses_default_message(
 ) -> None:
     service = PurposeFlowService(supabase_client=_make_event_client([]))
 
-    result = await service.handle_event_participation(language, _make_identity())
+    result = await service.handle_event_participation(language, "session-test", _make_identity())
 
     assert expected_fragment in result.response_text
     assert result.action_data == {"events": [], "event_count": 0}
@@ -121,11 +124,12 @@ async def test_handle_event_participation_falls_back_on_supabase_error() -> None
     client = MagicMock()
     builder = MagicMock()
     builder.select.return_value = builder
+    builder.limit.return_value = builder
     builder.execute.side_effect = RuntimeError("supabase unavailable")
     client.table.return_value = builder
     service = PurposeFlowService(supabase_client=client)
 
-    result = await service.handle_event_participation("en", _make_identity())
+    result = await service.handle_event_participation("en", "session-test", _make_identity())
 
     assert "couldn't check today's event listing right now" in result.response_text
     assert result.action_data == {"events": [], "lookup_failed": True}
@@ -145,7 +149,7 @@ async def test_handle_tour_returns_handoff_result(
 ) -> None:
     service = PurposeFlowService()
 
-    result = await service.handle_tour(language, _make_identity())
+    result = await service.handle_tour(language, "session-test", _make_identity())
 
     assert expected_fragment in result.response_text
     assert result.target_agent == "slide"
@@ -223,7 +227,7 @@ async def test_handle_other_returns_general_handoff(
 ) -> None:
     service = PurposeFlowService()
 
-    result = await service.handle_other(language, _make_identity())
+    result = await service.handle_other(language, "session-test", _make_identity())
 
     assert expected_fragment in result.response_text
     assert result.target_agent == "general_knowledge"

--- a/backend/tests/services/test_reception_handoff_service.py
+++ b/backend/tests/services/test_reception_handoff_service.py
@@ -1,0 +1,304 @@
+"""Tests for ReceptionHandoffService."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from backend.domain.reception.models import (
+    ReceptionSession,
+    VisitPurpose,
+    VisitorIdentity,
+    VisitorType,
+)
+from backend.services.purpose_flow_service import PurposeFlowResult
+from backend.services.reception_handoff_service import HandoffResult, ReceptionHandoffService
+
+
+def _make_identity(
+    visitor_type: str = "new",
+    name: str | None = "Tanaka",
+    visit_count: int = 2,
+) -> VisitorIdentity:
+    return VisitorIdentity(
+        visitor_type=VisitorType(value=visitor_type),
+        name=name,
+        visit_count=visit_count,
+    )
+
+
+def _make_purpose(
+    category: str = "facility_use",
+    detail: str | None = "I want to use the coworking space",
+) -> VisitPurpose:
+    return VisitPurpose(category=category, detail=detail)
+
+
+def _make_session(
+    *,
+    language: str = "ja",
+    purpose: VisitPurpose | None = None,
+    visitor_identity: VisitorIdentity | None = None,
+) -> ReceptionSession:
+    return ReceptionSession(
+        id="reception-123",
+        session_id="session-123",
+        language=language,
+        purpose=purpose,
+        visitor_identity=visitor_identity,
+        stage="routing",
+    )
+
+
+def _make_purpose_flow_result(
+    *,
+    response_text: str = "Handled by mocked purpose flow",
+    target_agent: str = "facility",
+    action_type: str = "guide",
+    action_data: dict | None = None,
+    requires_staff: bool = False,
+) -> PurposeFlowResult:
+    return PurposeFlowResult(
+        response_text=response_text,
+        target_agent=target_agent,
+        action_type=action_type,
+        action_data=action_data or {"source": "mock"},
+        requires_staff=requires_staff,
+    )
+
+
+def _make_service(
+    purpose_flow_result: PurposeFlowResult,
+) -> tuple[ReceptionHandoffService, MagicMock]:
+    purpose_flow_service = MagicMock()
+    purpose_flow_service.resolve = AsyncMock(return_value=purpose_flow_result)
+    service = ReceptionHandoffService(purpose_flow_service=purpose_flow_service)
+    return service, purpose_flow_service
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("category", "expected_agent", "requires_staff", "action_type"),
+    [
+        ("facility_use", "facility", False, "guide"),
+        ("event_participation", "event", False, "lookup"),
+        ("tour", "slide", False, "handoff"),
+        ("consultation", "general_knowledge", True, "escalate"),
+        ("other", "general_knowledge", False, "handoff"),
+    ],
+)
+async def test_prepare_handoff_routes_by_purpose_category(
+    category: str,
+    expected_agent: str,
+    requires_staff: bool,
+    action_type: str,
+) -> None:
+    purpose = _make_purpose(category=category, detail=f"detail for {category}")
+    identity = _make_identity(visitor_type="returning", name="Aki", visit_count=5)
+    session = _make_session(language="en", purpose=purpose, visitor_identity=identity)
+    purpose_flow_result = _make_purpose_flow_result(
+        target_agent=expected_agent,
+        action_type=action_type,
+        requires_staff=requires_staff,
+    )
+    service, purpose_flow_service = _make_service(purpose_flow_result)
+
+    result = await service.prepare_handoff(session)
+
+    assert isinstance(result, HandoffResult)
+    assert result.target_agent == expected_agent
+    assert result.purpose_flow == purpose_flow_result
+    assert result.requires_staff is requires_staff
+    assert result.workflow_state["routing"]["agent"] == expected_agent
+    purpose_flow_service.resolve.assert_awaited_once_with(
+        purpose=purpose,
+        language="en",
+        session_id="session-123",
+        visitor_identity=identity,
+    )
+
+
+@pytest.mark.asyncio
+async def test_prepare_handoff_raises_when_purpose_is_missing() -> None:
+    session = _make_session(purpose=None, visitor_identity=_make_identity())
+    service, purpose_flow_service = _make_service(_make_purpose_flow_result())
+
+    with pytest.raises(ValueError, match="purpose not set"):
+        await service.prepare_handoff(session)
+
+    purpose_flow_service.resolve.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_prepare_handoff_raises_when_visitor_identity_is_missing() -> None:
+    session = _make_session(purpose=_make_purpose(), visitor_identity=None)
+    service, purpose_flow_service = _make_service(_make_purpose_flow_result())
+
+    with pytest.raises(ValueError, match="visitor_identity not set"):
+        await service.prepare_handoff(session)
+
+    purpose_flow_service.resolve.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_prepare_handoff_builds_expected_workflow_state_structure() -> None:
+    purpose = _make_purpose(category="event_participation", detail="Join tonight's meetup")
+    identity = _make_identity(name="Mika")
+    session = _make_session(language="ja", purpose=purpose, visitor_identity=identity)
+    purpose_flow_result = _make_purpose_flow_result(
+        target_agent="event",
+        action_type="lookup",
+        action_data={"events": [{"id": 1, "title": "Night Meetup"}]},
+    )
+    service, _ = _make_service(purpose_flow_result)
+
+    result = await service.prepare_handoff(session)
+
+    workflow_state = result.workflow_state
+
+    assert {
+        "messages",
+        "query",
+        "session_id",
+        "language",
+        "routing",
+        "answer",
+        "emotion",
+        "metadata",
+        "context",
+        "image_data",
+        "ocr_result",
+    }.issubset(workflow_state)
+    assert workflow_state["messages"] == []
+    assert workflow_state["query"] == "Join tonight's meetup"
+    assert workflow_state["session_id"] == "session-123"
+    assert workflow_state["language"] == "ja"
+    assert workflow_state["answer"] is None
+    assert workflow_state["emotion"] is None
+    assert workflow_state["image_data"] is None
+    assert workflow_state["routing"] == {
+        "agent": "event",
+        "category": "event_participation",
+        "request_type": "lookup",
+        "confidence": 1.0,
+        "reasoning": "Routed from autonomous reception flow",
+        "debug_info": {},
+    }
+
+
+@pytest.mark.asyncio
+async def test_prepare_handoff_generates_synthetic_query_when_detail_is_missing() -> None:
+    purpose = _make_purpose(category="consultation", detail=None)
+    session = _make_session(
+        language="en",
+        purpose=purpose,
+        visitor_identity=_make_identity(name="John"),
+    )
+    purpose_flow_result = _make_purpose_flow_result(
+        target_agent="general_knowledge",
+        action_type="escalate",
+        requires_staff=True,
+    )
+    service, _ = _make_service(purpose_flow_result)
+
+    result = await service.prepare_handoff(session)
+
+    assert result.workflow_state["query"] == "I'd like to consult about something"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("language", "expected_query"),
+    [
+        ("ja", "施設を利用したいです"),
+        ("en", "I'd like to use the facility"),
+        ("zh", "我想使用设施"),
+        ("ko", "시설을 이용하고 싶습니다"),
+    ],
+)
+async def test_prepare_handoff_uses_language_specific_synthetic_queries(
+    language: str,
+    expected_query: str,
+) -> None:
+    purpose = _make_purpose(category="facility_use", detail=None)
+    session = _make_session(
+        language=language,
+        purpose=purpose,
+        visitor_identity=_make_identity(),
+    )
+    service, _ = _make_service(_make_purpose_flow_result())
+
+    result = await service.prepare_handoff(session)
+
+    assert result.workflow_state["query"] == expected_query
+
+
+@pytest.mark.asyncio
+async def test_prepare_handoff_prefers_custom_purpose_detail_over_synthetic_query() -> None:
+    purpose = _make_purpose(category="tour", detail="Please guide me to the startup exhibits")
+    session = _make_session(
+        language="ko",
+        purpose=purpose,
+        visitor_identity=_make_identity(name="Sora"),
+    )
+    service, _ = _make_service(
+        _make_purpose_flow_result(target_agent="slide", action_type="handoff")
+    )
+
+    result = await service.prepare_handoff(session)
+
+    assert result.workflow_state["query"] == "Please guide me to the startup exhibits"
+
+
+@pytest.mark.asyncio
+async def test_prepare_handoff_metadata_contains_reception_information() -> None:
+    purpose = _make_purpose(category="consultation", detail="Need startup funding advice")
+    identity = _make_identity(visitor_type="returning", name="Yuki", visit_count=7)
+    session = _make_session(language="ja", purpose=purpose, visitor_identity=identity)
+    purpose_flow_result = _make_purpose_flow_result(
+        response_text="Staff has been notified",
+        target_agent="general_knowledge",
+        action_type="escalate",
+        action_data={"reason": "consultation", "notification_sent": True},
+        requires_staff=True,
+    )
+    service, _ = _make_service(purpose_flow_result)
+
+    result = await service.prepare_handoff(session)
+
+    assert result.workflow_state["metadata"] == {
+        "reception_session_id": "reception-123",
+        "reception_handoff": True,
+        "visitor_type": "returning",
+        "purpose_category": "consultation",
+        "purpose_detail": "Need startup funding advice",
+        "purpose_flow_action": "escalate",
+        "purpose_flow_data": {"reason": "consultation", "notification_sent": True},
+        "requires_staff": True,
+    }
+
+
+@pytest.mark.asyncio
+async def test_prepare_handoff_context_contains_reception_visitor_information() -> None:
+    purpose = _make_purpose(category="other", detail="I have a package delivery")
+    identity = _make_identity(visitor_type="new", name="Chris", visit_count=0)
+    session = _make_session(language="en", purpose=purpose, visitor_identity=identity)
+    purpose_flow_result = _make_purpose_flow_result(
+        response_text="I'll connect you to the right guidance",
+        target_agent="general_knowledge",
+        action_type="handoff",
+        action_data={"purpose_category": "other"},
+    )
+    service, _ = _make_service(purpose_flow_result)
+
+    result = await service.prepare_handoff(session)
+
+    assert result.workflow_state["context"] == {
+        "reception_context": {
+            "visitor_name": "Chris",
+            "visitor_type": "new",
+            "visit_count": 0,
+            "purpose_response_text": "I'll connect you to the right guidance",
+        }
+    }


### PR DESCRIPTION
## Summary

Wave 3 of Issue #117 (autonomous reception flow). Adds the handoff bridge between ReceptionWorkflow and MainWorkflow, plus a `/complete` API endpoint.

### New files
- `backend/services/reception_handoff_service.py` — Transforms completed ReceptionSession into WorkflowStateDict for MainWorkflow
- `backend/tests/services/test_reception_handoff_service.py` — 16 tests covering all purpose categories, validation, synthetic queries, metadata

### Modified files
- `backend/api/reception.py` — Added `/complete` endpoint, IDOR fix on `/status`, lazy singleton, race condition guard
- `backend/services/purpose_flow_service.py` — Unified handler signatures, `.limit(200)` safety, KeyError guard
- `backend/tests/api/test_reception_api.py` — 4 new `/complete` endpoint tests (total 20)
- `backend/tests/services/test_purpose_flow_service.py` — Updated for unified handler signatures

### Review findings fixed
| Source | Severity | Issue | Fix |
|--------|----------|-------|-----|
| Codex | HIGH | Race condition in `/complete` | Advance stage before async work |
| Codex | HIGH | MainWorkflow routing override | Return workflow_state for caller to use |
| Codex | MEDIUM | Missing `ocr_result` key | Added to workflow state |
| Codex | LOW | `/status` IDOR | Added session_id verification |
| Codex | LOW | Duplicate agent mapping | Use PurposeFlowResult.target_agent |
| Internal | CRITICAL | `/status` IDOR | session_id query param verification |
| Internal | CRITICAL | Unbounded events query | Added `.limit(200)` |
| Internal | HIGH | Inconsistent handler signatures | Unified to (language, session_id, visitor_identity) |
| Internal | HIGH | `_consultation_reason` KeyError | `.get()` with fallback |
| Internal | HIGH | HandoffService per-request instantiation | Lazy singleton |
| Internal | MEDIUM | `workflow_state` PII leak | Removed from response |
| Internal | MEDIUM | No `/complete` endpoint tests | 4 tests added |
| Internal | MEDIUM | Missing `ocr_result` | Added |

### Test results
- 51 tests passing (15 purpose flow + 16 handoff + 20 API)
- ruff: all checks passed
- black: all files formatted

## Test plan
- [x] All 51 unit tests pass
- [x] ruff lint clean
- [x] black format clean
- [ ] CI pipeline green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>