### PR TITLE
feat(backend): implement voice interrupt task cancellation

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -4,12 +4,15 @@ FastAPIアプリケーションとLangGraphエージェントの統合
 """
 
 import hmac
+import asyncio
+import base64
 import json
 import logging
 import os
 import re
 import time
 from contextlib import asynccontextmanager
+from io import BytesIO
 
 from fastapi import Depends, FastAPI, HTTPException
 from fastapi.middleware.cors import CORSMiddleware
@@ -25,6 +28,7 @@ from backend.utils.structured_logging import (
     generate_request_id,
     setup_structured_logging,
 )
+from backend.utils.session_task_manager import get_session_task_manager
 
 logger = logging.getLogger(__name__)
 
@@ -123,6 +127,14 @@ async def lifespan(app: FastAPI):
     except Exception as e:
         logger.warning("Checkpoint cleanup setup failed (non-critical): %s", e)
 
+    try:
+        session_task_manager = get_session_task_manager()
+        await session_task_manager.initialize()
+        app.state.session_task_manager = session_task_manager
+        logger.info("Session task manager initialized")
+    except Exception as e:
+        logger.warning("Session task manager setup failed (non-critical): %s", e)
+
     yield
 
     # Shutdown
@@ -141,6 +153,13 @@ async def lifespan(app: FastAPI):
         logger.info("Store closed on shutdown")
     except Exception as e:
         logger.warning("Error closing store on shutdown: %s", e)
+
+    try:
+        session_task_manager = get_session_task_manager()
+        await session_task_manager.shutdown()
+        logger.info("Session task manager shutdown complete")
+    except Exception as e:
+        logger.warning("Error shutting down session task manager: %s", e)
 
 
 app = FastAPI(
@@ -235,6 +254,21 @@ class ChatResponse(BaseModel):
     metadata: Dict[str, Any]
 
 
+async def _run_workflow_with_tracking(payload: Dict[str, Any], session_id: str) -> Dict[str, Any]:
+    from backend.workflows.main_workflow import get_workflow
+
+    workflow = await get_workflow()
+    await _session_task_manager.register_session(session_id)
+    llm_task = asyncio.create_task(workflow.ainvoke(payload))
+    await _session_task_manager.set_llm_task(session_id, llm_task)
+
+    try:
+        return await llm_task
+    except asyncio.CancelledError:
+        logger.info("LLM task cancelled for session %s", session_id)
+        raise HTTPException(status_code=409, detail="Request interrupted")
+
+
 @app.get("/health")
 @_rate_limit("60/minute")
 async def health_check(request: Request):
@@ -279,17 +313,15 @@ async def chat(request: Request, body: ChatRequest):
     LangGraphエージェントを使用してクエリを処理します
     """
     try:
