### PR TITLE
ci: add backend API URL env vars for frontend deploy

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -124,6 +124,8 @@ jobs:
           SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.SUPABASE_SERVICE_ROLE_KEY || 'placeholder-service-role-key' }}
           GOOGLE_GENERATIVE_AI_API_KEY: ${{ secrets.GOOGLE_GENERATIVE_AI_API_KEY || 'placeholder-google-ai-key' }}
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY || 'placeholder-openai-key' }}
+          NEXT_PUBLIC_BACKEND_API_URL: ${{ secrets.NEXT_PUBLIC_BACKEND_API_URL || 'https://engineer-cafe-backend-639959525777.asia-northeast1.run.app' }}
+          BACKEND_API_URL: ${{ secrets.BACKEND_API_URL || 'https://engineer-cafe-backend-639959525777.asia-northeast1.run.app' }}
 
   # Backend: Lint
   backend-lint:
@@ -349,6 +351,8 @@ jobs:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           NEXT_PUBLIC_SUPABASE_URL: ${{ secrets.NEXT_PUBLIC_SUPABASE_URL || 'https://placeholder.supabase.co' }}
           NEXT_PUBLIC_SUPABASE_ANON_KEY: ${{ secrets.NEXT_PUBLIC_SUPABASE_ANON_KEY || 'placeholder-anon-key' }}
+          NEXT_PUBLIC_BACKEND_API_URL: ${{ secrets.NEXT_PUBLIC_BACKEND_API_URL || 'https://engineer-cafe-backend-639959525777.asia-northeast1.run.app' }}
+          BACKEND_API_URL: ${{ secrets.BACKEND_API_URL || 'https://engineer-cafe-backend-639959525777.asia-northeast1.run.app' }}
 
   # Final status check for branch protection
   ci-success:


### PR DESCRIPTION
## Summary
- Add `NEXT_PUBLIC_BACKEND_API_URL` and `BACKEND_API_URL` environment variables to frontend build and deploy jobs
- Enables frontend to connect to Cloud Run backend at `https://engineer-cafe-backend-639959525777.asia-northeast1.run.app`
- Uses GitHub Secrets with fallback defaults

## Context
Backend Cloud Run deployment succeeded. Frontend needs the backend URL at build time (`NEXT_PUBLIC_` prefix) and runtime.

## Test plan
- [ ] CI passes on this PR
- [ ] After merge to develop, frontend-deploy-staging runs with correct env vars
- [ ] Frontend can reach backend `/health` endpoint

🤖 Generated with [Claude Code](https://claude.com/claude-code)