### PR TITLE
feat: reception integration + voice UI hooks + SessionTaskManager fix

### DIFF
--- a/backend/services/seat_availability_service.py
+++ b/backend/services/seat_availability_service.py
@@ -1,0 +1,149 @@
+"""Seat Availability Service - Read-only access to reception seat data.
+
+Queries the ``seats`` and ``seat_categories`` tables managed by the
+engineercafe-reception-2025 system.  This service is strictly READ ONLY
+and never mutates the underlying data.
+"""
+
+import logging
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+
+class SeatAvailabilityService:
+    """Provides seat availability information from the shared Supabase project.
+
+    The reception system (engineercafe-reception-2025) owns the ``seats`` and
+    ``seat_categories`` tables.  This service reads them to power Navigator
+    queries such as "Are there any free desks?".
+
+    Args:
+        supabase_client: Optional pre-configured Supabase client.  When
+            ``None`` the client is resolved lazily via ``supabase_helper``.
+    """
+
+    def __init__(self, supabase_client: Any = None) -> None:
+        self._supabase = supabase_client
+
+    async def _get_supabase(self) -> Any:
+        """Return the Supabase client, resolving lazily if needed."""
+        if self._supabase:
+            return self._supabase
+        try:
+            from backend.utils.supabase_helper import get_supabase_client
+
+            return get_supabase_client()
+        except Exception as e:
+            logger.warning("Supabase client unavailable: %s", e)
+            return None
+
+    # ------------------------------------------------------------------
+    # Public query methods (READ ONLY)
+    # ------------------------------------------------------------------
+
+    async def get_available_seats(self) -> list[dict[str, Any]]:
+        """Return a list of currently available seats with category info.
+
+        Returns:
+            A list of seat dicts for seats where ``is_available`` is True.
+            Returns an empty list when Supabase is unavailable or on error.
+        """
+        client = await self._get_supabase()
+        if not client:
+            return []
+        try:
+            result = (
+                client.table("seats")
+                .select(
+                    "id, name, seat_category_id, is_available,"
+                    " seat_categories(id, name, description)"
+                )
+                .eq("is_available", True)
+                .execute()
+            )
+            return result.data or []
+        except Exception as e:
+            logger.warning("Failed to fetch available seats: %s", e)
+            return []
+
+    async def get_seat_summary(self) -> dict[str, Any]:
+        """Return an aggregate summary of seat availability.
+
+        Returns:
+            A dict containing:
+                - ``total``: Total number of seats.
+                - ``available``: Number of available seats.
+                - ``occupied``: Number of occupied seats.
+                - ``categories``: Per-category breakdown with name, total,
+                  and available counts.
+            Returns zero-value defaults on error.
+        """
+        default: dict[str, Any] = {
+            "total": 0,
+            "available": 0,
+            "occupied": 0,
+            "categories": [],
+        }
+        client = await self._get_supabase()
+        if not client:
+            return default
+        try:
+            result = (
+                client.table("seats")
+                .select(
+                    "id, name, seat_category_id, is_available,"
+                    " seat_categories(id, name, description)"
+                )
+                .execute()
+            )
+            seats = result.data or []
+            if not seats:
+                return default
+
+            total = len(seats)
+            available = sum(1 for s in seats if s.get("is_available"))
+            occupied = total - available
+
+            # Build per-category breakdown
+            cat_map: dict[str, dict[str, Any]] = {}
+            for seat in seats:
+                cat_info = seat.get("seat_categories") or {}
+                cat_name = cat_info.get("name", "Unknown")
+                if cat_name not in cat_map:
+                    cat_map[cat_name] = {"name": cat_name, "total": 0, "available": 0}
+                cat_map[cat_name]["total"] += 1
+                if seat.get("is_available"):
+                    cat_map[cat_name]["available"] += 1
+
+            return {
+                "total": total,
+                "available": available,
+                "occupied": occupied,
+                "categories": list(cat_map.values()),
+            }
+        except Exception as e:
+            logger.warning("Failed to fetch seat summary: %s", e)
+            return default
+
+    async def is_seat_available(self, seat_id: int) -> bool:
+        """Check whether a specific seat is available.
+
+        Args:
+            seat_id: The database ID of the seat to check.
+
+        Returns:
+            ``True`` if the seat exists and is available, ``False`` otherwise
+            (including when Supabase is unavailable or on error).
+        """
+        client = await self._get_supabase()
+        if not client:
+            return False
+        try:
+            result = client.table("seats").select("id, is_available").eq("id", seat_id).execute()
+            if result.data:
+                return bool(result.data[0].get("is_available", False))
+            return False
+        except Exception as e:
+            logger.warning("Failed to check seat %s availability: %s", seat_id, e)
+            return False

--- a/backend/services/visitor_identification_service.py
+++ b/backend/services/visitor_identification_service.py
@@ -65,6 +65,20 @@ class VisitorIdentificationService:
             logger.warning("NFC lookup failed: %s", e)
         return None
 
