### PR TITLE
docs: update architecture and status for Wave 1 completion

### DIFF
--- a/Plans.md
+++ b/Plans.md
@@ -1,6 +1,6 @@
 # Plans.md - Engineer Cafe Navigator
 
-> 最終更新: 2026-02-15
+> 最終更新: 2026-03-07
 > モード: 2-Agent (Cursor PM + Claude Code Worker)
 
 ---
@@ -9,11 +9,11 @@
 
 | 項目 | 状態 |
 |------|------|
-| **フェーズ** | ✅ 全フェーズ完了 (A/B/C/D/E) |
+| **フェーズ** | ✅ Phase A-E 完了 + Wave 1 完了 |
 | **CI/CD** | ✅ グリーン |
-| **テスト** | ✅ 852 passed (25 skipped), E2E 10/10 PASS (KW率100%) |
-| **オープン PR** | #78 (RouterAgent削除 + クリーンアップ) |
-| **エージェント数** | 8種（RouterAgent削除済み、ClarificationAgent・MemoryAgent吸収済み） |
+| **テスト** | ✅ 2587 passed (172 skipped) |
+| **マージ済みPR** | #184 (VRM UI復元), #185 (Reception tour), #186 (Wave 1 Agents) |
+| **エージェント数** | 7 workflow + 3 support（FarewellAgent追加） |
 
 ---
 
@@ -80,34 +80,78 @@
 
 ---
 
-## エージェント実装状況（8種）
+## エージェント実装状況（7 workflow + 3 support）
 
+### Workflow Agents（LangGraphノード）
 | エージェント | 系統 | 備考 |
 |-------------|------|------|
