### PR TITLE
fix(docker): update docker-compose and Dockerfile for network accessi…

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,6 +4,10 @@
 # Note: For local PostgreSQL (LangGraph Checkpointer), use Supabase CLI:
 #   supabase start
 # This provides PostgreSQL at localhost:54322
+#
+# Access from iPad / other devices on the same network:
+#   - Open http://<MacBookのIPアドレス>:3000 (e.g. http://192.168.1.10:3000)
+#   - Ports are bound to 0.0.0.0 so the host accepts external connections
 
 services:
   # Frontend service - Next.js
@@ -13,7 +17,7 @@ services:
       target: development
     container_name: engineer-cafe-frontend
     ports:
-      - "3000:3000"
+      - "0.0.0.0:3000:3000"
     volumes:
       # Hot reload support
       - ./frontend:/app
@@ -22,6 +26,8 @@ services:
     environment:
       - NODE_ENV=development
       - NEXT_PUBLIC_API_URL=http://localhost:8000
+      # コンテナ内のAPIルートからバックエンドへはサービス名で参照
+      - BACKEND_API_URL=http://backend:8000
     env_file:
       - ./frontend/.env.local
     depends_on:
@@ -37,7 +43,7 @@ services:
       target: development
     container_name: engineer-cafe-backend
     ports:
-      - "8000:8000"
+      - "0.0.0.0:8000:8000"
     volumes:
       # Hot reload support
       - ./backend:/app

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -25,8 +25,8 @@ COPY . .
 # Expose port
 EXPOSE 3000
 
-# Start development server
-CMD ["pnpm", "dev"]
+# Start development server (0.0.0.0 so iPad/other devices can connect)
+CMD ["pnpm", "run", "dev:network"]
 
 # Production build stage
 FROM base AS builder

--- a/frontend/src/app/components/VoiceInterface.tsx
+++ b/frontend/src/app/components/VoiceInterface.tsx
@@ -109,6 +109,22 @@ const LOADING_LABELS = {
   },
 } as const;
 
+/** UUID v4 を生成する。crypto.randomUUID が無い環境（HTTP や古いブラウザ）用のフォールバック付き。 */
+const generateUuid = (): string => {
+  if (typeof window !== 'undefined' && typeof window.crypto?.randomUUID === 'function') {
+    return window.crypto.randomUUID();
+  }
+  if (typeof window !== 'undefined' && window.crypto?.getRandomValues) {
+    const bytes = new Uint8Array(16);
+    window.crypto.getRandomValues(bytes);
+    bytes[6] = (bytes[6]! & 0x0f) | 0x40;
+    bytes[8] = (bytes[8]! & 0x3f) | 0x80;
+    const hex = Array.from(bytes, (b) => b.toString(16).padStart(2, '0')).join('');
+    return `${hex.slice(0, 8)}-${hex.slice(8, 12)}-${hex.slice(12, 16)}-${hex.slice(16, 20)}-${hex.slice(20)}`;
+  }
+  return `fallback-${Date.now()}-${Math.random().toString(36).slice(2, 11)}`;
+};
+
 const getOrCreateVisitorId = (): string => {
   if (typeof window === 'undefined') {
     return 'anonymous';
@@ -120,7 +136,7 @@ const getOrCreateVisitorId = (): string => {
     return existing;
   }
 
-  const created = window.crypto.randomUUID();
+  const created = generateUuid();
   window.localStorage.setItem(key, created);
   return created;
 };


### PR DESCRIPTION
## Summary

localhostで起動させて、外部端末（タブレットなど）から開けるようにするための外部ネットワーク許可
およびその過程で発生した、`window.crypto.randomUUID` エラーの対応

## Changes

- docker-compose.ymlのポートバインディングを変更し、外部アクセス（0.0.0.0）を許可しました。
- フロントエンドのDockerfileを更新し、ネットワークアクセスを有効にして開発サーバーを起動するようにしました。
- crypto.randomUUIDをサポートしていない環境向けに、VoiceInterface.tsxにUUID生成機能を追加しました。

## Test Plan

- [x] ローカルで動作確認済み
- [ ] 既存機能への影響がないことを確認済み

## Checklist

- [ ] コードが目的を達成している
- [ ] 不要なコード・コメントを削除した
- [ ] 必要に応じてドキュメントを更新した
- [x] `pnpm lint` が通る
- [x] `pnpm typecheck` が通る

## Screenshots

自端末内から `http://192.168.2.55:3000` で接続出来ている状態

<img width="1680" height="909" alt="image" src="https://github.com/user-attachments/assets/9cea065e-aa14-4623-ab8c-f9f64465c99a" />

### 補足

同じネットワークに接続していることや、ファイアウォールで指定ポートをブロックしていないことも必要。

さらに、GoogleChromeで HTTP + localhost以外のホストを開くと、プライバシー保護のためマイクなどが使用できない。

有効化するには、以下の手順で「安全なオリジン」として設定する必要がある。

1. Chrome で chrome://flags/#unsafely-treat-insecure-origin-as-secure を開く
2. 「Insecure origins treated as secure」の入力欄に、指定パスを入力し、「有効」にする
3. Chromeを再起動後、開き直す

なお、Safariの場合は回避策は無い模様。