### PR TITLE
fix(frontend): handle Web Audio autoplay policy with user interaction gate

### DIFF
--- a/frontend/src/lib/audio/audio-interaction-manager.ts
+++ b/frontend/src/lib/audio/audio-interaction-manager.ts
@@ -4,6 +4,12 @@
  */
 
 import { GlobalAudioManager } from './web-audio-player';
+import {
+  hasAudioUserInteraction,
+  markAudioUserInteraction,
+  registerAudioInteractionCallback,
+  resetAudioUserInteractionGate
+} from './audio-user-interaction-gate';
 
 export interface AudioInteractionEvents {
   onContextInitialized?: () => void;
@@ -30,6 +36,7 @@ export class AudioInteractionManager {
 
   private constructor() {
     this.globalAudioManager = GlobalAudioManager.getInstance();
+    this.hasUserInteracted = hasAudioUserInteraction();
     this.setupInteractionListeners();
   }
 
@@ -44,56 +51,16 @@ export class AudioInteractionManager {
    * Setup interaction event listeners
    */
   private setupInteractionListeners(): void {
-    // List of user interaction events that can unlock audio
-    const interactionEvents = [
-      'touchstart',
-      'touchend',
-      'mousedown',
-      'mouseup',
-      'click',
-      'keydown'
-    ];
-
-    const handleUserInteraction = async (event: Event) => {
-      if (this.hasUserInteracted) return;
-      
-
+    registerAudioInteractionCallback(async () => {
       this.hasUserInteracted = true;
-      
-      // Hide interaction prompt if visible
       this.hideInteractionPrompt();
-      
+
       try {
         await this.initializeAudioContext();
-        
-        // Execute any pending callbacks
-        const callbacks = [...this.pendingInteractionCallbacks];
-        this.pendingInteractionCallbacks = [];
-        callbacks.forEach(callback => {
-          try {
-            callback();
-          } catch (err) {
-            console.error('Error executing pending callback:', err);
-          }
-        });
-        
-        // Remove event listeners after first interaction
-        interactionEvents.forEach(eventType => {
-          document.removeEventListener(eventType, handleUserInteraction, { capture: true });
-        });
       } catch (error) {
         console.error('Failed to initialize audio context on user interaction:', error);
         this.interactionEventListeners.onError?.(error as Error);
       }
-    };
-
-    // Add event listeners with capture phase to catch early
-    interactionEvents.forEach(eventType => {
-      document.addEventListener(eventType, handleUserInteraction, { 
-        capture: true, 
-        passive: true,
-        once: false // Don't use once in case first attempt fails
-      });
     });
   }
 
@@ -139,6 +106,7 @@ export class AudioInteractionManager {
       return this.globalAudioManager.getContext()!;
     }
 
+    this.hasUserInteracted = this.hasUserInteracted || hasAudioUserInteraction();
     if (!this.hasUserInteracted) {
       this.interactionEventListeners.onInteractionRequired?.();
       throw new Error('User interaction required for audio playback');
@@ -232,9 +200,22 @@ export class AudioInteractionManager {
    */
   public async requestUserInteraction(options: UserInteractionPromptOptions = {}): Promise<AudioContext> {
     return new Promise((resolve, reject) => {
+      this.hasUserInteracted = this.hasUserInteracted || hasAudioUserInteraction();
       if (this.isContextInitialized) {
         this.globalAudioManager.ensureResumed().then(() => {
           resolve(this.globalAudioManager.getContext()!);
+        }).catch(reject);
+        return;
+      }
+
+      if (this.hasUserInteracted) {
+        this.initializeAudioContext().then(() => {
+          const context = this.globalAudioManager.getContext();
+          if (context) {
+            resolve(context);
+          } else {
+            reject(new Error('Failed to get AudioContext'));
+          }
         }).catch(reject);
         return;
       }
@@ -261,6 +242,7 @@ export class AudioInteractionManager {
    * Execute callback when audio context is ready
    */
   public executeWhenReady(callback: () => void): void {
+    this.hasUserInteracted = this.hasUserInteracted || hasAudioUserInteraction();
     if (this.isContextInitialized) {
       callback();
     } else {
@@ -282,6 +264,7 @@ export class AudioInteractionManager {
    * Check if user has interacted
    */
   public hasUserInteraction(): boolean {
+    this.hasUserInteracted = this.hasUserInteracted || hasAudioUserInteraction();
     return this.hasUserInteracted;
   }
 
@@ -304,6 +287,7 @@ export class AudioInteractionManager {
    * Force initialize context (use with caution)
    */
   public async forceInitialize(): Promise<AudioContext> {
+    markAudioUserInteraction();
     this.hasUserInteracted = true;
     await this.initializeAudioContext();
     return this.globalAudioManager.getContext()!;
@@ -316,6 +300,7 @@ export class AudioInteractionManager {
     this.hasUserInteracted = false;
     this.isContextInitialized = false;
     this.pendingInteractionCallbacks = [];
+    resetAudioUserInteractionGate();
     this.globalAudioManager.dispose();
   }
 

--- a/frontend/src/lib/audio/audio-interaction-manager.ts
+++ b/frontend/src/lib/audio/audio-interaction-manager.ts
@@ -28,6 +28,7 @@ export class AudioInteractionManager {
   private static instance: AudioInteractionManager;
   private globalAudioManager: GlobalAudioManager;
   private isContextInitialized = false;
+  private initializationPromise: Promise<void> | null = null;
   private pendingInteractionCallbacks: (() => void)[] = [];
   private interactionEventListeners: AudioInteractionEvents = {};
   private hasUserInteracted = false;
@@ -41,10 +42,40 @@ export class AudioInteractionManager {
   }
 
   public static getInstance(): AudioInteractionManager {
+    if (typeof window === 'undefined') {
+      throw new Error('AudioInteractionManager is not available during SSR');
+    }
+
     if (!AudioInteractionManager.instance) {
       AudioInteractionManager.instance = new AudioInteractionManager();
     }
     return AudioInteractionManager.instance;
+  }
+
+  private runCallbackSafely(callback: () => void): void {
+    try {
+      callback();
+    } catch (error) {
+      console.error('Error executing pending audio callback:', error);
+    }
+  }
+
+  private enqueuePendingInteractionCallback(callback: () => void): void {
+    if (this.isContextInitialized) {
+      this.runCallbackSafely(callback);
+      return;
+    }
+
+    this.pendingInteractionCallbacks.push(callback);
+  }
+
+  private flushPendingInteractionCallbacks(): void {
+    const callbacks = [...this.pendingInteractionCallbacks];
+    this.pendingInteractionCallbacks = [];
+
+    callbacks.forEach((callback) => {
+      this.runCallbackSafely(callback);
+    });
   }
 
   /**
@@ -70,31 +101,29 @@ export class AudioInteractionManager {
   private async initializeAudioContext(): Promise<void> {
     if (this.isContextInitialized) {
       await this.globalAudioManager.ensureResumed();
+      this.flushPendingInteractionCallbacks();
       return;
     }
 
-    try {
-      await this.globalAudioManager.initialize();
-      this.isContextInitialized = true;
-      
-      // Execute pending callbacks
-      const callbacks = [...this.pendingInteractionCallbacks];
-      this.pendingInteractionCallbacks = [];
-      
-      callbacks.forEach(callback => {
+    if (!this.initializationPromise) {
+      this.initializationPromise = (async () => {
         try {
-          callback();
-        } catch (error) {
-          console.error('Error executing pending audio callback:', error);
-        }
-      });
+          await this.globalAudioManager.initialize();
+          this.isContextInitialized = true;
+          this.flushPendingInteractionCallbacks();
 
-      this.interactionEventListeners.onContextInitialized?.();
-    } catch (error) {
-      console.error('Failed to initialize AudioContext:', error);
-      this.interactionEventListeners.onError?.(error as Error);
-      throw error;
+          this.interactionEventListeners.onContextInitialized?.();
+        } catch (error) {
+          console.error('Failed to initialize AudioContext:', error);
+          this.interactionEventListeners.onError?.(error as Error);
+          throw error;
+        } finally {
+          this.initializationPromise = null;
+        }
+      })();
     }
+
+    await this.initializationPromise;
   }
 
   /**
@@ -224,7 +253,7 @@ export class AudioInteractionManager {
       this.showInteractionPrompt(options);
 
       // Add to pending callbacks
-      this.pendingInteractionCallbacks.push(() => {
+      this.enqueuePendingInteractionCallback(() => {
         const context = this.globalAudioManager.getContext();
         if (context) {
           resolve(context);
@@ -244,13 +273,21 @@ export class AudioInteractionManager {
   public executeWhenReady(callback: () => void): void {
     this.hasUserInteracted = this.hasUserInteracted || hasAudioUserInteraction();
     if (this.isContextInitialized) {
-      callback();
-    } else {
-      this.pendingInteractionCallbacks.push(callback);
-      if (!this.hasUserInteracted) {
-        this.interactionEventListeners.onInteractionRequired?.();
-      }
+      this.runCallbackSafely(callback);
+      return;
     }
+
+    this.enqueuePendingInteractionCallback(callback);
+
+    if (this.hasUserInteracted) {
+      this.initializeAudioContext().catch((error) => {
+        console.error('Failed to initialize AudioContext for pending callback:', error);
+        this.interactionEventListeners.onError?.(error as Error);
+      });
+      return;
+    }
+
+    this.interactionEventListeners.onInteractionRequired?.();
   }
 
   /**
@@ -299,6 +336,7 @@ export class AudioInteractionManager {
   public reset(): void {
     this.hasUserInteracted = false;
     this.isContextInitialized = false;
+    this.initializationPromise = null;
     this.pendingInteractionCallbacks = [];
     resetAudioUserInteractionGate();
     this.globalAudioManager.dispose();
@@ -309,6 +347,7 @@ export class AudioInteractionManager {
    */
   public dispose(): void {
     this.globalAudioManager.dispose();
+    this.initializationPromise = null;
     this.pendingInteractionCallbacks = [];
     this.interactionEventListeners = {};
   }

--- a/frontend/src/lib/audio/audio-user-interaction-gate.ts
+++ b/frontend/src/lib/audio/audio-user-interaction-gate.ts
@@ -1,6 +1,6 @@
 type UserInteractionCallback = () => void | Promise<void>;
 
-const INTERACTION_EVENTS: Array<'click' | 'touchstart'> = ['click', 'touchstart'];
+const INTERACTION_EVENTS: Array<'click' | 'touchstart' | 'keydown'> = ['click', 'touchstart', 'keydown'];
 
 let hasUserInteracted = false;
 let listenersRegistered = false;

--- a/frontend/src/lib/audio/audio-user-interaction-gate.ts
+++ b/frontend/src/lib/audio/audio-user-interaction-gate.ts
@@ -1,0 +1,118 @@
+type UserInteractionCallback = () => void | Promise<void>;
+
+const INTERACTION_EVENTS: Array<'click' | 'touchstart'> = ['click', 'touchstart'];
+
+let hasUserInteracted = false;
+let listenersRegistered = false;
+const pendingCallbacks = new Set<UserInteractionCallback>();
+let pendingInteractionPromise: Promise<void> | null = null;
+let resolvePendingInteraction: (() => void) | null = null;
+
+const isBrowser = (): boolean => typeof window !== 'undefined' && typeof document !== 'undefined';
+
+const clearPendingInteraction = (): void => {
+  resolvePendingInteraction?.();
+  pendingInteractionPromise = null;
+  resolvePendingInteraction = null;
+};
+
+const removeInteractionListeners = (): void => {
+  if (!listenersRegistered || !isBrowser()) {
+    return;
+  }
+
+  INTERACTION_EVENTS.forEach((eventType) => {
+    document.removeEventListener(eventType, handleFirstUserInteraction, true);
+  });
+  listenersRegistered = false;
+};
+
+const flushPendingCallbacks = (): void => {
+  const callbacks = Array.from(pendingCallbacks);
+  pendingCallbacks.clear();
+
+  callbacks.forEach((callback) => {
+    Promise.resolve(callback()).catch((error) => {
+      console.error('[AudioInteractionGate] Failed to handle first user interaction:', error);
+    });
+  });
+};
+
+const unlockAudioInteraction = (): void => {
+  if (hasUserInteracted) {
+    return;
+  }
+
+  hasUserInteracted = true;
+  removeInteractionListeners();
+  clearPendingInteraction();
+  flushPendingCallbacks();
+};
+
+function handleFirstUserInteraction(): void {
+  unlockAudioInteraction();
+}
+
+const ensureInteractionListenersRegistered = (): void => {
+  if (hasUserInteracted || listenersRegistered || !isBrowser()) {
+    return;
+  }
+
+  INTERACTION_EVENTS.forEach((eventType) => {
+    document.addEventListener(eventType, handleFirstUserInteraction, {
+      capture: true,
+      passive: true
+    });
+  });
+  listenersRegistered = true;
+};
+
+export const registerAudioInteractionCallback = (callback: UserInteractionCallback): void => {
+  if (hasUserInteracted) {
+    Promise.resolve(callback()).catch((error) => {
+      console.error('[AudioInteractionGate] Failed to run audio interaction callback:', error);
+    });
+    return;
+  }
+
+  pendingCallbacks.add(callback);
+  ensureInteractionListenersRegistered();
+};
+
+export const waitForAudioUserInteraction = (): Promise<void> => {
+  if (hasUserInteracted) {
+    return Promise.resolve();
+  }
+
+  ensureInteractionListenersRegistered();
+
+  if (!pendingInteractionPromise) {
+    pendingInteractionPromise = new Promise<void>((resolve) => {
+      resolvePendingInteraction = resolve;
+    });
+  }
+
+  return pendingInteractionPromise;
+};
+
+export const markAudioUserInteraction = (): void => {
+  unlockAudioInteraction();
+};
+
+export const hasAudioUserInteraction = (): boolean => hasUserInteracted;
+
+export const registerAudioContextResumeOnInteraction = (audioContext: AudioContext): void => {
+  registerAudioInteractionCallback(async () => {
+    if (audioContext.state === 'suspended') {
+      await audioContext.resume();
+    }
+  });
+};
+
+export const resetAudioUserInteractionGate = (): void => {
+  removeInteractionListeners();
+  pendingCallbacks.clear();
+  pendingInteractionPromise = null;
+  resolvePendingInteraction = null;
+  hasUserInteracted = false;
+};

--- a/frontend/src/lib/audio/web-audio-player.ts
+++ b/frontend/src/lib/audio/web-audio-player.ts
@@ -13,6 +13,11 @@ import {
   type AudioInfo,
   type AudioPlaybackState
 } from './audio-interfaces';
+import {
+  hasAudioUserInteraction,
+  registerAudioContextResumeOnInteraction,
+  waitForAudioUserInteraction
+} from './audio-user-interaction-gate';
 
 export class WebAudioPlayer {
   private audioContext: AudioContext | null = null;
@@ -34,9 +39,7 @@ export class WebAudioPlayer {
    */
   public async initializeContext(): Promise<void> {
     if (this.audioContext) {
-      if (this.audioContext.state === 'suspended') {
-        await this.audioContext.resume();
-      }
+      await this.resumeContextIfNeeded();
       return;
     }
 
@@ -44,10 +47,8 @@ export class WebAudioPlayer {
       // Use webkitAudioContext for Safari compatibility
       const AudioContextClass = window.AudioContext || (window as any).webkitAudioContext;
       this.audioContext = new AudioContextClass();
-
-      if (this.audioContext.state === 'suspended') {
-        await this.audioContext.resume();
-      }
+      registerAudioContextResumeOnInteraction(this.audioContext);
+      await this.resumeContextIfNeeded();
 
       // Create gain node for volume control
       this.gainNode = this.audioContext.createGain();
@@ -198,6 +199,8 @@ export class WebAudioPlayer {
     }
 
     try {
+      await this.resumeContextIfNeeded();
+
       // Stop current playback if any
       this.stop();
 
@@ -361,6 +364,20 @@ export class WebAudioPlayer {
   public getAudioContextState(): AudioContextState | null {
     return this.audioContext?.state || null;
   }
+
+  private async resumeContextIfNeeded(): Promise<void> {
+    if (!this.audioContext || this.audioContext.state !== 'suspended') {
+      return;
+    }
+
+    if (!hasAudioUserInteraction()) {
+      await waitForAudioUserInteraction();
+    }
+
+    if (this.audioContext.state === 'suspended') {
+      await this.audioContext.resume();
+    }
+  }
 }
 
 /**
@@ -382,19 +399,15 @@ export class GlobalAudioManager {
 
   public async initialize(): Promise<AudioContext> {
     if (this.audioContext && this.audioContext.state !== 'closed') {
-      if (this.audioContext.state === 'suspended') {
-        await this.audioContext.resume();
-      }
+      await this.ensureResumed();
       return this.audioContext;
     }
 
     try {
       const AudioContextClass = window.AudioContext || (window as any).webkitAudioContext;
       this.audioContext = new AudioContextClass();
-
-      if (this.audioContext.state === 'suspended') {
-        await this.audioContext.resume();
-      }
+      registerAudioContextResumeOnInteraction(this.audioContext);
+      await this.ensureResumed();
 
       this.isInitialized = true;
       return this.audioContext;
@@ -409,7 +422,15 @@ export class GlobalAudioManager {
   }
 
   public async ensureResumed(): Promise<void> {
-    if (this.audioContext && this.audioContext.state === 'suspended') {
+    if (!this.audioContext || this.audioContext.state !== 'suspended') {
+      return;
+    }
+
+    if (!hasAudioUserInteraction()) {
+      await waitForAudioUserInteraction();
+    }
+
+    if (this.audioContext.state === 'suspended') {
       await this.audioContext.resume();
     }
   }


### PR DESCRIPTION
## Summary
- Created `audio-user-interaction-gate.ts` — registers click/touchstart listener once to resume AudioContext
- Updated `AudioInteractionManager` and `WebAudioPlayer` to use the gate
- AudioContext.resume() called on first user interaction, preventing autoplay policy errors

## Related Issues
Closes #218

## Test plan
- [x] `pnpm typecheck` passed
- [x] `pnpm lint` passed
- [x] `pnpm build` passed
- [ ] Manual: verify no "User interaction required" console error after clicking mic button

🤖 Generated with [Claude Code](https://claude.com/claude-code)