### PR TITLE
fix(backend): add security headers, CORS strictening, and input length validation

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -17,7 +17,7 @@ from io import BytesIO
 from fastapi import Depends, FastAPI, HTTPException
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import StreamingResponse
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 from typing import Optional, Dict, Any, cast
 
 from starlette.middleware.base import BaseHTTPMiddleware
@@ -220,31 +220,32 @@ async def verify_api_key(request: Request) -> None:
         raise HTTPException(status_code=403, detail="Invalid or missing API key")
 
 
-# CORS設定
-_default_origins = ["http://localhost:3000", "http://localhost:3001"]
-_env = os.getenv("ENVIRONMENT", "development")
-_configured_origins = [o.strip() for o in os.getenv("ALLOWED_ORIGINS", "").split(",") if o.strip()]
-
-if _env == "production" and not _configured_origins:
-    logger.warning(
-        "ALLOWED_ORIGINS not set in production. "
-        "Falling back to localhost origins — this is insecure."
-    )
-
-_allowed_origins = _configured_origins or _default_origins
+ALLOWED_ORIGINS = os.getenv(
+    "ALLOWED_ORIGINS", "https://engineer-cafe-navigator.company-997.workers.dev"
+).split(",")
 app.add_middleware(
     CORSMiddleware,
-    allow_origins=_allowed_origins,
+    allow_origins=ALLOWED_ORIGINS,
     allow_credentials=True,
     allow_methods=["GET", "POST", "PUT", "DELETE", "OPTIONS"],
     allow_headers=["Content-Type", "Authorization", "X-API-Key", "X-Request-ID"],
 )
 
 
+@app.middleware("http")
+async def add_security_headers(request: Request, call_next):
+    response = await call_next(request)
+    response.headers["X-Content-Type-Options"] = "nosniff"
+    response.headers["X-Frame-Options"] = "DENY"
+    response.headers["X-XSS-Protection"] = "1; mode=block"
+    response.headers["Referrer-Policy"] = "strict-origin-when-cross-origin"
+    return response
+
+
 class ChatRequest(BaseModel):
-    query: str
+    query: str = Field(max_length=2000)
     session_id: Optional[str] = None
-    language: Optional[str] = "ja"
+    language: Optional[str] = Field(default="ja", max_length=10)
     context: Optional[Dict[str, Any]] = None
     visitor_id: Optional[str] = None  # Cross-session visitor identification
 
@@ -280,7 +281,7 @@ async def _run_workflow_with_tracking(payload: Dict[str, Any], session_id: str) 
     await _get_stm().set_llm_task(session_id, llm_task)
 
     try:
-        return await llm_task
+        return cast(Dict[str, Any], await llm_task)
     except asyncio.CancelledError:
         logger.info("LLM task cancelled for session %s", session_id)
         raise HTTPException(status_code=409, detail="Request interrupted")
@@ -470,8 +471,8 @@ class VoiceRequest(BaseModel):
     action: str
     audioData: Optional[str] = None
     sessionId: Optional[str] = None
-    language: Optional[str] = "ja"
-    text: Optional[str] = None
+    language: Optional[str] = Field(default="ja", max_length=10)
+    text: Optional[str] = Field(default=None, max_length=5000)
     streaming: Optional[bool] = False
     conversationStage: Optional[str] = None
     emotion: Optional[str] = None  # Emotion for TTS synthesis

--- a/backend/tests/e2e/test_http_endpoint_e2e.py
+++ b/backend/tests/e2e/test_http_endpoint_e2e.py
@@ -439,10 +439,11 @@ class TestMiddleware:
 
     async def test_cors_headers_on_preflight(self, client: httpx.AsyncClient):
         """OPTIONS リクエストで CORS ヘッダーが設定されること"""