-| orchestrator-agent | 統括 | RouterAgent機能統合済み |
-| business-info-agent | 実務系 | |
-| event-agent | 実務系 | |
-| facility-agent | 実務系 | |
-| slide-agent | 実務系 | |
-| general-knowledge-agent | 実務系 | Web検索Tavily移行済み、メモリクエリ処理統合済み |
-| ~~clarification-agent~~ | 音声系 | ✅ ワークフロー吸収済み（voice_agentのみ参照） |
-| voice-agent | 音声系 | |
-| character-control-agent | UI系 | |
+| orchestrator-agent | 統括 | RouterAgent機能統合済み、LLM動的ルーティング |
+| business-info-agent | 実務系 | 営業時間、料金、相談、コミュニティ |
+| facility-agent | 実務系 | 設備、地下、**近隣施設(#109)**、**忘れ物(#110)** |
+| event-agent | 実務系 | Google Calendar + Connpass |
+| slide-agent | 実務系 | Marpスライド + ナレーション |
+| general-knowledge-agent | 実務系 | Web検索Tavily移行済み、メモリクエリ統合済み |
+| **farewell-agent** | 実務系 | **退館フロー(#108)** 受付カード返却案内、荷物確認 |
 
-レビュー中: ocr-agent
-統合済み: ~~memory-agent~~ → general-knowledge-agent (#55)
-削除済み: ~~router-agent~~ (#78, -793行)
+### Support Agents
+| エージェント | 系統 | 備考 |
+|-------------|------|------|
+| voice-agent | 音声系 | STT/TTS |
+| character-control-agent | UI系 | VRM表情制御 |
+| ocr-agent (vision) | 入力系 | 画像/OCR処理 |
+
+### 統合・削除済み
+- ~~router-agent~~ → orchestrator-agent (#78, -793行)
+- ~~clarification-agent~~ → orchestratorインライン処理
+- ~~memory-agent~~ → general-knowledge-agent (#55)
 
 ---
 
-## チーム編成
+## チーム編成（2026-03-07更新）
 
-| チーム | 担当者 | 主なタスク |
-|--------|--------|-----------|
-| 実務系統括記憶 | テリスケ | Supabase統合、Memory/RAG再設計 |
-| 音声系 | Jun, Chie, たけがわ | STT/TTS連携、音声フロー |
-| OCR系 | けいてぃー, たけがわ | 画像認識→ルーター連携 |
-| フロント系 | takegg0311, 中村 | VRM制御、API移行 |
+| 担当 | メンバー | 主なタスク |
+|------|---------|-----------|
+| バックエンド | terisuke | エージェント実装、RAG改善、Memory/RAG再設計 |
+| フロントエンド（カスタマーUI） | takegg0311, NKMAK | VRM制御、ダッシュボード、スライド表示 |
+| フロントエンド（管理者UI） | NKMAK | ナレッジ管理UI (#72) |
+| 音声系 | takegawa333, junfabregas4 | STT/TTS連携、音声フロー |
+| デバイス | chie0349ja | デバイス検知 (#128) |
+
+## オープンIssue（2026-03-07時点）
+
+### P0
+| # | タイトル | 担当 | 状態 |
+|---|---------|------|------|
+| #183 | VTuber UI復元 | takegg0311/NKMAK | PR #184マージ済み、残受入基準あり |
+
+### P1 Backend
+| # | タイトル | 担当 | 状態 |
+|---|---------|------|------|
+| #137 | answer_correctness 0.7+改善 | terisuke | RAGAS未検証 |
+| #138 | 多言語対応品質改善 | terisuke | 中国語/韓国語テスト不足 |
+| #141 | RAG context_precision改善 | terisuke | Reranker未実装 |
+
+### P1 Frontend
+| # | タイトル | 担当 | 状態 |
+|---|---------|------|------|
+| #72 | ナレッジ管理UI | NKMAK | BE API実装済み、FEファイルアップロードUI未実装 |
+| #117 | 自律受付フロー統合 | takegg0311/NKMAK | BE実装済み、FE ReceptionPanel未統合 |
+| #139 | FE E2Eテスト | takegg0311/NKMAK | Playwright設定済み |
+
+### P1 Other
+| # | タイトル | 担当 | 状態 |
+|---|---------|------|------|
+| #122 | Admin認証ミドルウェア | NKMAK | Phase 2 |
+| #128 | デバイス検知調査 | chie0349ja | 調査中 |
+| #140 | 負荷テスト | terisuke | 未着手 |
+
+### P2 (Infrastructure)
+| # | タイトル |
+|---|---------|
+| #150-#154 | Oracle Cloud VM / Docker / Cloudflare Tunnel / 本番デプロイ |
+| #165 | Reception-2025 × Navigator統合境界分析 |
+| #169 | FE Supabase直接接続→BE API経由分離 |
+| #174 | FE Supabase環境変数バリデーション |
 
 ---
 

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -2,12 +2,12 @@
 
 > Current implementation status and roadmap for Engineer Cafe Navigator
 
-Last Updated: 2026-01-24
+Last Updated: 2026-03-07
 
 ## 🟢 Implemented Features
 
 ### Core Features
-- ✅ **9-Agent Architecture** - LangGraph backend coordinating specialized agents
+- ✅ **7+3 Agent Architecture** - LangGraph backend with 7 workflow agents + 3 support agents
 - ✅ **Voice Processing API** - Speech recognition, AI response generation, and text-to-speech using Google Cloud
 - ✅ **Google Cloud Service Account Authentication** - Secure authentication without API keys
 - ✅ **Multi-language Support** - Japanese and English voice interactions
@@ -47,24 +47,30 @@ Last Updated: 2026-01-24
 - ✅ **Lip-sync System** - Optimized with intelligent caching
 - ✅ **Production Monitoring** - Real-time metrics and alerting
 
-### 9-Agent Architecture (LangGraph Backend - 2026/01)
-- ✅ **RouterAgent** - Context-dependent query routing and classification
-- ✅ **BusinessInfoAgent** - Hours, pricing, location with Enhanced RAG
-- ✅ **FacilityAgent** - Equipment, basement facilities with Enhanced RAG
-- ✅ **EventAgent** - Calendar and event information
+### Agent Architecture (LangGraph Backend - 2026/03)
+
+**Workflow Agents** (LangGraph nodes):
+- ✅ **OrchestratorAgent** - Supervisor Pattern, LLM dynamic routing (RouterAgent統合済み)
+- ✅ **BusinessInfoAgent** - Hours, pricing, consultation, community (Enhanced RAG)
+- ✅ **FacilityAgent** - Equipment, basement, nearby facilities, lost & found (Enhanced RAG)
+- ✅ **EventAgent** - Google Calendar ICS + Connpass API v2
 - ✅ **SlideAgent** - Slide presentation and narration
-- ✅ **GeneralKnowledgeAgent** - Out-of-scope queries via Google Gemini Search
-- ✅ **MemoryAgent** - Conversation history and context management
-- ✅ **ClarificationAgent** - Ambiguous query clarification
+- ✅ **GeneralKnowledgeAgent** - Web search (Tavily) + memory queries (MemoryAgent統合済み)
+- ✅ **FarewellAgent** - Departure flow, card return reminder, brand message
+
+**Support Agents**:
 - ✅ **VoiceAgent** - STT/TTS processing
 - ✅ **CharacterControlAgent** - VRM character control
+- ✅ **OCRAgent (VisionAgent)** - Image/OCR processing
+
+**Deprecated**: ~~RouterAgent~~, ~~ClarificationAgent~~ (inline), ~~MemoryAgent~~ (→GKA)
 
 ## 🔴 Features NOT Implemented (Despite Being Referenced)
 
 ### Documented but Non-Existent Features
 - ❌ **Web Speech API Integration** - Hardcoded to false in VoiceInterface.tsx, never actually used
-- ❌ **Facial Expression Detection** - face-api.js is loaded but no implementation exists
-- ❌ **Test Framework** - No test command (`pnpm test`) configured despite references in documentation
+- ~~❌ **Facial Expression Detection** - face-api.js is loaded but no implementation exists~~ → ✅ Removed dead code (PR #184)
+- ✅ **Test Framework** - Backend: pytest 2587+ tests, Frontend: Playwright E2E setup
 
 ### Unused Environment Variables
 These variables are documented but not referenced in the actual codebase:

--- a/docs/architecture/SYSTEM-ARCHITECTURE.md
+++ b/docs/architecture/SYSTEM-ARCHITECTURE.md
@@ -57,19 +57,26 @@ Engineer Cafe Navigator is a multilingual AI navigation system for the Engineer 
 - **Context Window**: 3-minute conversation memory
 - **State Schema**: ConversationState (messages, context, query, intermediate_steps, current_agent)
 
-### Agent Architecture (12 Agents)
-1. **OrchestratorAgent**: Supervisor Pattern with LLM-based dynamic routing
-2. **BusinessInfoAgent**: Business hours, pricing, access (Enhanced RAG)
-3. **FacilityAgent**: Facilities, equipment, basement (Enhanced RAG)
+### Agent Architecture (7 Workflow Agents + Support Agents)
+
+**Workflow Agents** (LangGraph nodes with Supervisor Pattern routing):
+1. **OrchestratorAgent**: Supervisor Pattern with LLM-based dynamic routing (RouterAgent統合済み)
+2. **BusinessInfoAgent**: Business hours, pricing, access, consultation, community (Enhanced RAG)
+3. **FacilityAgent**: Facilities, equipment, basement, nearby, lost & found (Enhanced RAG)
 4. **EventAgent**: Google Calendar ICS + Connpass API v2
 5. **SlideAgent**: Slide display and narration
-6. **GeneralKnowledgeAgent**: Web search + memory queries (merged from MemoryAgent)
-7. **ClarificationAgent**: Ambiguity resolution (context-aware)
-8. **VoiceAgent**: TTS (VoiceVox local / Google Cloud)
-9. **STTAgent**: STT (Vosk local / Google Cloud)
-10. **CharacterControlAgent**: VRM character control
-11. **OCRAgent**: OCR processing
-12. **MemoryAgent**: DEPRECATED (merged into GeneralKnowledgeAgent)
+6. **GeneralKnowledgeAgent**: Web search + memory queries (MemoryAgent統合済み)
+7. **FarewellAgent**: Departure flow with card return reminder and brand message
+
+**Support Agents** (not LangGraph nodes):
+- **VoiceAgent**: TTS (VoiceVox local / Google Cloud)
+- **CharacterControlAgent**: VRM character control
+- **OCRAgent** (VisionAgent): OCR processing
+
+**Deprecated/Merged**:
+- ~~RouterAgent~~: Merged into OrchestratorAgent
+- ~~ClarificationAgent~~: Absorbed into orchestrator inline processing
+- ~~MemoryAgent~~: Merged into GeneralKnowledgeAgent
 
 ## 📊 Data Flow
 
@@ -79,12 +86,12 @@ User Query → Frontend → FastAPI Backend (Python)
 OrchestratorAgent (LLM-based Supervisor Pattern routing)
     ↓
 [Route to Appropriate Specialized Agent]
-    ├─→ BusinessInfoAgent (Enhanced RAG: section chunking, parent context)
-    ├─→ FacilityAgent (Enhanced RAG: category-specific strategies)
+    ├─→ BusinessInfoAgent (Enhanced RAG: hours, pricing, consultation, community)
+    ├─→ FacilityAgent (Enhanced RAG: equipment, nearby, lost & found, parking)
     ├─→ EventAgent (Google Calendar ICS + Connpass API v2)
-    ├─→ GeneralKnowledgeAgent (Web search: Gemini grounding + Tavily)
-    ├─→ ClarificationAgent (Context-aware ambiguity resolution)
-    └─→ [Other Specialized Agents]
+    ├─→ GeneralKnowledgeAgent (Web search: Tavily + memory queries)
+    ├─→ SlideAgent (Marp slide presentation + narration)
+    └─→ FarewellAgent (Departure flow: card return, belongings check)
     ↓
 Response Generation (OpenRouter LLM)
     ↓


### PR DESCRIPTION
## Summary
- Update agent architecture documentation (7 workflow + 3 support agents)
- Add FarewellAgent (#108), nearby facility routing (#109), lost & found routing (#110) to docs
- Update STATUS.md with current test count (2587+) and agent list
- Update Plans.md with open issues tracker and team assignments

## Changed Files
- `docs/architecture/SYSTEM-ARCHITECTURE.md`
- `docs/STATUS.md`
- `Plans.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)