### PR TITLE
fix(infrastructure): Cloud Run ENVIRONMENT=production に修正

### DIFF
--- a/cloud-run-service.yaml
+++ b/cloud-run-service.yaml
@@ -1,0 +1,172 @@
+# Cloud Run Service with Sidecar Containers (VoiceVox + Kokoro TTS)
+#
+# Prerequisites before deploying:
+#   1. Copy the Kokoro TTS image from ghcr.io to Artifact Registry (Cloud Run
+#      does not allow ghcr.io images directly):
+#
+#      # Install crane if needed: go install github.com/google/go-containerregistry/cmd/crane@latest
+#      # Or: brew install crane
+#      crane copy \
+#        ghcr.io/remsky/kokoro-fastapi-cpu:latest \
+#        asia-northeast1-docker.pkg.dev/aipartner-426616/cloud-run-source-deploy/kokoro-fastapi-cpu:latest
+#
+#      Alternatively, use docker pull + tag + push:
+#        docker pull --platform linux/amd64 ghcr.io/remsky/kokoro-fastapi-cpu:latest
+#        docker tag ghcr.io/remsky/kokoro-fastapi-cpu:latest \
+#          asia-northeast1-docker.pkg.dev/aipartner-426616/cloud-run-source-deploy/kokoro-fastapi-cpu:latest
+#        docker push asia-northeast1-docker.pkg.dev/aipartner-426616/cloud-run-source-deploy/kokoro-fastapi-cpu:latest
+#
+#   2. Copy the VoiceVox image from Docker Hub to Artifact Registry:
+#
+#      crane copy \
+#        docker.io/voicevox/voicevox_engine:latest \
+#        asia-northeast1-docker.pkg.dev/aipartner-426616/cloud-run-source-deploy/voicevox-engine:latest
+#
+#      Or:
+#        docker pull --platform linux/amd64 voicevox/voicevox_engine:latest
+#        docker tag voicevox/voicevox_engine:latest \
+#          asia-northeast1-docker.pkg.dev/aipartner-426616/cloud-run-source-deploy/voicevox-engine:latest
+#        docker push asia-northeast1-docker.pkg.dev/aipartner-426616/cloud-run-source-deploy/voicevox-engine:latest
+#
+# Deploy with:
+#   gcloud run services replace cloud-run-service.yaml \
+#     --region asia-northeast1 \
+#     --project aipartner-426616
+#
+# Resource allocation:
+#   Backend:    2 CPU / 2Gi  (ingress container, serves HTTP on port 8000)
+#   VoiceVox:   1 CPU / 4Gi  (Japanese TTS, port 50021 on localhost)
+#   Kokoro TTS: 1 CPU / 2Gi  (English TTS, port 8880 on localhost)
+#   Total:      4 CPU / 8Gi per instance (max 3 instances)
+
+apiVersion: serving.knative.dev/v1
+kind: Service
+metadata:
+  name: engineer-cafe-backend
+  labels:
+    cloud.googleapis.com/location: asia-northeast1
+  annotations:
+    run.googleapis.com/ingress: all
+    run.googleapis.com/launch-stage: BETA
+spec:
+  template:
+    metadata:
+      annotations:
+        autoscaling.knative.dev/maxScale: '3'
+        run.googleapis.com/startup-cpu-boost: 'true'
+        # Backend depends on both TTS sidecars being healthy before starting
+        run.googleapis.com/container-dependencies: '{"backend":["voicevox","kokoro-tts"]}'
+    spec:
+      containerConcurrency: 160
+      timeoutSeconds: 300
+      serviceAccountName: 639959525777-compute@developer.gserviceaccount.com
+      containers:
+        # ---- Main (ingress) container: FastAPI backend ----
+        - name: backend
+          image: asia-northeast1-docker.pkg.dev/aipartner-426616/cloud-run-source-deploy/engineer-cafe-backend:a38d235faa9072422028f4f6824c9ee6c5b884a3
+          ports:
+            - name: http1
+              containerPort: 8000
+          resources:
+            limits:
+              cpu: '2'
+              memory: 2Gi
+          env:
+            - name: ENVIRONMENT
+              value: production
+            - name: TTS_PROVIDER
+              value: voicevox
+            - name: VOICEVOX_API_URL
+              value: http://localhost:50021
+            - name: KOKORO_API_URL
+              value: http://localhost:8880
+            - name: OPENROUTER_API_KEY
+              valueFrom:
+                secretKeyRef:
+                  key: latest
+                  name: OPENROUTER_API_KEY
+            - name: SUPABASE_URL
+              valueFrom:
+                secretKeyRef:
+                  key: latest
+                  name: SUPABASE_URL
+            - name: SUPABASE_KEY
+              valueFrom:
+                secretKeyRef:
+                  key: latest
+                  name: SUPABASE_KEY
+            - name: SUPABASE_DB_URI
+              valueFrom:
+                secretKeyRef:
+                  key: latest
+                  name: SUPABASE_DB_URI
+          startupProbe:
+            httpGet:
+              path: /health
+              port: 8000
+            initialDelaySeconds: 10
+            periodSeconds: 10
+            timeoutSeconds: 5
+            failureThreshold: 30
+          livenessProbe:
+            httpGet:
+              path: /health
+              port: 8000
+            periodSeconds: 30
+            timeoutSeconds: 5
+            failureThreshold: 3
+
+        # ---- Sidecar 1: VoiceVox TTS Engine (Japanese) ----
+        - name: voicevox
+          image: asia-northeast1-docker.pkg.dev/aipartner-426616/cloud-run-source-deploy/voicevox-engine:latest
+          env:
+            - name: CPU_NUM_THREADS
+              value: '2'
+          resources:
+            limits:
+              cpu: '1'
+              memory: 4Gi
+          startupProbe:
+            httpGet:
+              path: /version
+              port: 50021
+            initialDelaySeconds: 10
+            periodSeconds: 10
+            timeoutSeconds: 5
+            # VoiceVox loads voice models at startup (~60-240s)
+            failureThreshold: 24
+          livenessProbe:
+            httpGet:
+              path: /version
+              port: 50021
+            periodSeconds: 30
+            timeoutSeconds: 5
+            failureThreshold: 3
+
+        # ---- Sidecar 2: Kokoro TTS Engine (English) ----
+        - name: kokoro-tts
+          image: asia-northeast1-docker.pkg.dev/aipartner-426616/cloud-run-source-deploy/kokoro-fastapi-cpu:latest
+          resources:
+            limits:
+              cpu: '1'
+              memory: 2Gi
+          startupProbe:
+            httpGet:
+              path: /v1/audio/voices
+              port: 8880
+            initialDelaySeconds: 5
+            periodSeconds: 10
+            timeoutSeconds: 5
+            # Kokoro loads TTS models at startup (~30-180s)
+            failureThreshold: 18
+          livenessProbe:
+            httpGet:
+              path: /v1/audio/voices
+              port: 8880
+            periodSeconds: 30
+            timeoutSeconds: 5
+            failureThreshold: 3
+
+  traffic:
+    - percent: 100
+      latestRevision: true


### PR DESCRIPTION
## Summary
- `cloud-run-service.yaml` の `ENVIRONMENT` を `staging` → `production` に修正
- staging モードではログレベル、エラー詳細、セキュリティチェックが本番向けでない

## Test plan
- [ ] cloud-run-service.yaml の ENVIRONMENT 値が `production` であること確認
- [ ] デプロイ後 `/health` エンドポイントで ENVIRONMENT=production を確認

Closes #199

🤖 Generated with [Claude Code](https://claude.com/claude-code)