### PR TITLE
fix(backend): improve error handling for knowledge upload endpoint

### DIFF
--- a/backend/api/knowledge.py
+++ b/backend/api/knowledge.py
@@ -8,12 +8,15 @@ embedding生成は自動で行われる。
 NOTE: 認証は別Issueで対応予定。現時点ではCORS制限のみ。
 """
 
+import asyncio
 import logging
 import os
 import re
 from typing import Any, Dict, List, Optional
 
+import httpx
 from fastapi import APIRouter, File, Form, HTTPException, Query, UploadFile
+from postgrest import APIError
 from starlette.requests import Request
 from pydantic import BaseModel, Field
 from supabase import create_client
@@ -269,7 +272,13 @@ async def upload_knowledge(
     title: Optional[str] = Form(default=None),
 ):
     """ファイルアップロードでナレッジ登録（.md/.pdf → パース → embedding生成）"""
-    try:
+    effective_title = title or (file.filename.rsplit(".", 1)[0] if file.filename else "unknown")
+    file_type = "unknown"
+    content_size = 0
+
+    async def _perform_upload() -> KnowledgeResponse:
+        nonlocal effective_title, file_type, content_size
+
         if not file.filename:
             raise HTTPException(status_code=400, detail="Filename is required")
 
@@ -293,9 +302,10 @@ async def upload_knowledge(
 
         # ファイルサイズ制限チェック
         content_bytes = await file.read()
+        content_size = len(content_bytes)
         if not content_bytes:
             raise HTTPException(status_code=400, detail="File is empty")
-        if len(content_bytes) > MAX_UPLOAD_SIZE:
+        if content_size > MAX_UPLOAD_SIZE:
             raise HTTPException(
                 status_code=400,
                 detail=f"File too large. Maximum size is {MAX_UPLOAD_SIZE // (1024 * 1024)}MB.",
@@ -334,7 +344,41 @@ async def upload_knowledge(
 
         # Embedding生成
         embedding_text = f"{effective_title}\n{parsed_content}"
-        embedding = await generate_embedding(embedding_text)
+        embedding: List[float] = []
+        try:
+            embedding = await generate_embedding(embedding_text)
+            if not embedding:
+                logger.warning(
+                    "Embedding unavailable for upload: filename=%s title=%s file_type=%s "
+                    "content_size=%s",
+                    file.filename,
+                    effective_title,
+                    file_type,
+                    content_size,
+                )
+        except httpx.TimeoutException as exc:
+            logger.warning(
+                "Embedding generation timed out for upload: filename=%s title=%s file_type=%s "
+                "content_size=%s error=%s",
+                file.filename,
+                effective_title,
+                file_type,
+                content_size,
+                exc,
+            )
+            embedding = []
+        except Exception as exc:
+            logger.warning(
+                "Embedding generation failed for upload (%s): filename=%s title=%s "
+                "file_type=%s content_size=%s error=%s",
+                type(exc).__name__,
+                file.filename,
+                effective_title,
+                file_type,
+                content_size,
+                exc,
+            )
+            embedding = []
 
         # DB挿入
         insert_data: Dict[str, Any] = {
@@ -348,7 +392,29 @@ async def upload_knowledge(
         if embedding:
             insert_data["content_embedding"] = embedding
 
-        result = supabase.table("knowledge_base").insert(insert_data).execute()
+        try:
+            result = supabase.table("knowledge_base").insert(insert_data).execute()
+        except APIError as exc:
+            if _is_unique_violation(exc):
+                raise HTTPException(
+                    status_code=409,
+                    detail=f"Knowledge with title '{effective_title}' already exists",
+                )
+            logger.error(
+                "Supabase insert failed: table=knowledge_base title=%s filename=%s error=%s",
+                effective_title,
+                file.filename,
+                exc,
+            )
+            raise HTTPException(status_code=503, detail="Knowledge storage unavailable")
+        except httpx.HTTPError as exc:
+            logger.error(
+                "Supabase insert failed: table=knowledge_base title=%s filename=%s error=%s",
+                effective_title,
+                file.filename,
+                exc,
+            )
+            raise HTTPException(status_code=503, detail="Knowledge storage unavailable")
 
         if not result.data:
             raise HTTPException(status_code=500, detail="Failed to insert knowledge entry")
@@ -358,15 +424,32 @@ async def upload_knowledge(
             data=_row_to_item(result.data[0]),
         )
 
+    try:
+        return await asyncio.wait_for(_perform_upload(), timeout=60)
     except HTTPException:
         raise
+    except asyncio.TimeoutError:
+        logger.error(
+            "Knowledge upload timed out after 60 seconds: filename=%s file_type=%s content_size=%s",
+            file.filename,
+            file_type,
+            content_size,
+        )
+        raise HTTPException(status_code=504, detail="Knowledge upload timed out")
     except Exception as e:
         if _is_unique_violation(e):
             raise HTTPException(
                 status_code=409,
                 detail=f"Knowledge with title '{effective_title}' already exists",
             )
-        logger.error("Failed to upload knowledge: %s", e)
+        logger.error(
+            "Failed to upload knowledge (%s): %s; filename=%s file_type=%s content_size=%s",
+            type(e).__name__,
+            e,
+            file.filename,
+            file_type,
+            content_size,
+        )
         raise HTTPException(status_code=500, detail="Failed to upload knowledge entry")
 
 

--- a/backend/tests/api/test_knowledge_api.py
+++ b/backend/tests/api/test_knowledge_api.py
@@ -1,9 +1,12 @@
 """Knowledge CRUD API Tests"""
 
+import asyncio
 import io
 from unittest.mock import AsyncMock, MagicMock, patch
 
+import httpx
 import pytest
+from postgrest import APIError
 
 pytest.importorskip("fastapi", reason="fastapi not installed")
 
@@ -378,3 +381,89 @@ def test_upload_pdf(mock_get_sb, mock_embed, mock_parse_pdf):
     assert body["success"] is True
     mock_parse_pdf.assert_called_once()
     mock_embed.assert_called_once()
+
+
+@patch("backend.api.knowledge.parse_markdown")
+@patch("backend.api.knowledge.generate_embedding", new_callable=AsyncMock)
+@patch("backend.api.knowledge._get_supabase")
+def test_upload_continues_when_embedding_times_out(mock_get_sb, mock_embed, mock_parse_md):
+    """embedding timeout時も保存は継続し、embeddingなしで登録する"""
+    mock_embed.side_effect = httpx.TimeoutException("Request timed out")
+    mock_parse_md.return_value = "Parsed markdown content"
+    mock_sb = _mock_supabase()
+    mock_get_sb.return_value = mock_sb
+
+    mock_sb.table.return_value.select.return_value.eq.return_value.execute.return_value = (
+        _mock_table_result([])
+    )
+    uploaded_row = {
+        **SAMPLE_ROW,
+        "title": "timeout_doc",
+        "content": "Parsed markdown content",
+        "source": "file:timeout_doc.md",
+    }
+    mock_sb.table.return_value.insert.return_value.execute.return_value = _mock_table_result(
+        [uploaded_row]
+    )
+
+    response = client.post(
+        "/api/knowledge/upload",
+        data={"category": "general", "language": "ja"},
+        files={"file": ("timeout_doc.md", io.BytesIO(b"# Test"), "text/markdown")},
+    )
+
+    assert response.status_code == 201
+    insert_data = mock_sb.table.return_value.insert.call_args.args[0]
+    assert "content_embedding" not in insert_data
+
+
+@patch("backend.api.knowledge.parse_markdown")
+@patch("backend.api.knowledge.generate_embedding", new_callable=AsyncMock)
+@patch("backend.api.knowledge._get_supabase")
+def test_upload_returns_503_when_supabase_insert_fails(mock_get_sb, mock_embed, mock_parse_md):
+    """Supabase insert失敗時は503を返す"""
+    mock_embed.return_value = FAKE_EMBEDDING
+    mock_parse_md.return_value = "Parsed markdown content"
+    mock_sb = _mock_supabase()
+    mock_get_sb.return_value = mock_sb
+
+    mock_sb.table.return_value.select.return_value.eq.return_value.execute.return_value = (
+        _mock_table_result([])
+    )
+    mock_sb.table.return_value.insert.return_value.execute.side_effect = APIError(
+        {
+            "message": "Supabase unavailable",
+            "code": "08006",
+            "hint": "",
+            "details": "",
+        }
+    )
+
+    response = client.post(
+        "/api/knowledge/upload",
+        data={"category": "general", "language": "ja"},
+        files={"file": ("failed_doc.md", io.BytesIO(b"# Test"), "text/markdown")},
+    )
+
+    assert response.status_code == 503
+    assert response.json()["detail"] == "Knowledge storage unavailable"
+
+
+@patch("backend.api.knowledge.asyncio.wait_for", new_callable=AsyncMock)
+def test_upload_returns_504_on_overall_timeout(mock_wait_for):
+    """全体のアップロード処理がタイムアウトした場合は504を返す"""
+
+    async def _raise_timeout(awaitable, timeout):
+        awaitable.close()
+        raise asyncio.TimeoutError()
+
+    mock_wait_for.side_effect = _raise_timeout
+
+    response = client.post(
+        "/api/knowledge/upload",
+        data={"category": "general", "language": "ja"},
+        files={"file": ("timeout_guard.md", io.BytesIO(b"# Test"), "text/markdown")},
+    )
+
+    assert response.status_code == 504
+    assert response.json()["detail"] == "Knowledge upload timed out"


### PR DESCRIPTION
## Summary
- `/api/knowledge/upload` が500エラーを返していた問題のエラーハンドリングを改善
- Cloud Runログで2026-03-08〜03/11に3回の500エラー発生を確認（13秒タイムアウト含む）

## Changes
- `backend/api/knowledge.py`:
  - Embedding生成のタイムアウト/エラーを個別キャッチ（embedding失敗時もinsert継続）
  - Supabase insert失敗時に503（Service Unavailable）を返却
  - 全体を`asyncio.wait_for(timeout=60)`でガード、超過時504返却
  - 全エラーログにfilename/file_type/content_sizeの詳細情報を追加
- `backend/tests/api/test_knowledge_api.py`: エラーハンドリングのテスト追加

## Root Cause
1. `generate_embedding()` のタイムアウト（30s）後にgeneric 500が返されていた
2. Supabase接続エラー時の区別がなく、全て同じ500エラーメッセージだった
3. エラーログに問題特定に必要な情報（ファイル名等）が含まれていなかった

## Test plan
- [x] ruff check / black --check パス
- [x] エラーハンドリングのテストケース追加
- [ ] CI全グリーン確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)