### PR TITLE
Issue #116 Phase 2〜5 — 音声主体UI完全統合

### DIFF
--- a/frontend/src/app/components/CharacterAvatar.tsx
+++ b/frontend/src/app/components/CharacterAvatar.tsx
@@ -48,6 +48,7 @@ interface CharacterAvatarProps {
   modelPath?: string;
   initialExpression?: string;
   initialAnimation?: string;
+  sessionState?: 'idle' | 'listening' | 'processing' | 'speaking';
   autoRotate?: boolean;
   showControls?: boolean;
   background?: BackgroundOption;
@@ -86,10 +87,44 @@ const SETTINGS_TAB_LABELS: Record<
   audio: 'Audio',
 };
 
+const getSessionPoseOffsets = (sessionState: 'idle' | 'listening' | 'processing' | 'speaking') => {
+  switch (sessionState) {
+    case 'listening':
+      return {
+        position: { x: 0, y: 0, z: 0.08 },
+        rotation: { x: -0.08, y: 0, z: 0 },
+        expression: 'surprised',
+        animation: 'idle',
+      };
+    case 'processing':
+      return {
+        position: { x: 0.02, y: 0, z: 0.04 },
+        rotation: { x: -0.03, y: 0.08, z: 0.03 },
+        expression: 'thinking',
+        animation: 'idle',
+      };
+    case 'speaking':
+      return {
+        position: { x: 0.03, y: 0, z: 0.05 },
+        rotation: { x: -0.04, y: -0.04, z: 0 },
+        expression: 'happy',
+        animation: 'idle',
+      };
+    default:
+      return {
+        position: { x: 0, y: 0, z: 0 },
+        rotation: { x: 0, y: 0, z: 0 },
+        expression: 'neutral',
+        animation: 'idle',
+      };
+  }
+};
+
 export default function CharacterAvatar({
   modelPath = '/characters/models/sakura.vrm',
   initialExpression = 'neutral',
   initialAnimation = 'idle',
+  sessionState = 'idle',
   autoRotate = false,
   showControls = true,
   background = {
@@ -206,34 +241,36 @@ export default function CharacterAvatar({
     if (charactersRef.current) {
       // Check if current animation is idle
       const isCurrentlyIdle = currentAnimationUrlRef.current === '/animations/idle_loop.vrma' || isIdleAnimationActive.current;
+      const sessionPose = getSessionPoseOffsets(sessionState);
       
       if (isCurrentlyIdle) {
         // Apply idle animation position adjustment
         charactersRef.current.scene.position.set(
-          modelPositionOffset.x + 0.15,
-          modelPositionOffset.y,
-          modelPositionOffset.z
+          modelPositionOffset.x + 0.15 + sessionPose.position.x,
+          modelPositionOffset.y + sessionPose.position.y,
+          modelPositionOffset.z + sessionPose.position.z
         );
       } else {
         charactersRef.current.scene.position.set(
-          modelPositionOffset.x,
-          modelPositionOffset.y,
-          modelPositionOffset.z
+          modelPositionOffset.x + sessionPose.position.x,
+          modelPositionOffset.y + sessionPose.position.y,
+          modelPositionOffset.z + sessionPose.position.z
         );
       }
     }
-  }, [modelPositionOffset]);
+  }, [modelPositionOffset, sessionState]);
 
   // Update model rotation when offset changes
   useEffect(() => {
     if (charactersRef.current) {
+      const sessionPose = getSessionPoseOffsets(sessionState);
       charactersRef.current.scene.rotation.set(
-        modelRotationOffset.x,
-        Math.PI + modelRotationOffset.y,
-        modelRotationOffset.z
+        modelRotationOffset.x + sessionPose.rotation.x,
+        Math.PI + modelRotationOffset.y + sessionPose.rotation.y,
+        modelRotationOffset.z + sessionPose.rotation.z
       );
     }
-  }, [modelRotationOffset]);
+  }, [modelRotationOffset, sessionState]);
 
   // Update character state when props change
   useEffect(() => {
@@ -242,6 +279,16 @@ export default function CharacterAvatar({
       void updateCharacterAnimationRef.current(initialAnimation);
     }
   }, [initialExpression, initialAnimation]);
+
+  useEffect(() => {
+    if (!charactersRef.current) {
+      return;
+    }
+
+    const sessionPose = getSessionPoseOffsets(sessionState);
+    void updateCharacterExpressionRef.current(sessionPose.expression);
+    void updateCharacterAnimationRef.current(sessionPose.animation);
+  }, [sessionState]);
 
   // Update background when options change
   useEffect(() => {
@@ -969,8 +1016,8 @@ export default function CharacterAvatar({
             'relaxed': 'relaxed',
             // Additional mappings for character actions
             'thinking': 'relaxed',
-            'speaking': 'neutral',
-            'listening': 'neutral',
+            'speaking': 'happy',
+            'listening': 'surprised',
             'greeting': 'happy',
             'explaining': 'neutral'
           };

--- a/frontend/src/app/components/ClarificationButtons.tsx
+++ b/frontend/src/app/components/ClarificationButtons.tsx
@@ -1,0 +1,59 @@
+'use client';
+
+import { cn } from '@/lib/cn';
+import { Loader2 } from 'lucide-react';
+import { useEffect, useState } from 'react';
+
+interface ClarificationButtonsProps {
+  options: string[];
+  onSelect: (option: string) => Promise<void>;
+}
+
+export default function ClarificationButtons({
+  options,
+  onSelect,
+}: ClarificationButtonsProps) {
+  const [selectedOption, setSelectedOption] = useState<string | null>(null);
+  const [isSubmitting, setIsSubmitting] = useState(false);
+
+  useEffect(() => {
+    setSelectedOption(null);
+    setIsSubmitting(false);
+  }, [options]);
+
+  if (options.length === 0 || selectedOption) {
+    return null;
+  }
+
+  return (
+    <div className="flex flex-col gap-3 sm:flex-row sm:flex-wrap">
+      {options.map((option) => (
+        <button
+          key={option}
+          type="button"
+          onClick={() => {
+            setSelectedOption(option);
+            setIsSubmitting(true);
+            void onSelect(option).finally(() => {
+              setIsSubmitting(false);
+            });
+          }}
+          disabled={isSubmitting}
+          className={cn(
+            'inline-flex min-h-11 items-center justify-center rounded-2xl border border-slate-200 bg-white px-4 py-3 text-sm font-medium text-slate-800 shadow-sm transition-colors',
+            'hover:bg-slate-50 disabled:cursor-not-allowed disabled:bg-slate-100 disabled:text-slate-400',
+          )}
+        >
+          {isSubmitting && selectedOption === option ? (
+            <span className="inline-flex items-center gap-2">
+              <Loader2 className="size-4 animate-spin" />
+              {option}
+            </span>
+          ) : (
+            option
+          )}
+        </button>
+      ))}
+    </div>
+  );
+}

--- a/frontend/src/app/components/VoiceConversationShell.tsx
+++ b/frontend/src/app/components/VoiceConversationShell.tsx
@@ -1,0 +1,300 @@
+'use client';
+
+import { cn } from '@/lib/cn';
+import {
+  ChevronDown,
+  Loader2,
+  MessageSquare,
+  Mic,
+  MicOff,
+  SendHorizontal,
+  Volume2,
+  XCircle,
+} from 'lucide-react';
+import { useState, type ReactNode } from 'react';
+import VoiceInterface, {
+  type VoiceSessionState,
+} from './VoiceInterface';
+
+interface VoiceConversationShellProps {
+  language?: 'ja' | 'en';
+  onLanguageChange?: (language: 'ja' | 'en') => void;
+  onVisemeControl?: ((viseme: string, intensity: number) => void) | null;
+  renderAvatar?: (props: {
+    sessionState: VoiceSessionState;
+    isMuted: boolean;
+    volume: number;
+  }) => ReactNode;
+}
+
+const shellLabels = {
+  ja: {
+    title: '音声ガイド',
+    subtitle: 'マイク中心で案内します。必要なときだけテキストを補助入力してください。',
+    idle: '話しかける',
+    listening: '録音を止める',
+    processing: '応答を生成中',
+    speaking: '応答を再生中',
+    responseTitle: '応答',
+    transcriptTitle: '聞き取り結果',
+    wakeWordReady: 'ウェイクワード待機中',
+    wakeWordOff: 'マイク操作で開始',
+    textToggle: 'テキスト入力を開く',
+    textPlaceholder: 'ここに質問を入力します',
+    send: '送信',
+    cancel: 'キャンセル',
+    languageJa: '日本語',
+    languageEn: 'English',
+  },
+  en: {
+    title: 'Voice Guide',
+    subtitle: 'Voice is the primary interaction. Open the text field only when you need a backup.',
+    idle: 'Start talking',
+    listening: 'Stop recording',
+    processing: 'Generating',
+    speaking: 'Speaking',
+    responseTitle: 'Answer',
+    transcriptTitle: 'Transcript',
+    wakeWordReady: 'Wake word is armed',
+    wakeWordOff: 'Use the mic button',
+    textToggle: 'Open text input',
+    textPlaceholder: 'Type your question here',
+    send: 'Send',
+    cancel: 'Cancel',
+    languageJa: 'Japanese',
+    languageEn: 'English',
+  },
+} as const;
+
+const buttonCopy: Record<VoiceSessionState, keyof typeof shellLabels.ja> = {
+  idle: 'idle',
+  listening: 'listening',
+  processing: 'processing',
+  speaking: 'speaking',
+};
+
+export default function VoiceConversationShell({
+  language = 'ja',
+  onLanguageChange,
+  onVisemeControl,
+  renderAvatar,
+}: VoiceConversationShellProps) {
+  const [draft, setDraft] = useState('');
+
+  return (
+    <VoiceInterface
+      language={language}
+      onLanguageChange={onLanguageChange}
+      onVisemeControl={onVisemeControl}
+      showDefaultUI={false}
+    >
+      {(voice) => {
+        const labels = shellLabels[voice.currentLanguage];
+        const isListening = voice.sessionState === 'listening';
+        const isProcessing = voice.sessionState === 'processing';
+        const isSpeaking = voice.sessionState === 'speaking';
+        const waveformBars = (
+          isListening || isSpeaking ? voice.waveformBars : [0.18, 0.24, 0.2, 0.26, 0.18]
+        ).map((value) => Math.max(value, 0.16));
+
+        const submitDraft = async () => {
+          const trimmed = draft.trim();
+          if (!trimmed) {
+            return;
+          }
+
+          await voice.sendMessage(trimmed);
+          setDraft('');
+        };
+
+        return (
+          <section className="rounded-[28px] border border-slate-200 bg-white/90 p-4 shadow-sm backdrop-blur-sm md:p-6">
+            <div className="grid gap-6 xl:grid-cols-[minmax(0,1.05fr)_minmax(320px,420px)]">
+              <div className="space-y-4">
+                <header className="flex flex-wrap items-start justify-between gap-4">
+                  <div className="space-y-2">
+                    <p className="text-sm font-medium text-slate-500">{labels.title}</p>
+                    <h1 className="text-balance text-2xl font-semibold text-slate-950 md:text-3xl">
+                      {labels.subtitle}
+                    </h1>
+                  </div>
+                  <div className="flex items-center gap-2">
+                    <button
+                      type="button"
+                      onClick={() => onLanguageChange?.('ja')}
+                      className={cn(
+                        'rounded-full px-3 py-1.5 text-sm font-medium transition-colors',
+                        voice.currentLanguage === 'ja'
+                          ? 'bg-slate-900 text-white'
+                          : 'bg-slate-100 text-slate-700',
+                      )}
+                    >
+                      {labels.languageJa}
+                    </button>
+                    <button
+                      type="button"
+                      onClick={() => onLanguageChange?.('en')}
+                      className={cn(
+                        'rounded-full px-3 py-1.5 text-sm font-medium transition-colors',
+                        voice.currentLanguage === 'en'
+                          ? 'bg-slate-900 text-white'
+                          : 'bg-slate-100 text-slate-700',
+                      )}
+                    >
+                      {labels.languageEn}
+                    </button>
+                  </div>
+                </header>
+
+                {renderAvatar ? (
+                  <div className="overflow-hidden rounded-[24px] border border-slate-200 bg-slate-50">
+                    {renderAvatar({
+                      sessionState: voice.sessionState,
+                      isMuted: voice.isMuted,
+                      volume: voice.volume,
+                    })}
+                  </div>
+                ) : null}
+
+                <div className="rounded-[24px] border border-slate-200 bg-slate-950 px-5 py-6 text-white">
+                  <div className="flex items-center justify-between gap-3">
+                    <div>
+                      <p className="text-sm font-medium text-slate-300">
+                        {voice.wakeWord.isSupported && !voice.error
+                          ? labels.wakeWordReady
+                          : labels.wakeWordOff}
+                      </p>
+                      <p className="mt-1 text-sm text-slate-400">
+                        {labels[buttonCopy[voice.sessionState]]}
+                      </p>
+                    </div>
+                    <button
+                      type="button"
+                      onClick={isListening ? voice.stopListening : voice.startListening}
+                      disabled={isProcessing}
+                      aria-label={labels[buttonCopy[voice.sessionState]]}
+                      className={cn(
+                        'relative flex size-28 items-center justify-center rounded-full text-white transition-transform duration-200 md:size-32',
+                        isListening && 'bg-rose-500 motion-safe:animate-pulse',
+                        isProcessing && 'bg-amber-500',
+                        isSpeaking && 'bg-sky-500',
+                        voice.sessionState === 'idle' && 'bg-white text-slate-950',
+                        !isProcessing && 'motion-safe:hover:scale-[1.02]',
+                      )}
+                    >
+                      <span className="absolute inset-0 rounded-full border border-white/10" />
+                      {isProcessing ? (
+                        <Loader2 className="size-11 animate-spin" />
+                      ) : isListening ? (
+                        <MicOff className="size-11" />
+                      ) : isSpeaking ? (
+                        <Volume2 className="size-11" />
+                      ) : (
+                        <Mic className="size-11" />
+                      )}
+                    </button>
+                  </div>
+
+                  <div className="mt-5 flex items-end justify-center gap-2">
+                    {waveformBars.map((bar, index) => (
+                      <span
+                        key={`${index}-${bar}`}
+                        className={cn(
+                          'w-2 rounded-full bg-white/85 transition-transform duration-150',
+                          (isListening || isSpeaking) && 'motion-safe:animate-pulse',
+                          isProcessing && 'bg-amber-100',
+                        )}
+                        style={{ height: '48px', transform: `scaleY(${bar})` }}
+                      />
+                    ))}
+                  </div>
+
+                  <div className="mt-5 flex flex-wrap gap-3">
+                    <button
+                      type="button"
+                      onClick={voice.clearConversation}
+                      className="inline-flex items-center gap-2 rounded-full border border-white/15 px-4 py-2 text-sm font-medium text-white/90 transition-colors hover:bg-white/10"
+                    >
+                      <XCircle className="size-4" />
+                      {labels.cancel}
+                    </button>
+                    {voice.loadingMessage ? (
+                      <div className="inline-flex items-center gap-2 rounded-full bg-white/10 px-4 py-2 text-sm text-white/80">
+                        <Loader2 className="size-4 animate-spin" />
+                        {voice.loadingMessage}
+                      </div>
+                    ) : null}
+                  </div>
+                </div>
+              </div>
+
+              <div className="space-y-4">
+                <div className="rounded-[24px] border border-slate-200 bg-slate-50 p-5">
+                  <p className="text-sm font-medium text-slate-500">{labels.responseTitle}</p>
+                  <div className="mt-3 space-y-4">
+                    {voice.transcript ? (
+                      <div className="rounded-2xl bg-white p-4">
+                        <p className="text-xs font-semibold uppercase tracking-wide text-slate-400">
+                          {labels.transcriptTitle}
+                        </p>
+                        <p className="mt-2 text-pretty text-sm leading-6 text-slate-700">
+                          {voice.transcript}
+                        </p>
+                      </div>
+                    ) : null}
+                    <div className="min-h-40 rounded-2xl bg-white p-4">
+                      <p className="text-pretty text-sm leading-7 text-slate-800">
+                        {voice.response ||
+                          (voice.currentLanguage === 'ja'
+                            ? '回答はここに表示されます。'
+                            : 'The answer will appear here.')}
+                      </p>
+                    </div>
+                  </div>
+                </div>
+
+                {voice.error ? (
+                  <div className="rounded-2xl border border-rose-200 bg-rose-50 p-4 text-sm text-rose-700">
+                    {voice.error}
+                  </div>
+                ) : null}
+
+                <details className="group rounded-[24px] border border-slate-200 bg-white p-5">
+                  <summary className="flex cursor-pointer list-none items-center justify-between gap-3 text-sm font-medium text-slate-700">
+                    <span className="inline-flex items-center gap-2">
+                      <MessageSquare className="size-4" />
+                      {labels.textToggle}
+                    </span>
+                    <ChevronDown className="size-4 text-slate-400 transition-transform duration-200 group-open:rotate-180" />
+                  </summary>
+                  <div className="mt-4 space-y-3">
+                    <textarea
+                      value={draft}
+                      onChange={(event) => setDraft(event.target.value)}
+                      placeholder={labels.textPlaceholder}
+                      rows={4}
+                      className="w-full rounded-2xl border border-slate-200 px-4 py-3 text-sm leading-6 text-slate-900 outline-none transition-colors focus:border-slate-400"
+                    />
+                    <div className="flex justify-end">
+                      <button
+                        type="button"
+                        onClick={() => {
+                          void submitDraft();
+                        }}
+                        disabled={!draft.trim()}
+                        className="inline-flex items-center gap-2 rounded-full bg-slate-900 px-4 py-2 text-sm font-medium text-white transition-colors disabled:bg-slate-300"
+                      >
+                        <SendHorizontal className="size-4" />
+                        {labels.send}
+                      </button>
+                    </div>
+                  </div>
+                </details>
+              </div>
+            </div>
+          </section>
+        );
+      }}
+    </VoiceInterface>
+  );
+}

--- a/frontend/src/app/components/VoiceConversationShell.tsx
+++ b/frontend/src/app/components/VoiceConversationShell.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { cn } from '@/lib/cn';
+import { ClarificationUtils } from '@/lib/clarification-utils';
 import {
   ChevronDown,
   Loader2,
@@ -15,6 +16,7 @@ import { useState, type ReactNode } from 'react';
 import VoiceInterface, {
   type VoiceSessionState,
 } from './VoiceInterface';
+import ClarificationButtons from './ClarificationButtons';
 
 interface VoiceConversationShellProps {
   language?: 'ja' | 'en';
@@ -73,6 +75,48 @@ const buttonCopy: Record<VoiceSessionState, keyof typeof shellLabels.ja> = {
   speaking: 'speaking',
 };
 
+const clarificationOptionMap = {
+  ja: {
+    'cafe-clarification-needed': ['エンジニアカフェ', 'サイノカフェ'],
+    'meeting-room-clarification-needed': ['2階の有料会議室', '地下1階の無料ミーティングスペース'],
+    'event-clarification-needed': ['イベント情報', 'コミュニティ情報'],
+    'space-clarification-needed': ['作業スペース', '会議スペース'],
+  },
+  en: {
+    'cafe-clarification-needed': ['Engineer Cafe', 'Saino Cafe'],
+    'meeting-room-clarification-needed': ['Paid meeting room on 2F', 'Free meeting space on B1'],
+    'event-clarification-needed': ['Event information', 'Community information'],
+    'space-clarification-needed': ['Workspace', 'Meeting space'],
+  },
+} as const;
+
+const getClarificationOptions = (
+  currentLanguage: 'ja' | 'en',
+  response: string,
+  metadata: Record<string, unknown> | null,
+): string[] => {
+  const metadataOptions = Array.isArray(metadata?.clarification_options)
+    ? metadata.clarification_options.filter((value): value is string => typeof value === 'string')
+    : [];
+  if (metadataOptions.length > 0) {
+    return metadataOptions;
+  }
+
+  const clarification = metadata?.clarification;
+  const clarificationType =
+    clarification &&
+    typeof clarification === 'object' &&
+    typeof (clarification as { clarification_type?: unknown }).clarification_type === 'string'
+      ? (clarification as { clarification_type: keyof typeof clarificationOptionMap.ja }).clarification_type
+      : null;
+
+  if (clarificationType && clarificationType in clarificationOptionMap[currentLanguage]) {
+    return [...clarificationOptionMap[currentLanguage][clarificationType]];
+  }
+
+  return ClarificationUtils.extractClarificationOptions(response);
+};
+
 export default function VoiceConversationShell({
   language = 'ja',
   onLanguageChange,
@@ -96,6 +140,11 @@ export default function VoiceConversationShell({
         const waveformBars = (
           isListening || isSpeaking ? voice.waveformBars : [0.18, 0.24, 0.2, 0.26, 0.18]
         ).map((value) => Math.max(value, 0.16));
+        const clarificationOptions = getClarificationOptions(
+          voice.currentLanguage,
+          voice.response,
+          voice.metadata,
+        );
 
         const submitDraft = async () => {
           const trimmed = draft.trim();
@@ -250,6 +299,15 @@ export default function VoiceConversationShell({
                             : 'The answer will appear here.')}
                       </p>
                     </div>
+                    {clarificationOptions.length > 0 ? (
+                      <div className="rounded-2xl bg-white p-4">
+                        <ClarificationButtons
+                          key={`${voice.response}-${clarificationOptions.join('|')}`}
+                          options={clarificationOptions}
+                          onSelect={voice.sendMessage}
+                        />
+                      </div>
+                    ) : null}
                   </div>
                 </div>
 

--- a/frontend/src/app/components/VoiceInterface.tsx
+++ b/frontend/src/app/components/VoiceInterface.tsx
@@ -1,14 +1,70 @@
 'use client';
 
 import { AudioQueue } from '@/lib/audio-queue';
-import { formatError } from '@/lib/error-messages';
 import { MobileAudioService } from '@/lib/audio/mobile-audio-service';
-import { useAudioInteraction } from '@/lib/audio/audio-interaction-manager';
-import { VoiceRecorder } from '@/lib/voice-recorder';
 import { audioStateManager } from '@/lib/audio-state-manager';
-import { AlertCircle, Loader2, Mic, MicOff, Settings, Volume2, VolumeX } from 'lucide-react';
-import { useCallback, useEffect, useRef, useState } from 'react';
-import { useMicVAD, utils } from '@ricky0123/vad-react';
+import { cn } from '@/lib/cn';
+import { EmotionTagParser } from '@/lib/emotion-tag-parser';
+import { formatError } from '@/lib/error-messages';
+import { LipSyncAnalyzer } from '@/lib/lip-sync-analyzer';
+import { preprocessTTS } from '@/utils/tts-preprocess';
+import { AlertCircle, Loader2, Mic, MicOff, Volume2, VolumeX, XCircle } from 'lucide-react';
+import {
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+  type MutableRefObject,
+  type ReactNode,
+} from 'react';
+import {
+  useVoiceSessionController,
+  type VoiceCharacterState,
+} from '../hooks/useVoiceSessionController';
+import type { WakeWordMatch } from '../hooks/useWakeWord';
+import { VoiceRecorder } from '@/lib/voice-recorder';
+
+export type VoiceSessionState = 'idle' | 'listening' | 'processing' | 'speaking';
+
+export interface VoiceInterfaceMetadata {
+  clarification?: {
+    clarification_type?: string;
+    [key: string]: unknown;
+  };
+  clarification_options?: string[];
+  requires_followup?: boolean;
+  [key: string]: unknown;
+}
+
+export interface VoiceInterfaceRenderProps {
+  sessionState: VoiceSessionState;
+  characterState: VoiceCharacterState;
+  transcript: string;
+  response: string;
+  metadata: VoiceInterfaceMetadata | null;
+  error: string | null;
+  isLoading: boolean;
+  loadingMessage: string;
+  currentLanguage: 'ja' | 'en';
+  volume: number;
+  isMuted: boolean;
+  waveformBars: number[];
+  wakeWord: {
+    isSupported: boolean;
+    isListening: boolean;
+    error: string | null;
+    lastMatch: WakeWordMatch | null;
+  };
+  startListening: () => void;
+  stopListening: () => void;
+  cancelSession: () => void;
+  clearConversation: () => void;
+  sendMessage: (message: string) => Promise<void>;
+  setVolume: (value: number) => void;
+  setMuted: (value: boolean) => void;
+  toggleLanguage: () => void;
+}
 
 interface VoiceInterfaceProps {
   onLanguageChange?: (language: 'ja' | 'en') => void;
@@ -16,1256 +72,754 @@ interface VoiceInterfaceProps {
   language?: 'ja' | 'en';
   autoGreeting?: boolean;
   onVisemeControl?: ((viseme: string, intensity: number) => void) | null;
+  children?: (props: VoiceInterfaceRenderProps) => ReactNode;
+  showDefaultUI?: boolean;
+  className?: string;
 }
 
-export default function VoiceInterface({ 
-  onLanguageChange, 
+const DEFAULT_WAKE_WORDS = ['すみません', 'hello'];
+
+const STATUS_LABELS: Record<'ja' | 'en', Record<VoiceSessionState, string>> = {
+  ja: {
+    idle: '待機中',
+    listening: '聞いています',
+    processing: '考えています',
+    speaking: '話しています',
+  },
+  en: {
+    idle: 'Ready',
+    listening: 'Listening',
+    processing: 'Thinking',
+    speaking: 'Speaking',
+  },
+};
+
+const LOADING_LABELS = {
+  ja: {
+    microphone: 'マイクに接続しています...',
+    recognize: '音声を文字にしています...',
+    answer: '回答を準備しています...',
+    speaking: '音声を再生しています...',
+  },
+  en: {
+    microphone: 'Connecting to the microphone...',
+    recognize: 'Transcribing your speech...',
+    answer: 'Preparing the answer...',
+    speaking: 'Playing the response...',
+  },
+} as const;
+
+const getOrCreateVisitorId = (): string => {
+  if (typeof window === 'undefined') {
+    return 'anonymous';
+  }
+
+  const key = 'engineer_cafe_visitor_id';
+  const existing = window.localStorage.getItem(key);
+  if (existing) {
+    return existing;
+  }
+
+  const created = window.crypto.randomUUID();
+  window.localStorage.setItem(key, created);
+  return created;
+};
+
+const createSessionId = (): string =>
+  `voice-session-${Date.now()}-${Math.random().toString(36).slice(2, 11)}`;
+
+const toLocale = (language: 'ja' | 'en'): string => (language === 'ja' ? 'ja-JP' : 'en-US');
+
+const normalizeSessionState = (mode: string): VoiceSessionState =>
+  mode === 'listening' || mode === 'processing' || mode === 'speaking' ? mode : 'idle';
+
+const toBase64 = async (blob: Blob): Promise<string> => {
+  const arrayBuffer = await blob.arrayBuffer();
+  return VoiceRecorder.arrayBufferToBase64(arrayBuffer);
+};
+
+const stopAudioPlayback = (
+  audioQueueRef: MutableRefObject<AudioQueue | null>,
+  mobileAudioServiceRef: MutableRefObject<MobileAudioService | null>,
+  onVisemeControl?: ((viseme: string, intensity: number) => void) | null,
+) => {
+  audioStateManager.stopAll();
+  audioQueueRef.current?.clear();
+  mobileAudioServiceRef.current?.stop();
+  onVisemeControl?.('Closed', 0);
+};
+
+export default function VoiceInterface({
+  onLanguageChange,
   layout = 'vertical',
   language = 'ja',
   autoGreeting = false,
-  onVisemeControl
+  onVisemeControl,
+  children,
+  showDefaultUI,
+  className,
 }: VoiceInterfaceProps) {
-  const [isListening, setIsListening] = useState(false);
-  const [isSpeaking, setIsSpeaking] = useState(false);
-  const [isRecording, setIsRecording] = useState(false);
-  const [conversationState, setConversationState] = useState<'idle' | 'listening' | 'processing' | 'speaking'>('idle');
   const [currentLanguage, setCurrentLanguage] = useState<'ja' | 'en'>(language);
   const [volume, setVolumeState] = useState(0.8);
   const [isMuted, setIsMuted] = useState(false);
   const [transcript, setTranscript] = useState('');
   const [response, setResponse] = useState('');
+  const [metadata, setMetadata] = useState<VoiceInterfaceMetadata | null>(null);
   const [error, setError] = useState<string | null>(null);
   const [isLoading, setIsLoading] = useState(false);
   const [loadingMessage, setLoadingMessage] = useState('');
-  const [autoListen, setAutoListen] = useState(true); // Auto-listen after response
-  const [currentEmotion, setCurrentEmotion] = useState<string | null>(null);
-  const [audioUnlocked, setAudioUnlocked] = useState(false);
-  
-  // Custom setVolume that also updates audio queue
-  const setVolume = (newVolume: number) => {
-    setVolumeState(newVolume);
-    if (audioQueueRef.current) {
-      audioQueueRef.current.setVolume(newVolume);
-    }
-  };
-  
+  const [mediaStream, setMediaStream] = useState<MediaStream | null>(null);
 
-  const audioContextRef = useRef<AudioContext | null>(null);
+  const sessionIdRef = useRef(createSessionId());
+  const visitorIdRef = useRef<string>('anonymous');
+  const recorderRef = useRef<VoiceRecorder | null>(null);
+  const shouldDiscardNextAudioRef = useRef(false);
+  const requestAbortRef = useRef<AbortController | null>(null);
+  const lipSyncAnalyzerRef = useRef<LipSyncAnalyzer | null>(null);
+  const lipSyncTimersRef = useRef<number[]>([]);
   const audioQueueRef = useRef<AudioQueue | null>(null);
   const mobileAudioServiceRef = useRef<MobileAudioService | null>(null);
-  const voiceRecorderRef = useRef<VoiceRecorder | null>(null);
-  const initialVolumeRef = useRef(volume);
-  const performAutoGreetingRef = useRef<() => Promise<void>>(async () => {});
-  const { ensureAudioContext, isReady: isAudioReady, hasInteraction } = useAudioInteraction();
+  const audioUrlRef = useRef<string | null>(null);
+  const isRecordingRef = useRef(false);
 
-  // --- VAD barge-in integration ---
-  // VAD is active only while AI is speaking (conversationState === 'speaking')
-  const vadActiveRef = useRef(false);
-
-  // Keep vadActiveRef in sync with conversationState
   useEffect(() => {
-    vadActiveRef.current = conversationState === 'speaking';
-  }, [conversationState]);
-
-  // Stable callback for processing VAD-captured audio
-  const processVadAudio = useCallback(async (audioBlob: Blob) => {
-    await processAudioInput(audioBlob);
-  // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [currentLanguage, isMuted]);
-
-  // Stable callback for VAD-triggered interruption
-  const handleVadInterrupt = useCallback(() => {
-
-    // 1. Stop AI audio playback
-    if (mobileAudioServiceRef.current) {
-      mobileAudioServiceRef.current.stop();
-    }
-    audioStateManager.stopAll();
-    if (audioQueueRef.current) {
-      audioQueueRef.current.clear();
-    }
-
-    // 2. Stop lip-sync
-    if (onVisemeControl) {
-      onVisemeControl('X', 0);
-    }
-
-    // 3. Update UI state
-    setIsSpeaking(false);
-    setConversationState('listening');
-
-    // 4. Notify backend of interruption (fire-and-forget)
-    fetch('/api/voice', {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ action: 'handle_interruption' }),
-    }).catch((err) => console.error('[VAD] Failed to notify backend of interruption:', err));
-  // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [onVisemeControl]);
-
-  const vadInstance = useMicVAD({
-    // Kiosk-optimized thresholds
-    positiveSpeechThreshold: 0.6,
-    negativeSpeechThreshold: 0.45,
-    minSpeechMs: 150,
-    redemptionMs: 400,
-    startOnLoad: true,
-
-    onSpeechStart: () => {
-      // Only act when AI is speaking
-      if (!vadActiveRef.current) return;
-      handleVadInterrupt();
-    },
-
-    onSpeechEnd: (audio: Float32Array) => {
-      // Only process if we were in a barge-in scenario (now in 'listening' state after interrupt)
-      // or if conversation is idle/listening (VAD detected real speech)
-      if (vadActiveRef.current) {
-        // Still speaking and speech ended quickly — treat as misfire, ignore
-        return;
-      }
-
-      // Convert Float32Array to WAV Blob and send to existing STT pipeline
-      const wavBuffer = utils.encodeWAV(audio);
-      const audioBlob = new Blob([wavBuffer], { type: 'audio/wav' });
-
-      // Only process if the blob has meaningful size (avoid empty/tiny misfires)
-      if (audioBlob.size < 1000) {
-        return;
-      }
-
-      setConversationState('processing');
-      processVadAudio(audioBlob);
-    },
-
-    onVADMisfire: () => {
-      // No action needed - if we already interrupted, audio is stopped and
-      // we cannot resume it. The brief false positive is acceptable for kiosk UX.
-    },
-  });
-
-  // Audio unlock function
-  const unlockAudio = async () => {
-    if (audioUnlocked) return;
-
-    try {
-      // Initialize AudioContext if it doesn't exist
-      if (!audioContextRef.current) {
-        audioContextRef.current = new (window.AudioContext || (window as any).webkitAudioContext)();
-      }
-
-      // Resume AudioContext if suspended
-      if (audioContextRef.current.state === 'suspended') {
-        await audioContextRef.current.resume();
-      }
-      
-      setAudioUnlocked(true);
-    } catch (error) {
-      console.warn('[AUDIO] Audio unlock failed:', error);
-    }
-  };
-
-  // Initialize mobile audio service
-  useEffect(() => {
-    if (!mobileAudioServiceRef.current) {
-      mobileAudioServiceRef.current = new MobileAudioService({
-        volume: initialVolumeRef.current,
-        onPlay: () => setIsSpeaking(true),
-        onEnded: () => setIsSpeaking(false),
-        onError: (error) => {
-          console.error('[AUDIO] Mobile audio service error:', error);
-          setError(`Audio playback error: ${error.message}`);
-        }
-      });
-    }
-
-    const audioQueue = audioQueueRef.current;
-    const audioContext = audioContextRef.current;
-    const mobileAudioService = mobileAudioServiceRef.current;
-
-    return () => {
-      // Cleanup VoiceRecorder
-      if (voiceRecorderRef.current) {
-        voiceRecorderRef.current.cleanup();
-        voiceRecorderRef.current = null;
-      }
-      
-      if (audioContext) {
-        audioContext.close();
-      }
-      if (audioQueue) {
-        audioQueue.clear();
-      }
-      if (mobileAudioService) {
-        mobileAudioService.dispose();
-      }
-    };
+    visitorIdRef.current = getOrCreateVisitorId();
   }, []);
 
-  // Update mobile audio service volume
-  useEffect(() => {
-    if (mobileAudioServiceRef.current) {
-      mobileAudioServiceRef.current.setVolume(volume);
-    }
-  }, [volume]);
-
-  // Update language when prop changes
   useEffect(() => {
     setCurrentLanguage(language);
   }, [language]);
 
-  // Auto greeting when component mounts with autoGreeting enabled
-  useEffect(() => {
-    if (autoGreeting) {
-      void performAutoGreetingRef.current();
+  const clearLipSyncTimers = useCallback(() => {
+    lipSyncTimersRef.current.forEach((timerId) => window.clearTimeout(timerId));
+    lipSyncTimersRef.current = [];
+    onVisemeControl?.('Closed', 0);
+  }, [onVisemeControl]);
+
+  const revokeAudioUrl = useCallback(() => {
+    if (!audioUrlRef.current) {
+      return;
     }
-  }, [autoGreeting, language]);
 
-  // Perform automatic greeting
-  const performAutoGreeting = async () => {
-    const greetingText = language === 'ja' 
-      ? 'はじめまして！何かお手伝いできることはありますか？'
-      : 'Hello there! How can I help you today?';
-    
-    try {
-      // Wait a bit to ensure audio context can be initialized
-      await new Promise(resolve => setTimeout(resolve, 100));
-      
-      // Ensure audio context is ready
-      if (audioContextRef.current?.state === 'suspended') {
-      }
-      
-      setConversationState('speaking');
-      setResponse(greetingText);
-      setIsLoading(true);
-      setLoadingMessage(language === 'ja' ? '挨拶を準備中...' : 'Preparing greeting...');
+    URL.revokeObjectURL(audioUrlRef.current);
+    audioUrlRef.current = null;
+  }, []);
 
-      // Generate TTS audio for greeting
-      const response = await fetch('/api/voice', {
-        method: 'POST',
-        headers: {
-          'Content-Type': 'application/json',
-        },
-        body: JSON.stringify({
-          action: 'text_to_speech',
-          text: greetingText,
-          language: language,
-          sessionId: generateSessionId(),
-        }),
-      });
+  const cleanupAudioPlayback = useCallback(() => {
+    clearLipSyncTimers();
+    revokeAudioUrl();
+  }, [clearLipSyncTimers, revokeAudioUrl]);
 
-      const result = await response.json();
+  const cancelPendingRequest = useCallback(() => {
+    requestAbortRef.current?.abort();
+    requestAbortRef.current = null;
+  }, []);
 
-      if (result.success && result.audioResponse && !isMuted) {
-        await playAudioResponse(result.audioResponse);
-      } else {
-        setConversationState('idle');
-        setIsLoading(false);
-        setLoadingMessage('');
-      }
-
-      // Update character animation for greeting
-      updateCharacter('greeting');
-
-    } catch (error) {
-      console.error('Auto greeting error:', error);
-      setError(language === 'ja' ? '挨拶の再生に失敗しました' : 'Failed to play greeting');
-      setConversationState('idle');
-      setIsLoading(false);
-      setLoadingMessage('');
+  const ensureAudioService = useCallback(() => {
+    if (!mobileAudioServiceRef.current) {
+      mobileAudioServiceRef.current = new MobileAudioService({ volume });
     }
-  };
 
-  performAutoGreetingRef.current = performAutoGreeting;
+    mobileAudioServiceRef.current.setVolume(volume);
+    return mobileAudioServiceRef.current;
+  }, [volume]);
 
-
-  // Start voice recording
-  const startListening = async () => {
-    try {
+  const voiceController = useVoiceSessionController({
+    enabled: true,
+    stream: mediaStream,
+    wakeWords: DEFAULT_WAKE_WORDS,
+    language: toLocale(currentLanguage),
+    onWakeWord: () => {
       setError(null);
-      
-      // Stop any currently playing audio to prevent overlap
-      audioStateManager.stopAll();
-      
-      // Also stop local audio queue if it exists
-      if (audioQueueRef.current && audioQueueRef.current.clear) {
-        audioQueueRef.current.clear();
-      }
-      
-      // Initialize and unlock audio for iOS - this is critical!
-      
-      // Ensure audio context is initialized and running
-      if (!audioContextRef.current) {
-        audioContextRef.current = new (window.AudioContext || (window as any).webkitAudioContext)();
-      }
-      
-      if (audioContextRef.current?.state === 'suspended') {
-        await audioContextRef.current.resume();
-      }
-      
-      // Ensure iOS audio is unlocked
-      await unlockAudio();
-      
-      // Import VoiceRecorder
-      const { VoiceRecorder } = await import('@/lib/voice-recorder');
-      
-      setIsLoading(true);
-      setLoadingMessage(currentLanguage === 'ja' ? 'マイクにアクセス中...' : 'Accessing microphone...');
-      
-      // Create and initialize VoiceRecorder instance
-      const recorder = new VoiceRecorder(
-        (audioBlob: Blob) => {
-          // onDataAvailable callback
-          processAudioInput(audioBlob);
-        },
-        (error: Error) => {
-          // onError callback
-          console.error('VoiceRecorder error:', error);
-          setError(error.message);
-          setIsLoading(false);
-          setLoadingMessage('');
-          setIsRecording(false);
-          setIsListening(false);
-          setConversationState('idle');
-        }
-      );
-      
-      // Initialize the recorder (handles iOS-specific requirements)
-      await recorder.initialize();
-      
-      // Check if initialization was successful
-      if (!recorder.isInitialized()) {
-        // Error already handled by onError callback
+    },
+  });
+
+  const sessionState = normalizeSessionState(voiceController.mode);
+
+  const setVolume = useCallback((nextVolume: number) => {
+    setVolumeState(nextVolume);
+    mobileAudioServiceRef.current?.setVolume(nextVolume);
+  }, []);
+
+  const setMuted = useCallback((nextMuted: boolean) => {
+    setIsMuted(nextMuted);
+  }, []);
+
+  const resetConversation = useCallback(() => {
+    setTranscript('');
+    setResponse('');
+    setMetadata(null);
+    setError(null);
+    setIsLoading(false);
+    setLoadingMessage('');
+    sessionIdRef.current = createSessionId();
+  }, []);
+
+  const applyLipSync = useCallback(
+    async (audioBlob: Blob) => {
+      if (!onVisemeControl) {
         return;
       }
-      
-      // Store recorder reference in component ref
-      voiceRecorderRef.current = recorder;
-      
-      // Start recording
-      recorder.start();
-      
-      setIsRecording(true);
-      setIsListening(true);
-      setConversationState('listening');
-      setIsLoading(false);
-      setLoadingMessage('');
-    } catch (error: any) {
-      console.error('Error starting voice recording:', error);
-      setError(formatError(error, currentLanguage));
-      setIsLoading(false);
-      setLoadingMessage('');
-    }
-  };
 
-  // Stop voice recording
-  const stopListening = () => {
-    // Stop any currently playing audio
-    audioStateManager.stopAll();
-    
-    // Also stop local audio queue if it exists
-    if (audioQueueRef.current && audioQueueRef.current.clear) {
-      audioQueueRef.current.clear();
-    }
-    
-    if (isRecording && voiceRecorderRef.current) {
-      const recorder = voiceRecorderRef.current;
-      recorder.stop();
-      // Cleanup immediately, no setTimeout needed
-      recorder.cleanup();
-      voiceRecorderRef.current = null;
-      
-      setIsRecording(false);
-      setIsListening(false);
-      setConversationState('processing');
-    }
-  };
+      if (!lipSyncAnalyzerRef.current) {
+        lipSyncAnalyzerRef.current = new LipSyncAnalyzer();
+      }
 
-  // Process audio input
-  const processAudioInput = async (audioBlob: Blob) => {
-    try {
-      setIsLoading(true);
-      setLoadingMessage(currentLanguage === 'ja' ? '音声を認識中...' : 'Recognizing speech...');
-      const audioBuffer = await audioBlob.arrayBuffer();
-      const uint8Array = new Uint8Array(audioBuffer);
-      const audioBase64 = btoa(String.fromCharCode.apply(null, Array.from(uint8Array)));
+      const lipSyncData = await lipSyncAnalyzerRef.current.analyzeLipSync(audioBlob);
+      clearLipSyncTimers();
 
-      const response = await fetch('/api/voice', {
-        method: 'POST',
-        headers: {
-          'Content-Type': 'application/json',
-        },
-        body: JSON.stringify({
-          action: 'process_voice',
-          audioData: audioBase64,
-          sessionId: generateSessionId(),
-          language: currentLanguage, // 重要：言語設定を明示的に指定
-        }),
+      lipSyncData.frames.forEach((frame) => {
+        const timerId = window.setTimeout(() => {
+          onVisemeControl(frame.mouthShape, frame.mouthOpen);
+        }, frame.time * 1000);
+        lipSyncTimersRef.current.push(timerId);
       });
+    },
+    [clearLipSyncTimers, onVisemeControl],
+  );
 
-      const result = await response.json();
+  const stopPlayback = useCallback(
+    (completeTurn: boolean) => {
+      stopAudioPlayback(audioQueueRef, mobileAudioServiceRef, onVisemeControl);
+      cleanupAudioPlayback();
 
-      if (result.success) {
-        setTranscript(result.transcript);
-        setResponse(result.response);
-        
-        // Update loading message for TTS generation
-        setLoadingMessage(currentLanguage === 'ja' ? '音声を生成中...' : 'Generating voice...');
-
-        // Play audio response
-        
-        if (result.audioResponse && !isMuted) {
-          try {
-            await playAudioResponse(result.audioResponse);
-          } catch (audioError) {
-            console.error('[DEBUG] Audio playback failed:', audioError);
-            // Fallback: show manual play button
-            setError(currentLanguage === 'ja' 
-              ? '🔊 音声再生に失敗しました。下のボタンをタップして再生してください。' 
-              : '🔊 Audio playback failed. Tap the button below to play.');
-            setConversationState('idle');
-            setIsLoading(false);
-            setLoadingMessage('');
-          }
-        } else {
-          setConversationState('idle');
-          setIsLoading(false);
-          setLoadingMessage('');
-        }
-
-        // Update character if needed
-        if (result.shouldUpdateCharacter) {
-          if (result.characterAction) {
-            updateCharacter(result.characterAction);
-          }
-          // Update character expression based on emotion
-          if (result.emotion || result.primaryEmotion) {
-            const emotion = result.primaryEmotion || result.emotion?.emotion || 'neutral';
-            setCurrentEmotion(emotion);
-            updateCharacterExpression(emotion);
-          }
-        }
-      } else {
-        setError(result.error || formatError({ code: 'VOICE_PROCESSING_ERROR' }, currentLanguage));
+      if (completeTurn) {
+        voiceController.notifySpeakingComplete();
       }
-    } catch (error: any) {
-      console.error('Error processing audio:', error);
-      setError(formatError(error, currentLanguage));
-    } finally {
-      setConversationState('idle');
-      setIsLoading(false);
-      setLoadingMessage('');
-    }
-  };
+    },
+    [cleanupAudioPlayback, onVisemeControl, voiceController],
+  );
 
-  // Play streaming audio response
-
-  // Play audio response
-  const playAudioResponse = async (audioBase64: string) => {
-    try {
-      
-      
-      // Attempt audio unlock for mobile devices
-      try {
-        await unlockAudio();
-      } catch (error) {
-        console.warn('[AUDIO] Audio unlock failed, continuing with standard playback');
-      }
-      setIsLoading(true);
-      setLoadingMessage(currentLanguage === 'ja' ? '音声を再生準備中...' : 'Preparing audio playback...');
-      setIsSpeaking(true);
-      setConversationState('speaking');
-
-      // Stop any currently playing audio via mobile audio service
-      if (mobileAudioServiceRef.current) {
-        mobileAudioServiceRef.current.stop();
-      }
-      
-      // Clean up audio queue if exists
-      if (audioQueueRef.current) {
-        audioQueueRef.current.clear();
+  const playAssistantAudio = useCallback(
+    async (audioBase64: string) => {
+      if (isMuted) {
+        voiceController.notifySpeaking();
+        window.setTimeout(() => {
+          voiceController.notifySpeakingComplete();
+        }, 240);
+        return;
       }
 
-      const audioData = Uint8Array.from(atob(audioBase64), c => c.charCodeAt(0));
-      const audioBlob = new Blob([audioData], { type: 'audio/mp3' });
+      const audioBytes = Uint8Array.from(atob(audioBase64), (char) => char.charCodeAt(0));
+      const audioBlob = new Blob([audioBytes], { type: 'audio/mpeg' });
       const audioUrl = URL.createObjectURL(audioBlob);
-      
-      
-      // Ensure mobile audio service is available (should already be initialized by useEffect)
-      if (!mobileAudioServiceRef.current) {
-        console.error('[AUDIO] MobileAudioService not initialized');
-        setError('Audio service not available');
+      const audioService = ensureAudioService();
+
+      revokeAudioUrl();
+      audioUrlRef.current = audioUrl;
+
+      setLoadingMessage(LOADING_LABELS[currentLanguage].speaking);
+      voiceController.notifySpeaking();
+
+      await applyLipSync(audioBlob).catch(() => {
+        clearLipSyncTimers();
+      });
+
+      audioService.updateEventHandlers({
+        onEnded: () => {
+          cleanupAudioPlayback();
+          voiceController.notifySpeakingComplete();
+        },
+        onError: (playbackError) => {
+          cleanupAudioPlayback();
+          setError(formatError(playbackError, currentLanguage));
+          voiceController.notifySpeakingComplete();
+        },
+      });
+
+      const result = await audioService.playAudio(audioUrl);
+      if (!result.success) {
+        cleanupAudioPlayback();
+        voiceController.notifySpeakingComplete();
+        throw result.error ?? new Error('音声再生に失敗しました');
+      }
+    },
+    [
+      applyLipSync,
+      cleanupAudioPlayback,
+      clearLipSyncTimers,
+      currentLanguage,
+      ensureAudioService,
+      isMuted,
+      revokeAudioUrl,
+      voiceController,
+    ],
+  );
+
+  const sendMessage = useCallback(
+    async (message: string) => {
+      const trimmed = message.trim();
+      if (!trimmed) {
         return;
       }
 
-      // Import performance monitor functions
-      const { measurePerformance } = await import('@/lib/performance-monitor');
+      cancelPendingRequest();
+      stopPlayback(false);
+      setError(null);
+      setTranscript(trimmed);
+      setIsLoading(true);
+      setLoadingMessage(LOADING_LABELS[currentLanguage].answer);
+      voiceController.notifyProcessing();
 
-      // Skip lip-sync for very large audio files to improve performance
-      const skipLipSync = audioBlob.size > 500000;
-      
-      // Start lip-sync analysis in background (non-blocking)
-      const lipSyncPromise = (async () => {
-        if (skipLipSync) {
-          return;
-        }
-        
-        try {
-          
-          // Analyze audio for lip-sync
-          const { LipSyncAnalyzer } = await import('@/lib/lip-sync-analyzer');
-          const analyzer = new LipSyncAnalyzer();
-          const lipSyncData = await measurePerformance(
-            'Lip-sync analysis',
-            () => analyzer.analyzeLipSync(audioBlob)
-          );
-          
-          
-          // Apply lip-sync to character using direct viseme callback
-          if (onVisemeControl) {
-            
-            // Schedule viseme updates using direct callback
-            let frameIndex = 0;
-            const updateLipSync = () => {
-              if (frameIndex < lipSyncData.frames.length && onVisemeControl) {
-                const frame = lipSyncData.frames[frameIndex];
-                
-                
-                // Use direct viseme callback instead of API
-                onVisemeControl(frame.mouthShape, frame.mouthOpen);
-                
-                frameIndex++;
-                setTimeout(updateLipSync, 100); // 10fps for better performance
-              } else {
-                // Reset to closed mouth
-                if (onVisemeControl) {
-                  onVisemeControl('X', 0);
-                }
-              }
-            };
-            
-            // Start lip-sync animation immediately since we control playback timing
-            updateLipSync();
-          } else {
-            console.warn('onVisemeControl callback not available - skipping lip-sync');
-          }
+      const abortController = new AbortController();
+      requestAbortRef.current = abortController;
 
-          analyzer.dispose();
-        } catch (lipSyncError) {
-          console.warn('Lip-sync analysis failed, continuing with audio playback:', lipSyncError);
-        }
-      })();
-
-      // Audio service should already be initialized by useEffect
-      
-      // Set up audio ended handler for this specific playback
-      const handleAudioEnd = () => {
-        setIsSpeaking(false);
-        setConversationState('idle');
-        setIsLoading(false);
-        setLoadingMessage('');
-        
-        // Clean up audio resources
-        if (mobileAudioServiceRef.current) {
-          mobileAudioServiceRef.current.stop();
-        }
-        
-        // Revoke object URL after a delay to ensure cleanup
-        setTimeout(() => {
-          URL.revokeObjectURL(audioUrl);
-        }, 100);
-        
-        // Stop lip-sync with direct callback
-        if (onVisemeControl) {
-          onVisemeControl('X', 0);
-        }
-        
-        // Restore emotion expression after lip-sync if needed
-        if (currentEmotion && currentEmotion !== 'neutral') {
-          setTimeout(() => {
-            updateCharacterExpression(currentEmotion);
-          }, 200);
-        }
-        
-        // Auto-listen if enabled
-        if (autoListen && !isMuted) {
-          setTimeout(() => {
-            startListening();
-          }, 1000); // 1 second delay before auto-listening
-        }
-      };
-      
-      const handleAudioError = (error: Error) => {
-        console.error('[AUDIO] Mobile audio service error:', error);
-        setIsSpeaking(false);
-        setConversationState('idle');
-        setIsLoading(false);
-        setLoadingMessage('');
-        setError(formatError({ code: 'VOICE_PROCESSING_ERROR' }, currentLanguage));
-        URL.revokeObjectURL(audioUrl);
-        
-        // Stop lip-sync on error with direct callback
-        if (onVisemeControl) {
-          onVisemeControl('X', 0);
-        }
-      };
-
-      // Update event handlers for this specific playback
-      mobileAudioServiceRef.current.updateEventHandlers({
-        onPlay: () => setIsSpeaking(true),
-        onEnded: handleAudioEnd,
-        onError: handleAudioError
-      });
-
-      // Set loading state to false before playing audio (UI becomes responsive)
-      setIsLoading(false);
-      setLoadingMessage('');
-      
       try {
-        const isTablet = /iPad|Android.*Tablet/i.test(navigator.userAgent);
-
-        // Use mobile audio service for better compatibility
-        const result = await mobileAudioServiceRef.current!.playAudio(audioUrl);
-        
-        
-        if (result.success) {
-          
-          // Skip lip-sync processing entirely on iOS
-          if (!skipLipSync) {
-            // Start lip-sync processing in background (non-blocking)
-            lipSyncPromise.catch(error => {
-              console.warn('Lip-sync processing error (non-critical):', error);
-            });
-          }
-        } else {
-          console.error('[AUDIO] Audio playback failed:', {
-            error: result.error,
-            method: result.method,
-            requiresInteraction: result.error?.requiresUserInteraction || false,
-            isTablet
-          });
-          throw result.error || new Error('Audio playback failed');
-        }
-      } catch (playError: any) {
-        console.error('Audio playback failed:', playError);
-        
-        // If interaction is required, show a message and retry on next user interaction
-        if (playError.message?.includes('User interaction required') || playError.name === 'NotAllowedError') {
-          
-          // Create a one-time click handler to retry playback
-          const retryPlayback = async () => {
-            try {
-              // Ensure audio context and retry playback
-              await ensureAudioContext();
-              
-              const retryResult = await mobileAudioServiceRef.current!.playAudio(audioUrl);
-              if (retryResult.success) {
-                
-                // Clear the error message
-                setError(null);
-                
-                // Skip lip-sync processing entirely on iOS
-                if (!skipLipSync) {
-                  lipSyncPromise.catch(error => {
-                    console.warn('Lip-sync processing error (non-critical):', error);
-                  });
-                }
-              } else {
-                throw retryResult.error || new Error('Retry playback failed');
-              }
-              
-            } catch (retryError) {
-              console.error('[AUDIO] Retry playback failed:', retryError);
-              setError(currentLanguage === 'ja' 
-                ? '音声再生に失敗しました。ページを更新してください。' 
-                : 'Audio playback failed. Please refresh the page.');
-            }
-            
-            // Remove event listeners
-            document.removeEventListener('click', retryPlayback);
-            document.removeEventListener('touchstart', retryPlayback);
-            document.removeEventListener('keydown', retryPlayback);
-          };
-          
-          // Add multiple event listeners for user interaction
-          document.addEventListener('click', retryPlayback, { once: true });
-          document.addEventListener('touchstart', retryPlayback, { once: true });
-          document.addEventListener('keydown', retryPlayback, { once: true });
-          
-          // Update UI to show user needs to interact
-          setError(currentLanguage === 'ja' 
-            ? '🔊 音声を再生するには画面をタップしてください' 
-            : '🔊 Tap anywhere to play audio');
-          
-          // Don't throw the error, just wait for user interaction
-          return;
-        } else {
-          throw playError;
-        }
-      }
-    } catch (error: any) {
-      console.error('[AUDIO] Error playing audio:', error);
-      setIsSpeaking(false);
-      setConversationState('idle');
-      setIsLoading(false);
-      setLoadingMessage('');
-      setError(formatError(error, currentLanguage));
-    }
-  };
-
-  // Update character animation
-  const updateCharacter = async (action: string) => {
-    try {
-      await fetch('/api/character', {
-        method: 'POST',
-        headers: {
-          'Content-Type': 'application/json',
-        },
-        body: JSON.stringify({
-          action: 'playAnimation',
-          animation: action,
-          transition: true,
-        }),
-      });
-    } catch (error) {
-      console.error('Error updating character:', error);
-    }
-  };
-  
-  // Update character expression
-  const updateCharacterExpression = async (expression: string) => {
-    try {
-      const response = await fetch('/api/character', {
-        method: 'POST',
-        headers: {
-          'Content-Type': 'application/json',
-        },
-        body: JSON.stringify({
-          action: 'setExpression',
-          expression: expression,
-          transition: true,
-        }),
-      });
-      const result = await response.json();
-    } catch (error) {
-      console.error('Error updating character expression:', error);
-    }
-  };
-
-  // Generate session ID
-  const generateSessionId = () => {
-    return `session_${Date.now()}_${Math.random().toString(36).substr(2, 9)}`;
-  };
-
-  // Handle interruption
-  const handleInterruption = async () => {
-    if (isSpeaking) {
-      // Stop current audio via mobile audio service
-      if (mobileAudioServiceRef.current) {
-        mobileAudioServiceRef.current.stop();
-      }
-      
-      // Stop audio queue if streaming
-      if (audioQueueRef.current) {
-        audioQueueRef.current.clear();
-      }
-
-      // Notify backend of interruption
-      try {
-        await fetch('/api/voice', {
+        const qaResponse = await fetch('/api/qa', {
           method: 'POST',
           headers: {
             'Content-Type': 'application/json',
           },
           body: JSON.stringify({
-            action: 'handle_interruption',
+            action: 'ask',
+            question: trimmed,
+            text: trimmed,
+            sessionId: sessionIdRef.current,
+            language: currentLanguage,
+            visitorId: visitorIdRef.current,
           }),
+          signal: abortController.signal,
         });
-      } catch (error) {
-        console.error('Error handling interruption:', error);
+
+        const qaResult = await qaResponse.json();
+        if (!qaResponse.ok || !qaResult.success) {
+          throw new Error(qaResult.error || '質問の送信に失敗しました');
+        }
+
+        const parsedAnswer = EmotionTagParser.parseEmotionTags(
+          typeof qaResult.answer === 'string' ? qaResult.answer : '',
+        );
+        const cleanAnswer = parsedAnswer.cleanText;
+
+        setResponse(cleanAnswer);
+        setMetadata((qaResult.metadata as VoiceInterfaceMetadata | null) ?? null);
+
+        const ttsResponse = await fetch('/api/voice', {
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json',
+          },
+          body: JSON.stringify({
+            action: 'text_to_speech',
+            text: preprocessTTS(cleanAnswer, currentLanguage),
+            language: currentLanguage,
+            sessionId: sessionIdRef.current,
+          }),
+          signal: abortController.signal,
+        });
+
+        const ttsResult = await ttsResponse.json();
+        if (!ttsResponse.ok || !ttsResult.success) {
+          throw new Error(ttsResult.error || '音声の生成に失敗しました');
+        }
+
+        if (typeof ttsResult.audioResponse === 'string' && ttsResult.audioResponse.length > 0) {
+          await playAssistantAudio(ttsResult.audioResponse);
+        } else {
+          voiceController.notifySpeaking();
+          window.setTimeout(() => {
+            voiceController.notifySpeakingComplete();
+          }, 240);
+        }
+      } catch (sendError) {
+        if (sendError instanceof DOMException && sendError.name === 'AbortError') {
+          return;
+        }
+
+        setError(formatError(sendError, currentLanguage));
+        voiceController.notifySpeakingComplete();
+      } finally {
+        if (requestAbortRef.current === abortController) {
+          requestAbortRef.current = null;
+        }
+        setIsLoading(false);
+        setLoadingMessage('');
+      }
+    },
+    [cancelPendingRequest, currentLanguage, playAssistantAudio, stopPlayback, voiceController],
+  );
+
+  const handleRecordedAudio = useCallback(
+    async (audioBlob: Blob) => {
+      if (shouldDiscardNextAudioRef.current) {
+        shouldDiscardNextAudioRef.current = false;
+        return;
       }
 
-      setIsSpeaking(false);
-      setConversationState('idle');
-    }
-  };
-
-  // Toggle language
-  const toggleLanguage = async () => {
-    const newLanguage = currentLanguage === 'ja' ? 'en' : 'ja';
-    
-    try {
+      cancelPendingRequest();
+      setError(null);
       setIsLoading(true);
-      setLoadingMessage(currentLanguage === 'ja' ? '言語を切り替え中...' : 'Switching language...');
-      const response = await fetch('/api/voice', {
-        method: 'POST',
-        headers: {
-          'Content-Type': 'application/json',
-        },
-        body: JSON.stringify({
-          action: 'set_language',
-          language: newLanguage,
-        }),
-      });
+      setLoadingMessage(LOADING_LABELS[currentLanguage].recognize);
 
-      const result = await response.json();
-      
-      if (result.success) {
-        setCurrentLanguage(newLanguage);
-        onLanguageChange?.(newLanguage);
+      const abortController = new AbortController();
+      requestAbortRef.current = abortController;
+
+      try {
+        const sttResponse = await fetch('/api/voice', {
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json',
+          },
+          body: JSON.stringify({
+            action: 'speech_to_text',
+            audioData: await toBase64(audioBlob),
+            language: currentLanguage,
+          }),
+          signal: abortController.signal,
+        });
+
+        const sttResult = await sttResponse.json();
+        if (!sttResponse.ok || !sttResult.success || typeof sttResult.transcript !== 'string') {
+          throw new Error(sttResult.error || '音声認識に失敗しました');
+        }
+
+        setTranscript(sttResult.transcript);
+        setIsLoading(false);
+        setLoadingMessage('');
+        await sendMessage(sttResult.transcript);
+      } catch (recordingError) {
+        if (recordingError instanceof DOMException && recordingError.name === 'AbortError') {
+          return;
+        }
+
+        setError(formatError(recordingError, currentLanguage));
+        voiceController.notifySpeakingComplete();
+      } finally {
+        if (requestAbortRef.current === abortController) {
+          requestAbortRef.current = null;
+        }
+        setIsLoading(false);
+        setLoadingMessage('');
       }
-    } catch (error: any) {
-      console.error('Error changing language:', error);
-      setError(formatError(error, currentLanguage));
-    } finally {
+    },
+    [cancelPendingRequest, currentLanguage, sendMessage, voiceController],
+  );
+
+  const ensureRecorder = useCallback(async () => {
+    const existingRecorder = recorderRef.current;
+    if (existingRecorder?.isInitialized()) {
+      return existingRecorder;
+    }
+
+    const recorder = new VoiceRecorder(
+      (audioBlob) => {
+        void handleRecordedAudio(audioBlob);
+      },
+      (recorderError) => {
+        setError(formatError(recorderError, currentLanguage));
+        setIsLoading(false);
+        setLoadingMessage('');
+        isRecordingRef.current = false;
+      },
+    );
+
+    setIsLoading(true);
+    setLoadingMessage(LOADING_LABELS[currentLanguage].microphone);
+    await recorder.initialize();
+
+    if (!recorder.isInitialized()) {
       setIsLoading(false);
       setLoadingMessage('');
+      throw new Error(currentLanguage === 'ja' ? 'マイクを初期化できませんでした' : 'Unable to initialize the microphone');
     }
-  };
 
-  // Clear conversation
-  const clearConversation = async () => {
+    recorderRef.current = recorder;
+    setMediaStream((recorder as VoiceRecorder & { stream?: MediaStream | null }).stream ?? null);
+    setIsLoading(false);
+    setLoadingMessage('');
+
+    return recorder;
+  }, [currentLanguage, handleRecordedAudio]);
+
+  const startRecorderCapture = useCallback(async () => {
+    if (isRecordingRef.current) {
+      return;
+    }
+
     try {
-      await fetch('/api/voice', {
-        method: 'POST',
-        headers: {
-          'Content-Type': 'application/json',
-        },
-        body: JSON.stringify({
-          action: 'clear_conversation',
-        }),
-      });
+      const recorder = await ensureRecorder();
+      if (recorder.getState() === 'recording') {
+        return;
+      }
 
-      setTranscript('');
-      setResponse('');
-      setError(null);
-    } catch (error) {
-      console.error('Error clearing conversation:', error);
+      recorder.start();
+      isRecordingRef.current = true;
+      shouldDiscardNextAudioRef.current = false;
+    } catch (startError) {
+      setError(formatError(startError, currentLanguage));
+      voiceController.endManualSession();
     }
-  };
+  }, [currentLanguage, ensureRecorder, voiceController]);
 
-  if (layout === 'horizontal') {
-    return (
-      <div className="glass rounded-2xl p-4 shadow-2xl border border-white/30">
-        
-        <div className="flex items-center gap-6">
-          {/* Status Indicator */}
-          <div className="flex items-center space-x-3">
-            {isLoading ? (
-              <Loader2 className="w-3 h-3 animate-spin text-blue-500" />
-            ) : (
-              <div className={`w-3 h-3 rounded-full transition-all duration-500 ${
-                conversationState === 'idle' ? 'bg-gray-400' :
-                conversationState === 'listening' ? 'bg-blue-500 animate-pulse' :
-                conversationState === 'processing' ? 'bg-yellow-500 animate-bounce' :
-                'bg-green-500 animate-pulse'
-              }`} />
-            )}
-            <span className="text-base md:text-lg font-medium text-gray-700 whitespace-nowrap">
-              {isLoading && loadingMessage ? loadingMessage :
-                conversationState === 'idle' && (currentLanguage === 'ja' ? '待機中' : 'Ready') ||
-                conversationState === 'listening' && (currentLanguage === 'ja' ? '聞いています...' : 'Listening...') ||
-                conversationState === 'processing' && (currentLanguage === 'ja' ? '処理中...' : 'Processing...') ||
-                conversationState === 'speaking' && (currentLanguage === 'ja' ? '話しています...' : 'Speaking...')
-              }
-            </span>
-          </div>
+  const stopRecorderCapture = useCallback((discard: boolean) => {
+    if (!recorderRef.current || !isRecordingRef.current) {
+      shouldDiscardNextAudioRef.current = false;
+      return;
+    }
 
-          {/* Voice Waveform Indicator */}
-          {(isListening || isSpeaking) && (
-            <div className="flex items-center space-x-1 h-6">
-              {[...Array(5)].map((_, i) => (
-                <div
-                  key={i}
-                  className="voice-wave-bar w-1 bg-primary rounded-full transition-all"
-                  style={{ height: '100%' }}
-                />
-              ))}
-            </div>
-          )}
+    shouldDiscardNextAudioRef.current = discard;
+    recorderRef.current.stop();
+    isRecordingRef.current = false;
+  }, []);
 
-          {/* Main Controls */}
-          <div className="flex items-center space-x-3">
-            {/* Voice button */}
-            <button
-              onClick={isListening ? stopListening : startListening}
-              disabled={conversationState === 'processing' || isLoading}
-              className={`p-5 md:p-6 rounded-full transition-smooth transform ${
-                isListening 
-                  ? 'bg-gradient-to-r from-red-500 to-red-600 hover:from-red-600 hover:to-red-700 text-white shadow-lg scale-110 ring-4 ring-red-500/30' 
-                  : (conversationState === 'processing' || isLoading)
-                  ? 'bg-gray-400 text-white cursor-not-allowed'
-                  : 'bg-gradient-to-r from-primary to-secondary hover:from-secondary hover:to-primary text-white shadow-lg hover:shadow-xl hover:scale-105'
-              }`}
-              title={isLoading && loadingMessage ? loadingMessage : 
-                     isListening ? (currentLanguage === 'ja' ? '停止' : 'Stop') : 
-                     (currentLanguage === 'ja' ? '録音開始' : 'Start recording')}
-            >
-              {isLoading && !isListening ? (
-                <Loader2 className="w-7 h-7 md:w-8 md:h-8 animate-spin" />
-              ) : isListening ? (
-                <MicOff className="w-7 h-7 md:w-8 md:h-8" />
-              ) : (
-                <Mic className="w-7 h-7 md:w-8 md:h-8" />
-              )}
-            </button>
+  useEffect(() => {
+    if (voiceController.shouldListen) {
+      void startRecorderCapture();
+      return;
+    }
 
-            {/* Interruption button */}
-            {isSpeaking && (
-              <button
-                onClick={handleInterruption}
-                className="p-4 md:p-5 rounded-full bg-gradient-to-r from-orange-500 to-orange-600 hover:from-orange-600 hover:to-orange-700 text-white shadow-lg transition-smooth transform hover:scale-105 touch-manipulation"
-                title={currentLanguage === 'ja' ? '話を止める' : 'Interrupt'}
-              >
-                <VolumeX className="w-6 h-6 md:w-7 md:h-7" />
-              </button>
-            )}
+    if (!isRecordingRef.current) {
+      return;
+    }
 
-            {/* Volume control */}
-            <button
-              onClick={() => setIsMuted(!isMuted)}
-              className={`p-4 md:p-5 rounded-full transition-smooth transform hover:scale-105 touch-manipulation ${
-                isMuted 
-                  ? 'bg-gray-500 hover:bg-gray-600' 
-                  : 'bg-gradient-to-r from-purple-500 to-purple-600 hover:from-purple-600 hover:to-purple-700'
-              } text-white shadow-lg`}
-            >
-              {isMuted ? (
-                <VolumeX className="w-6 h-6 md:w-7 md:h-7" />
-              ) : (
-                <Volume2 className="w-6 h-6 md:w-7 md:h-7" />
-              )}
-            </button>
-          </div>
+    stopRecorderCapture(sessionState === 'idle');
+  }, [sessionState, startRecorderCapture, stopRecorderCapture, voiceController.shouldListen]);
 
-          {/* Volume Slider */}
-          {!isMuted && (
-            <div className="flex items-center space-x-3 flex-1 max-w-xs">
-              <label className="text-sm md:text-base text-gray-600 whitespace-nowrap">
-                {currentLanguage === 'ja' ? '音量' : 'Volume'}
-              </label>
-              <div className="slider-container flex-1">
-                <div 
-                  className="slider-fill" 
-                  style={{ width: `${volume * 100}%` }}
-                />
-                <input
-                  type="range"
-                  min="0"
-                  max="1"
-                  step="0.1"
-                  value={volume}
-                  onChange={(e) => setVolume(parseFloat(e.target.value))}
-                  className="slider w-full"
-                />
-              </div>
-              <span className="text-sm md:text-base text-gray-500 whitespace-nowrap">
-                {Math.round(volume * 100)}%
-              </span>
-            </div>
-          )}
+  const startListening = useCallback(() => {
+    cancelPendingRequest();
+    stopPlayback(false);
+    setError(null);
+    voiceController.startManualSession();
+  }, [cancelPendingRequest, stopPlayback, voiceController]);
 
-          {/* Conversation Display (Compact) */}
-          {(transcript || response) && (
-            <div className="flex-1 max-w-lg">
-              <div className="bg-gray-50/50 backdrop-blur-sm rounded-lg px-4 py-2 max-h-12 overflow-hidden">
-                {response ? (
-                  <p className="text-sm text-gray-800 truncate">
-                    <span className="text-xs text-secondary font-semibold">AI: </span>
-                    {response}
-                  </p>
-                ) : transcript && (
-                  <p className="text-sm text-gray-800 truncate">
-                    <span className="text-xs text-primary font-semibold">
-                      {currentLanguage === 'ja' ? 'あなた: ' : 'You: '}
-                    </span>
-                    {transcript}
-                  </p>
-                )}
-              </div>
-            </div>
-          )}
+  const stopListening = useCallback(() => {
+    if (sessionState !== 'listening') {
+      return;
+    }
 
-          {/* Action Buttons */}
-          <div className="flex items-center space-x-2">
-            <div className="px-2 py-1 bg-primary/10 rounded-full">
-              <span className="text-xs font-semibold text-primary">
-                {currentLanguage.toUpperCase()}
-              </span>
-            </div>
-            
-            <button
-              onClick={toggleLanguage}
-              className="btn-primary text-sm px-3 py-1.5"
-            >
-              {currentLanguage === 'ja' ? 'EN' : 'JP'}
-            </button>
-            
-            <button
-              onClick={clearConversation}
-              className="btn-secondary text-sm px-3 py-1.5"
-            >
-              {currentLanguage === 'ja' ? 'リセット' : 'Clear'}
-            </button>
-            
-            <button
-              className="p-2 bg-gray-100 hover:bg-gray-200 text-gray-700 rounded-lg transition-smooth"
-              title={currentLanguage === 'ja' ? '設定' : 'Settings'}
-            >
-              <Settings className="w-4 h-4" />
-            </button>
-          </div>
-        </div>
+    voiceController.notifyProcessing();
+  }, [sessionState, voiceController]);
 
-        {/* Error Display */}
-        {error && (
-          <div className="mt-3 bg-red-50/80 border border-red-200 rounded-lg px-3 py-2 backdrop-blur-sm flex items-center space-x-2">
-            <AlertCircle className="w-4 h-4 text-red-500 flex-shrink-0" />
-            <p className="text-sm text-red-800">{error}</p>
-            <button
-              onClick={() => setError(null)}
-              className="ml-auto text-red-500 hover:text-red-700 transition-colors"
-              aria-label={currentLanguage === 'ja' ? 'エラーを閉じる' : 'Close error'}
-            >
-              ×
-            </button>
-          </div>
-        )}
-      </div>
-    );
+  const cancelSession = useCallback(() => {
+    cancelPendingRequest();
+    stopPlayback(false);
+    shouldDiscardNextAudioRef.current = true;
+    stopRecorderCapture(true);
+    setIsLoading(false);
+    setLoadingMessage('');
+    voiceController.endManualSession();
+  }, [cancelPendingRequest, stopPlayback, stopRecorderCapture, voiceController]);
+
+  const clearConversation = useCallback(() => {
+    cancelSession();
+    resetConversation();
+  }, [cancelSession, resetConversation]);
+
+  const toggleLanguage = useCallback(() => {
+    const nextLanguage = currentLanguage === 'ja' ? 'en' : 'ja';
+    setCurrentLanguage(nextLanguage);
+    onLanguageChange?.(nextLanguage);
+  }, [currentLanguage, onLanguageChange]);
+
+  useEffect(() => {
+    if (!autoGreeting) {
+      return;
+    }
+
+    const greeting =
+      currentLanguage === 'ja'
+        ? 'こんにちは。エンジニアカフェで知りたいことを話しかけてください。'
+        : 'Hello. Ask me anything about Engineer Cafe.';
+
+    setResponse(greeting);
+  }, [autoGreeting, currentLanguage]);
+
+  useEffect(() => {
+    return () => {
+      cancelPendingRequest();
+      cleanupAudioPlayback();
+      recorderRef.current?.cleanup();
+      lipSyncAnalyzerRef.current?.dispose();
+      mobileAudioServiceRef.current?.dispose();
+    };
+  }, [cancelPendingRequest, cleanupAudioPlayback]);
+
+  const renderProps = useMemo<VoiceInterfaceRenderProps>(
+    () => ({
+      sessionState,
+      characterState: voiceController.characterState,
+      transcript,
+      response,
+      metadata,
+      error,
+      isLoading,
+      loadingMessage,
+      currentLanguage,
+      volume,
+      isMuted,
+      waveformBars: voiceController.waveformBars,
+      wakeWord: {
+        isSupported: voiceController.isWakeWordSupported,
+        isListening: voiceController.isWakeWordListening,
+        error: voiceController.wakeWordError,
+        lastMatch: voiceController.lastWakeWordMatch,
+      },
+      startListening,
+      stopListening,
+      cancelSession,
+      clearConversation,
+      sendMessage,
+      setVolume,
+      setMuted,
+      toggleLanguage,
+    }),
+    [
+      cancelSession,
+      clearConversation,
+      currentLanguage,
+      error,
+      isLoading,
+      isMuted,
+      loadingMessage,
+      metadata,
+      response,
+      sendMessage,
+      sessionState,
+      setMuted,
+      setVolume,
+      startListening,
+      stopListening,
+      toggleLanguage,
+      transcript,
+      voiceController.characterState,
+      voiceController.isWakeWordListening,
+      voiceController.isWakeWordSupported,
+      voiceController.lastWakeWordMatch,
+      voiceController.wakeWordError,
+      voiceController.waveformBars,
+      volume,
+    ],
+  );
+
+  const shouldRenderDefaultUi = showDefaultUI ?? !children;
+
+  if (children && !shouldRenderDefaultUi) {
+    return <>{children(renderProps)}</>;
   }
 
-  // Original vertical layout
+  const statusText = isLoading && loadingMessage ? loadingMessage : STATUS_LABELS[currentLanguage][sessionState];
+  const isListening = sessionState === 'listening';
+  const isSpeaking = sessionState === 'speaking';
+  const isBusy = sessionState === 'processing' || isLoading;
+  const waveformActive = isListening || isSpeaking;
+
   return (
-    <div className="glass rounded-2xl p-6 max-w-md shadow-2xl border border-white/30">
-      
-      {/* Status Indicator */}
-      <div className="flex items-center justify-between mb-4">
-        <div className="flex items-center space-x-2">
-          {isLoading ? (
-            <Loader2 className="w-3 h-3 animate-spin text-blue-500" />
-          ) : (
-            <div className={`w-3 h-3 rounded-full transition-all duration-500 ${
-              conversationState === 'idle' ? 'bg-gray-400' :
-              conversationState === 'listening' ? 'bg-blue-500 animate-pulse' :
-              conversationState === 'processing' ? 'bg-yellow-500 animate-bounce' :
-              'bg-green-500 animate-pulse'
-            }`} />
+    <div
+      className={cn(
+        'rounded-3xl border border-slate-200 bg-white/90 p-6 shadow-sm backdrop-blur-sm',
+        layout === 'horizontal' ? 'w-full' : 'max-w-md',
+        className,
+      )}
+    >
+      <div className="flex items-center justify-between gap-4">
+        <div className="min-w-0">
+          <p className="text-sm font-medium text-slate-500">{currentLanguage.toUpperCase()}</p>
+          <h2 className="text-balance text-lg font-semibold text-slate-900">{statusText}</h2>
+        </div>
+        <div
+          className={cn(
+            'size-3 rounded-full',
+            sessionState === 'idle' && 'bg-slate-300',
+            sessionState === 'listening' && 'bg-emerald-500 motion-safe:animate-pulse',
+            sessionState === 'processing' && 'bg-amber-500 motion-safe:animate-pulse',
+            sessionState === 'speaking' && 'bg-sky-500 motion-safe:animate-pulse',
           )}
-          <span className="text-base md:text-lg font-medium text-gray-700">
-            {isLoading && loadingMessage ? loadingMessage :
-              conversationState === 'idle' && (currentLanguage === 'ja' ? '待機中' : 'Ready') ||
-              conversationState === 'listening' && (currentLanguage === 'ja' ? '聞いています...' : 'Listening...') ||
-              conversationState === 'processing' && (currentLanguage === 'ja' ? '処理中...' : 'Processing...') ||
-              conversationState === 'speaking' && (currentLanguage === 'ja' ? '話しています...' : 'Speaking...')
-            }
-          </span>
-        </div>
-        <div className="flex items-center gap-2">
-          <div className="px-2 py-1 bg-primary/10 rounded-full">
-            <span className="text-xs font-semibold text-primary">
-              {currentLanguage.toUpperCase()}
-            </span>
-          </div>
-        </div>
+        />
       </div>
 
-      {/* Voice Waveform Indicator */}
-      {(isListening || isSpeaking) && (
-        <div className="flex items-center justify-center space-x-1 mb-4 h-8">
-          {[...Array(5)].map((_, i) => (
-            <div
-              key={i}
-              className="voice-wave-bar w-1 bg-primary rounded-full transition-all"
-              style={{ height: '100%' }}
-            />
-          ))}
-        </div>
-      )}
-
-      {/* Main Controls */}
-      <div className="flex items-center justify-center space-x-4 mb-4">
-        {/* Voice button */}
+      <div className="mt-6 flex items-center justify-center gap-3">
         <button
+          type="button"
           onClick={isListening ? stopListening : startListening}
-          disabled={conversationState === 'processing' || isLoading}
-          className={`p-6 md:p-8 rounded-full transition-smooth transform ${
-            isListening 
-              ? 'bg-gradient-to-r from-red-500 to-red-600 hover:from-red-600 hover:to-red-700 text-white shadow-lg scale-110 ring-4 ring-red-500/30' 
-              : (conversationState === 'processing' || isLoading)
-              ? 'bg-gray-400 text-white cursor-not-allowed'
-              : 'bg-gradient-to-r from-primary to-secondary hover:from-secondary hover:to-primary text-white shadow-lg hover:shadow-xl hover:scale-105'
-          }`}
-          title={isLoading && loadingMessage ? loadingMessage : 
-                 isListening ? (currentLanguage === 'ja' ? '停止' : 'Stop') : 
-                 (currentLanguage === 'ja' ? '録音開始' : 'Start recording')}
+          disabled={isBusy && !isListening}
+          aria-label={isListening ? '録音を停止' : '録音を開始'}
+          className={cn(
+            'flex size-20 items-center justify-center rounded-full text-white shadow-sm transition-transform duration-200',
+            isListening ? 'bg-rose-500 motion-safe:scale-105' : 'bg-slate-900',
+            isBusy && !isListening && 'cursor-not-allowed bg-slate-400',
+          )}
         >
-          {isLoading && !isListening ? (
-            <Loader2 className="w-8 h-8 md:w-10 md:h-10 animate-spin" />
+          {isBusy && !isListening ? (
+            <Loader2 className="size-8 animate-spin" />
           ) : isListening ? (
-            <MicOff className="w-8 h-8 md:w-10 md:h-10" />
+            <MicOff className="size-8" />
           ) : (
-            <Mic className="w-8 h-8 md:w-10 md:h-10" />
+            <Mic className="size-8" />
           )}
         </button>
 
-        {/* Interruption button */}
-        {isSpeaking && (
-          <button
-            onClick={handleInterruption}
-            className="p-5 md:p-6 rounded-full bg-gradient-to-r from-orange-500 to-orange-600 hover:from-orange-600 hover:to-orange-700 text-white shadow-lg transition-smooth transform hover:scale-105 touch-manipulation"
-            title={currentLanguage === 'ja' ? '話を止める' : 'Interrupt'}
-          >
-            <VolumeX className="w-7 h-7 md:w-8 md:h-8" />
-          </button>
-        )}
-
-        {/* Volume control */}
         <button
-          onClick={() => setIsMuted(!isMuted)}
-          className={`p-5 md:p-6 rounded-full transition-smooth transform hover:scale-105 touch-manipulation ${
-            isMuted 
-              ? 'bg-gray-500 hover:bg-gray-600' 
-              : 'bg-gradient-to-r from-purple-500 to-purple-600 hover:from-purple-600 hover:to-purple-700'
-          } text-white shadow-lg`}
+          type="button"
+          onClick={cancelSession}
+          aria-label="セッションをキャンセル"
+          className="flex size-12 items-center justify-center rounded-full border border-slate-200 bg-white text-slate-700 shadow-sm transition-colors duration-200 hover:bg-slate-50"
         >
-          {isMuted ? (
-            <VolumeX className="w-7 h-7 md:w-8 md:h-8" />
-          ) : (
-            <Volume2 className="w-7 h-7 md:w-8 md:h-8" />
-          )}
+          <XCircle className="size-5" />
+        </button>
+
+        <button
+          type="button"
+          onClick={() => setMuted(!isMuted)}
+          aria-label={isMuted ? 'ミュートを解除' : 'ミュートにする'}
+          className="flex size-12 items-center justify-center rounded-full border border-slate-200 bg-white text-slate-700 shadow-sm transition-colors duration-200 hover:bg-slate-50"
+        >
+          {isMuted ? <VolumeX className="size-5" /> : <Volume2 className="size-5" />}
         </button>
       </div>
 
-      {/* Volume Slider */}
+      <div className="mt-5 flex items-center justify-center gap-1.5">
+        {(waveformActive ? renderProps.waveformBars : [0.2, 0.24, 0.2, 0.18, 0.22]).map((bar, index) => (
+          <span
+            key={`${index}-${bar}`}
+            className={cn(
+              'w-1 rounded-full bg-slate-900 transition-transform duration-150',
+              waveformActive ? 'motion-safe:animate-pulse' : 'bg-slate-300',
+            )}
+            style={{ height: '40px', transform: `scaleY(${Math.max(bar, 0.18)})` }}
+          />
+        ))}
+      </div>
+
       {!isMuted && (
-        <div className="mb-4">
-          <div className="flex items-center justify-between mb-1">
-            <label className="text-sm md:text-base text-gray-600">
-              {currentLanguage === 'ja' ? '音量' : 'Volume'}
-            </label>
-            <span className="text-sm md:text-base text-gray-500">
-              {Math.round(volume * 100)}%
-            </span>
+        <div className="mt-5">
+          <div className="mb-2 flex items-center justify-between text-sm text-slate-600">
+            <span>音量</span>
+            <span>{Math.round(volume * 100)}%</span>
           </div>
-          <div className="slider-container">
-            <div 
-              className="slider-fill" 
-              style={{ width: `${volume * 100}%` }}
-            />
-            <input
-              type="range"
-              min="0"
-              max="1"
-              step="0.1"
-              value={volume}
-              onChange={(e) => setVolume(parseFloat(e.target.value))}
-              className="slider"
-            />
-          </div>
+          <input
+            type="range"
+            min="0"
+            max="1"
+            step="0.05"
+            value={volume}
+            onChange={(event) => setVolume(Number(event.target.value))}
+            className="w-full accent-slate-900"
+          />
         </div>
       )}
 
-      {/* Conversation Display */}
       {(transcript || response) && (
-        <div className="bg-gray-50/50 backdrop-blur-sm rounded-lg p-3 mb-4 max-h-40 overflow-y-auto scrollbar-thin">
+        <div className="mt-5 rounded-2xl bg-slate-50 p-4">
           {transcript && (
-            <div className="mb-2">
-              <span className="text-xs text-primary font-semibold">
-                {currentLanguage === 'ja' ? 'あなた:' : 'You:'}
+            <p className="text-pretty text-sm text-slate-600">
+              <span className="mr-2 font-medium text-slate-900">
+                {currentLanguage === 'ja' ? 'あなた' : 'You'}
               </span>
-              <p className="text-sm text-gray-800 mt-1">
-                {transcript}
-              </p>
-            </div>
+              {transcript}
+            </p>
           )}
           {response && (
-            <div>
-              <span className="text-xs text-secondary font-semibold">
-                {currentLanguage === 'ja' ? 'AI:' : 'AI:'}
-              </span>
-              <p className="text-sm text-gray-800 mt-1">{response}</p>
-            </div>
+            <p className="mt-3 text-pretty text-sm leading-6 text-slate-800">{response}</p>
           )}
         </div>
       )}
 
-      {/* Error Display */}
       {error && (
-        <div className="bg-red-50/80 border border-red-200 rounded-lg p-3 mb-4 backdrop-blur-sm">
-          <div className="flex items-center space-x-2">
-            <AlertCircle className="w-4 h-4 text-red-500 flex-shrink-0" />
-            <p className="text-sm text-red-800 flex-1">{error}</p>
-            <button
-              onClick={() => setError(null)}
-              className="text-red-500 hover:text-red-700 transition-colors text-lg leading-none"
-              aria-label={currentLanguage === 'ja' ? 'エラーを閉じる' : 'Close error'}
-            >
-              ×
-            </button>
-          </div>
+        <div className="mt-5 flex items-start gap-3 rounded-2xl border border-rose-200 bg-rose-50 p-4 text-rose-700">
+          <AlertCircle className="mt-0.5 size-4 shrink-0" />
+          <p className="text-pretty text-sm">{error}</p>
         </div>
       )}
-
-
-      {/* Action Buttons */}
-      <div className="flex flex-col gap-2">
-        {/* Main actions */}
-        <div className="flex space-x-2">
-          <button
-            onClick={toggleLanguage}
-            className="btn-primary flex-1 py-4 md:py-5 text-base md:text-lg touch-manipulation"
-          >
-            {currentLanguage === 'ja' ? 'English' : '日本語'}
-          </button>
-          
-          <button
-            onClick={clearConversation}
-            className="btn-secondary flex-1 py-4 md:py-5 text-base md:text-lg touch-manipulation"
-          >
-            {currentLanguage === 'ja' ? 'リセット' : 'Clear'}
-          </button>
-          
-          <button
-            className="p-2 bg-gray-100 hover:bg-gray-200 text-gray-700 rounded-lg transition-smooth"
-            title={currentLanguage === 'ja' ? '設定' : 'Settings'}
-          >
-            <Settings className="w-4 h-4" />
-          </button>
-        </div>
-        
-        {/* Auto-listen toggle */}
-        <div className="flex items-center justify-center space-x-2">
-          <label className="flex items-center cursor-pointer">
-            <input
-              type="checkbox"
-              checked={autoListen}
-              onChange={(e) => setAutoListen(e.target.checked)}
-              className="sr-only"
-            />
-            <div className={`relative inline-flex h-6 w-11 items-center rounded-full transition-colors ${
-              autoListen ? 'bg-primary' : 'bg-gray-300'
-            }`}>
-              <span className={`inline-block h-4 w-4 transform rounded-full bg-white transition-transform ${
-                autoListen ? 'translate-x-6' : 'translate-x-1'
-              }`} />
-            </div>
-            <span className="ml-2 text-base md:text-lg text-gray-700">
-              {currentLanguage === 'ja' ? '自動リスニング' : 'Auto-listen'}
-            </span>
-          </label>
-        </div>
-      </div>
-
-      {/* Instructions */}
-      <div className="mt-4 text-center">
-        <p className="text-sm md:text-base text-gray-500">
-          {currentLanguage === 'ja' 
-            ? 'マイクボタンを押して話しかけてください' 
-            : 'Press the mic button to start talking'
-          }
-        </p>
-      </div>
     </div>
   );
 }

--- a/frontend/src/app/components/VoiceInterface.tsx
+++ b/frontend/src/app/components/VoiceInterface.tsx
@@ -300,7 +300,14 @@ export default function VoiceInterface({
         return;
       }
 
-      const audioBytes = Uint8Array.from(atob(audioBase64), (char) => char.charCodeAt(0));
+      let audioBytes: Uint8Array;
+      try {
+        audioBytes = Uint8Array.from(atob(audioBase64), (char) => char.charCodeAt(0));
+      } catch (decodeError) {
+        console.error('Audio decode failed:', decodeError);
+        voiceController.notifySpeakingComplete();
+        return;
+      }
       const audioBlob = new Blob([audioBytes], { type: 'audio/mpeg' });
       const audioUrl = URL.createObjectURL(audioBlob);
       const audioService = ensureAudioService();
@@ -524,7 +531,7 @@ export default function VoiceInterface({
     }
 
     recorderRef.current = recorder;
-    setMediaStream((recorder as VoiceRecorder & { stream?: MediaStream | null }).stream ?? null);
+    setMediaStream(recorder.getStream());
     setIsLoading(false);
     setLoadingMessage('');
 

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -41,9 +41,10 @@ export default function Home() {
             language={currentLanguage}
             onLanguageChange={setCurrentLanguage}
             onVisemeControl={setVisemeFunction}
-            renderAvatar={() => (
+            renderAvatar={({ sessionState }) => (
               <CharacterAvatar
                 modelPath="/characters/models/sakura.vrm"
+                sessionState={sessionState}
                 background={characterBackground}
                 lightingIntensity={lightingIntensity}
                 enableClickAnimation={!showSlideMode}

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -1,26 +1,14 @@
 'use client';
 
-import { audioStateManager } from '@/lib/audio-state-manager';
-import { preprocessTTS } from '@/utils/tts-preprocess';
-import { MessageSquare, Presentation, UserPlus, X } from 'lucide-react';
-import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { Presentation, Play, X } from 'lucide-react';
+import { useCallback, useState } from 'react';
 import { BackgroundOption } from './components/BackgroundSelector';
 import CharacterAvatar from './components/CharacterAvatar';
 import MarpViewer from './components/MarpViewer';
-import { EmotionMapping } from '@/lib/emotion-mapping';
-
-const getOrCreateVisitorId = (): string => {
-  if (typeof window === 'undefined') return 'anonymous';
-  const key = 'engineer_cafe_visitor_id';
-  let id = localStorage.getItem(key);
-  if (!id) {
-    id = crypto.randomUUID();
-    localStorage.setItem(key, id);
-  }
-  return id;
-};
+import VoiceConversationShell from './components/VoiceConversationShell';
 
 export default function Home() {
+  const [currentLanguage, setCurrentLanguage] = useState<'ja' | 'en'>('ja');
   const [showSlideMode, setShowSlideMode] = useState(false);
   const [characterBackground, setCharacterBackground] = useState<BackgroundOption>({
     id: 'engineer-cafe-bg',
@@ -28,924 +16,125 @@ export default function Home() {
     type: 'image',
     value: '/backgrounds/IMG_5573.JPG',
   });
-  const [selectedBackground, setSelectedBackground] = useState<BackgroundOption>({
-    id: 'solid-black',
-    name: 'Black',
-    type: 'solid',
-    value: '#000000',
-  });
   const [lightingIntensity, setLightingIntensity] = useState(1);
-  // Audio control state
-  const [isMuted, setIsMuted] = useState(false);
-  const [volume, setVolume] = useState(80);
-  const [currentLanguage, setCurrentLanguage] = useState<'ja' | 'en'>('ja');
-  const [isVoiceActive, setIsVoiceActive] = useState(false);
-  const [voiceRecorder, setVoiceRecorder] = useState<any>(null);
-  const [isListening, setIsListening] = useState(false);
-  const [isRecording, setIsRecording] = useState(false);
-  const [isInitializingRecorder, setIsInitializingRecorder] = useState(false);
   const [setVisemeFunction, setSetVisemeFunction] = useState<((viseme: string, intensity: number) => void) | null>(null);
   const [setExpressionFunction, setSetExpressionFunction] = useState<((expression: string, weight: number) => void) | null>(null);
-  // Loading state
-  const [isProcessing, setIsProcessing] = useState(false);
-  const [processingMessage, setProcessingMessage] = useState('');
-  
-  // Persistent session ID for the entire conversation
-  const [sessionId] = useState(() => `session_${Date.now()}_${Math.random().toString(36).substring(2, 11)}`);
-  const [visitorId] = useState(() => getOrCreateVisitorId());
 
-  // ボイスウェーブの高さ（scaleY）を一度だけ生成して保持
-  const voiceWaveScales = useMemo(() =>
-    Array.from({ length: 5 }, () => Math.random() * 0.5 + 0.5),
-    []
-  );
-
-  const lipSyncTimeoutsRef = useRef<NodeJS.Timeout[]>([]);
-  const prevVolumeRef = useRef<number>(80);
-
-  // Cleanup lip sync timeouts on unmount
-  useEffect(() => {
-    return () => {
-      lipSyncTimeoutsRef.current.forEach(id => clearTimeout(id));
-    };
-  }, []);
-
-  // Sync audioStateManager when volume or mute changes
-  useEffect(() => {
-    audioStateManager.setVolume(volume / 100);
-  }, [volume]);
-
-  useEffect(() => {
-    audioStateManager.setMuted(isMuted);
-  }, [isMuted]);
-
-  const toggleMute = () => {
-    if (isMuted) {
-      setIsMuted(false);
-      setVolume(prevVolumeRef.current || 80);
-    } else {
-      prevVolumeRef.current = volume;
-      setIsMuted(true);
-      setVolume(0);
-    }
-  };
-
-  const handleVolumeChange = (val:number) => {
-    setVolume(val);
-    if (val === 0) {
-      setIsMuted(true);
-    } else {
-      setIsMuted(false);
-      prevVolumeRef.current = val;
-    }
-  };
-
-  // Apply selected background to both character and main display
-  const handleBackgroundChange = (newBackground: BackgroundOption) => {
-    setCharacterBackground(newBackground);
-    setSelectedBackground(newBackground);
-  };
-
-  // Generate CSS for selected background
-  const getBackgroundStyle = () => {
-    if (selectedBackground.type === 'gradient') {
-      return { background: selectedBackground.value };
-    } else if (selectedBackground.type === 'image') {
-      return {
-        backgroundImage: `url(${selectedBackground.value})`,
-        backgroundSize: 'contain',
-        backgroundPosition: 'center',
-        backgroundRepeat: 'no-repeat'
-      };
-    } else if (selectedBackground.type === 'solid') {
-      return { backgroundColor: selectedBackground.value };
-    }
-    return {};
-  };
-
-
-  // Initialize audio context on user interaction
-  const initializeAudioContext = async () => {
-    try {
-      const { AudioInteractionManager } = await import('@/lib/audio/audio-interaction-manager');
-      const manager = AudioInteractionManager.getInstance();
-      await manager.forceInitialize();
-      // Audio context initialized
-    } catch (error) {
-      // Audio context initialization failed
-      // Don't block the UI - audio will request permission later if needed
-    }
-  };
-
-  // Handle language-based voice interaction start
-  const handleLanguageVoiceStart = async (language: 'ja' | 'en') => {
+  const startPresentation = useCallback((language: 'ja' | 'en') => {
     setCurrentLanguage(language);
-    setIsProcessing(true);
-    setProcessingMessage(language === 'ja' ? '挨拶を準備中...' : 'Preparing greeting...');
-    
-    // Start voice interaction directly with the character
-    try {
-      // Set language in voice service
-      await fetch('/api/voice', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({
-          action: 'set_language',
-          language: language
-        })
-      });
+    setShowSlideMode(true);
 
-      // Start auto greeting using cache for speed
-      const { GreetingCache } = await import('@/lib/greeting-cache');
-      const cachedGreeting = GreetingCache.getGreeting(language, 'initial');
-      
-      if (cachedGreeting.audioBase64) {
-        // Use cached audio for instant playback
-        // Using cached greeting audio
-        setIsProcessing(false);
-        setProcessingMessage('');
-        await playAudioWithLipSync(cachedGreeting.audioBase64);
-        
-        // Apply emotion tags from cached greeting
-        if (cachedGreeting.text.includes('[')) {
-          const { EmotionTagParser } = await import('@/lib/emotion-tag-parser');
-          const parsedResponse = EmotionTagParser.parseEmotionTags(cachedGreeting.text);
-          
-          if (parsedResponse.primaryEmotion && setExpressionFunction) {
-            const expressionWeights = EmotionTagParser.getExpressionWeights(parsedResponse.primaryEmotion, 0.8);
-            const strongestExpression = Object.entries(expressionWeights)
-              .filter(([_, weight]) => weight > 0.1)
-              .sort(([_, a], [__, b]) => b - a)[0];
-            
-            if (strongestExpression) {
-              const [expressionName, weight] = strongestExpression;
-              setExpressionFunction(expressionName, weight);
-            }
-          }
-        }
-      } else {
-        // Fallback to API if no cached audio
-        // No cached audio, using API
-        const { EmotionTagParser } = await import('@/lib/emotion-tag-parser');
-        let cleanText = EmotionTagParser.parseEmotionTags(cachedGreeting.text).cleanText;
-        cleanText = preprocessTTS(cleanText, language);
-        
-        const response = await fetch('/api/voice', {
-          method: 'POST',
-          headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify({
-            action: 'text_to_speech',
-            text: cleanText,
-            language: language,
-            sessionId: sessionId
-          })
-        });
-        
-        const result = await response.json();
-        if (result.success && result.audioResponse) {
-          // Cache this greeting for future use
-          GreetingCache.cacheGreeting({
-            ...cachedGreeting,
-            audioBase64: result.audioResponse
-          });
-          
-          // Play greeting audio with lip-sync
-          setIsProcessing(false);
-          setProcessingMessage('');
-          await playAudioWithLipSync(result.audioResponse);
-        }
-      }
-
-      // Set character to speaking state
-      await fetch('/api/character', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({
-          action: 'setExpression',
-          expression: 'happy',
-          transition: true
-        })
-      });
-
-    } catch (error) {
-      // Error starting voice interaction
-      setIsProcessing(false);
-      setProcessingMessage('');
-    }
-  };
-
-  // Initialize voice recorder
-  const initializeVoiceRecorder = async () => {
-    if (isInitializingRecorder) {
-      // Voice recorder initialization in progress
-      return null;
-    }
-
-    try {
-      setIsInitializingRecorder(true);
-      // Initializing voice recorder
-      const { VoiceRecorder } = await import('@/lib/voice-recorder');
-      
-      const recorder = new VoiceRecorder(
-        async (audioBlob: Blob) => {
-          // Audio recorded, processing
-          // Handle recorded audio
-          await processVoiceInput(audioBlob);
-        },
-        (error: Error) => {
-          // Voice recorder error
-          setIsListening(false);
-          setIsRecording(false);
-        }
+    window.setTimeout(() => {
+      window.dispatchEvent(
+        new CustomEvent('autoStartPresentation', {
+          detail: { autoPlay: true, language },
+        }),
       );
-      
-      // Voice recorder created
-      await recorder.initialize();
-      // Voice recorder initialized
-      setVoiceRecorder(recorder);
-      setIsInitializingRecorder(false);
-      return recorder;
-    } catch (error) {
-      // Failed to initialize voice recorder
-      setIsInitializingRecorder(false);
-      alert('マイクの初期化に失敗しました。ブラウザの設定でマイクの許可を確認してください。');
-      return null;
-    }
-  };
-
-  // Process voice input
-  const processVoiceInput = async (audioBlob: Blob) => {
-    try {
-      setIsListening(false);
-      setIsRecording(false);
-      setIsProcessing(true);
-      setProcessingMessage(currentLanguage === 'ja' ? '音声を認識中...' : 'Recognizing speech...');
-      
-      // First try to get speech-to-text for quick response check
-      const audioBuffer = await audioBlob.arrayBuffer();
-      const audioBase64 = Buffer.from(audioBuffer).toString('base64');
-      
-      // Try speech recognition first for quick response
-      const speechResponse = await fetch('/api/voice', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({
-          action: 'speech_to_text',
-          audioData: audioBase64,
-          language: currentLanguage
-        })
-      });
-      
-      const speechResult = await speechResponse.json();
-      
-      // Check for quick cached responses
-      if (speechResult.success && speechResult.transcript) {
-        setProcessingMessage(currentLanguage === 'ja' ? 'AIが考えています...' : 'AI is thinking...');
-        const { ResponseCache } = await import('@/lib/response-cache');
-        const { EnhancedEmotionManager } = await import('@/lib/enhanced-emotion-manager');
-        const { ConversationMemory } = await import('@/lib/conversation-memory');
-        
-        // Speech transcript received
-        
-        // First check FAQ database
-        const faqMatch = ConversationMemory.searchFAQ(speechResult.transcript, currentLanguage);
-        
-        let quickResponse;
-        if (faqMatch) {
-          // FAQ match found
-          quickResponse = {
-            text: faqMatch.answer,
-            emotion: faqMatch.emotion,
-            audioBase64: faqMatch.audioBase64,
-            cached: !!faqMatch.audioBase64
-          };
-        } else {
-          // Try to get a quick response from cache or predefined responses
-          quickResponse = await ResponseCache.getQuickResponse(
-            speechResult.transcript,
-            currentLanguage
-          );
-        }
-        
-        if (quickResponse) {
-          // Using quick response
-          
-          // Analyze emotion from the response text
-          const emotionManager = new EnhancedEmotionManager();
-          const emotionAnalysis = emotionManager.analyzeTextEmotion(quickResponse.text, currentLanguage);
-          
-          // Set emotion with enhanced analysis
-          const emotionToUse = quickResponse.emotion || emotionAnalysis.emotion;
-          // Setting enhanced emotion
-          
-          // Apply character control for quick response
-          const quickCharacterData = {
-            emotion: emotionToUse,
-            expression: EmotionMapping.mapToVRMEmotion(emotionToUse),
-            emotionIntensity: 0.8
-          };
-          await handleCharacterControl(quickCharacterData);
-          
-          // If we have cached audio, use it; otherwise generate TTS
-          if (quickResponse.audioBase64) {
-            // 音声再生を開始してすぐにモーダルを閉じる
-            playAudioWithLipSync(quickResponse.audioBase64).catch(error => {
-              console.error('[processVoiceInput] Quick response audio playback error:', error);
-            });
-            setIsProcessing(false);
-            setProcessingMessage('');
-          } else {
-            setProcessingMessage(currentLanguage === 'ja' ? '音声を生成中...' : 'Generating voice...');
-            // Generate TTS for the quick response
-            const ttsResponse = await fetch('/api/voice', {
-              method: 'POST',
-              headers: { 'Content-Type': 'application/json' },
-              body: JSON.stringify({
-                action: 'text_to_speech',
-                text: preprocessTTS(quickResponse.text, currentLanguage),
-                language: currentLanguage,
-                emotion: emotionToUse,
-                intensity: emotionAnalysis.intensity,
-                sessionId: sessionId
-              })
-            });
-            
-            const ttsResult = await ttsResponse.json();
-            if (ttsResult.success && ttsResult.audioResponse) {
-              // Cache the audio for future use
-              await ResponseCache.cacheResponse({
-                id: `quick_${Date.now()}`,
-                text: preprocessTTS(quickResponse.text, currentLanguage),
-                audioBase64: ttsResult.audioResponse,
-                emotion: emotionToUse,
-                language: currentLanguage,
-                category: 'common'
-              });
-              
-              // 音声再生を開始してすぐにモーダルを閉じる
-              playAudioWithLipSync(ttsResult.audioResponse).catch(error => {
-                console.error('[processVoiceInput] Generated audio playback error:', error);
-              });
-              setIsProcessing(false);
-              setProcessingMessage('');
-            } else {
-              // TTSに失敗した場合もモーダルを閉じる
-              setIsProcessing(false);
-              setProcessingMessage('');
-            }
-          }
-          
-          // Save conversation to memory
-          ConversationMemory.saveConversation({
-            userInput: speechResult.transcript,
-            aiResponse: preprocessTTS(quickResponse.text, currentLanguage),
-            emotion: emotionToUse,
-            language: currentLanguage,
-            responseTime: Date.now() - (speechResult.startTime || Date.now()),
-            cached: quickResponse.cached
-          });
-          
-          return; // Early return for quick response
-        }
-      }
-      
-      // If no quick response, proceed with full AI processing
-      setProcessingMessage(currentLanguage === 'ja' ? 'AIが応答を生成中...' : 'AI is generating response...');
-      const response = await fetch('/api/voice', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({
-          action: 'process_voice',
-          audioData: audioBase64,
-          language: currentLanguage,
-          sessionId: sessionId
-        })
-      });
-      
-      const result = await response.json();
-      
-      if (result.success) {
-        // Voice processing result received
-        
-        // Enhanced emotion processing
-        if (result.responseText) {
-          const { EnhancedEmotionManager } = await import('@/lib/enhanced-emotion-manager');
-          const { ResponseCache } = await import('@/lib/response-cache');
-          const { ConversationMemory } = await import('@/lib/conversation-memory');
-          
-          const emotionManager = new EnhancedEmotionManager();
-          const emotionAnalysis = emotionManager.analyzeTextEmotion(result.responseText, currentLanguage);
-          
-          // 安全なemotion抽出
-          let emotionToUse = 'neutral';
-          if (typeof result.primaryEmotion === 'string' && result.primaryEmotion) {
-            emotionToUse = result.primaryEmotion;
-          } else if (typeof result.emotion === 'string' && result.emotion) {
-            emotionToUse = result.emotion;
-          } else if (typeof emotionAnalysis.emotion === 'string' && emotionAnalysis.emotion) {
-            emotionToUse = emotionAnalysis.emotion;
-          }
-          
-          const intensity = emotionAnalysis.intensity;
-          
-          // Enhanced emotion analysis complete
-          
-          // Handle character control through unified API
-          if (result.characterControlData) {
-            await handleCharacterControl(result.characterControlData);
-          } else {
-            // Fallback: Apply expressions directly
-            if (setExpressionFunction) {
-              try {
-                // Always use neutral expression for Q&A to avoid distracting face changes
-                setExpressionFunction('neutral', 0.8);
-              } catch (error) {
-                console.error('[Character Control] Fallback expression error:', error);
-                // 完全なフォールバック
-                setExpressionFunction('neutral', 0.8);
-              }
-            }
-          }
-          
-          // Cache the response for future use
-          if (result.audioResponse && result.responseText) {
-            await ResponseCache.cacheResponse({
-              id: `ai_${Date.now()}`,
-              text: preprocessTTS(result.responseText, currentLanguage),
-              audioBase64: result.audioResponse,
-              emotion: emotionToUse,
-              language: currentLanguage,
-              category: 'common'
-            });
-          }
-          
-          // Save conversation to memory
-          if (result.responseText && (result.transcript || speechResult?.transcript)) {
-            ConversationMemory.saveConversation({
-              userInput: result.transcript || speechResult?.transcript || '',
-              aiResponse: preprocessTTS(result.responseText, currentLanguage),
-              emotion: emotionToUse,
-              language: currentLanguage,
-              responseTime: Date.now() - (speechResult?.startTime || Date.now()),
-              cached: false
-            });
-          }
-        }
-        
-        // Play response audio with lip-sync
-        if (result.audioResponse) {
-          // 音声再生を開始（awaitしない）
-          playAudioWithLipSync(result.audioResponse).catch(error => {
-            console.error('[processVoiceInput] Audio playback error:', error);
-          });
-          // すぐにモーダルを閉じる
-          setIsProcessing(false);
-          setProcessingMessage('');
-        } else {
-          console.warn('[processVoiceInput] No audio response from API');
-        }
-      } else {
-        console.error('[processVoiceInput] API call was not successful:', result);
-      }
-    } catch (error) {
-      // Error processing voice input
-      console.error('[processVoiceInput] Error details:', error);
-      console.error('[processVoiceInput] Error stack:', error instanceof Error ? error.stack : 'No stack trace');
-      
-      // エラー時は静かに失敗させ、「ごめんなさい」メッセージを表示しない
-      console.warn('[processVoiceInput] Voice processing failed silently, no error message to user');
-      
-      // 必要に応じて表情だけリセット
-      try {
-        const errorCharacterData = {
-          emotion: 'neutral',
-          expression: 'neutral', 
-          emotionIntensity: 0.5
-        };
-        await handleCharacterControl(errorCharacterData);
-      } catch (characterError) {
-        console.error('[processVoiceInput] Character reset failed:', characterError);
-      }
-      
-      // エラー時もモーダルを確実に閉じる
-      setIsProcessing(false);
-      setProcessingMessage('');
-    }
-  };
-
-  // Start voice recording
-  const startVoiceRecording = async () => {
-    if (isInitializingRecorder) {
-      // Voice recorder initializing
-      return;
-    }
-
-    if (isRecording) {
-      // Already recording
-      return;
-    }
-
-    let recorder = voiceRecorder;
-    
-    if (!recorder) {
-      // No recorder found, initializing
-      recorder = await initializeVoiceRecorder();
-      if (!recorder) {
-        // Failed to initialize voice recorder
-        return;
-      }
-    }
-
-    // Verify recorder is properly initialized
-    if (!recorder.isInitialized()) {
-      // Recorder not initialized, re-initializing
-      recorder = await initializeVoiceRecorder();
-      if (!recorder) {
-        // Failed to re-initialize voice recorder
-        return;
-      }
-    }
-
-    // Check if recorder is in a valid state to start
-    const recorderState = recorder.getState();
-    if (recorderState === 'recording') {
-      // Recorder already recording, stopping first
-      recorder.stop();
-      // Wait a bit for the recorder to fully stop
-      await new Promise(resolve => setTimeout(resolve, 100));
-    }
-    
-    try {
-      setIsListening(true);
-      setIsRecording(true);
-      recorder.start();
-      
-      // Auto-stop recording after 10 seconds
-      const timeoutId = setTimeout(() => {
-        stopVoiceRecording();
-      }, 10000);
-      
-      // Store timeout ID for potential cleanup
-      (recorder as any).autoStopTimeout = timeoutId;
-    } catch (error) {
-      // Error starting voice recording
-      setIsListening(false);
-      setIsRecording(false);
-    }
-  };
-
-  // Stop voice recording
-  const stopVoiceRecording = () => {
-    if (voiceRecorder) {
-      // Clear auto-stop timeout if it exists
-      if ((voiceRecorder as any).autoStopTimeout) {
-        clearTimeout((voiceRecorder as any).autoStopTimeout);
-        (voiceRecorder as any).autoStopTimeout = null;
-      }
-      
-      if (isRecording) {
-        voiceRecorder.stop();
-      }
-      setIsRecording(false);
-      setIsListening(false);
-    }
-  };
-
-  // Handle character control through unified API
-  const handleCharacterControl = async (characterControlData: any) => {
-    try {
-      if (characterControlData.expression && setExpressionFunction) {
-        // Always use neutral expression for Q&A to avoid distracting face changes
-        setExpressionFunction('neutral', 0.8);
-      }
-      
-      if (characterControlData.lipSyncData && setVisemeFunction) {
-        // Clear previous lip sync timeouts
-        lipSyncTimeoutsRef.current.forEach(id => clearTimeout(id));
-        lipSyncTimeoutsRef.current = [];
-        // Apply lip sync data frame by frame
-        characterControlData.lipSyncData.forEach((frame: any) => {
-          const id = setTimeout(() => {
-            setVisemeFunction(frame.viseme, frame.intensity);
-          }, frame.time);
-          lipSyncTimeoutsRef.current.push(id);
-        });
-      }
-      
-      // Handle animations if needed
-      if (characterControlData.animation) {
-        await fetch('/api/character', {
-          method: 'POST',
-          headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify({
-            action: 'playAnimation',
-            animation: characterControlData.animation,
-            transition: true
-          })
-        });
-      }
-    } catch (error) {
-      console.error('[Character Control] Error applying character control:', error);
-    }
-  };
-
-  // Play audio with unified character control
-  const playAudioWithLipSync = async (audioBase64: string, characterControlData?: any) => {
-    try {
-      const { AudioPlaybackService } = await import('@/lib/audio/audio-playback-service');
-      
-      // Apply character control if provided
-      if (characterControlData) {
-        await handleCharacterControl(characterControlData);
-      }
-      
-      await AudioPlaybackService.playAudioWithLipSync(audioBase64, {
-        volume: volume / 100,
-        enableLipSync: !!setVisemeFunction && !characterControlData?.lipSyncData, // Skip if already handled
-        onVisemeUpdate: setVisemeFunction || undefined,
-        onError: (error) => {
-          // Audio playback failed
-          if (error.message?.includes('not allowed') || error.message?.includes('permission')) {
-            console.warn('[Audio] Permission denied, playing audio only');
-          }
-        }
-      });
-    } catch (error) {
-      console.error('[Audio] Playback with lip-sync failed:', error);
-    }
-  };
-
-  // Pre-generate greetings on app load for faster responses
-  useEffect(() => {
-    const preGenerateGreetings = async () => {
-      try {
-        const { GreetingCache } = await import('@/lib/greeting-cache');
-        const stats = GreetingCache.getCacheStats();
-        
-        // Only pre-generate if cache is empty or has few greetings
-        if (stats.totalCached < 4) {
-          // Pre-generating greetings
-          await GreetingCache.preGenerateGreetings();
-          // Greeting pre-generation complete
-        } else {
-          // Greetings already cached
-        }
-      } catch (error) {
-        // Failed to pre-generate greetings
-      }
-    };
-
-    // Delay the pre-generation to not block initial load
-    const timer = setTimeout(preGenerateGreetings, 2000);
-    return () => clearTimeout(timer);
+    }, 150);
   }, []);
 
   return (
-    <main className="min-h-screen relative" style={getBackgroundStyle()}>
-      {/* Loading Overlay */}
-      {isProcessing && (
-        <div className="fixed inset-0 z-[100] bg-black/50 backdrop-blur-sm flex items-center justify-center">
-          <div className="bg-white/90 backdrop-blur-md rounded-2xl shadow-2xl p-8 max-w-md mx-4">
-            <div className="flex flex-col items-center space-y-4">
-              {/* Animated loader */}
-              <div className="relative">
-                <div className="w-20 h-20 border-4 border-blue-200 rounded-full animate-pulse"></div>
-                <div className="absolute inset-0 w-20 h-20 border-4 border-blue-500 rounded-full animate-spin border-t-transparent"></div>
-              </div>
-              
-              {/* Loading message */}
-              <h2 className="text-xl font-semibold text-gray-800">
-                {processingMessage}
-              </h2>
-              
-              {/* Sub-message */}
-              <p className="text-sm text-gray-600 text-center">
-                {currentLanguage === 'ja' 
-                  ? 'しばらくお待ちください...' 
-                  : 'Please wait a moment...'
-                }
-              </p>
-              
-              {/* Voice wave animation */}
-              <div className="flex items-center space-x-1 h-8">
-                {voiceWaveScales.map((scale, i) => (
-                  <div
-                    key={i}
-                    className="w-1 bg-blue-500 rounded-full animate-pulse"
-                    style={{ 
-                      height: '100%',
-                      animationDelay: `${i * 0.1}s`,
-                      transform: `scaleY(${scale})`
-                    }}
-                  />
-                ))}
-              </div>
-            </div>
-          </div>
-        </div>
-      )}
-      
-      {/* Main Content */}
-      <div className="h-screen flex flex-col">
-        <div className="flex-1 pt-4">
-          <div className="h-full flex flex-col lg:flex-row">
-            {/* Character Section */}
-            <div className={`${showSlideMode ? 'w-full lg:w-1/3 h-[45vh] lg:h-full' : 'w-full h-full'} transition-all duration-500 ease-in-out`}>
-              <div className="h-full p-4">
-                {showSlideMode && (
-                  <div className="flex items-center space-x-2 mb-4 px-4 py-3 bg-white/90 backdrop-blur-sm rounded-lg shadow-sm">
-                    <MessageSquare className="w-5 h-5 text-primary" />
-                    <h2 className="text-lg font-semibold text-gray-800">AI ガイド</h2>
-                  </div>
-                )}
-                <div className="h-[calc(100%-4rem)] relative">
-                  <CharacterAvatar 
-                    modelPath="/characters/models/sakura.vrm"
-                    background={characterBackground}
-                    lightingIntensity={lightingIntensity}
-                    modelPositionOffset={showSlideMode ? { x: -1.2, y: 0, z: 0 } : { x: 0, y: 0, z: 0 }}
-                    cameraPositionOffset={showSlideMode ? { x: 0, y: 0, z: 0 } : { x: 0, y: 0, z: 0 }}
-                    modelRotationOffset={showSlideMode ? { x: -0.1, y: 1, z: 0.1 } : { x: 0, y: 0, z: 0 }}
-                    enableClickAnimation={!showSlideMode}
-                    onVisemeControl={(setViseme) => {
-                      setSetVisemeFunction(() => setViseme);
-                    }}
-                    onExpressionControl={(setExpression) => {
-                      setSetExpressionFunction(() => setExpression);
-                    }}
-                    onBackgroundChange={handleBackgroundChange}
-                    onLightingChange={setLightingIntensity}
-                    volume={volume}
-                    onVolumeChange={handleVolumeChange}
-                    isMuted={isMuted}
-                    onMuteToggle={toggleMute}
-                  />
-
-                  {/* Voice interaction controls - only show when not in slide mode */}
-                  {!showSlideMode && (
-                    <div className="absolute bottom-12 md:bottom-16 left-0 right-0 px-8 md:px-12">
-                      <div className="container mx-auto">
-                        {!isVoiceActive ? (
-                          // Language selection buttons - grouped layout
-                          <div className="flex flex-col lg:flex-row lg:justify-between items-center lg:items-end gap-8 lg:gap-6">
-                            {/* Japanese buttons group - left side */}
-                            <div className="flex flex-col gap-6 w-full lg:w-auto">
-                              <button
-                                onClick={async () => {
-                                  await initializeAudioContext();
-                                  handleLanguageVoiceStart('ja');
-                                  setIsVoiceActive(true);
-                                }}
-                                className="flex items-center justify-center gap-0 md:gap-4 px-6 md:px-8 py-6 md:py-8 bg-gradient-to-r from-blue-500 to-indigo-600 text-white rounded-2xl shadow-lg hover:shadow-xl transform hover:scale-105 transition-all duration-200 min-w-[56px] md:min-w-[320px] touch-manipulation"
-                              >
-                                <MessageSquare className="w-6 h-6 md:w-8 md:h-8" />
-                                <span className="hidden md:inline text-lg md:text-xl font-semibold ml-2">日本語で話しかける</span>
-                              </button>
-                              <button
-                                onClick={async () => {
-                                  // Button clicked
-                                  await initializeAudioContext();
-                                  // Setting slide mode
-                                  setShowSlideMode(true);
-                                  // Auto-start presentation in Japanese
-                                  setTimeout(() => {
-                                    // Dispatching auto-start event
-                                    // Find MarpViewer and trigger auto-play
-                                    const autoPlayEvent = new CustomEvent('autoStartPresentation', { 
-                                      detail: { autoPlay: true, language: 'ja' } 
-                                    });
-                                    window.dispatchEvent(autoPlayEvent);
-                                    // Event dispatched
-                                  }, 100);
-                                }}
-                                className="flex items-center justify-center gap-4 px-8 py-6 md:py-8 bg-gradient-to-r from-purple-500 to-purple-600 text-white rounded-2xl shadow-lg hover:shadow-xl transform hover:scale-105 transition-all duration-200 min-w-[280px] md:min-w-[320px] touch-manipulation"
-                              >
-                                <UserPlus className="w-7 h-7 md:w-8 md:h-8" />
-                                <span className="text-lg md:text-xl font-semibold">初めての方へ</span>
-                              </button>
-                            </div>
-                            
-                            {/* English buttons group - right side */}
-                            <div className="flex flex-col gap-6 w-full lg:w-auto">
-                              <button
-                                onClick={async () => {
-                                  await initializeAudioContext();
-                                  handleLanguageVoiceStart('en');
-                                  setIsVoiceActive(true);
-                                }}
-                                className="flex items-center justify-center gap-4 px-8 py-6 md:py-8 bg-gradient-to-r from-green-500 to-emerald-600 text-white rounded-2xl shadow-lg hover:shadow-xl transform hover:scale-105 transition-all duration-200 min-w-[280px] md:min-w-[320px] touch-manipulation"
-                              >
-                                <MessageSquare className="w-7 h-7 md:w-8 md:h-8" />
-                                <span className="text-lg md:text-xl font-semibold">Speak English</span>
-                              </button>
-                              <button
-                                onClick={async () => {
-                                  await initializeAudioContext();
-                                  setShowSlideMode(true);
-                                  // Auto-start presentation in English
-                                  setTimeout(() => {
-                                    // Find MarpViewer and trigger auto-play
-                                    const autoPlayEvent = new CustomEvent('autoStartPresentation', { 
-                                      detail: { autoPlay: true, language: 'en' } 
-                                    });
-                                    window.dispatchEvent(autoPlayEvent);
-                                  }, 100);
-                                }}
-                                className="flex items-center justify-center gap-4 px-8 py-6 md:py-8 bg-gradient-to-r from-blue-500 to-blue-600 text-white rounded-2xl shadow-lg hover:shadow-xl transform hover:scale-105 transition-all duration-200 min-w-[280px] md:min-w-[320px] touch-manipulation"
-                              >
-                                <UserPlus className="w-7 h-7 md:w-8 md:h-8" />
-                                <span className="text-lg md:text-xl font-semibold">For first-time users</span>
-                              </button>
-                            </div>
-                          </div>
-                        ) : (
-                          // Voice control interface
-                          <div className="flex flex-col items-center gap-6">
-                            {/* Mic button */}
-                            <button
-                              onMouseDown={startVoiceRecording}
-                              onMouseUp={stopVoiceRecording}
-                              onTouchStart={startVoiceRecording}
-                              onTouchEnd={stopVoiceRecording}
-                              onContextMenu={(e) => e.preventDefault()}
-                              className={`select-none w-20 h-20 md:w-24 md:h-24 rounded-full flex items-center justify-center shadow-xl transition-all duration-200 ${
-                                isListening 
-                                  ? 'bg-red-500 hover:bg-red-600 scale-110' 
-                                  : 'bg-blue-500 hover:bg-blue-600 hover:scale-105'
-                              }`}
-                            >
-                              <svg 
-                                className="w-10 h-10 md:w-12 md:h-12 text-white" 
-                                fill="none" 
-                                stroke="currentColor" 
-                                viewBox="0 0 24 24"
-                              >
-                                <path 
-                                  strokeLinecap="round" 
-                                  strokeLinejoin="round" 
-                                  strokeWidth={2} 
-                                  d="M19 11a7 7 0 01-7 7m0 0a7 7 0 01-7-7m7 7v4m0 0H8m4 0h4m-4-8a3 3 0 01-3-3V5a3 3 0 116 0v6a3 3 0 01-3 3z" 
-                                />
-                              </svg>
-                            </button>
-                            {/* End conversation button */}
-                            <button
-                              onClick={() => {
-                                setIsVoiceActive(false);
-                                setIsListening(false);
-                                setIsRecording(false);
-                                if (voiceRecorder) {
-                                  voiceRecorder.cleanup();
-                                  setVoiceRecorder(null);
-                                }
-                              }}
-                              className="px-6 py-3 md:py-4 bg-gray-500 hover:bg-gray-600 text-white text-base md:text-lg rounded-xl transition-colors touch-manipulation"
-                            >
-                              {currentLanguage === 'ja' ? '会話を終了' : 'End'}
-                            </button>
-                          </div>
-                        )}
-                      </div>
-                    </div>
-                  )}
-                  
-                </div>
-              </div>
-            </div>
-            
-            {/* Slide Section - only show when in slide mode */}
-            {showSlideMode && (
-              <div className="w-full lg:w-2/3 h-[55vh] lg:h-full transition-all duration-500 ease-in-out">
-                <div className="h-full p-4">
-                  <div className="h-full bg-white/90 backdrop-blur-sm rounded-lg shadow-lg overflow-hidden">
-                    <div className="flex items-center justify-between p-4 border-b bg-white/95">
-                      <div className="flex items-center space-x-2">
-                        <Presentation className="w-5 h-5 text-primary" />
-                        <h2 className="text-lg font-semibold text-gray-800">プレゼンテーション & Q&A</h2>
-                      </div>
-                      <button
-                        onClick={() => setShowSlideMode(false)}
-                        className="p-2 bg-gray-100 hover:bg-gray-200 rounded-lg transition-colors"
-                        title="初期画面に戻る"
-                      >
-                        <X className="w-5 h-5 text-gray-600" />
-                      </button>
-                    </div>
-                    <div className="h-[calc(100%-4rem)]">
-                      <MarpViewer 
-                        onVisemeControl={setVisemeFunction}
-                        onExpressionControl={setExpressionFunction}
-                        volume={volume}
-                      />
-                    </div>
-                  </div>
-                </div>
-              </div>
+    <main className="min-h-dvh bg-slate-100">
+      <div className="mx-auto flex w-full max-w-7xl flex-col gap-6 px-4 py-4 md:px-6 md:py-6">
+        <div className="grid gap-6 xl:grid-cols-[minmax(0,1.3fr)_minmax(320px,0.9fr)]">
+          <VoiceConversationShell
+            language={currentLanguage}
+            onLanguageChange={setCurrentLanguage}
+            onVisemeControl={setVisemeFunction}
+            renderAvatar={() => (
+              <CharacterAvatar
+                modelPath="/characters/models/sakura.vrm"
+                background={characterBackground}
+                lightingIntensity={lightingIntensity}
+                enableClickAnimation={!showSlideMode}
+                onVisemeControl={(setViseme) => {
+                  setSetVisemeFunction(() => setViseme);
+                }}
+                onExpressionControl={(setExpression) => {
+                  setSetExpressionFunction(() => setExpression);
+                }}
+                onBackgroundChange={setCharacterBackground}
+                onLightingChange={setLightingIntensity}
+              />
             )}
-          </div>
+          />
+
+          <section className="rounded-[28px] border border-slate-200 bg-white/90 p-4 shadow-sm backdrop-blur-sm md:p-6">
+            <div className="flex flex-wrap items-start justify-between gap-4">
+              <div>
+                <p className="text-sm font-medium text-slate-500">Presentation</p>
+                <h2 className="text-balance text-2xl font-semibold text-slate-950">
+                  {currentLanguage === 'ja' ? 'スライド案内' : 'Presentation Guide'}
+                </h2>
+                <p className="mt-2 text-pretty text-sm leading-6 text-slate-600">
+                  {currentLanguage === 'ja'
+                    ? '初めての方向けの案内をスライドで再生できます。'
+                    : 'You can start the introductory slide deck for first-time visitors.'}
+                </p>
+              </div>
+
+              <div className="flex flex-wrap gap-2">
+                <button
+                  type="button"
+                  onClick={() => startPresentation('ja')}
+                  className="inline-flex items-center gap-2 rounded-full bg-slate-900 px-4 py-2 text-sm font-medium text-white transition-colors hover:bg-slate-800"
+                >
+                  <Play className="size-4" />
+                  日本語で開始
+                </button>
+                <button
+                  type="button"
+                  onClick={() => startPresentation('en')}
+                  className="inline-flex items-center gap-2 rounded-full bg-slate-200 px-4 py-2 text-sm font-medium text-slate-800 transition-colors hover:bg-slate-300"
+                >
+                  <Presentation className="size-4" />
+                  Start in English
+                </button>
+                {showSlideMode ? (
+                  <button
+                    type="button"
+                    onClick={() => setShowSlideMode(false)}
+                    className="inline-flex items-center gap-2 rounded-full border border-slate-200 px-4 py-2 text-sm font-medium text-slate-700 transition-colors hover:bg-slate-50"
+                  >
+                    <X className="size-4" />
+                    {currentLanguage === 'ja' ? '閉じる' : 'Close'}
+                  </button>
+                ) : null}
+              </div>
+            </div>
+
+            <div className="mt-5 overflow-hidden rounded-[24px] border border-slate-200 bg-slate-50">
+              {showSlideMode ? (
+                <div className="h-[560px]">
+                  <MarpViewer
+                    language={currentLanguage}
+                    onVisemeControl={setVisemeFunction}
+                    onExpressionControl={setExpressionFunction}
+                  />
+                </div>
+              ) : (
+                <div className="flex min-h-[560px] items-center justify-center px-8 text-center">
+                  <div className="max-w-sm">
+                    <div className="mx-auto flex size-16 items-center justify-center rounded-full bg-slate-900 text-white">
+                      <Presentation className="size-7" />
+                    </div>
+                    <h3 className="mt-5 text-balance text-xl font-semibold text-slate-900">
+                      {currentLanguage === 'ja'
+                        ? 'プレゼンテーションは必要なときだけ起動'
+                        : 'Start the presentation only when needed'}
+                    </h3>
+                    <p className="mt-3 text-pretty text-sm leading-6 text-slate-600">
+                      {currentLanguage === 'ja'
+                        ? '音声で案内しながら、必要なら右上のボタンからスライド説明へ切り替えられます。'
+                        : 'Stay in voice mode by default, then switch to slides from the buttons above when you need the guided tour.'}
+                    </p>
+                  </div>
+                </div>
+              )}
+            </div>
+          </section>
         </div>
       </div>
-      
     </main>
   );
 }

--- a/frontend/src/lib/voice-recorder.ts
+++ b/frontend/src/lib/voice-recorder.ts
@@ -217,6 +217,10 @@ export class VoiceRecorder {
     return this.mediaRecorder !== null && this.stream !== null;
   }
 
+  public getStream(): MediaStream | null {
+    return this.stream;
+  }
+
   private getSupportedMimeType(): string {
     // Check if we're on iOS
     const isIOS = /iPad|iPhone|iPod/.test(navigator.userAgent) && !(window as any).MSStream;


### PR DESCRIPTION
## 概要
- `useVoiceSessionController` を `VoiceInterface` に統合し、音声録音・/api/qa 経由の応答取得・TTS 再生・Wake Word 起動を一本化
- `VoiceConversationShell` を追加し、音声主体のマイク中心 UI を `page.tsx` に統合
- Clarification 用のタップ選択ボタンと、セッション状態に連動する `CharacterAvatar` の表情・姿勢制御を追加

## 変更内容
- Phase 2: `VoiceInterface` を headless にも使える構成へ再設計し、render prop でセッション状態と操作を外部へ公開
- Phase 3: `VoiceConversationShell` を新設し、CharacterAvatar と MarpViewer を併用する新しいホーム画面へ差し替え
- Phase 4: `ClarificationButtons` を追加し、`metadata.clarification_options` / `clarification_type` / 応答文から選択肢を生成して送信可能にした
- Phase 5: `CharacterAvatar` に `sessionState` を追加し、idle / listening / processing / speaking に応じて表情と姿勢を切り替えるようにした

## 確認項目
- `cd frontend && pnpm lint`
- `cd frontend && pnpm typecheck`
- `cd frontend && pnpm build`

## 関連
- Closes #116