+        production_origin = "https://engineer-cafe-navigator.company-997.workers.dev"
         response = await client.options(
             "/api/chat",
             headers={
-                "Origin": "http://localhost:3000",
+                "Origin": production_origin,
                 "Access-Control-Request-Method": "POST",
                 "Access-Control-Request-Headers": "Content-Type, X-API-Key",
             },
@@ -456,19 +457,18 @@ class TestMiddleware:
 
     async def test_cors_allows_configured_origin(self, client: httpx.AsyncClient):
         """設定済みのオリジンが CORS で許可されること"""
+        production_origin = "https://engineer-cafe-navigator.company-997.workers.dev"
         response = await client.options(
             "/api/chat",
             headers={
-                "Origin": "http://localhost:3000",
+                "Origin": production_origin,
                 "Access-Control-Request-Method": "POST",
             },
         )
         assert response.status_code == 200
         allowed_origin = response.headers.get("access-control-allow-origin", "")
-        # localhost:3000 がデフォルトで許可されていること
-        assert (
-            allowed_origin == "http://localhost:3000"
-        ), f"許可オリジンが期待と異なる: {allowed_origin}"
+        # 本番オリジンがデフォルトで許可されていること
+        assert allowed_origin == production_origin, f"許可オリジンが期待と異なる: {allowed_origin}"
 
 
 # ---------------------------------------------------------------------------

--- a/backend/tests/test_main_endpoints.py
+++ b/backend/tests/test_main_endpoints.py
@@ -210,14 +210,16 @@ class TestSlidesContentEndpoint:
 
 class TestCORSConfiguration:
     def test_cors_default_origins(self, monkeypatch):
-        """Without ALLOWED_ORIGINS env var, defaults are used"""
+        """Without ALLOWED_ORIGINS env var, production default is used"""
         monkeypatch.delenv("ALLOWED_ORIGINS", raising=False)
         import importlib
         import backend.main
 
         importlib.reload(backend.main)
-        assert "http://localhost:3000" in backend.main._allowed_origins
-        assert "http://localhost:3001" in backend.main._allowed_origins
+        assert (
+            "https://engineer-cafe-navigator.company-997.workers.dev"
+            in backend.main.ALLOWED_ORIGINS
+        )
 
     def test_cors_custom_origins(self, monkeypatch):
         """With ALLOWED_ORIGINS set, custom origins are used"""
@@ -226,8 +228,8 @@ class TestCORSConfiguration:
         import backend.main
 
         importlib.reload(backend.main)
-        assert "https://example.com" in backend.main._allowed_origins
-        assert "https://app.example.com" in backend.main._allowed_origins
+        assert "https://example.com" in backend.main.ALLOWED_ORIGINS
+        assert "https://app.example.com" in backend.main.ALLOWED_ORIGINS
         # Restore
         monkeypatch.delenv("ALLOWED_ORIGINS", raising=False)
         importlib.reload(backend.main)


### PR DESCRIPTION
## Summary
- セキュリティレスポンスヘッダー追加（X-Content-Type-Options, X-Frame-Options等）
- CORS設定を環境変数`ALLOWED_ORIGINS`ベースに変更（デフォルト:本番URL）
- Pydantic Fieldによる入力長制限（query:2000, text:5000, language:10）

## Changes
- `backend/main.py`:
  - `add_security_headers`ミドルウェア追加
  - CORS `allow_origins` を `ALLOWED_ORIGINS` 環境変数から取得
  - `ChatRequest.query`: `Field(max_length=2000)`
  - `ChatRequest.language`: `Field(default="ja", max_length=10)`
  - `VoiceRequest.language`: `Field(default="ja", max_length=10)`
  - `VoiceRequest.text`: `Field(default=None, max_length=5000)`

## Related Issues
Closes #202

## Deployment Note
Cloud Runに`ALLOWED_ORIGINS`環境変数を設定する必要があります。未設定時のデフォルトは`https://engineer-cafe-navigator.company-997.workers.dev`。ローカル開発時は`http://localhost:3000,http://localhost:3001`を設定してください。

## Test plan
- [x] ruff check / black --check パス
- [ ] CI全グリーン確認
- [ ] デプロイ後にセキュリティヘッダー確認: `curl -I`

🤖 Generated with [Claude Code](https://claude.com/claude-code)