### PR TITLE
chore(frontend): demote unused AI/DB env vars to optional

### DIFF
--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -17,19 +17,8 @@ GOOGLE_CLOUD_PROJECT_ID=your-gcp-project-id
 GOOGLE_CLOUD_CREDENTIALS=./config/service-account-key.json
 
 # ---------------------------------------------------------------------------
-# [REQUIRED] Gemini AI
-# ---------------------------------------------------------------------------
-GOOGLE_GENERATIVE_AI_API_KEY=your-gemini-api-key
-
-# ---------------------------------------------------------------------------
-# [REQUIRED] OpenAI (for embeddings — 1536 dimensions to match database)
-# ---------------------------------------------------------------------------
-OPENAI_API_KEY=your-openai-api-key
-
-# ---------------------------------------------------------------------------
 # [REQUIRED] Database (Supabase)
 # ---------------------------------------------------------------------------
-POSTGRES_URL=postgresql://postgres:password@db.project.supabase.co:5432/postgres
 NEXT_PUBLIC_SUPABASE_URL=https://project.supabase.co
 NEXT_PUBLIC_SUPABASE_ANON_KEY=your-anon-key
 
@@ -60,6 +49,13 @@ SUPABASE_SERVICE_ROLE_KEY=your-service-role-key
 # ---------------------------------------------------------------------------
 GEMINI_MODEL=gemini-2.5-flash-preview-05-20
 # GEMINI_API_KEY=              # Alternative Gemini key (falls back to GOOGLE_GENERATIVE_AI_API_KEY)
+
+# ---------------------------------------------------------------------------
+# [OPTIONAL] AI / DB Integrations
+# ---------------------------------------------------------------------------
+# GOOGLE_GENERATIVE_AI_API_KEY=your-gemini-api-key
+# OPENAI_API_KEY=your-openai-api-key
+# POSTGRES_URL=postgresql://postgres:password@db.project.supabase.co:5432/postgres
 
 # ---------------------------------------------------------------------------
 # [OPTIONAL] Google Cloud Services

--- a/frontend/.env.production.example
+++ b/frontend/.env.production.example
@@ -16,10 +16,6 @@ NEXT_PUBLIC_SUPABASE_URL=https://your-project.supabase.co
 NEXT_PUBLIC_SUPABASE_ANON_KEY=your-production-anon-key
 SUPABASE_SERVICE_ROLE_KEY=your-production-service-role-key
 
-# AI Keys
-GOOGLE_GENERATIVE_AI_API_KEY=your-production-gemini-api-key
-OPENAI_API_KEY=your-production-openai-api-key
-
 # =============================================================================
 # Google Cloud Configuration
 # =============================================================================
@@ -35,6 +31,11 @@ NEXTAUTH_URL=https://your-domain.vercel.app
 # =============================================================================
 # Optional
 # =============================================================================
+
+# AI / DB integrations used by optional workflows
+# GOOGLE_GENERATIVE_AI_API_KEY=your-production-gemini-api-key
+# OPENAI_API_KEY=your-production-openai-api-key
+# POSTGRES_URL=postgresql://username:password@host:5432/database_name
 
 # CRON job authentication
 CRON_SECRET=your-cron-secret

--- a/frontend/.env.template
+++ b/frontend/.env.template
@@ -4,14 +4,8 @@ GOOGLE_CLOUD_CREDENTIALS=./config/service-account-key.json
 GOOGLE_SPEECH_API_KEY=your-speech-api-key
 GOOGLE_TRANSLATE_API_KEY=your-translate-api-key
 
-# Gemini AI
-GOOGLE_GENERATIVE_AI_API_KEY=your-gemini-api-key
+# Gemini Model Override
 GEMINI_MODEL=gemini-2.5-flash-preview-05-20
