### PR TITLE
fix(backend): validate audio format before WAV parsing in STT agent

### DIFF
--- a/backend/agents/stt_agent.py
+++ b/backend/agents/stt_agent.py
@@ -383,7 +383,7 @@ class LocalSTTClient:
             lang_grammar = (grammar or {}).get(lang)
             try:
                 return await self.transcribe(audio_data, lang, grammar=lang_grammar)
-            except RuntimeError as e:
+            except (RuntimeError, ValueError) as e:
                 logger.debug("Auto-detect: %s model returned error: %s", lang, e)
                 return None
 

--- a/backend/agents/stt_agent.py
+++ b/backend/agents/stt_agent.py
@@ -31,6 +31,14 @@ import concurrent.futures
 
 logger = logging.getLogger(__name__)
 
+WAV_RIFF_HEADER = b"RIFF"
+MIN_WAV_HEADER_BYTES = 44
+NON_WAV_AUDIO_ERROR = "Audio data must be in WAV format (RIFF). Received non-WAV data."
+TRUNCATED_WAV_AUDIO_ERROR = (
+    "Audio data must be in WAV format (RIFF) and include a complete WAV header "
+    "(minimum 44 bytes). Received truncated data."
+)
+
 
 # -----------------------------------------------------------------------------
 # TranscriptionResult
@@ -264,6 +272,12 @@ class LocalSTTClient:
         """
         import wave
 
+        if len(audio_data) < MIN_WAV_HEADER_BYTES:
+            raise ValueError(TRUNCATED_WAV_AUDIO_ERROR)
+
+        if not audio_data.startswith(WAV_RIFF_HEADER):
+            raise ValueError(NON_WAV_AUDIO_ERROR)
+
         from vosk import KaldiRecognizer
 
         bio = io.BytesIO(audio_data)
@@ -340,6 +354,12 @@ class LocalSTTClient:
                     pool,
                     lambda: self._sync_transcribe(audio_data, language, grammar),
                 )
+        except ValueError as e:
+            if str(e) in {NON_WAV_AUDIO_ERROR, TRUNCATED_WAV_AUDIO_ERROR}:
+                message = f"Invalid audio data for STT transcription: {e}"
+                logger.warning(message)
+                raise ValueError(message) from e
+            raise
         except Exception as e:
             logger.exception("Vosk transcription error: %s", e)
             raise

--- a/backend/tests/agents/test_stt_agent.py
+++ b/backend/tests/agents/test_stt_agent.py
@@ -179,6 +179,16 @@ class TestLocalSTTClient:
 
         mock_load.assert_not_called()
 
+    @pytest.mark.asyncio
+    async def test_transcribe_auto_detect_non_wav_returns_error(self):
+        """transcribe_auto_detect handles non-WAV data gracefully via ValueError catch."""
+        client = LocalSTTClient()
+        non_wav_audio = b"\x1a\x45\xdf\xa3" + (b"webm-data" * 8)  # EBML/WebM header
+
+        with patch("backend.agents.stt_agent.LocalSTTClient._load_model"):
+            with pytest.raises(RuntimeError, match="Auto-detect failed"):
+                await client.transcribe_auto_detect(non_wav_audio)
+
 
 # ==============================================================================
 # Confidence Extraction Tests

--- a/backend/tests/agents/test_stt_agent.py
+++ b/backend/tests/agents/test_stt_agent.py
@@ -155,6 +155,30 @@ class TestLocalSTTClient:
                 with pytest.raises(RuntimeError):
                     await client.transcribe(test_wav_16khz, language="ja")
 
+    @pytest.mark.asyncio
+    async def test_transcribe_non_wav_data_raises_value_error(self):
+        """LocalSTTClient rejects non-WAV payloads before parsing."""
+        client = LocalSTTClient()
+        non_wav_audio = b"\x1a\x45\xdf\xa3" + (b"webm-opus-data" * 4)
+
+        with patch("backend.agents.stt_agent.LocalSTTClient._load_model") as mock_load:
+            with pytest.raises(ValueError, match="Invalid audio data for STT transcription"):
+                await client.transcribe(non_wav_audio, language="ja")
+
+        mock_load.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_transcribe_truncated_wav_header_raises_value_error(self):
+        """LocalSTTClient rejects payloads smaller than a WAV header."""
+        client = LocalSTTClient()
+        truncated_audio = b"RIFF123456"
+
+        with patch("backend.agents.stt_agent.LocalSTTClient._load_model") as mock_load:
+            with pytest.raises(ValueError, match="minimum 44 bytes"):
+                await client.transcribe(truncated_audio, language="ja")
+
+        mock_load.assert_not_called()
+
 
 # ==============================================================================
 # Confidence Extraction Tests


### PR DESCRIPTION
## Summary
- STT agent (`stt_agent.py`) が非WAV形式の音声データを受け取った時に `wave.Error: file does not start with RIFF id` でクラッシュしていた問題を修正
- `wave.open()` の前にRIFFヘッダーチェックと最小サイズ検証を追加
- 明確なエラーメッセージ付きの `ValueError` を返すように変更

## Root Cause
ブラウザから送信される音声データがWebM/Opus形式の場合、WAV形式を前提とした `wave.open()` がクラッシュ。Cloud Runログで2026-03-08に複数回発生確認。

## Changes
- `backend/agents/stt_agent.py`: RIFF headerチェック + 最小ヘッダーサイズ(44bytes)検証
- `backend/tests/agents/test_stt_agent.py`: 非WAVデータ拒否のテスト2件追加

## Related Issues
Closes #195 の関連課題（STTエラー）、#189 テスト依頼の前提修正

## Test plan
- [x] ruff check / black --check パス
- [x] 非WAVデータのテストケース追加
- [x] ヘッダー短縮データのテストケース追加
- [ ] CI全グリーン確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)