### PR TITLE
fix(ci): add Docker platform flag and fix ENVIRONMENT to production

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -295,6 +295,7 @@ jobs:
       - name: Build and push Docker image
         run: |
           docker build \
+            --platform linux/amd64 \
             -t asia-northeast1-docker.pkg.dev/aipartner-426616/cloud-run-source-deploy/engineer-cafe-backend:${{ github.sha }} \
             -t asia-northeast1-docker.pkg.dev/aipartner-426616/cloud-run-source-deploy/engineer-cafe-backend:latest \
             --target production \
@@ -315,7 +316,7 @@ jobs:
             --cpu 2 \
             --min-instances 0 \
             --max-instances 3 \
-            --update-env-vars "ENVIRONMENT=staging,TTS_PROVIDER=voicevox,VOICEVOX_API_URL=https://voicevox-proto-639959525777.asia-northeast2.run.app" \
+            --update-env-vars "ENVIRONMENT=production,TTS_PROVIDER=voicevox,VOICEVOX_API_URL=https://voicevox-proto-639959525777.asia-northeast2.run.app" \
             --set-secrets "OPENROUTER_API_KEY=OPENROUTER_API_KEY:latest,SUPABASE_URL=SUPABASE_URL:latest,SUPABASE_KEY=SUPABASE_KEY:latest,SUPABASE_DB_URI=SUPABASE_DB_URI:latest"
 
   # Frontend: Deploy to Cloudflare Workers (staging)


### PR DESCRIPTION
## Summary
- Docker buildに`--platform linux/amd64`を追加（Apple Silicon→GCP互換性）
- CI deploy stepの`ENVIRONMENT=staging`を`ENVIRONMENT=production`に修正

## Root Cause
CIの`backend-deploy-staging`がdevelopへのpush時に`--update-env-vars "ENVIRONMENT=staging"`で毎回`ENVIRONMENT`を`staging`に戻していた。Wave 2AでA1として`gcloud`で直接`production`に修正したが、PR #212/#213/#214マージ後のCI自動デプロイで再び`staging`に上書きされた。

## Changes
- `.github/workflows/ci.yml`:
  - docker build: `--platform linux/amd64` 追加
  - gcloud run deploy: `ENVIRONMENT=staging` → `ENVIRONMENT=production`

## Related Issues
Closes #201

## Test plan
- [x] CIワークフローの構文確認
- [ ] 次回develop pushでデプロイ後にENVIRONMENT=production確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)