### PR TITLE
refactor(frontend): unify all proxy routes to use backendFetch with X-API-Key

### DIFF
--- a/frontend/src/app/api/character/route.ts
+++ b/frontend/src/app/api/character/route.ts
@@ -1,28 +1,20 @@
 import { NextRequest, NextResponse } from 'next/server';
-// TODO: Re-enable after backend migration is complete
-// import { getEngineerCafeNavigator } from '@/mastra';
-// import { Config } from '@/mastra/types/config';
 
-import { getBackendApiUrl } from '@/lib/api/backend-url';
+import { backendFetch } from '@/lib/api/backend-proxy';
 
 export async function POST(request: NextRequest) {
   try {
     const body = await request.json();
 
-    // バックエンドAPIにプロキシ
-    const backendUrl = `${getBackendApiUrl()}/api/character`;
-    const response = await fetch(backendUrl, {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify(body),
+    const response = await backendFetch('/api/character', {
+      body,
     });
 
     if (!response.ok) {
-      throw new Error(`Backend API error: ${response.statusText}`);
+      throw new Error(`Backend API error: ${response.status}`);
     }
 
-    const result = await response.json();
-    return NextResponse.json(result);
+    return NextResponse.json(response.data);
   } catch (error) {
     console.error('Character API error:', error);
     return NextResponse.json(

--- a/frontend/src/app/api/marp/route.ts
+++ b/frontend/src/app/api/marp/route.ts
@@ -1,6 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server';
 
-import { getBackendApiUrl } from '@/lib/api/backend-url';
+import { backendFetch } from '@/lib/api/backend-proxy';
 import { MarpProcessor } from '@/lib/marp-processor';
 
 let marpProcessor: MarpProcessor | null = null;
@@ -17,18 +17,23 @@ export async function POST(request: NextRequest) {
     const body = await request.json();
     const language = body.language || 'ja';
 
-    const backendUrl = `${getBackendApiUrl()}/api/slides/content`;
-    const backendResponse = await fetch(backendUrl, {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ language }),
+    const backendResponse = await backendFetch<{
+      success?: boolean;
+      markdown?: string;
+      error?: string;
+      metadata?: {
+        title?: string;
+      };
+      narrationData?: unknown;
+    }>('/api/slides/content', {
+      body: { language },
     });
 
     if (!backendResponse.ok) {
-      throw new Error(`Backend error: ${backendResponse.statusText}`);
+      throw new Error(`Backend error: ${backendResponse.status}`);
     }
 
-    const backendData = await backendResponse.json();
+    const backendData = backendResponse.data;
     if (!backendData.success || !backendData.markdown) {
       throw new Error(backendData.error || 'No markdown content returned');
     }

--- a/frontend/src/app/api/qa/route.ts
+++ b/frontend/src/app/api/qa/route.ts
@@ -1,36 +1,34 @@
 import { NextRequest, NextResponse } from 'next/server';
 
-import { getBackendApiUrl } from '@/lib/api/backend-url';
+import { backendFetch } from '@/lib/api/backend-proxy';
 
 export async function POST(request: NextRequest) {
   try {
     const body = await request.json();
     const { action, question, sessionId, language, text, fromLanguage, toLanguage, visitorId } = body;
 
-    // バックエンドAPIにプロキシ
-    const backendUrl = `${getBackendApiUrl()}/api/chat`;
-    const response = await fetch(backendUrl, {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({
+    const response = await backendFetch<{
+      answer?: string;
+      emotion?: string;
+      metadata?: unknown;
+    }>('/api/chat', {
+      body: {
         query: question || text,
         session_id: sessionId,
         language: language || 'ja',
         visitor_id: visitorId,
-      }),
+      },
     });
 
-    if (!response.ok) {
-      throw new Error(`Backend API error: ${response.statusText}`);
+    if (!response.ok || !response.data) {
+      throw new Error(`Backend API error: ${response.status}`);
     }
-
-    const result = await response.json();
 
     return NextResponse.json({
       success: true,
-      answer: result.answer,
-      emotion: result.emotion,
-      metadata: result.metadata,
+      answer: response.data.answer,
+      emotion: response.data.emotion,
+      metadata: response.data.metadata,
     });
   } catch (error) {
     console.error('Q&A API error:', error);

--- a/frontend/src/app/api/reception/_shared.ts
+++ b/frontend/src/app/api/reception/_shared.ts
@@ -1,19 +1,34 @@
 import { NextResponse } from 'next/server';
 
-import { getBackendApiUrl } from '@/lib/api/backend-url';
+import { backendFetch } from '@/lib/api/backend-proxy';
 
 type JsonValue = Record<string, unknown> | Array<unknown> | string | number | boolean | null;
 
-async function readJson(response: Response): Promise<JsonValue | null> {
-  const contentType = response.headers.get('content-type') ?? '';
-  if (!contentType.includes('application/json')) {
-    return null;
+function toHeaderRecord(headers?: HeadersInit): Record<string, string> {
+  if (!headers) {
+    return {};
+  }
+
+  if (headers instanceof Headers) {
+    return Object.fromEntries(headers.entries());
+  }
+
+  if (Array.isArray(headers)) {
+    return Object.fromEntries(headers);
+  }
+
+  return { ...headers };
+}
+
+function parseJsonBody(body: BodyInit | null | undefined): unknown {
+  if (typeof body !== 'string') {
+    return undefined;
   }
 
   try {
-    return (await response.json()) as JsonValue;
+    return JSON.parse(body);
   } catch {
-    return null;
+    return undefined;
   }
 }
 
@@ -22,8 +37,13 @@ export async function proxyReceptionRequest(
   init: RequestInit
 ): Promise<NextResponse> {
   try {
-    const response = await fetch(`${getBackendApiUrl()}${path}`, init);
-    const data = await readJson(response);
+    const response = await backendFetch<JsonValue>(path, {
+      method: (init.method as 'GET' | 'POST' | 'PUT' | 'DELETE' | 'PATCH') ?? 'POST',
+      headers: toHeaderRecord(init.headers),
+      body: parseJsonBody(init.body),
+      signal: init.signal ?? undefined,
+    });
+    const data = response.data ?? null;
 
     if (!response.ok) {
       const message =

--- a/frontend/src/app/api/slides/route.ts
+++ b/frontend/src/app/api/slides/route.ts
@@ -1,28 +1,20 @@
 import { NextRequest, NextResponse } from 'next/server';
-// TODO: Re-enable after backend migration is complete
-// import { getEngineerCafeNavigator } from '@/mastra';
-// import { Config } from '@/mastra/types/config';
 
-import { getBackendApiUrl } from '@/lib/api/backend-url';
+import { backendFetch } from '@/lib/api/backend-proxy';
 
 export async function POST(request: NextRequest) {
   try {
     const body = await request.json();
 
-    // バックエンドAPIにプロキシ
-    const backendUrl = `${getBackendApiUrl()}/api/slides`;
-    const response = await fetch(backendUrl, {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify(body),
+    const response = await backendFetch('/api/slides', {
+      body,
     });
 
     if (!response.ok) {
-      throw new Error(`Backend API error: ${response.statusText}`);
+      throw new Error(`Backend API error: ${response.status}`);
     }
 
-    const result = await response.json();
-    return NextResponse.json(result);
+    return NextResponse.json(response.data);
   } catch (error) {
     console.error('Slides API error:', error);
     return NextResponse.json(

--- a/frontend/src/app/api/voice/route.ts
+++ b/frontend/src/app/api/voice/route.ts
@@ -1,6 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server';
 
-import { getBackendApiUrl } from '@/lib/api/backend-url';
+import { backendFetch } from '@/lib/api/backend-proxy';
 
 export async function POST(request: NextRequest) {
   try {
@@ -13,28 +13,22 @@ export async function POST(request: NextRequest) {
 
     const { action, audioData, sessionId, language, text, streaming } = body;
 
-    // バックエンドAPIにプロキシ
-    const backendUrl = `${getBackendApiUrl()}/api/voice`;
-    const response = await fetch(backendUrl, {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({
+    const response = await backendFetch('/api/voice', {
+      body: {
         action,
         audioData,
         sessionId,
         language: language || 'ja',
         text,
         streaming: streaming || false,
-      }),
+      },
     });
 
     if (!response.ok) {
-      throw new Error(`Backend API error: ${response.statusText}`);
+      throw new Error(`Backend API error: ${response.status}`);
     }
 
-    const result = await response.json();
-
-    return NextResponse.json(result);
+    return NextResponse.json(response.data);
   } catch (error) {
     console.error('Voice API error:', error);
     return NextResponse.json(
@@ -54,20 +48,16 @@ export async function GET(request: NextRequest) {
     const { searchParams } = new URL(request.url);
     const action = searchParams.get('action');
 
-    // バックエンドAPIにプロキシ
-    const backendUrl = `${getBackendApiUrl()}/api/voice?action=${action}`;
-    const response = await fetch(backendUrl, {
+    const response = await backendFetch('/api/voice', {
       method: 'GET',
-      headers: { 'Content-Type': 'application/json' },
+      params: action ? { action } : undefined,
     });
 
     if (!response.ok) {
-      throw new Error(`Backend API error: ${response.statusText}`);
+      throw new Error(`Backend API error: ${response.status}`);
     }
 
-    const result = await response.json();
-
-    return NextResponse.json(result);
+    return NextResponse.json(response.data);
   } catch (error) {
     console.error('Voice API GET error:', error);
     return NextResponse.json(

--- a/frontend/src/lib/api/backend-proxy.ts
+++ b/frontend/src/lib/api/backend-proxy.ts
@@ -43,10 +43,11 @@ export async function backendFetch<T = unknown>(
 
   const url = buildUrl(path, params);
 
-  const mergedHeaders: Record<string, string> = {
-    "Content-Type": "application/json",
-    ...headers,
-  };
+  const mergedHeaders: Record<string, string> = { ...headers };
+
+  if (!(method === "GET" && body === undefined)) {
+    mergedHeaders["Content-Type"] ??= "application/json";
+  }
 
   if (apiKey) {
     mergedHeaders["X-API-Key"] = apiKey;
@@ -63,7 +64,12 @@ export async function backendFetch<T = unknown>(
   }
 
   const response = await fetch(url, fetchInit);
-  const data = (await response.json()) as T;
+  let data: T;
+  try {
+    data = (await response.json()) as T;
+  } catch {
+    data = undefined as unknown as T;
+  }
 
   return { ok: response.ok, status: response.status, data };
 }

--- a/frontend/src/lib/api/backend-url.ts
+++ b/frontend/src/lib/api/backend-url.ts
@@ -1,6 +1,0 @@
-export function getBackendApiUrl(): string {
-  const url = process.env.BACKEND_API_URL;
-  if (url) return url;
-  if (process.env.NODE_ENV === 'development') return 'http://localhost:8000';
-  throw new Error('BACKEND_API_URL environment variable is required');
-}


### PR DESCRIPTION
## Summary
- All 6 proxy routes (`qa`, `voice`, `character`, `slides`, `marp`, `reception/_shared`) now use `backendFetch()` from `backend-proxy.ts`
- X-API-Key header automatically attached to all backend requests
- Removed commented Mastra imports and TODO comments from character/slides routes

## Related Issues
Ref #224 (Phase 1: core route proxy unification)

## Test plan
- [x] `pnpm typecheck` passed
- [x] `pnpm lint` passed
- [x] `pnpm build` passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)