### PR TITLE
feat(frontend): add useVoiceSessionController hook (#116)

### DIFF
--- a/frontend/src/app/hooks/useVoiceSessionController.ts
+++ b/frontend/src/app/hooks/useVoiceSessionController.ts
@@ -1,0 +1,281 @@
+'use client';
+
+import { useCallback, useEffect, useMemo, useRef } from 'react';
+import {
+  useContinuousListening,
+  type ContinuousListeningEndReason,
+  type ContinuousListeningMode,
+  type ContinuousListeningStartSource,
+} from './useContinuousListening';
+import { useSilenceDetection } from './useSilenceDetection';
+import { useVoiceWaveform } from './useVoiceWaveform';
+import { useWakeWord, type WakeWordMatch } from './useWakeWord';
+
+export type VoiceCharacterState = 'idle' | 'listening' | 'thinking' | 'speaking';
+
+export interface UseVoiceSessionControllerOptions {
+  enabled?: boolean;
+  stream?: MediaStream | null;
+  wakeWords?: string[];
+  language?: string;
+  wakeWordContinuous?: boolean;
+  wakeWordInterimResults?: boolean;
+  wakeWordRestartDelayMs?: number;
+  wakeWordDebounceMs?: number;
+  silenceTimeoutMs?: number;
+  silenceCheckIntervalMs?: number;
+  silenceLevelThreshold?: number;
+  waveformBarCount?: number;
+  waveformFftSize?: number;
+  waveformSmoothingTimeConstant?: number;
+  autoResumeDelayMs?: number;
+  onWakeWord?: (match: WakeWordMatch) => void;
+  onSessionStart?: (source: ContinuousListeningStartSource) => void;
+  onSessionEnd?: (reason: ContinuousListeningEndReason) => void;
+}
+
+export interface UseVoiceSessionControllerResult {
+  mode: ContinuousListeningMode;
+  characterState: VoiceCharacterState;
+  isConversationActive: boolean;
+  shouldListen: boolean;
+  shouldArmWakeWord: boolean;
+  waveformBars: number[];
+  startManualSession: () => void;
+  endManualSession: () => void;
+  notifyProcessing: () => void;
+  notifySpeaking: () => void;
+  notifySpeakingComplete: () => void;
+  isWakeWordSupported: boolean;
+  isWakeWordListening: boolean;
+  wakeWordError: string | null;
+  lastWakeWordMatch: WakeWordMatch | null;
+}
+
+const DEFAULT_WAKE_WORDS = ['すみません', 'hello'];
+
+export function useVoiceSessionController({
+  enabled = true,
+  stream = null,
+  wakeWords = DEFAULT_WAKE_WORDS,
+  language = 'ja-JP',
+  wakeWordContinuous = true,
+  wakeWordInterimResults = true,
+  wakeWordRestartDelayMs,
+  wakeWordDebounceMs,
+  silenceTimeoutMs,
+  silenceCheckIntervalMs,
+  silenceLevelThreshold,
+  waveformBarCount,
+  waveformFftSize,
+  waveformSmoothingTimeConstant,
+  autoResumeDelayMs,
+  onWakeWord,
+  onSessionStart,
+  onSessionEnd,
+}: UseVoiceSessionControllerOptions = {}): UseVoiceSessionControllerResult {
+  const hasDetectedSpeechRef = useRef(false);
+  const onWakeWordRef = useRef(onWakeWord);
+
+  useEffect(() => {
+    onWakeWordRef.current = onWakeWord;
+  }, [onWakeWord]);
+
+  const {
+    mode,
+    isConversationActive,
+    shouldListen,
+    shouldArmWakeWord,
+    startSession,
+    endSession,
+    beginListening,
+    beginProcessing,
+    beginSpeaking,
+    completeAssistantTurn,
+  } = useContinuousListening({
+    enabled,
+    autoResumeDelayMs,
+    onSessionStart,
+    onSessionEnd,
+  });
+
+  const silenceEnabled = enabled && isConversationActive && mode === 'listening';
+
+  const handleWakeWord = useCallback(
+    (match: WakeWordMatch) => {
+      if (!enabled || isConversationActive) {
+        return;
+      }
+
+      hasDetectedSpeechRef.current = false;
+      startSession('wake-word');
+      onWakeWordRef.current?.(match);
+    },
+    [enabled, isConversationActive, startSession],
+  );
+
+  const {
+    isSupported: isWakeWordSupported,
+    isListening: isWakeWordListening,
+    error: wakeWordError,
+    detectedWakeWord: lastWakeWordMatch,
+  } = useWakeWord({
+    wakeWords,
+    enabled: enabled && shouldArmWakeWord,
+    language,
+    continuous: wakeWordContinuous,
+    interimResults: wakeWordInterimResults,
+    restartDelayMs: wakeWordRestartDelayMs,
+    debounceMs: wakeWordDebounceMs,
+    onWakeWord: handleWakeWord,
+  });
+
+  const { levels: waveformBars, averageLevel } = useVoiceWaveform({
+    stream,
+    enabled: enabled && shouldListen,
+    barCount: waveformBarCount,
+    fftSize: waveformFftSize,
+    smoothingTimeConstant: waveformSmoothingTimeConstant,
+  });
+
+  const { markAudioLevel, resetSilenceTimer } = useSilenceDetection({
+    enabled: silenceEnabled,
+    timeoutMs: silenceTimeoutMs,
+    checkIntervalMs: silenceCheckIntervalMs,
+    levelThreshold: silenceLevelThreshold,
+    onSilence: () => {
+      if (hasDetectedSpeechRef.current) {
+        hasDetectedSpeechRef.current = false;
+        beginProcessing();
+        return;
+      }
+
+      endSession('silence');
+    },
+  });
+
+  useEffect(() => {
+    if (mode !== 'listening') {
+      hasDetectedSpeechRef.current = false;
+      return;
+    }
+
+    resetSilenceTimer();
+  }, [mode, resetSilenceTimer]);
+
+  useEffect(() => {
+    if (!silenceEnabled) {
+      return;
+    }
+
+    if (!markAudioLevel(averageLevel)) {
+      return;
+    }
+
+    hasDetectedSpeechRef.current = true;
+  }, [averageLevel, markAudioLevel, silenceEnabled]);
+
+  const startManualSession = useCallback(() => {
+    if (!enabled) {
+      return;
+    }
+
+    hasDetectedSpeechRef.current = false;
+
+    if (isConversationActive) {
+      beginListening();
+      return;
+    }
+
+    startSession('button');
+  }, [beginListening, enabled, isConversationActive, startSession]);
+
+  const endManualSession = useCallback(() => {
+    hasDetectedSpeechRef.current = false;
+    endSession('manual');
+  }, [endSession]);
+
+  const notifyProcessing = useCallback(() => {
+    if (!enabled) {
+      return;
+    }
+
+    if (!isConversationActive) {
+      startSession('manual');
+    }
+
+    hasDetectedSpeechRef.current = false;
+    beginProcessing();
+  }, [beginProcessing, enabled, isConversationActive, startSession]);
+
+  const notifySpeaking = useCallback(() => {
+    if (!enabled) {
+      return;
+    }
+
+    if (!isConversationActive) {
+      startSession('manual');
+    }
+
+    hasDetectedSpeechRef.current = false;
+    beginSpeaking();
+  }, [beginSpeaking, enabled, isConversationActive, startSession]);
+
+  const notifySpeakingComplete = useCallback(() => {
+    hasDetectedSpeechRef.current = false;
+    completeAssistantTurn();
+  }, [completeAssistantTurn]);
+
+  const characterState = useMemo<VoiceCharacterState>(() => {
+    if (mode === 'listening') {
+      return 'listening';
+    }
+
+    if (mode === 'processing') {
+      return 'thinking';
+    }
+
+    if (mode === 'speaking') {
+      return 'speaking';
+    }
+
+    return 'idle';
+  }, [mode]);
+
+  return useMemo(
+    () => ({
+      mode,
+      characterState,
+      isConversationActive,
+      shouldListen,
+      shouldArmWakeWord,
+      waveformBars,
+      startManualSession,
+      endManualSession,
+      notifyProcessing,
+      notifySpeaking,
+      notifySpeakingComplete,
+      isWakeWordSupported,
+      isWakeWordListening,
+      wakeWordError,
+      lastWakeWordMatch,
+    }),
+    [
+      characterState,
+      endManualSession,
+      isConversationActive,
+      isWakeWordListening,
+      isWakeWordSupported,
+      lastWakeWordMatch,
+      mode,
+      notifyProcessing,
+      notifySpeaking,
+      notifySpeakingComplete,
+      shouldArmWakeWord,
+      shouldListen,
+      startManualSession,
+      wakeWordError,
+      waveformBars,
+    ],
+  );
+}

--- a/frontend/src/app/hooks/useWakeWord.ts
+++ b/frontend/src/app/hooks/useWakeWord.ts
@@ -56,6 +56,7 @@ export function useWakeWord({
   const shouldRunRef = useRef(enabled);
   const manualStopRef = useRef(false);
   const lastDetectionRef = useRef<WakeWordMatch | null>(null);
+  const startListeningRef = useRef<() => boolean>(() => false);
 
   const [isSupported, setIsSupported] = useState(false);
   const [isListening, setIsListening] = useState(false);
@@ -175,7 +176,7 @@ export function useWakeWord({
 
       clearRestartTimer();
       restartTimeoutRef.current = window.setTimeout(() => {
-        startListening();
+        startListeningRef.current();
       }, restartDelayMs);
     };
 
@@ -221,6 +222,10 @@ export function useWakeWord({
       return false;
     }
   }, [createRecognition, enabled, isListening]);
+
+  useEffect(() => {
+    startListeningRef.current = startListening;
+  }, [startListening]);
 
   const stopListening = useCallback(() => {
     shouldRunRef.current = false;


### PR DESCRIPTION
## Summary
- add `useVoiceSessionController` to coordinate wake-word arming, listening, silence detection, speaking transitions, and waveform state
- expose a unified session API for manual start/end, processing notifications, speaking notifications, and derived avatar character state
- fix the existing `useWakeWord` restart callback dependency warning so frontend lint is clean

## Validation
- `cd frontend && pnpm lint`
- `cd frontend && pnpm typecheck`
- `cd frontend && pnpm build`

## Notes
- `pnpm typecheck` depends on `.next/types/**` in this repo, so it was rerun after `pnpm build` generated those files in the isolated worktree.