### PR TITLE
feat(backend): add tour/guide purpose keywords to reception API

### DIFF
--- a/backend/api/reception.py
+++ b/backend/api/reception.py
@@ -74,6 +74,16 @@ def _store_session(session: ReceptionSession) -> None:
 # ---------------------------------------------------------------------------
 
 _PURPOSE_KEYWORDS: dict[str, list[str]] = {
+    "tour": [
+        "tour",
+        "guide",
+        "guided",
+        "guidance",
+        "見学",
+        "ツアー",
+        "案内",
+        "館内",
+    ],
     "facility_use": [
         "cowork",
         "coworking",

--- a/backend/tests/api/test_reception_api.py
+++ b/backend/tests/api/test_reception_api.py
@@ -134,6 +134,46 @@ class TestRespondReception:
         data = response.json()
         assert data["purpose"]["category"] == "event_participation"
 
+    def test_respond_with_tour_purpose_classified_in_japanese(self):
+        start = _start_session(session_id="s1")
+        rid = start["reception_session_id"]
+
+        client.post(
+            "/api/reception/respond",
+            json={"session_id": "s1", "reception_session_id": rid, "message": "こんにちは"},
+        )
+        response = client.post(
+            "/api/reception/respond",
+            json={
+                "session_id": "s1",
+                "reception_session_id": rid,
+                "message": "館内を見学したいです",
+            },
+        )
+        assert response.status_code == 200
+        data = response.json()
+        assert data["purpose"]["category"] == "tour"
+
+    def test_respond_with_tour_purpose_classified_in_english(self):
+        start = _start_session(session_id="s1", language="en")
+        rid = start["reception_session_id"]
+
+        client.post(
+            "/api/reception/respond",
+            json={"session_id": "s1", "reception_session_id": rid, "message": "Hello"},
+        )
+        response = client.post(
+            "/api/reception/respond",
+            json={
+                "session_id": "s1",
+                "reception_session_id": rid,
+                "message": "I would like a guided tour of the facility",
+            },
+        )
+        assert response.status_code == 200
+        data = response.json()
+        assert data["purpose"]["category"] == "tour"
+
     def test_respond_unknown_purpose_stays_in_purpose_hearing(self):
         start = _start_session(session_id="s1")
         rid = start["reception_session_id"]


### PR DESCRIPTION
## Summary
- Add "tour", "guide", "見学", "ツアー", "案内", "館内" keywords to `_PURPOSE_KEYWORDS` in reception API
- Enable tour purpose classification for both Japanese and English visitor messages
- Add 2 test cases verifying tour detection in both languages

## Context
Split from session-1771 work on `fix/issue-183-vrm-stage-ui-pr` branch. Backend changes separated from frontend PR #184.

## Test plan
- [x] `pytest tests/api/test_reception_api.py` — 22 passed
- [x] `ruff check` — All checks passed
- [x] `black --check` — All files unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)