-        from backend.workflows.main_workflow import get_workflow
-
-        workflow = await get_workflow()
-        result = await workflow.ainvoke(
-            {
+        result = await _run_workflow_with_tracking(
+            payload={
                 "query": body.query,
                 "session_id": body.session_id,
                 "language": body.language,
                 "context": body.context or {},
                 "visitor_id": body.visitor_id,
-            }
+            },
+            session_id=body.session_id,
         )
 
         answer = result.get("answer", "回答を生成できませんでした。")
@@ -370,17 +402,15 @@ async def invoke_agent(request: Request, body: ChatRequest):
     LangGraphエージェントの直接実行エンドポイント
     """
     try:
-        from backend.workflows.main_workflow import get_workflow
-
-        workflow = await get_workflow()
-        result = await workflow.ainvoke(
-            {
+        result = await _run_workflow_with_tracking(
+            payload={
                 "query": body.query,
                 "session_id": body.session_id,
                 "language": body.language,
                 "context": body.context or {},
                 "visitor_id": body.visitor_id,
-            }
+            },
+            session_id=body.session_id,
         )
 
         return {"status": "success", "result": result}
@@ -413,11 +443,13 @@ class VoiceResponse(BaseModel):
     error: Optional[str] = None
     detectedLanguage: Optional[str] = None
     confidence: Optional[float] = None
+    interruptStatus: Optional[str] = None
 
 
 _voice_agent: Optional[Any] = None  # VoiceAgent (lazy-loaded)
 _stt_agent: Optional[Any] = None  # STTAgent (lazy-loaded)
 _slide_agent: Optional[Any] = None  # SlideAgent (lazy-loaded)
+_session_task_manager = get_session_task_manager()
 
 
 def _get_voice_agent():
@@ -453,8 +485,6 @@ async def _handle_stt(body: VoiceRequest) -> VoiceResponse:
     if not body.audioData:
         raise HTTPException(status_code=400, detail="Missing audioData")
 
-    import base64
-
     audio_bytes = base64.b64decode(body.audioData)
 
     stt_result = await _get_stt_agent().speech_to_text(
@@ -488,11 +518,28 @@ async def voice_api(request: Request, body: VoiceRequest):
             if not body.text or not body.text.strip():
                 raise HTTPException(status_code=400, detail="Missing text for text_to_speech")
 
-            result = await _get_voice_agent().text_to_speech(
-                text=body.text,
-                language=body.language or "ja",
-                emotion=body.emotion,  # Use requested emotion for TTS
+            if body.sessionId:
+                await _session_task_manager.register_session(body.sessionId)
+
+            tts_task = asyncio.create_task(
+                _get_voice_agent().text_to_speech(
+                    text=body.text,
+                    language=body.language or "ja",
+                    emotion=body.emotion,  # Use requested emotion for TTS
+                )
             )
+            if body.sessionId:
+                await _session_task_manager.set_tts_task(body.sessionId, tts_task)
+
+            result = await tts_task
+
+            if body.sessionId and result.get("audioResponse"):
+                try:
+                    audio_bytes = base64.b64decode(result["audioResponse"])
+                    await _session_task_manager.set_tts_buffer(body.sessionId, BytesIO(audio_bytes))
+                except Exception:
+                    logger.debug("Failed to register TTS buffer for session %s", body.sessionId)
+
             if not result.get("success"):
                 return VoiceResponse(
                     success=False,
@@ -516,6 +563,17 @@ async def voice_api(request: Request, body: VoiceRequest):
 
         elif body.action == "speech_to_text":
             return await _handle_stt(body)
+
+        elif body.action == "interrupt":
+            if not body.sessionId:
+                raise HTTPException(status_code=400, detail="Missing sessionId for interrupt")
+
+            cancelled = await _session_task_manager.cancel_all_tasks(body.sessionId)
+            return VoiceResponse(
+                success=True,
+                sessionId=body.sessionId,
+                interruptStatus="cancelled" if cancelled else "no_active_task",
+            )
 
         else:
             raise HTTPException(status_code=400, detail=f"Unknown action: {body.action}")

--- a/backend/tests/api/test_voice_api.py
+++ b/backend/tests/api/test_voice_api.py
@@ -38,6 +38,7 @@ class VoiceResponse(BaseModel):
     error: Optional[str] = None
     detectedLanguage: Optional[str] = None
     confidence: Optional[float] = None
+    interruptStatus: Optional[str] = None
 
 
 # =============================================================================
@@ -49,6 +50,7 @@ class VoiceResponse(BaseModel):
 
 mock_voice_agent = MagicMock()
 mock_stt_agent = MagicMock()
+mock_session_task_manager = MagicMock()
 
 _test_app = FastAPI()
 
@@ -119,6 +121,17 @@ async def voice_api(request: VoiceRequest):
         elif request.action == "speech_to_text":
             return await _handle_stt_test(request)
 
+        elif request.action == "interrupt":
+            if not request.sessionId:
+                raise HTTPException(status_code=400, detail="Missing sessionId for interrupt")
+
+            cancelled = await mock_session_task_manager.cancel_all_tasks(request.sessionId)
+            return VoiceResponse(
+                success=True,
+                sessionId=request.sessionId,
+                interruptStatus="cancelled" if cancelled else "no_active_task",
+            )
+
         else:
             raise HTTPException(status_code=400, detail=f"Unknown action: {request.action}")
 
@@ -148,6 +161,8 @@ def _reset_mocks():
     """各テスト前にモックをリセット"""
     mock_voice_agent.reset_mock()
     mock_stt_agent.reset_mock()
+    mock_session_task_manager.reset_mock()
+    mock_session_task_manager.cancel_all_tasks = AsyncMock(return_value=False)
 
 
 # =============================================================================
@@ -589,3 +604,59 @@ class TestLanguageParam:
 
         call_kwargs = mock_stt_agent.speech_to_text.call_args.kwargs
         assert call_kwargs["conversation_stage"] == "greeting"
+
+
+# =============================================================================
+# interrupt
+# =============================================================================
+
+
+class TestInterrupt:
+    """POST /api/voice  action=interrupt"""
+
+    def test_interrupt_cancelled(self):
+        """進行中タスクがある場合は cancelled を返す"""
+        mock_session_task_manager.cancel_all_tasks = AsyncMock(return_value=True)
+
+        resp = client.post(
+            "/api/voice",
+            json={
+                "action": "interrupt",
+                "sessionId": SAMPLE_SESSION_ID,
+            },
+        )
+
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["success"] is True
+        assert body["sessionId"] == SAMPLE_SESSION_ID
+        assert body["interruptStatus"] == "cancelled"
+
+    def test_interrupt_no_active_task(self):
+        """進行中タスクがない場合は no_active_task を返す"""
+        mock_session_task_manager.cancel_all_tasks = AsyncMock(return_value=False)
+
+        resp = client.post(
+            "/api/voice",
+            json={
+                "action": "interrupt",
+                "sessionId": SAMPLE_SESSION_ID,
+            },
+        )
+
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["success"] is True
+        assert body["interruptStatus"] == "no_active_task"
+
+    def test_interrupt_without_session_id_returns_400(self):
+        """sessionId なしのinterruptは400"""
+        resp = client.post(
+            "/api/voice",
+            json={
+                "action": "interrupt",
+            },
+        )
+
+        assert resp.status_code == 400
+        assert "Missing sessionId" in resp.json()["detail"]

--- a/backend/tests/utils/test_session_task_manager.py
+++ b/backend/tests/utils/test_session_task_manager.py
@@ -1,0 +1,400 @@
+"""
+SessionTaskManager ユニットテスト
+
+Issue #127: 音声割り込みバックエンド処理
+
+テスト対象:
+  - SessionTaskInfo データクラス
+  - SessionTaskManager シングルトン
+  - タスク登録・キャンセル・自動クリーンアップ
+"""
+
+import asyncio
+import pytest
+from io import BytesIO
+
+from backend.utils.session_task_manager import (
+    SessionTaskInfo,
+    SessionTaskManager,
+    get_session_task_manager,
+)
+
+
+@pytest.fixture
+async def manager():
+    """SessionTaskManager フィクスチャ"""
+    mgr = SessionTaskManager()
+    # Singleton を初期化
+    mgr._sessions.clear()
+    mgr._initialized = True
+
+    yield mgr
+
+
+@pytest.mark.asyncio
+class TestSessionTaskInfo:
+    """SessionTaskInfo テスト"""
+
+    async def test_creation(self):
+        """SessionTaskInfo の生成"""
+        info = SessionTaskInfo(session_id="test-001")
+        assert info.session_id == "test-001"
+        assert info.llm_task is None
+        assert info.tts_task is None
+        assert info.tts_buffer is None
+        assert info.is_active() is False
+
+    async def test_update_activity(self):
+        """activity 時刻更新"""
+        info = SessionTaskInfo(session_id="test-001")
+        old_time = info.last_activity
+        await asyncio.sleep(0.01)  # 時刻差を作る
+        info.update_activity()
+        assert info.last_activity > old_time
+
+    async def test_is_active_with_no_tasks(self):
+        """is_active (no tasks)"""
+        info = SessionTaskInfo(session_id="test-001")
+        assert info.is_active() is False
+
+    async def test_is_active_with_running_task(self):
+        """is_active (running task)"""
+
+        async def dummy_coro():
+            await asyncio.sleep(1)
+
+        info = SessionTaskInfo(session_id="test-001")
+        task = asyncio.create_task(dummy_coro())
+        info.llm_task = task
+
+        assert info.is_active() is True
+
+        # クリーンアップ
+        task.cancel()
+        try:
+            await task
+        except asyncio.CancelledError:
+            pass
+
+    async def test_is_active_with_completed_task(self):
+        """is_active (completed task)"""
+
+        async def dummy_coro():
+            return "done"
+
+        info = SessionTaskInfo(session_id="test-001")
+        task = asyncio.create_task(dummy_coro())
+        await task
+        info.llm_task = task
+
+        assert info.is_active() is False
+
+
+@pytest.mark.asyncio
+class TestSessionTaskManager:
+    """SessionTaskManager テスト"""
+
+    async def test_singleton_pattern(self):
+        """Singleton パターン動作"""
+        mgr1 = SessionTaskManager()
+        mgr2 = SessionTaskManager()
+        assert mgr1 is mgr2
+
+    async def test_register_session(self, manager):
+        """セッション登録"""
+        info = await manager.register_session("session-123")
+        assert info.session_id == "session-123"
+        assert await manager.get_session("session-123") is not None
+
+    async def test_register_session_twice(self, manager):
+        """セッション重複登録"""
+        info1 = await manager.register_session("session-123")
+        info2 = await manager.register_session("session-123")
+        # 同じ SessionTaskInfo が返される
+        assert info1 is info2
+
+    async def test_get_nonexistent_session(self, manager):
+        """存在しないセッション取得"""
+        info = await manager.get_session("nonexistent")
+        assert info is None
+
+    async def test_set_llm_task(self, manager):
+        """LLMタスク登録"""
+        await manager.register_session("session-123")
+
+        async def dummy_llm():
+            await asyncio.sleep(1)
+
+        task = asyncio.create_task(dummy_llm())
+        result = await manager.set_llm_task("session-123", task)
+
+        assert result is True
+        info = await manager.get_session("session-123")
+        assert info.llm_task is task
+
+        # クリーンアップ
+        task.cancel()
+        try:
+            await task
+        except asyncio.CancelledError:
+            pass
+
+    async def test_set_llm_task_nonexistent_session(self, manager):
+        """存在しないセッションへのLLMタスク登録"""
+
+        async def dummy_llm():
+            await asyncio.sleep(1)
+
+        task = asyncio.create_task(dummy_llm())
+        result = await manager.set_llm_task("nonexistent", task)
+
+        assert result is False
+        task.cancel()
+        try:
+            await task
+        except asyncio.CancelledError:
+            pass
+
+    async def test_set_tts_task(self, manager):
+        """TTSタスク登録"""
+        await manager.register_session("session-123")
+
+        async def dummy_tts():
+            await asyncio.sleep(1)
+
+        task = asyncio.create_task(dummy_tts())
+        result = await manager.set_tts_task("session-123", task)
+
+        assert result is True
+        info = await manager.get_session("session-123")
+        assert info.tts_task is task
+
+        # クリーンアップ
+        task.cancel()
+        try:
+            await task
+        except asyncio.CancelledError:
+            pass
+
+    async def test_set_tts_buffer(self, manager):
+        """TTSバッファ登録"""
+        await manager.register_session("session-123")
+
+        buffer = BytesIO(b"fake_audio_data")
+        result = await manager.set_tts_buffer("session-123", buffer)
+
+        assert result is True
+        retrieved_buffer = await manager.get_tts_buffer("session-123")
+        assert retrieved_buffer is buffer
+
+    async def test_get_tts_buffer_nonexistent(self, manager):
+        """存在しないセッションのバッファ取得"""
+        buffer = await manager.get_tts_buffer("nonexistent")
+        assert buffer is None
+
+    async def test_cancel_llm_task(self, manager):
+        """LLMタスクキャンセル"""
+        await manager.register_session("session-123")
+
+        async def dummy_llm():
+            await asyncio.sleep(10)
+
+        task = asyncio.create_task(dummy_llm())
+        await manager.set_llm_task("session-123", task)
+
+        result = await manager.cancel_llm_task("session-123")
+
+        assert result is True
+        await asyncio.sleep(0.01)  # 時間をプロセッサに譲る
+        assert task.cancelled()
+
+    async def test_cancel_llm_task_nonexistent_session(self, manager):
+        """存在しないセッションのLLMタスクキャンセル"""
+        result = await manager.cancel_llm_task("nonexistent")
+        assert result is False
+
+    async def test_cancel_llm_task_no_task(self, manager):
+        """タスクが未登録のセッションでキャンセル"""
+        await manager.register_session("session-123")
+        result = await manager.cancel_llm_task("session-123")
+        assert result is False
+
+    async def test_cancel_llm_task_already_done(self, manager):
+        """既に完了したタスクをキャンセル"""
+        await manager.register_session("session-123")
+
+        async def dummy_llm():
+            return "done"
+
+        task = asyncio.create_task(dummy_llm())
+        await task  # 完了待機
+
+        await manager.set_llm_task("session-123", task)
+        result = await manager.cancel_llm_task("session-123")
+
+        assert result is False
+
+    async def test_cancel_tts_task(self, manager):
+        """TTSタスクキャンセル"""
+        await manager.register_session("session-123")
+
+        async def dummy_tts():
+            await asyncio.sleep(10)
+
+        task = asyncio.create_task(dummy_tts())
+        await manager.set_tts_task("session-123", task)
+
+        result = await manager.cancel_tts_task("session-123")
+
+        assert result is True
+        await asyncio.sleep(0.01)  # 時間をプロセッサに譲る
+        assert task.cancelled()
+
+    async def test_clear_tts_buffer(self, manager):
+        """TTSバッファクリア"""
+        await manager.register_session("session-123")
+
+        buffer = BytesIO(b"fake_audio_data")
+        await manager.set_tts_buffer("session-123", buffer)
+
+        result = await manager.clear_tts_buffer("session-123")
+        assert result is True
+
+        retrieved_buffer = await manager.get_tts_buffer("session-123")
+        assert retrieved_buffer is None
+
+    async def test_cancel_all_tasks(self, manager):
+        """全タスクキャンセル"""
+        await manager.register_session("session-123")
+
+        async def dummy_coro():
+            await asyncio.sleep(10)
+
+        llm_task = asyncio.create_task(dummy_coro())
+        tts_task = asyncio.create_task(dummy_coro())
+        buffer = BytesIO(b"fake_audio")
+
+        await manager.set_llm_task("session-123", llm_task)
+        await manager.set_tts_task("session-123", tts_task)
+        await manager.set_tts_buffer("session-123", buffer)
+
+        result = await manager.cancel_all_tasks("session-123")
+
+        assert result is True
+        await asyncio.sleep(0.01)  # 時間をプロセッサに譲る
+        assert llm_task.cancelled()
+        assert tts_task.cancelled()
+        assert await manager.get_tts_buffer("session-123") is None
+
+    async def test_cleanup_session(self, manager):
+        """セッション削除"""
+        await manager.register_session("session-123")
+
+        result = await manager.cleanup_session("session-123")
+        assert result is True
+
+        info = await manager.get_session("session-123")
+        assert info is None
+
+    async def test_cleanup_session_with_running_tasks(self, manager):
+        """実行中タスク付きセッション削除"""
+        await manager.register_session("session-123")
+
+        async def dummy_coro():
+            await asyncio.sleep(10)
+
+        llm_task = asyncio.create_task(dummy_coro())
+        tts_task = asyncio.create_task(dummy_coro())
+
+        await manager.set_llm_task("session-123", llm_task)
+        await manager.set_tts_task("session-123", tts_task)
+
+        result = await manager.cleanup_session("session-123")
+
+        assert result is True
+        await asyncio.sleep(0.01)  # 時間をプロセッサに譲る
+        assert llm_task.cancelled()
+        assert tts_task.cancelled()
+
+    async def test_cleanup_nonexistent_session(self, manager):
+        """存在しないセッション削除"""
+        result = await manager.cleanup_session("nonexistent")
+        assert result is False
+
+    async def test_get_active_sessions(self, manager):
+        """進行中セッション一覧"""
+        await manager.register_session("session-1")
+        await manager.register_session("session-2")
+
+        async def dummy_coro():
+            await asyncio.sleep(10)
+
+        # session-1 をアクティブに
+        task1 = asyncio.create_task(dummy_coro())
+        await manager.set_llm_task("session-1", task1)
+
+        active = await manager.get_active_sessions()
+        assert len(active) == 1
+        assert "session-1" in active
+
+        # クリーンアップ
+        task1.cancel()
+        try:
+            await task1
+        except asyncio.CancelledError:
+            pass
+
+    async def test_get_session_count(self, manager):
+        """セッション数"""
+        await manager.register_session("session-1")
+        await manager.register_session("session-2")
+        await manager.register_session("session-3")
+
+        count = await manager.get_session_count()
+        assert count == 3
+
+    async def test_get_session_task_manager_singleton(self):
+        """グローバル関数 get_session_task_manager"""
+        mgr1 = get_session_task_manager()
+        mgr2 = get_session_task_manager()
+        assert mgr1 is mgr2
+        assert isinstance(mgr1, SessionTaskManager)
+
+
+@pytest.mark.asyncio
+class TestSessionTaskManagerThreadSafety:
+    """SessionTaskManager スレッド安全性テスト"""
+
+    async def test_concurrent_register_sessions(self, manager):
+        """並行セッション登録"""
+        tasks = [manager.register_session(f"session-{i}") for i in range(100)]
+        results = await asyncio.gather(*tasks)
+
+        count = await manager.get_session_count()
+        assert count == 100
+        assert all(r.session_id in [f"session-{i}" for i in range(100)] for r in results)
+
+    async def test_concurrent_cancel_tasks(self, manager):
+        """並行タスクキャンセル"""
+        # セッション準備
+        sessions = []
+        tasks_list = []
+
+        for i in range(10):
+            await manager.register_session(f"session-{i}")
+
+            async def dummy_coro():
+                await asyncio.sleep(10)
+
+            task = asyncio.create_task(dummy_coro())
+            await manager.set_llm_task(f"session-{i}", task)
+            sessions.append(f"session-{i}")
+            tasks_list.append(task)
+
+        # 並行キャンセル
+        cancel_tasks = [manager.cancel_llm_task(sid) for sid in sessions]
+        results = await asyncio.gather(*cancel_tasks)
+
+        assert all(results)
+        await asyncio.sleep(0.01)  # 時間をプロセッサに譲る
+        assert all(t.cancelled() for t in tasks_list)

--- a/backend/utils/session_task_manager.py
+++ b/backend/utils/session_task_manager.py
@@ -1,0 +1,326 @@
+"""
+セッション別タスク管理ユーティリティ
+
+音声割り込み機能（Issue #127）において、進行中のLLM生成・TTS処理を
+セッション単位で追跡・管理するためのモジュール。
+
+主要クラス:
+  - SessionTaskInfo: セッション内のタスク情報
+  - SessionTaskManager: セッション別タスク管理（Singleton）
+"""
+
+import asyncio
+import logging
+from dataclasses import dataclass, field
+from datetime import datetime
+from typing import Dict, Optional
+from io import BytesIO
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class SessionTaskInfo:
+    """セッション内の進行中タスク情報"""
+
+    session_id: str
+    llm_task: Optional[asyncio.Task] = None
+    """進行中のLLM生成タスク"""
+
+    tts_task: Optional[asyncio.Task] = None
+    """進行中のTTS処理タスク"""
+
+    tts_buffer: Optional[BytesIO] = None
+    """TTS出力バッファ（音声データ）"""
+
+    created_at: datetime = field(default_factory=datetime.now)
+    """セッション作成時刻"""
+
+    last_activity: datetime = field(default_factory=datetime.now)
+    """最後の活動時刻（TTL計算用）"""
+
+    def update_activity(self) -> None:
+        """最後の活動時刻を更新"""
+        self.last_activity = datetime.now()
+
+    def is_active(self) -> bool:
+        """タスクが進行中か判定"""
+        return (self.llm_task is not None and not self.llm_task.done()) or (
+            self.tts_task is not None and not self.tts_task.done()
+        )
+
+
+class SessionTaskManager:
+    """
+    セッション別タスク管理（Singleton パターン）
+
+    機能:
+      - セッション登録/取得/削除
+      - LLM/TTSタスク登録
+      - タスクキャンセル
+      - TTSバッファ管理
+      - TTL-based自動クリーンアップ
+
+    スレッド安全性: asyncio.Lock で保護
+
+    使用例:
+      ```python
+      manager = SessionTaskManager()
+      await manager.initialize()  # バックグラウンド クリーンアップ開始
+
+      # セッション登録
+      await manager.register_session("session-123")
+
+      # LLMタスク登録
+      llm_task = asyncio.create_task(llm_generation())
+      await manager.set_llm_task("session-123", llm_task)
+
+      # 割り込み: タスクキャンセル
+      await manager.cancel_llm_task("session-123")
+      ```
+    """
+
+    _instance: Optional["SessionTaskManager"] = None
+    CLEANUP_INTERVAL = 60  # クリーンアップ実行間隔（秒）
+    SESSION_TTL = 300  # セッション有効期限（秒、5分）
+
+    def __new__(cls) -> "SessionTaskManager":
+        """Singleton パターン実装"""
+        if cls._instance is None:
+            cls._instance = super(SessionTaskManager, cls).__new__(cls)
+            cls._instance._initialized = False
+        return cls._instance
+
+    def __init__(self):
+        """初期化"""
+        if self._initialized:
+            return
+
+        self._sessions: Dict[str, SessionTaskInfo] = {}
+        self._lock = asyncio.Lock()
+        self._cleanup_task: Optional[asyncio.Task] = None
+        self._initialized = True
+        logger.info("SessionTaskManager initialized")
+
+    async def initialize(self) -> None:
+        """バックグラウンド クリーンアップタスク開始"""
+        if self._cleanup_task is None or self._cleanup_task.done():
+            self._cleanup_task = asyncio.create_task(self._cleanup_loop())
+            logger.info("SessionTaskManager cleanup loop started")
+
+    async def shutdown(self) -> None:
+        """クリーンアップタスク停止＆セッション全削除"""
+        if self._cleanup_task and not self._cleanup_task.done():
+            self._cleanup_task.cancel()
+            try:
+                await self._cleanup_task
+            except asyncio.CancelledError:
+                pass
+
+        async with self._lock:
+            self._sessions.clear()
+
+        logger.info("SessionTaskManager shutdown complete")
+
+    async def register_session(self, session_id: str) -> SessionTaskInfo:
+        """セッションを登録/取得"""
+        async with self._lock:
+            if session_id not in self._sessions:
+                info = SessionTaskInfo(session_id=session_id)
+                self._sessions[session_id] = info
+                logger.debug("Session registered: %s", session_id)
+            else:
+                self._sessions[session_id].update_activity()
+
+            return self._sessions[session_id]
+
+    async def get_session(self, session_id: str) -> Optional[SessionTaskInfo]:
+        """セッション情報を取得"""
+        async with self._lock:
+            return self._sessions.get(session_id)
+
+    async def set_llm_task(self, session_id: str, task: asyncio.Task) -> bool:
+        """LLM生成タスクを登録"""
+        async with self._lock:
+            if session_id in self._sessions:
+                self._sessions[session_id].llm_task = task
+                self._sessions[session_id].update_activity()
+                logger.debug("LLM task set for session %s", session_id)
+                return True
+            return False
+
+    async def set_tts_task(self, session_id: str, task: asyncio.Task) -> bool:
+        """TTS処理タスクを登録"""
+        async with self._lock:
+            if session_id in self._sessions:
+                self._sessions[session_id].tts_task = task
+                self._sessions[session_id].update_activity()
+                logger.debug("TTS task set for session %s", session_id)
+                return True
+            return False
+
+    async def set_tts_buffer(self, session_id: str, buffer: BytesIO) -> bool:
+        """TTSバッファを登録"""
+        async with self._lock:
+            if session_id in self._sessions:
+                self._sessions[session_id].tts_buffer = buffer
+                self._sessions[session_id].update_activity()
+                logger.debug("TTS buffer set for session %s", session_id)
+                return True
+            return False
+
+    async def get_tts_buffer(self, session_id: str) -> Optional[BytesIO]:
+        """TTSバッファを取得"""
+        async with self._lock:
+            if session_id in self._sessions:
+                return self._sessions[session_id].tts_buffer
+            return None
+
+    async def cancel_llm_task(self, session_id: str) -> bool:
+        """LLMタスクをキャンセル"""
+        async with self._lock:
+            if session_id not in self._sessions:
+                logger.warning("Session not found for cancel_llm_task: %s", session_id)
+                return False
+
+            info = self._sessions[session_id]
+            if info.llm_task is None:
+                logger.warning("No LLM task for session %s", session_id)
+                return False
+
+            if info.llm_task.done():
+                logger.debug("LLM task already done for session %s", session_id)
+                return False
+
+            info.llm_task.cancel()
+            logger.info("LLM task cancelled for session %s", session_id)
+            return True
+
+    async def cancel_tts_task(self, session_id: str) -> bool:
+        """TTSタスクをキャンセル"""
+        async with self._lock:
+            if session_id not in self._sessions:
+                logger.warning("Session not found for cancel_tts_task: %s", session_id)
+                return False
+
+            info = self._sessions[session_id]
+            if info.tts_task is None:
+                logger.warning("No TTS task for session %s", session_id)
+                return False
+
+            if info.tts_task.done():
+                logger.debug("TTS task already done for session %s", session_id)
+                return False
+
+            info.tts_task.cancel()
+            logger.info("TTS task cancelled for session %s", session_id)
+            return True
+
+    async def clear_tts_buffer(self, session_id: str) -> bool:
+        """TTSバッファをクリア"""
+        async with self._lock:
+            if session_id in self._sessions:
+                self._sessions[session_id].tts_buffer = None
+                logger.debug("TTS buffer cleared for session %s", session_id)
+                return True
+            return False
+
+    async def cancel_all_tasks(self, session_id: str) -> bool:
+        """セッションの全タスクをキャンセル"""
+        async with self._lock:
+            if session_id not in self._sessions:
+                logger.warning("Session not found for cancel_all_tasks: %s", session_id)
+                return False
+
+            info = self._sessions[session_id]
+            any_cancelled = False
+
+            # LLMタスクキャンセル
+            if info.llm_task and not info.llm_task.done():
+                info.llm_task.cancel()
+                any_cancelled = True
+                logger.info("LLM task cancelled for session %s", session_id)
+
+            # TTSタスクキャンセル
+            if info.tts_task and not info.tts_task.done():
+                info.tts_task.cancel()
+                any_cancelled = True
+                logger.info("TTS task cancelled for session %s", session_id)
+
+            # バッファクリア
+            if info.tts_buffer is not None:
+                info.tts_buffer = None
+                logger.info("TTS buffer cleared for session %s", session_id)
+
+            return any_cancelled
+
+    async def cleanup_session(self, session_id: str) -> bool:
+        """セッションを削除"""
+        async with self._lock:
+            if session_id in self._sessions:
+                # タスクのキャンセルを試みる（念のため）
+                info = self._sessions[session_id]
+                if info.llm_task and not info.llm_task.done():
+                    info.llm_task.cancel()
+                if info.tts_task and not info.tts_task.done():
+                    info.tts_task.cancel()
+
+                del self._sessions[session_id]
+                logger.info("Session cleaned up: %s", session_id)
+                return True
+            return False
+
+    async def get_active_sessions(self) -> list:
+        """進行中のセッション一覧を取得"""
+        async with self._lock:
+            return [info.session_id for info in self._sessions.values() if info.is_active()]
+
+    async def get_session_count(self) -> int:
+        """登録されているセッション数"""
+        async with self._lock:
+            return len(self._sessions)
+
+    async def _cleanup_loop(self) -> None:
+        """バックグラウンド クリーンアップループ（TTL-based）"""
+        try:
+            while True:
+                await asyncio.sleep(self.CLEANUP_INTERVAL)
+                await self._cleanup_expired_sessions()
+        except asyncio.CancelledError:
+            logger.info("SessionTaskManager cleanup loop cancelled")
+
+    async def _cleanup_expired_sessions(self) -> None:
+        """期限切れセッションを自動削除"""
+        async with self._lock:
+            now = datetime.now()
+            expired_sessions = [
+                (sid, info)
+                for sid, info in self._sessions.items()
+                if (now - info.last_activity).total_seconds() > self.SESSION_TTL
+            ]
+
+            for session_id, info in expired_sessions:
+                # タスクをキャンセル
+                if info.llm_task and not info.llm_task.done():
+                    info.llm_task.cancel()
+                if info.tts_task and not info.tts_task.done():
+                    info.tts_task.cancel()
+
+                # セッション削除
+                del self._sessions[session_id]
+                logger.info("Expired session cleaned up: %s", session_id)
+
+            if expired_sessions:
+                logger.info("Cleaned up %d expired sessions", len(expired_sessions))
+
+
+# グローバルインスタンス
+_session_task_manager: Optional[SessionTaskManager] = None
+
+
+def get_session_task_manager() -> SessionTaskManager:
+    """SessionTaskManager のシングルトン インスタンスを取得"""
+    global _session_task_manager
+    if _session_task_manager is None:
+        _session_task_manager = SessionTaskManager()
+    return _session_task_manager


### PR DESCRIPTION
Issue #127 に対応し、音声割り込み（Barge-in）時にセッション単位で進行中の LLM/TTS タスクを追跡・キャンセルできるようにしました。  
`/api/voice` に `action=interrupt` を追加し、割り込み結果をAPIレスポンスで返すようにしています。
※作業にGithub Copilot(Claude)を利用しています。


## Changes

- `SessionTaskManager`（Singleton）を新規追加し、セッション単位で LLM/TTS タスクを登録・追跡・キャンセル可能にした
- FastAPI の lifespan（startup/shutdown）に Task Manager の初期化/終了処理を統合した
- `/api/voice` に `action=interrupt` を追加し、`interruptStatus`（`cancelled` / `no_active_task`）を返すようにした
- ワークフロー実行をタスク追跡付きで行う `_run_workflow_with_tracking` を追加し、キャンセル時の挙動を明確化した
- ユニット/統合テストを追加（`SessionTaskManager` 29件、`interrupt API` 3件）

## Related Issues

Closes #127

## Test Plan

- [x] ローカルで動作確認済み
- [x] 既存機能への影響がないことを確認済み
- [x] `python -m ruff check backend` が通る
- [x] `python -m black --check backend` が通る
- [x] `pytest -q backend/tests/utils/test_session_task_manager.py backend/tests/api/test_voice_api.py` が通る（52 passed）
- [x] `pnpm lint` が通る（frontend）
- [x] `pnpm typecheck` が通る（frontend）
- [x] `pnpm build` が通る（frontend）

## Checklist

- [x] コードが目的を達成している
- [x] 不要なコード・コメントを削除した
- [x] 必要に応じてドキュメントを更新した（コード内docstring/テスト追加）
- [x] `pnpm lint` が通る
- [x] `pnpm typecheck` が通る