+    async def identify_by_member_number(self, member_number: int) -> Optional[Dict[str, Any]]:
+        """Look up a visitor by their member number (users.id).
+
+        The member number is typically a 1-4 digit integer displayed on
+        the visitor's membership card, read via OCR.
+
+        Args:
+            member_number: The member number (equivalent to users.id).
+
+        Returns:
+            A dict with visitor identity fields, or None when not found.
+        """
+        return await self._get_user_profile(member_number)
+
     async def identify_by_visitor_id(self, visitor_id: str) -> Optional[Dict[str, Any]]:
         """Look up a visitor by frontend-generated persistent visitor_id.
 
@@ -143,21 +157,30 @@ class VisitorIdentificationService:
     # ------------------------------------------------------------------
 
     async def _get_user_profile(self, user_id: int) -> Optional[Dict[str, Any]]:
-        """Fetch user profile and visit count from the ``users`` table."""
+        """Fetch an enriched user profile and visit count from the ``users`` table."""
         client = await self._get_supabase()
         if not client:
             return None
         try:
-            result = client.table("users").select("id, name").eq("id", user_id).execute()
+            result = (
+                client.table("users")
+                .select("id, name, email, phone, prefecture, job, belong")
+                .eq("id", user_id)
+                .execute()
+            )
             if result.data:
                 user = result.data[0]
                 visit_count = await self._count_visits_by_user(user_id)
-                return {
+                profile = {
                     "visitor_type": "returning",
                     "user_id": user["id"],
                     "name": user.get("name"),
                     "visit_count": visit_count,
                 }
+                for field in ("email", "prefecture", "job", "belong"):
+                    if user.get(field) is not None:
+                        profile[field] = user.get(field)
+                return profile
         except Exception as e:
             logger.warning("User profile lookup failed: %s", e)
         return None

--- a/backend/tests/services/test_seat_availability_service.py
+++ b/backend/tests/services/test_seat_availability_service.py
@@ -1,0 +1,344 @@
+"""Tests for SeatAvailabilityService.
+
+All Supabase interactions are mocked to ensure tests run without
+external dependencies.  Follows the same patterns established in
+``test_visitor_identification_service.py``.
+"""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from backend.services.seat_availability_service import SeatAvailabilityService
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_mock_client() -> MagicMock:
+    """Build a mock Supabase client with chainable query builder."""
+    client = MagicMock()
+
+    def _table(name: str) -> MagicMock:
+        builder = MagicMock()
+        for method in ("select", "eq", "order", "limit", "neq"):
+            getattr(builder, method).return_value = builder
+        return builder
+
+    client.table = MagicMock(side_effect=_table)
+    return client
+
+
+def _make_query_result(data=None, count=None):
+    """Create a mock query result."""
+    result = MagicMock()
+    result.data = data or []
+    result.count = count
+    return result
+
+
+# ---------------------------------------------------------------------------
+# Sample data
+# ---------------------------------------------------------------------------
+
+SEAT_CATEGORIES = [
+    {"id": 1, "name": "Hot Desk", "description": "Open seating area"},
+    {"id": 2, "name": "Meeting Room", "description": "Private meeting rooms"},
+]
+
+AVAILABLE_SEATS = [
+    {
+        "id": 1,
+        "name": "A-1",
+        "seat_category_id": 1,
+        "is_available": True,
+        "seat_categories": {"id": 1, "name": "Hot Desk", "description": "Open seating area"},
+    },
+    {
+        "id": 2,
+        "name": "A-2",
+        "seat_category_id": 1,
+        "is_available": True,
+        "seat_categories": {"id": 1, "name": "Hot Desk", "description": "Open seating area"},
+    },
+    {
+        "id": 3,
+        "name": "B-1",
+        "seat_category_id": 2,
+        "is_available": True,
+        "seat_categories": {
+            "id": 2,
+            "name": "Meeting Room",
+            "description": "Private meeting rooms",
+        },
+    },
+]
+
+ALL_SEATS = [
+    {
+        "id": 1,
+        "name": "A-1",
+        "seat_category_id": 1,
+        "is_available": True,
+        "seat_categories": {"id": 1, "name": "Hot Desk", "description": "Open seating area"},
+    },
+    {
+        "id": 2,
+        "name": "A-2",
+        "seat_category_id": 1,
+        "is_available": False,
+        "seat_categories": {"id": 1, "name": "Hot Desk", "description": "Open seating area"},
+    },
+    {
+        "id": 3,
+        "name": "B-1",
+        "seat_category_id": 2,
+        "is_available": True,
+        "seat_categories": {
+            "id": 2,
+            "name": "Meeting Room",
+            "description": "Private meeting rooms",
+        },
+    },
+    {
+        "id": 4,
+        "name": "B-2",
+        "seat_category_id": 2,
+        "is_available": False,
+        "seat_categories": {
+            "id": 2,
+            "name": "Meeting Room",
+            "description": "Private meeting rooms",
+        },
+    },
+]
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def mock_client() -> MagicMock:
+    return _make_mock_client()
+
+
+@pytest.fixture
+def service(mock_client: MagicMock) -> SeatAvailabilityService:
+    return SeatAvailabilityService(supabase_client=mock_client)
+
+
+# ---------------------------------------------------------------------------
+# get_available_seats
+# ---------------------------------------------------------------------------
+
+
+async def test_get_available_seats_returns_available(
+    service: SeatAvailabilityService, mock_client: MagicMock
+):
+    """Should return only seats where is_available is True."""
+    builder = MagicMock()
+    builder.select.return_value = builder
+    builder.eq.return_value = builder
+    builder.execute.return_value = _make_query_result(data=AVAILABLE_SEATS)
+
+    mock_client.table = MagicMock(return_value=builder)
+
+    result = await service.get_available_seats()
+
+    assert len(result) == 3
+    assert all(seat["is_available"] for seat in result)
+    mock_client.table.assert_called_with("seats")
+
+
+async def test_get_available_seats_none_available(
+    service: SeatAvailabilityService, mock_client: MagicMock
+):
+    """Should return an empty list when all seats are occupied."""
+    builder = MagicMock()
+    builder.select.return_value = builder
+    builder.eq.return_value = builder
+    builder.execute.return_value = _make_query_result(data=[])
+
+    mock_client.table = MagicMock(return_value=builder)
+
+    result = await service.get_available_seats()
+
+    assert result == []
+
+
+# ---------------------------------------------------------------------------
+# get_seat_summary
+# ---------------------------------------------------------------------------
+
+
+async def test_get_seat_summary(service: SeatAvailabilityService, mock_client: MagicMock):
+    """Should return a summary with total, available, and per-category counts."""
+    builder = MagicMock()
+    builder.select.return_value = builder
+    builder.execute.return_value = _make_query_result(data=ALL_SEATS)
+
+    mock_client.table = MagicMock(return_value=builder)
+
+    result = await service.get_seat_summary()
+
+    assert result["total"] == 4
+    assert result["available"] == 2
+    assert result["occupied"] == 2
+
+    # Category breakdown
+    categories = result["categories"]
+    assert len(categories) == 2
+
+    hot_desk = next(c for c in categories if c["name"] == "Hot Desk")
+    assert hot_desk["total"] == 2
+    assert hot_desk["available"] == 1
+
+    meeting = next(c for c in categories if c["name"] == "Meeting Room")
+    assert meeting["total"] == 2
+    assert meeting["available"] == 1
+
+
+async def test_get_seat_summary_all_available(
+    service: SeatAvailabilityService, mock_client: MagicMock
+):
+    """Summary should report zero occupied when all seats are free."""
+    all_free = [
+        {
+            "id": 1,
+            "name": "A-1",
+            "seat_category_id": 1,
+            "is_available": True,
+            "seat_categories": {"id": 1, "name": "Hot Desk", "description": "Open area"},
+        },
+    ]
+    builder = MagicMock()
+    builder.select.return_value = builder
+    builder.execute.return_value = _make_query_result(data=all_free)
+
+    mock_client.table = MagicMock(return_value=builder)
+
+    result = await service.get_seat_summary()
+
+    assert result["total"] == 1
+    assert result["available"] == 1
+    assert result["occupied"] == 0
+
+
+# ---------------------------------------------------------------------------
+# is_seat_available
+# ---------------------------------------------------------------------------
+
+
+async def test_is_seat_available_true(service: SeatAvailabilityService, mock_client: MagicMock):
+    """Should return True when the seat exists and is_available is True."""
+    builder = MagicMock()
+    builder.select.return_value = builder
+    builder.eq.return_value = builder
+    builder.execute.return_value = _make_query_result(
+        data=[{"id": 1, "name": "A-1", "is_available": True}]
+    )
+
+    mock_client.table = MagicMock(return_value=builder)
+
+    result = await service.is_seat_available(1)
+
+    assert result is True
+
+
+async def test_is_seat_available_false(service: SeatAvailabilityService, mock_client: MagicMock):
+    """Should return False when the seat exists but is_available is False."""
+    builder = MagicMock()
+    builder.select.return_value = builder
+    builder.eq.return_value = builder
+    builder.execute.return_value = _make_query_result(
+        data=[{"id": 2, "name": "A-2", "is_available": False}]
+    )
+
+    mock_client.table = MagicMock(return_value=builder)
+
+    result = await service.is_seat_available(2)
+
+    assert result is False
+
+
+async def test_is_seat_available_nonexistent(
+    service: SeatAvailabilityService, mock_client: MagicMock
+):
+    """Should return False when the seat_id does not exist."""
+    builder = MagicMock()
+    builder.select.return_value = builder
+    builder.eq.return_value = builder
+    builder.execute.return_value = _make_query_result(data=[])
+
+    mock_client.table = MagicMock(return_value=builder)
+
+    result = await service.is_seat_available(999)
+
+    assert result is False
+
+
+# ---------------------------------------------------------------------------
+# Graceful degradation
+# ---------------------------------------------------------------------------
+
+
+async def test_supabase_unavailable_get_available_seats():
+    """get_available_seats should return [] when Supabase is unavailable."""
+    service = SeatAvailabilityService(supabase_client=None)
+
+    with patch(
+        "backend.services.seat_availability_service.SeatAvailabilityService._get_supabase",
+        new_callable=AsyncMock,
+        return_value=None,
+    ):
+        result = await service.get_available_seats()
+        assert result == []
+
+
+async def test_supabase_unavailable_get_seat_summary():
+    """get_seat_summary should return a default summary when Supabase is unavailable."""
+    service = SeatAvailabilityService(supabase_client=None)
+
+    with patch(
+        "backend.services.seat_availability_service.SeatAvailabilityService._get_supabase",
+        new_callable=AsyncMock,
+        return_value=None,
+    ):
+        result = await service.get_seat_summary()
+        assert result["total"] == 0
+        assert result["available"] == 0
+        assert result["occupied"] == 0
+        assert result["categories"] == []
+
+
+async def test_supabase_unavailable_is_seat_available():
+    """is_seat_available should return False when Supabase is unavailable."""
+    service = SeatAvailabilityService(supabase_client=None)
+
+    with patch(
+        "backend.services.seat_availability_service.SeatAvailabilityService._get_supabase",
+        new_callable=AsyncMock,
+        return_value=None,
+    ):
+        result = await service.is_seat_available(1)
+        assert result is False
+
+
+async def test_supabase_query_exception(service: SeatAvailabilityService, mock_client: MagicMock):
+    """All methods should handle query exceptions gracefully."""
+    builder = MagicMock()
+    builder.select.return_value = builder
+    builder.eq.return_value = builder
+    builder.execute.side_effect = Exception("Connection reset")
+
+    mock_client.table = MagicMock(return_value=builder)
+
+    assert await service.get_available_seats() == []
+    assert await service.is_seat_available(1) is False
+
+    summary = await service.get_seat_summary()
+    assert summary["total"] == 0
+    assert summary["available"] == 0

--- a/backend/tests/services/test_visitor_identification_service.py
+++ b/backend/tests/services/test_visitor_identification_service.py
@@ -69,7 +69,18 @@ async def test_identify_by_nfc_found(service: VisitorIdentificationService, mock
     user_builder = MagicMock()
     user_builder.select.return_value = user_builder
     user_builder.eq.return_value = user_builder
-    user_builder.execute.return_value = _make_query_result(data=[{"id": 42, "name": "Taro"}])
+    user_builder.execute.return_value = _make_query_result(
+        data=[
+            {
+                "id": 42,
+                "name": "Taro",
+                "email": "taro@example.com",
+                "prefecture": "Fukuoka",
+                "job": "Engineer",
+                "belong": "OpenAI",
+            }
+        ]
+    )
 
     count_builder = MagicMock()
     count_builder.select.return_value = count_builder
@@ -81,10 +92,15 @@ async def test_identify_by_nfc_found(service: VisitorIdentificationService, mock
 
     result = await service.identify_by_nfc("nfc-abc-123")
 
+    user_builder.select.assert_called_once_with("id, name, email, phone, prefecture, job, belong")
     assert result is not None
     assert result["visitor_type"] == "returning"
     assert result["user_id"] == 42
     assert result["name"] == "Taro"
+    assert result["email"] == "taro@example.com"
+    assert result["prefecture"] == "Fukuoka"
+    assert result["job"] == "Engineer"
+    assert result["belong"] == "OpenAI"
     assert result["visit_count"] == 5
 
 
@@ -201,6 +217,109 @@ async def test_get_recent_visits(service: VisitorIdentificationService, mock_cli
 
 
 # ---------------------------------------------------------------------------
+# Member-number identification
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_identify_by_member_number_found(
+    service: VisitorIdentificationService, mock_client: MagicMock
+):
+    """Should return user profile when a valid member number matches a user."""
+    user_builder = MagicMock()
+    user_builder.select.return_value = user_builder
+    user_builder.eq.return_value = user_builder
+    user_builder.execute.return_value = _make_query_result(
+        data=[
+            {
+                "id": 7,
+                "name": "Hanako",
+                "email": "hanako@example.com",
+                "prefecture": "Tokyo",
+                "job": "Designer",
+                "belong": "Engineer Cafe",
+            }
+        ]
+    )
+
+    count_builder = MagicMock()
+    count_builder.select.return_value = count_builder
+    count_builder.eq.return_value = count_builder
+    count_builder.execute.return_value = _make_query_result(count=12)
+
+    tables = {"users": user_builder, "visits": count_builder}
+    mock_client.table = MagicMock(side_effect=lambda n: tables[n])
+
+    result = await service.identify_by_member_number(7)
+
+    user_builder.select.assert_called_once_with("id, name, email, phone, prefecture, job, belong")
+    assert result is not None
+    assert result["visitor_type"] == "returning"
+    assert result["user_id"] == 7
+    assert result["name"] == "Hanako"
+    assert result["email"] == "hanako@example.com"
+    assert result["prefecture"] == "Tokyo"
+    assert result["job"] == "Designer"
+    assert result["belong"] == "Engineer Cafe"
+    assert result["visit_count"] == 12
+
+
+@pytest.mark.asyncio
+async def test_identify_by_member_number_omits_missing_profile_fields(
+    service: VisitorIdentificationService, mock_client: MagicMock
+):
+    """Should omit optional profile fields when they are not present on the user record."""
+    user_builder = MagicMock()
+    user_builder.select.return_value = user_builder
+    user_builder.eq.return_value = user_builder
+    user_builder.execute.return_value = _make_query_result(data=[{"id": 9, "name": "Ken"}])
+
+    count_builder = MagicMock()
+    count_builder.select.return_value = count_builder
+    count_builder.eq.return_value = count_builder
+    count_builder.execute.return_value = _make_query_result(count=1)
+
+    tables = {"users": user_builder, "visits": count_builder}
+    mock_client.table = MagicMock(side_effect=lambda n: tables[n])
+
+    result = await service.identify_by_member_number(9)
+
+    assert result is not None
+    assert result["name"] == "Ken"
+    assert "email" not in result
+    assert "prefecture" not in result
+    assert "job" not in result
+    assert "belong" not in result
+
+
+@pytest.mark.asyncio
+async def test_identify_by_member_number_not_found(
+    service: VisitorIdentificationService, mock_client: MagicMock
+):
+    """Should return None when no user matches the member number."""
+    builder = MagicMock()
+    builder.select.return_value = builder
+    builder.eq.return_value = builder
+    builder.execute.return_value = _make_query_result(data=[])
+
+    mock_client.table = MagicMock(return_value=builder)
+
+    result = await service.identify_by_member_number(9999)
+    assert result is None
+
+
+@pytest.mark.asyncio
+async def test_identify_by_member_number_supabase_failure(
+    service: VisitorIdentificationService, mock_client: MagicMock
+):
+    """Should return None gracefully when Supabase raises an exception."""
+    mock_client.table.side_effect = Exception("Connection refused")
+
+    result = await service.identify_by_member_number(1)
+    assert result is None
+
+
+# ---------------------------------------------------------------------------
 # Graceful degradation
 # ---------------------------------------------------------------------------
 
@@ -217,5 +336,6 @@ async def test_supabase_unavailable_graceful_fallback():
         return_value=None,
     ):
         assert await service.identify_by_nfc("any") is None
+        assert await service.identify_by_member_number(1) is None
         assert await service.identify_by_visitor_id("any") is None
         assert await service.get_recent_visits(visitor_id="any") == []

--- a/backend/tests/utils/test_session_task_manager.py
+++ b/backend/tests/utils/test_session_task_manager.py
@@ -17,17 +17,22 @@ from backend.utils.session_task_manager import (
     SessionTaskInfo,
     SessionTaskManager,
     get_session_task_manager,
+    reset_session_task_manager,
 )
+
+
+@pytest.fixture(autouse=True)
+def reset_manager_singleton():
+    """各テスト前後で SessionTaskManager シングルトンをリセット"""
+    reset_session_task_manager()
+    yield
+    reset_session_task_manager()
 
 
 @pytest.fixture
 async def manager():
     """SessionTaskManager フィクスチャ"""
     mgr = SessionTaskManager()
-    # Singleton を初期化
-    mgr._sessions.clear()
-    mgr._initialized = True
-
     yield mgr
 
 
@@ -99,6 +104,16 @@ class TestSessionTaskManager:
         mgr1 = SessionTaskManager()
         mgr2 = SessionTaskManager()
         assert mgr1 is mgr2
+
+    async def test_get_lock_lazy_initialization(self, manager):
+        """Lock がイベントループ内で遅延初期化される"""
+        assert manager._lock is None
+
+        lock = await manager._get_lock()
+
+        assert isinstance(lock, asyncio.Lock)
+        assert manager._lock is lock
+        assert await manager._get_lock() is lock
 
     async def test_register_session(self, manager):
         """セッション登録"""

--- a/backend/utils/session_task_manager.py
+++ b/backend/utils/session_task_manager.py
@@ -97,10 +97,16 @@ class SessionTaskManager:
             return
 
         self._sessions: Dict[str, SessionTaskInfo] = {}
-        self._lock = asyncio.Lock()
+        self._lock: Optional[asyncio.Lock] = None
         self._cleanup_task: Optional[asyncio.Task] = None
         self._initialized = True
         logger.info("SessionTaskManager initialized")
+
+    async def _get_lock(self) -> asyncio.Lock:
+        """イベントループ内で Lock を遅延初期化"""
+        if self._lock is None:
+            self._lock = asyncio.Lock()
+        return self._lock
 
     async def initialize(self) -> None:
         """バックグラウンド クリーンアップタスク開始"""
@@ -117,14 +123,14 @@ class SessionTaskManager:
             except asyncio.CancelledError:
                 pass
 
-        async with self._lock:
+        async with await self._get_lock():
             self._sessions.clear()
 
         logger.info("SessionTaskManager shutdown complete")
 
     async def register_session(self, session_id: str) -> SessionTaskInfo:
         """セッションを登録/取得"""
-        async with self._lock:
+        async with await self._get_lock():
             if session_id not in self._sessions:
                 info = SessionTaskInfo(session_id=session_id)
                 self._sessions[session_id] = info
@@ -136,12 +142,12 @@ class SessionTaskManager:
 
     async def get_session(self, session_id: str) -> Optional[SessionTaskInfo]:
         """セッション情報を取得"""
-        async with self._lock:
+        async with await self._get_lock():
             return self._sessions.get(session_id)
 
     async def set_llm_task(self, session_id: str, task: asyncio.Task) -> bool:
         """LLM生成タスクを登録"""
-        async with self._lock:
+        async with await self._get_lock():
             if session_id in self._sessions:
                 self._sessions[session_id].llm_task = task
                 self._sessions[session_id].update_activity()
@@ -151,7 +157,7 @@ class SessionTaskManager:
 
     async def set_tts_task(self, session_id: str, task: asyncio.Task) -> bool:
         """TTS処理タスクを登録"""
-        async with self._lock:
+        async with await self._get_lock():
             if session_id in self._sessions:
                 self._sessions[session_id].tts_task = task
                 self._sessions[session_id].update_activity()
@@ -161,7 +167,7 @@ class SessionTaskManager:
 
     async def set_tts_buffer(self, session_id: str, buffer: BytesIO) -> bool:
         """TTSバッファを登録"""
-        async with self._lock:
+        async with await self._get_lock():
             if session_id in self._sessions:
                 self._sessions[session_id].tts_buffer = buffer
                 self._sessions[session_id].update_activity()
@@ -171,14 +177,14 @@ class SessionTaskManager:
 
     async def get_tts_buffer(self, session_id: str) -> Optional[BytesIO]:
         """TTSバッファを取得"""
-        async with self._lock:
+        async with await self._get_lock():
             if session_id in self._sessions:
                 return self._sessions[session_id].tts_buffer
             return None
 
     async def cancel_llm_task(self, session_id: str) -> bool:
         """LLMタスクをキャンセル"""
-        async with self._lock:
+        async with await self._get_lock():
             if session_id not in self._sessions:
                 logger.warning("Session not found for cancel_llm_task: %s", session_id)
                 return False
@@ -198,7 +204,7 @@ class SessionTaskManager:
 
     async def cancel_tts_task(self, session_id: str) -> bool:
         """TTSタスクをキャンセル"""
-        async with self._lock:
+        async with await self._get_lock():
             if session_id not in self._sessions:
                 logger.warning("Session not found for cancel_tts_task: %s", session_id)
                 return False
@@ -218,7 +224,7 @@ class SessionTaskManager:
 
     async def clear_tts_buffer(self, session_id: str) -> bool:
         """TTSバッファをクリア"""
-        async with self._lock:
+        async with await self._get_lock():
             if session_id in self._sessions:
                 self._sessions[session_id].tts_buffer = None
                 logger.debug("TTS buffer cleared for session %s", session_id)
@@ -227,7 +233,7 @@ class SessionTaskManager:
 
     async def cancel_all_tasks(self, session_id: str) -> bool:
         """セッションの全タスクをキャンセル"""
-        async with self._lock:
+        async with await self._get_lock():
             if session_id not in self._sessions:
                 logger.warning("Session not found for cancel_all_tasks: %s", session_id)
                 return False
@@ -256,7 +262,7 @@ class SessionTaskManager:
 
     async def cleanup_session(self, session_id: str) -> bool:
         """セッションを削除"""
-        async with self._lock:
+        async with await self._get_lock():
             if session_id in self._sessions:
                 # タスクのキャンセルを試みる（念のため）
                 info = self._sessions[session_id]
@@ -272,12 +278,12 @@ class SessionTaskManager:
 
     async def get_active_sessions(self) -> list:
         """進行中のセッション一覧を取得"""
-        async with self._lock:
+        async with await self._get_lock():
             return [info.session_id for info in self._sessions.values() if info.is_active()]
 
     async def get_session_count(self) -> int:
         """登録されているセッション数"""
-        async with self._lock:
+        async with await self._get_lock():
             return len(self._sessions)
 
     async def _cleanup_loop(self) -> None:
@@ -291,7 +297,7 @@ class SessionTaskManager:
 
     async def _cleanup_expired_sessions(self) -> None:
         """期限切れセッションを自動削除"""
-        async with self._lock:
+        async with await self._get_lock():
             now = datetime.now()
             expired_sessions = [
                 (sid, info)
@@ -324,3 +330,10 @@ def get_session_task_manager() -> SessionTaskManager:
     if _session_task_manager is None:
         _session_task_manager = SessionTaskManager()
     return _session_task_manager
+
+
+def reset_session_task_manager() -> None:
+    """テスト用: SessionTaskManager シングルトンをリセット"""
+    global _session_task_manager
+    _session_task_manager = None
+    SessionTaskManager._instance = None

--- a/frontend/VOICE_UI_PLAN.md
+++ b/frontend/VOICE_UI_PLAN.md
@@ -1,0 +1,219 @@
+# Voice UI Migration Plan
+
+## Goal
+
+Issue #116 moves the main interaction surface from button-led controls to voice-led controls while keeping buttons and text input as accessibility fallbacks. Phase 1 in this change set only adds the core hooks required for that migration and documents the rollout path.
+
+## Current State Survey
+
+### Active screen flow
+
+- `src/app/page.tsx`
+  - This is the active entry surface today.
+  - The default experience is still button-first:
+    - language selection buttons
+    - first-time-user buttons
+    - push-to-talk mic button
+    - end conversation button
+  - Voice capture is handled directly in the page through `VoiceRecorder`.
+  - Recording is press-and-hold with a hard-coded 10 second auto-stop timeout.
+  - There is no compact text input, no clarification chip UI, and no accessibility-first mode.
+
+### Existing voice UI component
+
+- `src/app/components/VoiceInterface.tsx`
+  - Not imported by `page.tsx`, so it appears to be an unused or alternate voice UI surface.
+  - It already contains:
+    - a voice state machine (`idle`, `listening`, `processing`, `speaking`)
+    - `@ricky0123/vad-react` based barge-in handling
+    - waveform placeholder bars
+    - auto-listen toggle
+    - transcript/response display
+  - It is currently a large monolithic component and exceeds the intended long-term component size target.
+
+### Existing supporting code
+
+- `src/lib/voice-recorder.ts`
+  - Contains `VoiceRecorder` and `AdvancedVoiceRecorder`.
+  - Already supports microphone initialization and basic real-time level analysis.
+- `src/lib/audio/audio-interaction-manager.ts`
+  - Handles mobile/browser audio unlock requirements.
+- `src/lib/clarification-utils.ts`
+  - Detects clarification-style responses and extracts options.
+  - No UI layer currently consumes this to render tappable options.
+- `src/app/components/CharacterAvatar.tsx`
+  - Already maps voice-related character states such as `listening` and `speaking`.
+  - This is the correct integration point for stronger animation linkage later.
+
+### Gaps against Issue #116
+
+- No wake-word detection path
+- No session-level continuous listening controller
+- No silence-based session termination
+- No real waveform data connected to the main UI
+- No compact collapsible text input
+- No accessibility mode that foregrounds text input
+- No clarification option buttons connected to response parsing
+- No shared controller that coordinates wake word, VAD, waveform, silence, and character state
+- No dedicated chat panel/message list abstraction under `src/app/components`
+
+## Files To Change
+
+### Existing files to modify in later phases
+
+- `src/app/page.tsx`
+  - Replace push-to-talk-first orchestration with a session controller that can arm wake-word mode and continuous listening.
+- `src/app/components/VoiceInterface.tsx`
+  - Split into smaller controller/presentation components or retire in favor of the page-level shell.
+- `src/app/components/CharacterAvatar.tsx`
+  - Add tighter hooks for listening/speaking/wake-word animation state.
+- `src/app/globals.css`
+  - Add waveform-specific visual utilities only if Tailwind utilities are insufficient.
+- `src/lib/clarification-utils.ts`
+  - Expand structured extraction if backend responses need more robust parsing.
+
+### New files created in Phase 1
+
+- `src/app/hooks/browser-speech.ts`
+- `src/app/hooks/useWakeWord.ts`
+- `src/app/hooks/useContinuousListening.ts`
+- `src/app/hooks/useSilenceDetection.ts`
+- `src/app/hooks/useVoiceWaveform.ts`
+
+### Likely new files for later phases
+
+- `src/app/components/voice/VoiceConversationShell.tsx`
+- `src/app/components/voice/VoiceStatusBadge.tsx`
+- `src/app/components/voice/VoiceWaveform.tsx`
+- `src/app/components/voice/CompactTextInput.tsx`
+- `src/app/components/voice/ClarificationOptions.tsx`
+- `src/app/components/voice/AccessibilityModeToggle.tsx`
+- `src/app/hooks/useVoiceSessionController.ts`
+
+## Implementation Order
+
+### Step 1: Browser voice primitives
+
+Create browser-facing hooks that do not alter current behavior until they are explicitly wired in.
+
+- `useWakeWord`
+  - Wrap Web Speech API wake-word recognition.
+  - Detect configured phrases such as `すみません` and `hello`.
+  - Auto-restart recognition while idle.
+- `useContinuousListening`
+  - Provide a small state machine for session mode transitions.
+  - Expose `shouldArmWakeWord` and `shouldListen` so UI/controller layers can decide when to open the mic.
+- `useSilenceDetection`
+  - Track recent speech activity.
+  - Trigger a callback when no meaningful activity is detected for the configured timeout.
+- `useVoiceWaveform`
+  - Convert a `MediaStream` into bar data for visual feedback.
+  - Keep it presentation-agnostic so both page-level UI and a future `VoiceWaveform` component can reuse it.
+
+### Step 2: Session controller hook
+
+Add `useVoiceSessionController` to coordinate:
+
+- wake-word idle mode
+- explicit accessibility/manual text mode
+- continuous listening after AI speech ends
+- silence timeout termination
+- character animation state updates
+- fallback button and text actions
+
+This hook should own the high-level state machine so UI components remain presentational.
+
+### Step 3: Main voice-led shell
+
+Introduce a dedicated shell component that replaces the current button cluster in `page.tsx`.
+
+- Default state:
+  - large listening presence
+  - waveform feedback
+  - small secondary text input
+  - limited fallback buttons
+- Accessibility mode:
+  - expanded text input
+  - clear focus affordances
+  - voice controls still available but de-emphasized
+
+### Step 4: Clarification UX
+
+When the backend returns clarification-style responses:
+
+- parse options via `ClarificationUtils`
+- render tappable clarification buttons
+- submit the selected option as the next user turn
+- keep text input available for custom clarification replies
+
+### Step 5: Character linkage
+
+Drive character behavior from shared voice/session state instead of one-off local updates.
+
+- idle: neutral breathing
+- wake-word armed: subtle attentive animation
+- listening: stronger attentive pose
+- processing: thinking
+- speaking: lip-sync plus speaking expression
+- silence timeout: return smoothly to idle
+
+## Detailed Design Notes
+
+### `useWakeWord`
+
+- Browser-only, optional feature.
+- Uses `SpeechRecognition` or `webkitSpeechRecognition` if present.
+- Normalizes transcripts before matching.
+- Returns the last transcript and matched wake word so the controller can show feedback.
+- Debounces repeated matches from interim transcripts.
+
+### `useContinuousListening`
+
+- Does not directly access the microphone.
+- Exposes a state machine with explicit transition methods:
+  - `startSession`
+  - `endSession`
+  - `beginListening`
+  - `beginProcessing`
+  - `beginSpeaking`
+  - `completeAssistantTurn`
+- Keeps the policy separate from transport details.
+
+### `useSilenceDetection`
+
+- Tracks activity timestamps rather than owning audio capture.
+- Can be fed by:
+  - STT partial/final transcripts
+  - VAD activity
+  - waveform average level
+- This allows the future controller to combine multiple signals without duplicating timers.
+
+### `useVoiceWaveform`
+
+- Accepts an existing `MediaStream`.
+- Builds analyzer bars without changing the recording pipeline.
+- Returns normalized bar levels and an aggregate average level.
+- Safe to attach only while the stream is active.
+
+## Phase Boundaries
+
+### Included now
+
+- planning document
+- hook scaffolding with production TypeScript types
+- zero-risk additions that do not alter the active UI flow
+
+### Deferred intentionally
+
+- replacement of the current page UI
+- new voice shell and accessibility mode UI
+- clarification buttons in the active screen
+- direct integration of wake-word and silence timeout into live sessions
+- package-level test tooling changes
+
+## Validation Plan
+
+- `pnpm tsc --noEmit`
+- `pnpm biome check`
+
+At the time of writing, the repository does not appear to include Biome or Jest/React Testing Library dependencies/configuration, so validation may require separate tooling setup before those commands can pass consistently.

--- a/frontend/src/app/hooks/browser-speech.ts
+++ b/frontend/src/app/hooks/browser-speech.ts
@@ -1,0 +1,87 @@
+'use client';
+
+export interface BrowserSpeechRecognitionAlternative {
+  readonly transcript: string;
+  readonly confidence: number;
+}
+
+export interface BrowserSpeechRecognitionResult {
+  readonly isFinal: boolean;
+  readonly length: number;
+  item(index: number): BrowserSpeechRecognitionAlternative;
+  [index: number]: BrowserSpeechRecognitionAlternative;
+}
+
+export interface BrowserSpeechRecognitionResultList {
+  readonly length: number;
+  item(index: number): BrowserSpeechRecognitionResult;
+  [index: number]: BrowserSpeechRecognitionResult;
+}
+
+export interface BrowserSpeechRecognitionEvent extends Event {
+  readonly resultIndex: number;
+  readonly results: BrowserSpeechRecognitionResultList;
+}
+
+export interface BrowserSpeechRecognitionErrorEvent extends Event {
+  readonly error: string;
+  readonly message: string;
+}
+
+export interface BrowserSpeechRecognition extends EventTarget {
+  continuous: boolean;
+  interimResults: boolean;
+  lang: string;
+  maxAlternatives: number;
+  onstart: ((event: Event) => void) | null;
+  onend: ((event: Event) => void) | null;
+  onerror: ((event: BrowserSpeechRecognitionErrorEvent) => void) | null;
+  onresult: ((event: BrowserSpeechRecognitionEvent) => void) | null;
+  start(): void;
+  stop(): void;
+  abort(): void;
+}
+
+export interface BrowserSpeechRecognitionConstructor {
+  new (): BrowserSpeechRecognition;
+}
+
+declare global {
+  interface Window {
+    SpeechRecognition?: BrowserSpeechRecognitionConstructor;
+    webkitSpeechRecognition?: BrowserSpeechRecognitionConstructor;
+  }
+}
+
+export const getSpeechRecognitionConstructor = (): BrowserSpeechRecognitionConstructor | null => {
+  if (typeof window === 'undefined') {
+    return null;
+  }
+
+  return window.SpeechRecognition ?? window.webkitSpeechRecognition ?? null;
+};
+
+export const normalizeSpeechText = (value: string): string =>
+  value
+    .normalize('NFKC')
+    .toLowerCase()
+    .replace(/[.,!?;:。、「」『』（）()[\]{}]/g, ' ')
+    .replace(/\s+/g, ' ')
+    .trim();
+
+export const extractRecognitionTranscript = (
+  event: BrowserSpeechRecognitionEvent,
+): string => {
+  const parts: string[] = [];
+
+  for (let index = event.resultIndex; index < event.results.length; index += 1) {
+    const result = event.results[index];
+    if (!result || result.length === 0) {
+      continue;
+    }
+
+    parts.push(result[0].transcript);
+  }
+
+  return parts.join(' ').trim();
+};

--- a/frontend/src/app/hooks/useContinuousListening.ts
+++ b/frontend/src/app/hooks/useContinuousListening.ts
@@ -1,0 +1,199 @@
+'use client';
+
+import { useCallback, useEffect, useRef, useState } from 'react';
+
+export type ContinuousListeningMode =
+  | 'idle'
+  | 'wake-word'
+  | 'listening'
+  | 'processing'
+  | 'speaking';
+
+export type ContinuousListeningStartSource = 'manual' | 'wake-word' | 'button';
+export type ContinuousListeningEndReason = 'manual' | 'silence' | 'error';
+
+export interface UseContinuousListeningOptions {
+  enabled?: boolean;
+  autoResumeDelayMs?: number;
+  onSessionStart?: (source: ContinuousListeningStartSource) => void;
+  onSessionEnd?: (reason: ContinuousListeningEndReason) => void;
+  onListeningChange?: (shouldListen: boolean) => void;
+}
+
+export interface UseContinuousListeningResult {
+  mode: ContinuousListeningMode;
+  isConversationActive: boolean;
+  shouldListen: boolean;
+  shouldArmWakeWord: boolean;
+  turnCount: number;
+  sessionStartedAt: number | null;
+  startSession: (source?: ContinuousListeningStartSource) => void;
+  endSession: (reason?: ContinuousListeningEndReason) => void;
+  beginListening: () => void;
+  beginProcessing: () => void;
+  beginSpeaking: () => void;
+  completeAssistantTurn: () => void;
+  pauseListening: () => void;
+  resumeListening: () => void;
+}
+
+const DEFAULT_AUTO_RESUME_DELAY_MS = 800;
+
+export function useContinuousListening({
+  enabled = true,
+  autoResumeDelayMs = DEFAULT_AUTO_RESUME_DELAY_MS,
+  onSessionStart,
+  onSessionEnd,
+  onListeningChange,
+}: UseContinuousListeningOptions = {}): UseContinuousListeningResult {
+  const resumeTimerRef = useRef<number | null>(null);
+
+  const [mode, setMode] = useState<ContinuousListeningMode>(
+    enabled ? 'wake-word' : 'idle',
+  );
+  const [isConversationActive, setIsConversationActive] = useState(false);
+  const [shouldListen, setShouldListen] = useState(false);
+  const [turnCount, setTurnCount] = useState(0);
+  const [sessionStartedAt, setSessionStartedAt] = useState<number | null>(null);
+
+  const updateShouldListen = useCallback(
+    (value: boolean) => {
+      setShouldListen(value);
+      onListeningChange?.(value);
+    },
+    [onListeningChange],
+  );
+
+  const clearResumeTimer = useCallback(() => {
+    if (resumeTimerRef.current !== null) {
+      window.clearTimeout(resumeTimerRef.current);
+      resumeTimerRef.current = null;
+    }
+  }, []);
+
+  const startSession = useCallback(
+    (source: ContinuousListeningStartSource = 'manual') => {
+      clearResumeTimer();
+      setIsConversationActive(true);
+      setSessionStartedAt(Date.now());
+      setTurnCount(0);
+      setMode('listening');
+      updateShouldListen(true);
+      onSessionStart?.(source);
+    },
+    [clearResumeTimer, onSessionStart, updateShouldListen],
+  );
+
+  const endSession = useCallback(
+    (reason: ContinuousListeningEndReason = 'manual') => {
+      clearResumeTimer();
+      setIsConversationActive(false);
+      setTurnCount(0);
+      setSessionStartedAt(null);
+      setMode(enabled ? 'wake-word' : 'idle');
+      updateShouldListen(false);
+      onSessionEnd?.(reason);
+    },
+    [clearResumeTimer, enabled, onSessionEnd, updateShouldListen],
+  );
+
+  const beginListening = useCallback(() => {
+    clearResumeTimer();
+    setMode('listening');
+    updateShouldListen(true);
+  }, [clearResumeTimer, updateShouldListen]);
+
+  const beginProcessing = useCallback(() => {
+    clearResumeTimer();
+    setMode('processing');
+    updateShouldListen(false);
+  }, [clearResumeTimer, updateShouldListen]);
+
+  const beginSpeaking = useCallback(() => {
+    clearResumeTimer();
+    setMode('speaking');
+    updateShouldListen(false);
+    setTurnCount((currentTurnCount) => currentTurnCount + 1);
+  }, [clearResumeTimer, updateShouldListen]);
+
+  const completeAssistantTurn = useCallback(() => {
+    clearResumeTimer();
+
+    if (!enabled || !isConversationActive) {
+      setMode(enabled ? 'wake-word' : 'idle');
+      updateShouldListen(false);
+      return;
+    }
+
+    setMode('idle');
+    updateShouldListen(false);
+
+    resumeTimerRef.current = window.setTimeout(() => {
+      setMode('listening');
+      updateShouldListen(true);
+    }, autoResumeDelayMs);
+  }, [
+    autoResumeDelayMs,
+    clearResumeTimer,
+    enabled,
+    isConversationActive,
+    updateShouldListen,
+  ]);
+
+  const pauseListening = useCallback(() => {
+    clearResumeTimer();
+    updateShouldListen(false);
+
+    if (isConversationActive) {
+      setMode('idle');
+    }
+  }, [clearResumeTimer, isConversationActive, updateShouldListen]);
+
+  const resumeListening = useCallback(() => {
+    if (!enabled) {
+      return;
+    }
+
+    if (!isConversationActive) {
+      startSession('manual');
+      return;
+    }
+
+    beginListening();
+  }, [beginListening, enabled, isConversationActive, startSession]);
+
+  useEffect(() => {
+    if (enabled) {
+      if (!isConversationActive) {
+        setMode('wake-word');
+      }
+      return;
+    }
+
+    clearResumeTimer();
+    setMode('idle');
+    setIsConversationActive(false);
+    setTurnCount(0);
+    setSessionStartedAt(null);
+    updateShouldListen(false);
+  }, [clearResumeTimer, enabled, isConversationActive, updateShouldListen]);
+
+  useEffect(() => () => clearResumeTimer(), [clearResumeTimer]);
+
+  return {
+    mode,
+    isConversationActive,
+    shouldListen,
+    shouldArmWakeWord: enabled && !isConversationActive,
+    turnCount,
+    sessionStartedAt,
+    startSession,
+    endSession,
+    beginListening,
+    beginProcessing,
+    beginSpeaking,
+    completeAssistantTurn,
+    pauseListening,
+    resumeListening,
+  };
+}

--- a/frontend/src/app/hooks/useSilenceDetection.ts
+++ b/frontend/src/app/hooks/useSilenceDetection.ts
@@ -1,0 +1,126 @@
+'use client';
+
+import { useCallback, useEffect, useMemo, useState } from 'react';
+
+export interface UseSilenceDetectionOptions {
+  enabled?: boolean;
+  timeoutMs?: number;
+  checkIntervalMs?: number;
+  levelThreshold?: number;
+  onSilence?: (durationMs: number) => void;
+}
+
+export interface UseSilenceDetectionResult {
+  isSilent: boolean;
+  lastActivityAt: number | null;
+  silenceDurationMs: number;
+  remainingMs: number;
+  markActivity: () => void;
+  markAudioLevel: (level: number) => boolean;
+  resetSilenceTimer: () => void;
+}
+
+const DEFAULT_TIMEOUT_MS = 12_000;
+const DEFAULT_CHECK_INTERVAL_MS = 250;
+const DEFAULT_LEVEL_THRESHOLD = 0.08;
+
+export function useSilenceDetection({
+  enabled = true,
+  timeoutMs = DEFAULT_TIMEOUT_MS,
+  checkIntervalMs = DEFAULT_CHECK_INTERVAL_MS,
+  levelThreshold = DEFAULT_LEVEL_THRESHOLD,
+  onSilence,
+}: UseSilenceDetectionOptions = {}): UseSilenceDetectionResult {
+  const [lastActivityAt, setLastActivityAt] = useState<number | null>(null);
+  const [isSilent, setIsSilent] = useState(false);
+  const [silenceDurationMs, setSilenceDurationMs] = useState(0);
+  const [remainingMs, setRemainingMs] = useState(timeoutMs);
+
+  const markActivity = useCallback(() => {
+    const now = Date.now();
+    setLastActivityAt(now);
+    setIsSilent(false);
+    setSilenceDurationMs(0);
+    setRemainingMs(timeoutMs);
+  }, [timeoutMs]);
+
+  const resetSilenceTimer = useCallback(() => {
+    markActivity();
+  }, [markActivity]);
+
+  const markAudioLevel = useCallback(
+    (level: number) => {
+      if (level < levelThreshold) {
+        return false;
+      }
+
+      markActivity();
+      return true;
+    },
+    [levelThreshold, markActivity],
+  );
+
+  useEffect(() => {
+    if (!enabled || lastActivityAt === null) {
+      setIsSilent(false);
+      setSilenceDurationMs(0);
+      setRemainingMs(timeoutMs);
+      return;
+    }
+
+    let callbackFired = false;
+
+    const intervalId = window.setInterval(() => {
+      const elapsed = Date.now() - lastActivityAt;
+      const nextRemainingMs = Math.max(timeoutMs - elapsed, 0);
+
+      setRemainingMs(nextRemainingMs);
+
+      if (elapsed >= timeoutMs) {
+        setIsSilent(true);
+        setSilenceDurationMs(elapsed);
+
+        if (!callbackFired) {
+          callbackFired = true;
+          onSilence?.(elapsed);
+        }
+
+        return;
+      }
+
+      setIsSilent(false);
+      setSilenceDurationMs(0);
+    }, checkIntervalMs);
+
+    return () => {
+      window.clearInterval(intervalId);
+    };
+  }, [checkIntervalMs, enabled, lastActivityAt, onSilence, timeoutMs]);
+
+  useEffect(() => {
+    setRemainingMs(timeoutMs);
+  }, [timeoutMs]);
+
+  const result = useMemo(
+    () => ({
+      isSilent,
+      lastActivityAt,
+      silenceDurationMs,
+      remainingMs,
+      markActivity,
+      markAudioLevel,
+      resetSilenceTimer,
+    }),
+    [
+      isSilent,
+      lastActivityAt,
+      markActivity,
+      markAudioLevel,
+      remainingMs,
+      resetSilenceTimer,
+      silenceDurationMs,
+    ],
+  );
+
+  return result;
+}

--- a/frontend/src/app/hooks/useVoiceWaveform.ts
+++ b/frontend/src/app/hooks/useVoiceWaveform.ts
@@ -1,0 +1,145 @@
+'use client';
+
+import { useEffect, useMemo, useState } from 'react';
+
+export interface UseVoiceWaveformOptions {
+  stream: MediaStream | null;
+  enabled?: boolean;
+  barCount?: number;
+  fftSize?: number;
+  smoothingTimeConstant?: number;
+}
+
+export interface UseVoiceWaveformResult {
+  levels: number[];
+  averageLevel: number;
+  isAnalyzing: boolean;
+  isSupported: boolean;
+  error: string | null;
+}
+
+const DEFAULT_BAR_COUNT = 12;
+const DEFAULT_FFT_SIZE = 512;
+const DEFAULT_SMOOTHING = 0.7;
+
+const createLevels = (barCount: number): number[] =>
+  Array.from({ length: barCount }, () => 0);
+
+const getAudioContextConstructor = (): typeof AudioContext | null => {
+  if (typeof window === 'undefined') {
+    return null;
+  }
+
+  const audioWindow = window as Window &
+    typeof globalThis & {
+      webkitAudioContext?: typeof AudioContext;
+    };
+
+  return audioWindow.AudioContext ?? audioWindow.webkitAudioContext ?? null;
+};
+
+export function useVoiceWaveform({
+  stream,
+  enabled = true,
+  barCount = DEFAULT_BAR_COUNT,
+  fftSize = DEFAULT_FFT_SIZE,
+  smoothingTimeConstant = DEFAULT_SMOOTHING,
+}: UseVoiceWaveformOptions): UseVoiceWaveformResult {
+  const [levels, setLevels] = useState<number[]>(() => createLevels(barCount));
+  const [averageLevel, setAverageLevel] = useState(0);
+  const [isAnalyzing, setIsAnalyzing] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const isSupported = useMemo(() => getAudioContextConstructor() !== null, []);
+
+  useEffect(() => {
+    setLevels(createLevels(barCount));
+  }, [barCount]);
+
+  useEffect(() => {
+    if (!enabled || !stream) {
+      setIsAnalyzing(false);
+      setAverageLevel(0);
+      setLevels(createLevels(barCount));
+      return;
+    }
+
+    const AudioContextConstructor = getAudioContextConstructor();
+    if (!AudioContextConstructor) {
+      setError('AudioContext is not supported in this browser');
+      setIsAnalyzing(false);
+      return;
+    }
+
+    let isDisposed = false;
+    let animationFrameId: number | null = null;
+
+    const audioContext = new AudioContextConstructor();
+    const source = audioContext.createMediaStreamSource(stream);
+    const analyser = audioContext.createAnalyser();
+    const data = new Uint8Array(analyser.frequencyBinCount);
+
+    analyser.fftSize = fftSize;
+    analyser.smoothingTimeConstant = smoothingTimeConstant;
+    source.connect(analyser);
+
+    setIsAnalyzing(true);
+    setError(null);
+
+    const analyze = () => {
+      if (isDisposed) {
+        return;
+      }
+
+      analyser.getByteFrequencyData(data);
+
+      const bucketSize = Math.max(Math.floor(data.length / barCount), 1);
+      const nextLevels = Array.from({ length: barCount }, (_, bucketIndex) => {
+        const start = bucketIndex * bucketSize;
+        const end = Math.min(start + bucketSize, data.length);
+        let sum = 0;
+
+        for (let index = start; index < end; index += 1) {
+          sum += data[index];
+        }
+
+        const size = Math.max(end - start, 1);
+        return sum / size / 255;
+      });
+
+      const nextAverageLevel =
+        nextLevels.reduce((total, level) => total + level, 0) / nextLevels.length;
+
+      setLevels(nextLevels);
+      setAverageLevel(nextAverageLevel);
+      animationFrameId = window.requestAnimationFrame(analyze);
+    };
+
+    if (audioContext.state === 'suspended') {
+      void audioContext.resume();
+    }
+
+    animationFrameId = window.requestAnimationFrame(analyze);
+
+    return () => {
+      isDisposed = true;
+      setIsAnalyzing(false);
+
+      if (animationFrameId !== null) {
+        window.cancelAnimationFrame(animationFrameId);
+      }
+
+      source.disconnect();
+      analyser.disconnect();
+      void audioContext.close();
+    };
+  }, [barCount, enabled, fftSize, smoothingTimeConstant, stream]);
+
+  return {
+    levels,
+    averageLevel,
+    isAnalyzing,
+    isSupported,
+    error,
+  };
+}

--- a/frontend/src/app/hooks/useWakeWord.ts
+++ b/frontend/src/app/hooks/useWakeWord.ts
@@ -1,0 +1,270 @@
+'use client';
+
+import { useCallback, useEffect, useRef, useState } from 'react';
+import {
+  extractRecognitionTranscript,
+  getSpeechRecognitionConstructor,
+  normalizeSpeechText,
+  type BrowserSpeechRecognition,
+  type BrowserSpeechRecognitionErrorEvent,
+  type BrowserSpeechRecognitionEvent,
+} from './browser-speech';
+
+export interface WakeWordMatch {
+  word: string;
+  transcript: string;
+  detectedAt: number;
+}
+
+export interface UseWakeWordOptions {
+  wakeWords: string[];
+  enabled?: boolean;
+  language?: string;
+  continuous?: boolean;
+  interimResults?: boolean;
+  restartDelayMs?: number;
+  debounceMs?: number;
+  onWakeWord?: (match: WakeWordMatch) => void;
+}
+
+export interface UseWakeWordResult {
+  isSupported: boolean;
+  isListening: boolean;
+  error: string | null;
+  lastTranscript: string;
+  detectedWakeWord: WakeWordMatch | null;
+  startListening: () => boolean;
+  stopListening: () => void;
+  clearDetectedWakeWord: () => void;
+}
+
+const DEFAULT_RESTART_DELAY_MS = 400;
+const DEFAULT_DEBOUNCE_MS = 1_500;
+
+export function useWakeWord({
+  wakeWords,
+  enabled = true,
+  language = 'ja-JP',
+  continuous = true,
+  interimResults = true,
+  restartDelayMs = DEFAULT_RESTART_DELAY_MS,
+  debounceMs = DEFAULT_DEBOUNCE_MS,
+  onWakeWord,
+}: UseWakeWordOptions): UseWakeWordResult {
+  const recognitionRef = useRef<BrowserSpeechRecognition | null>(null);
+  const restartTimeoutRef = useRef<number | null>(null);
+  const shouldRunRef = useRef(enabled);
+  const manualStopRef = useRef(false);
+  const lastDetectionRef = useRef<WakeWordMatch | null>(null);
+
+  const [isSupported, setIsSupported] = useState(false);
+  const [isListening, setIsListening] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [lastTranscript, setLastTranscript] = useState('');
+  const [detectedWakeWord, setDetectedWakeWord] = useState<WakeWordMatch | null>(null);
+
+  const normalizedWakeWordsRef = useRef<Array<{ normalized: string; original: string }>>([]);
+  normalizedWakeWordsRef.current = wakeWords
+    .map((wakeWord) => ({
+      normalized: normalizeSpeechText(wakeWord),
+      original: wakeWord,
+    }))
+    .filter((wakeWord) => wakeWord.normalized.length > 0);
+
+  const clearRestartTimer = useCallback(() => {
+    if (restartTimeoutRef.current !== null) {
+      window.clearTimeout(restartTimeoutRef.current);
+      restartTimeoutRef.current = null;
+    }
+  }, []);
+
+  const clearDetectedWakeWord = useCallback(() => {
+    setDetectedWakeWord(null);
+  }, []);
+
+  const disposeRecognition = useCallback(() => {
+    const recognition = recognitionRef.current;
+    if (!recognition) {
+      return;
+    }
+
+    recognition.onstart = null;
+    recognition.onend = null;
+    recognition.onerror = null;
+    recognition.onresult = null;
+    recognition.abort();
+    recognitionRef.current = null;
+  }, []);
+
+  const handleResult = useCallback(
+    (event: BrowserSpeechRecognitionEvent) => {
+      const transcript = extractRecognitionTranscript(event);
+      if (!transcript) {
+        return;
+      }
+
+      setLastTranscript(transcript);
+
+      const normalizedTranscript = normalizeSpeechText(transcript);
+      const matchedWord = normalizedWakeWordsRef.current.find(({ normalized }) =>
+        normalizedTranscript.includes(normalized),
+      );
+
+      if (!matchedWord) {
+        return;
+      }
+
+      const now = Date.now();
+      const lastDetection = lastDetectionRef.current;
+      if (lastDetection && now - lastDetection.detectedAt < debounceMs) {
+        return;
+      }
+
+      const match: WakeWordMatch = {
+        word: matchedWord.original,
+        transcript,
+        detectedAt: now,
+      };
+
+      lastDetectionRef.current = match;
+      setDetectedWakeWord(match);
+      onWakeWord?.(match);
+    },
+    [debounceMs, onWakeWord],
+  );
+
+  const createRecognition = useCallback(() => {
+    const RecognitionConstructor = getSpeechRecognitionConstructor();
+    if (!RecognitionConstructor) {
+      setIsSupported(false);
+      return null;
+    }
+
+    setIsSupported(true);
+
+    const recognition = new RecognitionConstructor();
+    recognition.continuous = continuous;
+    recognition.interimResults = interimResults;
+    recognition.lang = language;
+    recognition.maxAlternatives = 1;
+
+    recognition.onstart = () => {
+      setIsListening(true);
+      setError(null);
+    };
+
+    recognition.onresult = (event) => {
+      handleResult(event);
+    };
+
+    recognition.onerror = (event: BrowserSpeechRecognitionErrorEvent) => {
+      if (manualStopRef.current && event.error === 'aborted') {
+        return;
+      }
+
+      setError(event.message || event.error || 'Wake word recognition failed');
+    };
+
+    recognition.onend = () => {
+      setIsListening(false);
+      recognitionRef.current = null;
+
+      if (!shouldRunRef.current || manualStopRef.current) {
+        return;
+      }
+
+      clearRestartTimer();
+      restartTimeoutRef.current = window.setTimeout(() => {
+        startListening();
+      }, restartDelayMs);
+    };
+
+    return recognition;
+  }, [
+    clearRestartTimer,
+    continuous,
+    handleResult,
+    interimResults,
+    language,
+    restartDelayMs,
+  ]);
+
+  const startListening = useCallback((): boolean => {
+    shouldRunRef.current = true;
+    manualStopRef.current = false;
+
+    if (!enabled) {
+      return false;
+    }
+
+    if (recognitionRef.current || isListening) {
+      return true;
+    }
+
+    const recognition = createRecognition();
+    if (!recognition) {
+      return false;
+    }
+
+    recognitionRef.current = recognition;
+
+    try {
+      recognition.start();
+      return true;
+    } catch (startError) {
+      recognitionRef.current = null;
+      setError(
+        startError instanceof Error
+          ? startError.message
+          : 'Unable to start wake word recognition',
+      );
+      return false;
+    }
+  }, [createRecognition, enabled, isListening]);
+
+  const stopListening = useCallback(() => {
+    shouldRunRef.current = false;
+    manualStopRef.current = true;
+    clearRestartTimer();
+    recognitionRef.current?.stop();
+  }, [clearRestartTimer]);
+
+  useEffect(() => {
+    setIsSupported(getSpeechRecognitionConstructor() !== null);
+  }, []);
+
+  useEffect(() => {
+    shouldRunRef.current = enabled;
+
+    if (!enabled) {
+      stopListening();
+      return;
+    }
+
+    return () => {
+      clearRestartTimer();
+      disposeRecognition();
+    };
+  }, [clearRestartTimer, disposeRecognition, enabled, stopListening]);
+
+  useEffect(() => {
+    if (!enabled) {
+      return;
+    }
+
+    if (!isListening && shouldRunRef.current) {
+      startListening();
+    }
+  }, [enabled, isListening, startListening]);
+
+  return {
+    isSupported,
+    isListening,
+    error,
+    lastTranscript,
+    detectedWakeWord,
+    startListening,
+    stopListening,
+    clearDetectedWakeWord,
+  };
+}


### PR DESCRIPTION
## Summary

3つの独立した Issue に対応する変更をまとめた PR:

### 1. Reception-2025 統合導線 (#165)
- **`SeatAvailabilityService`** 新規作成: 既存受付システムの座席データ (seats/seat_usage_logs) を READ ONLY で参照
  - `get_available_seats()`, `get_seat_summary()`, `is_seat_available()`
- **`identify_by_member_number()`** 追加: OCR で読み取った会員番号から users.id 検索
- **`_get_user_profile()`** 拡張: prefecture, job, belong フィールドも取得

### 2. SessionTaskManager 修正 (#163)
- `asyncio.Lock` を遅延初期化 (`_get_lock()`) — Python 3.10+ DeprecationWarning / 3.12+ RuntimeError 回避
- `reset_session_task_manager()` テスト用リセット関数追加

### 3. 音声主体 UI Phase 1 フック (#116)
- `useWakeWord`: ウェイクワード検出 (Web Speech API)
- `useContinuousListening`: 連続対話セッション状態マシン
- `useSilenceDetection`: 無音検出タイムアウト
- `useVoiceWaveform`: 音声波形データ取得
- `browser-speech.ts`: ブラウザ Speech API 型定義
- `VOICE_UI_PLAN.md`: 5段階移行計画書
- 既存UIへの配線なし — ゼロリスク追加

## Test plan

- [x] Backend: 51 tests passed (seat: 11, visitor: 10, session_task: 30)
- [x] Backend: ruff check — all passed
- [x] Backend: black --check — all passed
- [x] Frontend: `pnpm tsc --noEmit` — passed
- [ ] CI/CD green

## Related Issues

- Closes #165 (Phase 1 HIGH tasks)
- Fixes #163
- Partially addresses #116 (Phase 1 hooks only)

Generated with [Claude Code](https://claude.com/claude-code)