### PR TITLE
feat: Wave 4 - Supabase integration tests, frontend UI, MainWorkflow direct invoke (#117)

### DIFF
--- a/backend/supabase/migrations/20260308000003_add_events_table.sql
+++ b/backend/supabase/migrations/20260308000003_add_events_table.sql
@@ -1,0 +1,43 @@
+-- Events table for Issue #117
+-- Stores event information queried by PurposeFlowService._fetch_today_events()
+
+CREATE TABLE IF NOT EXISTS events (
+    id uuid DEFAULT gen_random_uuid() PRIMARY KEY,
+    title text NOT NULL,
+    name text,                                        -- Alternative title field
+    event_date date,                                  -- Primary date field
+    date date,                                        -- Alternative date field
+    start_date date,                                  -- Alternative date field
+    start_at timestamp with time zone,                -- Event start datetime
+    starts_at timestamp with time zone,               -- Alternative start datetime
+    start_time timestamp with time zone,              -- Alternative start time
+    location text,                                    -- Event location
+    venue text,                                       -- Alternative location field
+    description text,
+    organizer text,
+    capacity integer,
+    metadata jsonb DEFAULT '{}',
+    created_at timestamp with time zone DEFAULT now(),
+    updated_at timestamp with time zone DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS idx_events_event_date ON events(event_date);
+CREATE INDEX IF NOT EXISTS idx_events_start_at ON events(start_at);
+
+-- Enable RLS
+ALTER TABLE events ENABLE ROW LEVEL SECURITY;
+
+-- Service role policies
+CREATE POLICY events_service_select ON events
+    FOR SELECT USING (auth.role() = 'service_role');
+
+CREATE POLICY events_service_insert ON events
+    FOR INSERT WITH CHECK (auth.role() = 'service_role');
+
+CREATE POLICY events_service_update ON events
+    FOR UPDATE
+    USING (auth.role() = 'service_role')
+    WITH CHECK (auth.role() = 'service_role');
+
+CREATE POLICY events_service_delete ON events
+    FOR DELETE USING (auth.role() = 'service_role');

--- a/backend/tests/integration/test_reception_supabase_integration.py
+++ b/backend/tests/integration/test_reception_supabase_integration.py
@@ -1,0 +1,332 @@
+"""Integration tests for reception services against local Supabase.
+
+Tests PurposeFlowService._fetch_today_events() and
+VisitorIdentificationService.identify_by_visitor_id() with real DB queries.
+
+Run requirements:
+  - supabase start (local Supabase running)
+  - SUPABASE_URL and SUPABASE_SERVICE_ROLE_KEY set
+
+Run:
+  cd backend
+  SUPABASE_URL=http://127.0.0.1:54321 \
+  SUPABASE_SERVICE_ROLE_KEY=<service_role_key> \
+  python -m pytest tests/integration/test_reception_supabase_integration.py -v
+"""
+
+from __future__ import annotations
+
+import os
+import uuid
+from datetime import date, datetime, timedelta
+from zoneinfo import ZoneInfo
+
+import pytest
+from supabase import Client, create_client
+
+from backend.services.purpose_flow_service import PurposeFlowService
+from backend.services.visitor_identification_service import VisitorIdentificationService
+
+_JST = ZoneInfo("Asia/Tokyo")
+
+_supabase_url = os.getenv("SUPABASE_URL", "")
+_supabase_key = os.getenv("SUPABASE_SERVICE_ROLE_KEY", "")
+_is_local = any(m in _supabase_url for m in ["localhost", "127.0.0.1", "kong"])
+_available = bool(_supabase_url and _supabase_key and _is_local)
+
+pytestmark = [
+    pytest.mark.asyncio,
+    pytest.mark.skipif(
+        not _available,
+        reason="Local Supabase not available (SUPABASE_URL/SUPABASE_SERVICE_ROLE_KEY)",
+    ),
+]
+
+
+@pytest.fixture()
+def supabase_client() -> Client:
+    return create_client(_supabase_url, _supabase_key)
+
+
+@pytest.fixture()
+def _cleanup_events(supabase_client: Client):
+    """Clean up test events after each test."""
+    created_ids: list[str] = []
+    yield created_ids
+    for event_id in created_ids:
+        try:
+            supabase_client.table("events").delete().eq("id", event_id).execute()
+        except Exception:
+            pass
+
+
+@pytest.fixture()
+def _cleanup_visits(supabase_client: Client):
+    """Clean up test visits after each test."""
+    created_ids: list[str] = []
+    yield created_ids
+    for visit_id in created_ids:
+        try:
+            supabase_client.table("visits").delete().eq("id", visit_id).execute()
+        except Exception:
+            pass
+
+
+def _insert_event(
+    client: Client,
+    tracker: list[str],
+    *,
+    title: str,
+    event_date: date | None = None,
+    location: str | None = None,
+    start_at: str | None = None,
+) -> dict:
+    row = {"title": title}
+    if event_date is not None:
+        row["event_date"] = event_date.isoformat()
+    if location is not None:
+        row["location"] = location
+    if start_at is not None:
+        row["start_at"] = start_at
+    result = client.table("events").insert(row).execute()
+    inserted = result.data[0]
+    tracker.append(inserted["id"])
+    return inserted
+
+
+def _insert_visit(
+    client: Client,
+    tracker: list[str],
+    *,
+    visitor_id: str,
+    purpose: str = "facility_use",
+    purpose_detail: str | None = None,
+    started_at: str | None = None,
+) -> dict:
+    row = {
+        "visitor_id": visitor_id,
+        "purpose": purpose,
+        "visitor_type": "returning",
+    }
+    if purpose_detail is not None:
+        row["purpose_detail"] = purpose_detail
+    if started_at is not None:
+        row["started_at"] = started_at
+    result = client.table("visits").insert(row).execute()
+    inserted = result.data[0]
+    tracker.append(inserted["id"])
+    return inserted
+
+
+# ---------------------------------------------------------------
+# PurposeFlowService._fetch_today_events() tests
+# ---------------------------------------------------------------
+
+
+class TestFetchTodayEvents:
+    """Test _fetch_today_events against real Supabase events table."""
+
+    async def test_returns_today_events_only(
+        self, supabase_client: Client, _cleanup_events: list[str]
+    ) -> None:
+        today = datetime.now(_JST).date()
+        yesterday = today - timedelta(days=1)
+
+        _insert_event(
+            supabase_client,
+            _cleanup_events,
+            title="Today Meetup",
+            event_date=today,
+            location="Room A",
+        )
+        _insert_event(
+            supabase_client,
+            _cleanup_events,
+            title="Yesterday Event",
+            event_date=yesterday,
+            location="Room B",
+        )
+
+        service = PurposeFlowService(supabase_client=supabase_client)
+        events = await service._fetch_today_events()
+
+        titles = [e["title"] for e in events]
+        assert "Today Meetup" in titles
+        assert "Yesterday Event" not in titles
+
+    async def test_returns_empty_when_no_events(self, supabase_client: Client) -> None:
+        service = PurposeFlowService(supabase_client=supabase_client)
+        events = await service._fetch_today_events()
+        # May or may not be empty depending on pre-existing data,
+        # but should not raise
+        assert isinstance(events, list)
+
+    async def test_normalizes_event_fields(
+        self, supabase_client: Client, _cleanup_events: list[str]
+    ) -> None:
+        today = datetime.now(_JST).date()
+        _insert_event(
+            supabase_client,
+            _cleanup_events,
+            title="Normalized Test",
+            event_date=today,
+            location="Hall C",
+        )
+
+        service = PurposeFlowService(supabase_client=supabase_client)
+        events = await service._fetch_today_events()
+
+        matching = [e for e in events if e["title"] == "Normalized Test"]
+        assert len(matching) == 1
+
+        event = matching[0]
+        assert event["date"] == today.isoformat()
+        assert event["location"] == "Hall C"
+        assert "id" in event
+        assert "start_at" in event
+
+    async def test_events_with_start_at_datetime(
+        self, supabase_client: Client, _cleanup_events: list[str]
+    ) -> None:
+        today = datetime.now(_JST).date()
+        start_dt = datetime.combine(today, datetime.min.time().replace(hour=14), tzinfo=_JST)
+
+        _insert_event(
+            supabase_client,
+            _cleanup_events,
+            title="Afternoon Session",
+            event_date=today,
+            start_at=start_dt.isoformat(),
+        )
+
+        service = PurposeFlowService(supabase_client=supabase_client)
+        events = await service._fetch_today_events()
+
+        matching = [e for e in events if e["title"] == "Afternoon Session"]
+        assert len(matching) == 1
+        assert matching[0]["start_at"] is not None
+
+    async def test_multiple_today_events_sorted(
+        self, supabase_client: Client, _cleanup_events: list[str]
+    ) -> None:
+        today = datetime.now(_JST).date()
+
+        _insert_event(
+            supabase_client,
+            _cleanup_events,
+            title="Zebra Talk",
+            event_date=today,
+        )
+        _insert_event(
+            supabase_client,
+            _cleanup_events,
+            title="Alpha Workshop",
+            event_date=today,
+        )
+
+        service = PurposeFlowService(supabase_client=supabase_client)
+        events = await service._fetch_today_events()
+
+        test_titles = [e["title"] for e in events if e["title"] in ("Zebra Talk", "Alpha Workshop")]
+        assert test_titles == sorted(test_titles)
+
+
+# ---------------------------------------------------------------
+# VisitorIdentificationService tests
+# ---------------------------------------------------------------
+
+
+class TestVisitorIdentification:
+    """Test VisitorIdentificationService against real Supabase visits table."""
+
+    async def test_identify_returning_visitor(
+        self, supabase_client: Client, _cleanup_visits: list[str]
+    ) -> None:
+        visitor_id = str(uuid.uuid4())
+        _insert_visit(
+            supabase_client,
+            _cleanup_visits,
+            visitor_id=visitor_id,
+            purpose="event_participation",
+            purpose_detail="Morning meetup",
+        )
+
+        service = VisitorIdentificationService(supabase_client=supabase_client)
+        result = await service.identify_by_visitor_id(visitor_id)
+
+        assert result is not None
+        assert result["visitor_type"] == "returning"
+        assert result["last_purpose"] == "event_participation"
+        assert result["last_purpose_detail"] == "Morning meetup"
+        assert result["visit_count"] >= 1
+
+    async def test_identify_unknown_visitor_returns_none(self, supabase_client: Client) -> None:
+        unknown_id = str(uuid.uuid4())
+        service = VisitorIdentificationService(supabase_client=supabase_client)
+        result = await service.identify_by_visitor_id(unknown_id)
+        assert result is None
+
+    async def test_visit_count_increments(
+        self, supabase_client: Client, _cleanup_visits: list[str]
+    ) -> None:
+        visitor_id = str(uuid.uuid4())
+        for i in range(3):
+            _insert_visit(
+                supabase_client,
+                _cleanup_visits,
+                visitor_id=visitor_id,
+                purpose="facility_use",
+                started_at=(datetime.now(_JST) - timedelta(days=3 - i)).isoformat(),
+            )
+
+        service = VisitorIdentificationService(supabase_client=supabase_client)
+        result = await service.identify_by_visitor_id(visitor_id)
+
+        assert result is not None
+        assert result["visit_count"] == 3
+
+    async def test_returns_most_recent_visit(
+        self, supabase_client: Client, _cleanup_visits: list[str]
+    ) -> None:
+        visitor_id = str(uuid.uuid4())
+
+        _insert_visit(
+            supabase_client,
+            _cleanup_visits,
+            visitor_id=visitor_id,
+            purpose="tour",
+            started_at=(datetime.now(_JST) - timedelta(days=5)).isoformat(),
+        )
+        _insert_visit(
+            supabase_client,
+            _cleanup_visits,
+            visitor_id=visitor_id,
+            purpose="consultation",
+            started_at=datetime.now(_JST).isoformat(),
+        )
+
+        service = VisitorIdentificationService(supabase_client=supabase_client)
+        result = await service.identify_by_visitor_id(visitor_id)
+
+        assert result is not None
+        assert result["last_purpose"] == "consultation"
+
+    async def test_get_recent_visits(
+        self, supabase_client: Client, _cleanup_visits: list[str]
+    ) -> None:
+        visitor_id = str(uuid.uuid4())
+        for i in range(4):
+            _insert_visit(
+                supabase_client,
+                _cleanup_visits,
+                visitor_id=visitor_id,
+                purpose=f"purpose_{i}",
+                started_at=(datetime.now(_JST) - timedelta(days=4 - i)).isoformat(),
+            )
+
+        service = VisitorIdentificationService(supabase_client=supabase_client)
+        visits = await service.get_recent_visits(visitor_id=visitor_id, limit=2)
+
+        assert len(visits) == 2
+        assert visits[0]["purpose"] == "purpose_3"
+        assert visits[1]["purpose"] == "purpose_2"

--- a/backend/tests/workflows/test_reception_invoke.py
+++ b/backend/tests/workflows/test_reception_invoke.py
@@ -1,0 +1,242 @@
+"""Tests for MainWorkflow.ainvoke_from_reception (orchestrator bypass)."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from backend.services.purpose_flow_service import PurposeFlowResult
+from backend.services.reception_handoff_service import HandoffResult
+
+
+def _make_handoff_result(
+    *,
+    target_agent: str = "facility",
+    action_type: str = "guide",
+    requires_staff: bool = False,
+) -> HandoffResult:
+    return HandoffResult(
+        workflow_state={
+            "messages": [],
+            "query": "I want to use the coworking space",
+            "session_id": "session-test",
+            "language": "en",
+            "routing": {
+                "agent": target_agent,
+                "category": "facility_use",
+                "request_type": action_type,
+                "confidence": 1.0,
+                "reasoning": "Routed from autonomous reception flow",
+                "debug_info": {},
+            },
+            "answer": None,
+            "emotion": None,
+            "metadata": {
+                "reception_session_id": "reception-123",
+                "reception_handoff": True,
+            },
+            "context": {"reception_context": {"visitor_name": "Taro"}},
+            "image_data": None,
+            "ocr_result": None,
+        },
+        target_agent=target_agent,
+        purpose_flow=PurposeFlowResult(
+            response_text="Guide text",
+            target_agent=target_agent,
+            action_type=action_type,
+            action_data={"purpose_category": "facility_use"},
+            requires_staff=requires_staff,
+        ),
+        requires_staff=requires_staff,
+    )
+
+
+@pytest.mark.asyncio
+async def test_ainvoke_from_reception_calls_target_agent_node() -> None:
+    """Orchestrator should be bypassed; target agent node called directly."""
+    from backend.workflows.main_workflow import MainWorkflow
+
+    with patch.object(MainWorkflow, "__init__", lambda self, **kw: None):
+        wf = MainWorkflow()
+        wf.checkpointer = None
+        wf.store = None
+        wf._current_visitor_id = "test"
+
+        mock_result = {
+            "answer": "Welcome to the facility!",
+            "emotion": "friendly",
+            "metadata": {"reception_handoff": True},
+        }
+        wf._facility_node = AsyncMock(return_value=mock_result)
+        wf._format_response_node = AsyncMock(
+            return_value={
+                "answer": "Welcome to the facility!",
+                "emotion": "friendly",
+                "metadata": {"reception_handoff": True},
+                "messages": [],
+            }
+        )
+
+        handoff = _make_handoff_result(target_agent="facility")
+        result = await wf.ainvoke_from_reception(handoff)
+
+        assert result["answer"] == "Welcome to the facility!"
+        wf._facility_node.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_ainvoke_from_reception_routes_to_event_agent() -> None:
+    from backend.workflows.main_workflow import MainWorkflow
+
+    with patch.object(MainWorkflow, "__init__", lambda self, **kw: None):
+        wf = MainWorkflow()
+        wf.checkpointer = None
+        wf.store = None
+        wf._current_visitor_id = "test"
+
+        wf._event_node = AsyncMock(
+            return_value={
+                "answer": "Today's events: Meetup at 14:00",
+                "emotion": "neutral",
+                "metadata": {},
+            }
+        )
+        wf._format_response_node = AsyncMock(
+            return_value={
+                "answer": "Today's events: Meetup at 14:00",
+                "emotion": "neutral",
+                "metadata": {},
+                "messages": [],
+            }
+        )
+
+        handoff = _make_handoff_result(target_agent="event", action_type="lookup")
+        result = await wf.ainvoke_from_reception(handoff)
+
+        assert "Meetup" in result["answer"]
+        wf._event_node.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_ainvoke_from_reception_routes_to_general_knowledge() -> None:
+    from backend.workflows.main_workflow import MainWorkflow
+
+    with patch.object(MainWorkflow, "__init__", lambda self, **kw: None):
+        wf = MainWorkflow()
+        wf.checkpointer = None
+        wf.store = None
+        wf._current_visitor_id = "test"
+
+        wf._general_knowledge_node = AsyncMock(
+            return_value={
+                "answer": "Staff notified",
+                "emotion": "neutral",
+                "metadata": {},
+            }
+        )
+        wf._format_response_node = AsyncMock(
+            return_value={
+                "answer": "Staff notified",
+                "emotion": "neutral",
+                "metadata": {},
+                "messages": [],
+            }
+        )
+
+        handoff = _make_handoff_result(
+            target_agent="general_knowledge",
+            action_type="escalate",
+            requires_staff=True,
+        )
+        result = await wf.ainvoke_from_reception(handoff)
+
+        assert result["answer"] == "Staff notified"
+        wf._general_knowledge_node.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_ainvoke_from_reception_raises_for_unknown_agent() -> None:
+    from backend.workflows.main_workflow import MainWorkflow
+
+    with patch.object(MainWorkflow, "__init__", lambda self, **kw: None):
+        wf = MainWorkflow()
+        wf.checkpointer = None
+        wf.store = None
+        wf._current_visitor_id = "test"
+
+        handoff = _make_handoff_result(target_agent="nonexistent_agent")
+
+        with pytest.raises(ValueError, match="Unknown target agent"):
+            await wf.ainvoke_from_reception(handoff)
+
+
+@pytest.mark.asyncio
+async def test_ainvoke_from_reception_preserves_metadata() -> None:
+    from backend.workflows.main_workflow import MainWorkflow
+
+    with patch.object(MainWorkflow, "__init__", lambda self, **kw: None):
+        wf = MainWorkflow()
+        wf.checkpointer = None
+        wf.store = None
+        wf._current_visitor_id = "test"
+
+        wf._facility_node = AsyncMock(
+            return_value={
+                "answer": "Facility info",
+                "emotion": "neutral",
+                "metadata": {"reception_handoff": True, "extra": "data"},
+            }
+        )
+        wf._format_response_node = AsyncMock(
+            return_value={
+                "answer": "Facility info",
+                "emotion": "neutral",
+                "metadata": {"reception_handoff": True, "extra": "data"},
+                "messages": [],
+            }
+        )
+
+        handoff = _make_handoff_result(target_agent="facility")
+        result = await wf.ainvoke_from_reception(handoff)
+
+        assert result["metadata"]["reception_handoff"] is True
+
+
+@pytest.mark.asyncio
+async def test_ainvoke_from_reception_returns_purpose_flow_response() -> None:
+    """When requires_staff is True, the purpose_flow response_text
+    should be included in the result."""
+    from backend.workflows.main_workflow import MainWorkflow
+
+    with patch.object(MainWorkflow, "__init__", lambda self, **kw: None):
+        wf = MainWorkflow()
+        wf.checkpointer = None
+        wf.store = None
+        wf._current_visitor_id = "test"
+
+        wf._general_knowledge_node = AsyncMock(
+            return_value={
+                "answer": "Connecting to staff...",
+                "emotion": "neutral",
+                "metadata": {},
+            }
+        )
+        wf._format_response_node = AsyncMock(
+            return_value={
+                "answer": "Connecting to staff...",
+                "emotion": "neutral",
+                "metadata": {},
+                "messages": [],
+            }
+        )
+
+        handoff = _make_handoff_result(
+            target_agent="general_knowledge",
+            action_type="escalate",
+            requires_staff=True,
+        )
+        result = await wf.ainvoke_from_reception(handoff)
+
+        assert result["purpose_flow_response"] == "Guide text"
+        assert result["requires_staff"] is True

--- a/backend/workflows/main_workflow.py
+++ b/backend/workflows/main_workflow.py
@@ -930,6 +930,69 @@ class MainWorkflow:
 
         return state, config
 
+    _AGENT_NODE_MAP: dict[str, str] = {
+        "facility": "_facility_node",
+        "event": "_event_node",
+        "slide": "_slide_node",
+        "general_knowledge": "_general_knowledge_node",
+        "business_info": "_business_info_node",
+    }
+
+    async def ainvoke_from_reception(self, handoff: Any) -> dict:
+        """Invoke an agent node directly, bypassing the orchestrator.
+
+        Used by the autonomous reception flow after ReceptionHandoffService
+        has already determined the target agent and built the workflow state.
+
+        Args:
+            handoff: A HandoffResult from ReceptionHandoffService.
+
+        Returns:
+            A dict with answer, emotion, metadata, and reception-specific fields.
+
+        Raises:
+            ValueError: If the target agent is not a known node.
+        """
+        target = handoff.target_agent
+        node_attr = self._AGENT_NODE_MAP.get(target)
+        if node_attr is None:
+            raise ValueError(
+                f"Unknown target agent '{target}'. " f"Valid agents: {sorted(self._AGENT_NODE_MAP)}"
+            )
+
+        state = handoff.workflow_state
+        self._current_visitor_id = state.get("session_id", "anonymous")
+
+        agent_node = getattr(self, node_attr)
+        agent_result = await agent_node(state)
+
+        # Merge agent output into state for format_response
+        merged_state = {**state, **agent_result}
+
+        # format_response expects Runtime context — call directly with a
+        # lightweight shim since we're outside the graph execution.
+        try:
+            context = WorkflowContext(user_id=self._current_visitor_id)
+
+            class _RuntimeShim:
+                def __init__(self, ctx: WorkflowContext) -> None:
+                    self.context = ctx
+
+            formatted = await self._format_response_node(merged_state, _RuntimeShim(context))
+        except Exception:
+            logger.warning("format_response failed in reception invoke, using raw agent result")
+            formatted = agent_result
+
+        result = {
+            "answer": formatted.get("answer", agent_result.get("answer", "")),
+            "emotion": formatted.get("emotion", agent_result.get("emotion", "neutral")),
+            "metadata": formatted.get("metadata", agent_result.get("metadata", {})),
+            "purpose_flow_response": handoff.purpose_flow.response_text,
+            "requires_staff": handoff.requires_staff,
+        }
+
+        return result
+
     async def ainvoke(self, input_data: dict) -> dict:
         """ワークフローを非同期実行"""
         state, config = self._prepare_state(input_data)

--- a/frontend/src/app/api/reception/_shared.ts
+++ b/frontend/src/app/api/reception/_shared.ts
@@ -1,0 +1,51 @@
+import { NextResponse } from 'next/server';
+
+import { getBackendApiUrl } from '@/lib/api/backend-url';
+
+type JsonValue = Record<string, unknown> | Array<unknown> | string | number | boolean | null;
+
+async function readJson(response: Response): Promise<JsonValue | null> {
+  const contentType = response.headers.get('content-type') ?? '';
+  if (!contentType.includes('application/json')) {
+    return null;
+  }
+
+  try {
+    return (await response.json()) as JsonValue;
+  } catch {
+    return null;
+  }
+}
+
+export async function proxyReceptionRequest(
+  path: string,
+  init: RequestInit
+): Promise<NextResponse> {
+  try {
+    const response = await fetch(`${getBackendApiUrl()}${path}`, init);
+    const data = await readJson(response);
+
+    if (!response.ok) {
+      const message =
+        data && typeof data === 'object' && 'error' in data && typeof data.error === 'string'
+          ? data.error
+          : `Backend API error: ${response.status}`;
+
+      return NextResponse.json({ error: message }, { status: response.status });
+    }
+
+    return NextResponse.json(data ?? {});
+  } catch (error) {
+    console.error(`Reception proxy error for ${path}:`, error);
+
+    return NextResponse.json(
+      {
+        error: 'Internal server error',
+        ...(process.env.NODE_ENV === 'development' && {
+          details: error instanceof Error ? error.message : 'Unknown error',
+        }),
+      },
+      { status: 500 }
+    );
+  }
+}

--- a/frontend/src/app/api/reception/complete/route.ts
+++ b/frontend/src/app/api/reception/complete/route.ts
@@ -1,0 +1,13 @@
+import { NextRequest } from 'next/server';
+
+import { proxyReceptionRequest } from '../_shared';
+
+export async function POST(request: NextRequest) {
+  const body = await request.json();
+
+  return proxyReceptionRequest('/api/reception/complete', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(body),
+  });
+}

--- a/frontend/src/app/api/reception/respond/route.ts
+++ b/frontend/src/app/api/reception/respond/route.ts
@@ -1,0 +1,13 @@
+import { NextRequest } from 'next/server';
+
+import { proxyReceptionRequest } from '../_shared';
+
+export async function POST(request: NextRequest) {
+  const body = await request.json();
+
+  return proxyReceptionRequest('/api/reception/respond', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(body),
+  });
+}

--- a/frontend/src/app/api/reception/start/route.ts
+++ b/frontend/src/app/api/reception/start/route.ts
@@ -1,0 +1,13 @@
+import { NextRequest } from 'next/server';
+
+import { proxyReceptionRequest } from '../_shared';
+
+export async function POST(request: NextRequest) {
+  const body = await request.json();
+
+  return proxyReceptionRequest('/api/reception/start', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(body),
+  });
+}

--- a/frontend/src/app/api/reception/status/[receptionSessionId]/route.ts
+++ b/frontend/src/app/api/reception/status/[receptionSessionId]/route.ts
@@ -1,0 +1,23 @@
+import { NextRequest } from 'next/server';
+
+import { proxyReceptionRequest } from '../../_shared';
+
+interface RouteContext {
+  params: Promise<{
+    receptionSessionId: string;
+  }>;
+}
+
+export async function GET(request: NextRequest, context: RouteContext) {
+  const { receptionSessionId } = await context.params;
+  const sessionId = request.nextUrl.searchParams.get('session_id');
+
+  const search = sessionId
+    ? `?${new URLSearchParams({ session_id: sessionId }).toString()}`
+    : '';
+
+  return proxyReceptionRequest(`/api/reception/status/${receptionSessionId}${search}`, {
+    method: 'GET',
+    headers: { 'Content-Type': 'application/json' },
+  });
+}

--- a/frontend/src/components/reception/ReceptionPanel.tsx
+++ b/frontend/src/components/reception/ReceptionPanel.tsx
@@ -1,0 +1,200 @@
+'use client';
+
+import { FormEvent, useEffect, useRef, useState } from 'react';
+import { Loader2, MessageSquare, Sparkles } from 'lucide-react';
+
+import { cn } from '@/lib/cn';
+import { useReception } from '@/hooks/useReception';
+import { StageIndicator } from './StageIndicator';
+
+interface ReceptionPanelProps {
+  sessionId: string;
+  language?: string;
+  triggerType?: string;
+  className?: string;
+}
+
+export function ReceptionPanel({
+  sessionId,
+  language = 'ja',
+  triggerType = 'manual',
+  className,
+}: ReceptionPanelProps) {
+  const [draft, setDraft] = useState('');
+  const hasAutoCompletedRef = useRef(false);
+  const {
+    stage,
+    error,
+    isLoading,
+    purpose,
+    messages,
+    completion,
+    startReception,
+    sendMessage,
+    completeReception,
+    resetReception,
+  } = useReception({
+    sessionId,
+    language,
+    triggerType,
+  });
+
+  useEffect(() => {
+    if (stage !== 'routing') {
+      hasAutoCompletedRef.current = false;
+      return;
+    }
+
+    if (isLoading || hasAutoCompletedRef.current) {
+      return;
+    }
+
+    hasAutoCompletedRef.current = true;
+    void completeReception().catch(() => {
+      hasAutoCompletedRef.current = false;
+    });
+  }, [completeReception, isLoading, stage]);
+
+  const handleSubmit = async (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    const message = draft.trim();
+    if (!message || isLoading) {
+      return;
+    }
+
+    setDraft('');
+    await sendMessage(message);
+  };
+
+  const isConversationActive = stage !== 'idle';
+
+  return (
+    <section
+      className={cn(
+        'w-full max-w-3xl rounded-2xl border border-slate-200 bg-white p-6 shadow-sm',
+        className
+      )}
+    >
+      <div className="flex flex-col gap-5">
+        <div className="flex items-start justify-between gap-4">
+          <div className="space-y-2">
+            <span className="inline-flex items-center gap-2 rounded-full bg-slate-100 px-3 py-1 text-xs font-semibold text-slate-600">
+              <Sparkles className="size-3.5" aria-hidden="true" />
+              Reception Mode
+            </span>
+            <div className="space-y-1">
+              <h2 className="text-2xl font-semibold text-balance text-slate-950">
+                Front Desk Conversation
+              </h2>
+              <p className="text-sm text-pretty text-slate-600">
+                Start a guided reception flow, collect the visitor&apos;s purpose, and route them to
+                the right next action.
+              </p>
+            </div>
+          </div>
+          {isConversationActive && (
+            <button
+              type="button"
+              onClick={resetReception}
+              className="rounded-lg border border-slate-300 px-3 py-2 text-sm font-medium text-slate-700 transition-colors hover:bg-slate-50"
+            >
+              Reset
+            </button>
+          )}
+        </div>
+
+        <StageIndicator currentStage={stage} />
+
+        {!isConversationActive ? (
+          <div className="rounded-xl border border-dashed border-slate-300 bg-slate-50 p-8 text-center">
+            <p className="mx-auto max-w-xl text-sm text-pretty text-slate-600">
+              Start reception when a visitor arrives. The assistant will greet them, ask their
+              purpose, and finalize routing once enough detail is collected.
+            </p>
+            <button
+              type="button"
+              onClick={() => void startReception()}
+              disabled={isLoading}
+              className="mt-5 inline-flex items-center justify-center rounded-lg bg-slate-900 px-4 py-2.5 text-sm font-semibold text-white transition-colors hover:bg-slate-800 disabled:cursor-not-allowed disabled:bg-slate-400"
+            >
+              {isLoading ? <Loader2 className="size-4 animate-spin" aria-hidden="true" /> : null}
+              <span className={cn(isLoading && 'ml-2')}>Start Reception</span>
+            </button>
+            {error ? <p className="mt-3 text-sm text-red-600">{error}</p> : null}
+          </div>
+        ) : (
+          <>
+            <div className="rounded-xl border border-slate-200 bg-slate-50 p-4">
+              <div className="flex items-center gap-2 text-sm font-medium text-slate-700">
+                <MessageSquare className="size-4" aria-hidden="true" />
+                Conversation
+              </div>
+              <div className="mt-4 space-y-3">
+                {messages.map((message) => (
+                  <div
+                    key={message.id}
+                    className={cn(
+                      'max-w-[85%] rounded-2xl px-4 py-3 text-sm shadow-sm',
+                      message.role === 'assistant'
+                        ? 'bg-white text-slate-800'
+                        : 'ml-auto bg-slate-900 text-white'
+                    )}
+                  >
+                    <p className="text-pretty">{message.text}</p>
+                  </div>
+                ))}
+              </div>
+            </div>
+
+            {purpose ? (
+              <p className="text-sm text-slate-600">
+                Current purpose: <span className="font-medium text-slate-900">{purpose}</span>
+              </p>
+            ) : null}
+
+            {stage !== 'completed' ? (
+              <form className="space-y-3" onSubmit={(event) => void handleSubmit(event)}>
+                <label className="block text-sm font-medium text-slate-700" htmlFor="reception-message">
+                  Visitor response
+                </label>
+                <textarea
+                  id="reception-message"
+                  value={draft}
+                  onChange={(event) => setDraft(event.target.value)}
+                  rows={3}
+                  placeholder="Enter the visitor's message"
+                  disabled={isLoading}
+                  className="w-full rounded-xl border border-slate-300 bg-white px-4 py-3 text-sm text-slate-900 outline-none transition-colors placeholder:text-slate-400 focus:border-slate-900"
+                />
+                <div className="flex items-center justify-between gap-3">
+                  {error ? <p className="text-sm text-red-600">{error}</p> : <span />}
+                  <button
+                    type="submit"
+                    disabled={isLoading || !draft.trim()}
+                    className="inline-flex items-center justify-center rounded-lg bg-slate-900 px-4 py-2.5 text-sm font-semibold text-white transition-colors hover:bg-slate-800 disabled:cursor-not-allowed disabled:bg-slate-400"
+                  >
+                    {isLoading ? <Loader2 className="size-4 animate-spin" aria-hidden="true" /> : null}
+                    <span className={cn(isLoading && 'ml-2')}>{stage === 'routing' ? 'Finalizing' : 'Send Response'}</span>
+                  </button>
+                </div>
+              </form>
+            ) : (
+              <div className="rounded-xl border border-emerald-200 bg-emerald-50 p-4 text-sm text-slate-700">
+                <p className="font-semibold text-slate-900">Reception completed</p>
+                <p className="mt-1 text-pretty">{completion?.response_text}</p>
+                {completion?.target_agent ? (
+                  <p className="mt-3">
+                    Route to: <span className="font-medium text-slate-900">{completion.target_agent}</span>
+                  </p>
+                ) : null}
+                {completion?.requires_staff ? (
+                  <p className="mt-1 text-slate-600">Staff assistance is required for this visitor.</p>
+                ) : null}
+              </div>
+            )}
+          </>
+        )}
+      </div>
+    </section>
+  );
+}

--- a/frontend/src/components/reception/StageIndicator.tsx
+++ b/frontend/src/components/reception/StageIndicator.tsx
@@ -1,0 +1,67 @@
+'use client';
+
+import { Check } from 'lucide-react';
+
+import { cn } from '@/lib/cn';
+import type { ReceptionStage } from '@/lib/reception-api';
+
+const STAGES = [
+  { key: 'greeting', label: 'Greeting' },
+  { key: 'purpose_hearing', label: 'Purpose' },
+  { key: 'routing', label: 'Routing' },
+  { key: 'completed', label: 'Complete' },
+] as const;
+
+interface StageIndicatorProps {
+  currentStage: ReceptionStage;
+}
+
+export function StageIndicator({ currentStage }: StageIndicatorProps) {
+  const activeIndex =
+    currentStage === 'idle'
+      ? -1
+      : STAGES.findIndex((stage) => stage.key === currentStage);
+
+  return (
+    <ol className="flex items-start gap-3" aria-label="Reception progress">
+      {STAGES.map((stage, index) => {
+        const isCompleted = activeIndex > index;
+        const isCurrent = activeIndex === index;
+
+        return (
+          <li key={stage.key} className="flex min-w-0 flex-1 items-start gap-3">
+            <div className="flex flex-col items-center gap-2">
+              <div
+                className={cn(
+                  'flex size-8 items-center justify-center rounded-full border text-sm font-semibold',
+                  isCompleted && 'border-emerald-600 bg-emerald-600 text-white',
+                  isCurrent && 'border-slate-900 bg-slate-900 text-white',
+                  !isCompleted && !isCurrent && 'border-slate-300 bg-white text-slate-400'
+                )}
+              >
+                {isCompleted ? <Check className="size-4" aria-hidden="true" /> : index + 1}
+              </div>
+              <span
+                className={cn(
+                  'text-center text-xs font-medium',
+                  isCompleted || isCurrent ? 'text-slate-900' : 'text-slate-400'
+                )}
+              >
+                {stage.label}
+              </span>
+            </div>
+            {index < STAGES.length - 1 && (
+              <div
+                className={cn(
+                  'mt-4 h-px flex-1',
+                  activeIndex > index ? 'bg-emerald-600' : 'bg-slate-200'
+                )}
+                aria-hidden="true"
+              />
+            )}
+          </li>
+        );
+      })}
+    </ol>
+  );
+}

--- a/frontend/src/hooks/useReception.ts
+++ b/frontend/src/hooks/useReception.ts
@@ -1,0 +1,182 @@
+'use client';
+
+import { startTransition, useState } from 'react';
+
+import {
+  completeReception as completeReceptionRequest,
+  respondReception,
+  startReception as startReceptionRequest,
+  type CompleteReceptionResponse,
+  type ReceptionStage,
+} from '@/lib/reception-api';
+
+export interface ReceptionMessage {
+  id: string;
+  role: 'assistant' | 'visitor';
+  text: string;
+}
+
+export interface UseReceptionOptions {
+  sessionId: string;
+  language?: string;
+  triggerType?: string;
+}
+
+interface UseReceptionResult {
+  stage: ReceptionStage;
+  responseText: string | null;
+  purpose: string | null;
+  error: string | null;
+  isLoading: boolean;
+  receptionSessionId: string | null;
+  completion: CompleteReceptionResponse | null;
+  messages: ReceptionMessage[];
+  startReception: () => Promise<void>;
+  sendMessage: (message: string) => Promise<void>;
+  completeReception: () => Promise<CompleteReceptionResponse>;
+  resetReception: () => void;
+}
+
+function createMessage(role: ReceptionMessage['role'], text: string): ReceptionMessage {
+  return {
+    id: `${role}_${Date.now()}_${Math.random().toString(36).slice(2, 9)}`,
+    role,
+    text,
+  };
+}
+
+export function useReception({
+  sessionId,
+  language = 'ja',
+  triggerType = 'manual',
+}: UseReceptionOptions): UseReceptionResult {
+  const [stage, setStage] = useState<ReceptionStage>('idle');
+  const [responseText, setResponseText] = useState<string | null>(null);
+  const [purpose, setPurpose] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [isLoading, setIsLoading] = useState(false);
+  const [receptionSessionId, setReceptionSessionId] = useState<string | null>(null);
+  const [completion, setCompletion] = useState<CompleteReceptionResponse | null>(null);
+  const [messages, setMessages] = useState<ReceptionMessage[]>([]);
+
+  const resetReception = () => {
+    setStage('idle');
+    setResponseText(null);
+    setPurpose(null);
+    setError(null);
+    setIsLoading(false);
+    setReceptionSessionId(null);
+    setCompletion(null);
+    setMessages([]);
+  };
+
+  const startReception = async () => {
+    setIsLoading(true);
+    setError(null);
+
+    try {
+      const result = await startReceptionRequest({
+        session_id: sessionId,
+        language,
+        trigger_type: triggerType,
+      });
+
+      startTransition(() => {
+        setReceptionSessionId(result.reception_session_id);
+        setStage(result.stage);
+        setResponseText(result.greeting);
+        setPurpose(null);
+        setCompletion(null);
+        setMessages([createMessage('assistant', result.greeting)]);
+      });
+    } catch (requestError) {
+      setError(requestError instanceof Error ? requestError.message : 'Failed to start reception');
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  const sendMessage = async (message: string) => {
+    const trimmedMessage = message.trim();
+    if (!trimmedMessage || !receptionSessionId) {
+      return;
+    }
+
+    setIsLoading(true);
+    setError(null);
+    setMessages((currentMessages) => [...currentMessages, createMessage('visitor', trimmedMessage)]);
+
+    try {
+      const result = await respondReception({
+        session_id: sessionId,
+        reception_session_id: receptionSessionId,
+        message: trimmedMessage,
+      });
+
+      startTransition(() => {
+        setStage(result.stage);
+        setResponseText(result.response);
+        setPurpose(result.purpose);
+        setMessages((currentMessages) => [
+          ...currentMessages,
+          createMessage('assistant', result.response),
+        ]);
+      });
+    } catch (requestError) {
+      setError(requestError instanceof Error ? requestError.message : 'Failed to send message');
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  const completeReception = async (): Promise<CompleteReceptionResponse> => {
+    if (!receptionSessionId) {
+      throw new Error('Reception session has not started');
+    }
+
+    setIsLoading(true);
+    setError(null);
+
+    try {
+      const result = await completeReceptionRequest({
+        session_id: sessionId,
+        reception_session_id: receptionSessionId,
+      });
+
+      startTransition(() => {
+        setStage('completed');
+        setResponseText(result.response_text);
+        setPurpose((currentPurpose) => currentPurpose ?? result.purpose_category);
+        setCompletion(result);
+        setMessages((currentMessages) => [
+          ...currentMessages,
+          createMessage('assistant', result.response_text),
+        ]);
+      });
+
+      return result;
+    } catch (requestError) {
+      const message =
+        requestError instanceof Error ? requestError.message : 'Failed to complete reception';
+      setError(message);
+      throw new Error(message);
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  return {
+    stage,
+    responseText,
+    purpose,
+    error,
+    isLoading,
+    receptionSessionId,
+    completion,
+    messages,
+    startReception,
+    sendMessage,
+    completeReception,
+    resetReception,
+  };
+}

--- a/frontend/src/lib/cn.ts
+++ b/frontend/src/lib/cn.ts
@@ -1,0 +1,3 @@
+export function cn(...classes: Array<string | false | null | undefined>): string {
+  return classes.filter(Boolean).join(' ');
+}

--- a/frontend/src/lib/reception-api.ts
+++ b/frontend/src/lib/reception-api.ts
@@ -1,0 +1,117 @@
+export type ReceptionStage = 'idle' | 'greeting' | 'purpose_hearing' | 'routing' | 'completed';
+export type ReceptionActiveStage = Exclude<ReceptionStage, 'idle'>;
+
+export interface StartReceptionRequest {
+  session_id: string;
+  language: string;
+  trigger_type: string;
+}
+
+export interface StartReceptionResponse {
+  reception_session_id: string;
+  greeting: string;
+  stage: ReceptionActiveStage;
+}
+
+export interface RespondReceptionRequest {
+  session_id: string;
+  reception_session_id: string;
+  message: string;
+}
+
+export interface RespondReceptionResponse {
+  response: string;
+  stage: ReceptionActiveStage;
+  purpose: string | null;
+  next_action: string | null;
+}
+
+export interface CompleteReceptionRequest {
+  session_id: string;
+  reception_session_id: string;
+}
+
+export interface CompleteReceptionResponse {
+  response_text: string;
+  target_agent: string | null;
+  requires_staff: boolean;
+  purpose_category: string | null;
+  action_type: string | null;
+  action_data: Record<string, unknown> | null;
+}
+
+export interface ReceptionStatusResponse {
+  session_id: string;
+  stage: ReceptionActiveStage;
+  visitor_type: string | null;
+  purpose: string | null;
+}
+
+interface ApiErrorPayload {
+  error?: string;
+  details?: string;
+}
+
+async function requestReceptionApi<TResponse>(
+  input: RequestInfo,
+  init?: RequestInit
+): Promise<TResponse> {
+  const response = await fetch(input, {
+    ...init,
+    headers: {
+      'Content-Type': 'application/json',
+      ...init?.headers,
+    },
+  });
+
+  const isJson = response.headers.get('content-type')?.includes('application/json');
+  const payload = isJson ? ((await response.json()) as TResponse | ApiErrorPayload) : null;
+
+  if (!response.ok) {
+    const apiError = payload as ApiErrorPayload | null;
+    const message =
+      apiError?.error ?? apiError?.details ?? `Reception API request failed with ${response.status}`;
+    throw new Error(message);
+  }
+
+  return (payload ?? {}) as TResponse;
+}
+
+export async function startReception(
+  request: StartReceptionRequest
+): Promise<StartReceptionResponse> {
+  return requestReceptionApi<StartReceptionResponse>('/api/reception/start', {
+    method: 'POST',
+    body: JSON.stringify(request),
+  });
+}
+
+export async function respondReception(
+  request: RespondReceptionRequest
+): Promise<RespondReceptionResponse> {
+  return requestReceptionApi<RespondReceptionResponse>('/api/reception/respond', {
+    method: 'POST',
+    body: JSON.stringify(request),
+  });
+}
+
+export async function completeReception(
+  request: CompleteReceptionRequest
+): Promise<CompleteReceptionResponse> {
+  return requestReceptionApi<CompleteReceptionResponse>('/api/reception/complete', {
+    method: 'POST',
+    body: JSON.stringify(request),
+  });
+}
+
+export async function getReceptionStatus(
+  receptionSessionId: string,
+  sessionId: string
+): Promise<ReceptionStatusResponse> {
+  const search = new URLSearchParams({ session_id: sessionId }).toString();
+
+  return requestReceptionApi<ReceptionStatusResponse>(
+    `/api/reception/status/${receptionSessionId}?${search}`,
+    { method: 'GET' }
+  );
+}


### PR DESCRIPTION
## Summary

- **Supabase integration tests**: 10 tests verifying `PurposeFlowService._fetch_today_events()` and `VisitorIdentificationService.identify_by_visitor_id()` against real local Supabase
- **Events table migration**: `20260308000003_add_events_table.sql` with all date/location fields matching PurposeFlowService expectations  
- **Frontend reception UI**: ReceptionPanel, StageIndicator, useReception hook, reception-api client, Next.js proxy routes
- **MainWorkflow.ainvoke_from_reception()**: Orchestrator bypass for reception handoff — routes directly to target agent node using `_AGENT_NODE_MAP`

## Test plan

- [x] 10 Supabase integration tests pass (events + visits tables)
- [x] 6 MainWorkflow reception invoke tests pass
- [x] 51 existing reception unit tests pass (no regression)
- [x] ruff check + black format clean
- [x] Frontend lint + typecheck pass
- [ ] CI/CD all green

🤖 Generated with [Claude Code](https://claude.com/claude-code)