-
-# Database
-# Use environment variables for sensitive credentials:
-# POSTGRES_URL=postgresql://${DB_USERNAME}:${DB_PASSWORD}@${DB_HOST}:${DB_PORT}/${DB_NAME}
-POSTGRES_URL=postgresql://username:password@host:5432/database_name
 
 # Google Calendar Integration
 GOOGLE_CALENDAR_ICAL_URL=https://calendar.google.com/calendar/ical/your-calendar-id/public/basic.ics
@@ -24,8 +18,12 @@ NEXT_PUBLIC_SUPABASE_ANON_KEY=your-anon-key
 # Store this securely in your deployment environment
 SUPABASE_SERVICE_ROLE_KEY=your-service-role-key
 
-# OpenAI (for embeddings - 1536 dimensions to match database)
-OPENAI_API_KEY=your-openai-api-key
+# Optional AI / DB integrations
+# GOOGLE_GENERATIVE_AI_API_KEY=your-gemini-api-key
+# Use environment variables for sensitive credentials:
+# POSTGRES_URL=postgresql://${DB_USERNAME}:${DB_PASSWORD}@${DB_HOST}:${DB_PORT}/${DB_NAME}
+# POSTGRES_URL=postgresql://username:password@host:5432/database_name
+# OPENAI_API_KEY=your-openai-api-key
 
 # Next.js
 NEXTAUTH_URL=http://localhost:3000

--- a/frontend/src/lib/env.ts
+++ b/frontend/src/lib/env.ts
@@ -133,6 +133,7 @@ export function validateServerEnv(): EnvValidationResult {
   const recommendedOptional = [
     "SUPABASE_SERVICE_ROLE_KEY",
     "CRON_SECRET",
+    "GOOGLE_GENERATIVE_AI_API_KEY",
   ] as const;
 
   for (const key of recommendedOptional) {

--- a/frontend/src/lib/env.ts
+++ b/frontend/src/lib/env.ts
@@ -34,19 +34,6 @@ const requiredServerEnvSchema = z.object({
     .string()
     .min(1, "GOOGLE_CLOUD_CREDENTIALS path is required"),
 
-  // Gemini AI
-  GOOGLE_GENERATIVE_AI_API_KEY: z
-    .string()
-    .min(1, "GOOGLE_GENERATIVE_AI_API_KEY is required"),
-
-  // OpenAI (embeddings)
-  OPENAI_API_KEY: z.string().min(1, "OPENAI_API_KEY is required for embeddings"),
-
-  // Database
-  POSTGRES_URL: z
-    .string()
-    .min(1, "POSTGRES_URL is required (e.g. postgresql://user:pass@host:5432/db)"),
-
   // Next.js auth
   NEXTAUTH_URL: z.string().url("NEXTAUTH_URL must be a valid URL"),
   NEXTAUTH_SECRET: z.string().min(1, "NEXTAUTH_SECRET is required"),
@@ -63,6 +50,11 @@ const optionalServerEnvSchema = z.object({
   // Gemini model override
   GEMINI_MODEL: z.string().optional(),
   GEMINI_API_KEY: z.string().optional(),
+
+  // AI / DB integrations used by optional workflows
+  GOOGLE_GENERATIVE_AI_API_KEY: z.string().optional(),
+  OPENAI_API_KEY: z.string().optional(),
+  POSTGRES_URL: z.string().optional(),
 
   // Google Cloud services
   GOOGLE_SPEECH_API_KEY: z.string().optional(),


### PR DESCRIPTION
## Summary
- `OPENAI_API_KEY`, `GOOGLE_GENERATIVE_AI_API_KEY`, `POSTGRES_URL` demoted from required to optional in:
  - `env.ts` Zod schema
  - `.env.example`, `.env.production.example`, `.env.template`
- These vars are no longer needed in frontend since core routes proxy to backend

## Related Issues
Ref #224 (Phase 4: env cleanup)

## Test plan
- [x] `pnpm typecheck` passed
- [x] `pnpm lint` passed
- [x] `pnpm build` passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)