### PR TITLE
fix(frontend): proxy STT vocabulary through authenticated admin route

### DIFF
--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -33,6 +33,8 @@ NEXTAUTH_SECRET=your-secret-key
 # ---------------------------------------------------------------------------
 BACKEND_API_URL=http://localhost:8000
 BACKEND_API_KEY=your-backend-api-key
+# NEXT_PUBLIC_BACKEND_API_URL is deprecated for STT admin vocabulary requests.
+# Frontend admin STT traffic now routes through /api/admin/stt and should not expose backend URLs to the browser.
 
 # ---------------------------------------------------------------------------
 # [RECOMMENDED] Supabase Admin Access

--- a/frontend/src/app/api/admin/stt/route.ts
+++ b/frontend/src/app/api/admin/stt/route.ts
@@ -2,36 +2,56 @@ import { NextRequest, NextResponse } from 'next/server';
 
 import { backendFetch } from '@/lib/api/backend-proxy';
 
+const ID_PATTERN = /^[a-zA-Z0-9_-]+$/;
+
 function jsonResponse(data: unknown, status: number) {
   return NextResponse.json(data ?? null, { status });
 }
+
+function validateId(id: string | null): NextResponse | null {
+  if (!id) {
+    return NextResponse.json({ error: 'Missing id parameter' }, { status: 400 });
+  }
+  if (!ID_PATTERN.test(id)) {
+    return NextResponse.json({ error: 'Invalid id format' }, { status: 400 });
+  }
+  return null;
+}
+
+const ALLOWED_PARAMS = new Set(['category', 'search', 'page', 'limit', 'language', 'offset']);
 
 export async function GET(request: NextRequest) {
   try {
     const { searchParams } = new URL(request.url);
     const id = searchParams.get('id');
-    const params: Record<string, string> = {};
 
+    if (id) {
+      const error = validateId(id);
+      if (error) return error;
+
+      const response = await backendFetch(`/api/stt/vocabulary/${id}`, {
+        method: 'GET',
+      });
+      return jsonResponse(response.data, response.status);
+    }
+
+    const params: Record<string, string> = {};
     for (const [key, value] of searchParams.entries()) {
-      if (key !== 'id') {
+      if (ALLOWED_PARAMS.has(key)) {
         params[key] = value;
       }
     }
 
-    const response = await backendFetch(
-      id ? `/api/stt/vocabulary/${id}` : '/api/stt/vocabulary',
-      {
-        method: 'GET',
-        params: Object.keys(params).length > 0 ? params : undefined,
-      }
-    );
+    const response = await backendFetch('/api/stt/vocabulary', {
+      method: 'GET',
+      params: Object.keys(params).length > 0 ? params : undefined,
+    });
 
     return jsonResponse(response.data, response.status);
-  } catch (error) {
-    console.error('STT vocabulary GET proxy error:', error);
+  } catch {
     return NextResponse.json(
       { error: 'Failed to proxy STT vocabulary request' },
-      { status: 500 }
+      { status: 500 },
     );
   }
 }
@@ -45,11 +65,10 @@ export async function POST(request: NextRequest) {
     });
 
     return jsonResponse(response.data, response.status);
-  } catch (error) {
-    console.error('STT vocabulary POST proxy error:', error);
+  } catch {
     return NextResponse.json(
       { error: 'Failed to proxy STT vocabulary request' },
-      { status: 500 }
+      { status: 500 },
     );
   }
 }
@@ -58,10 +77,8 @@ export async function PUT(request: NextRequest) {
   try {
     const { searchParams } = new URL(request.url);
     const id = searchParams.get('id');
-
-    if (!id) {
-      return NextResponse.json({ error: 'Missing id parameter' }, { status: 400 });
-    }
+    const error = validateId(id);
+    if (error) return error;
 
     const body = await request.json();
     const response = await backendFetch(`/api/stt/vocabulary/${id}`, {
@@ -70,11 +87,10 @@ export async function PUT(request: NextRequest) {
     });
 
     return jsonResponse(response.data, response.status);
-  } catch (error) {
-    console.error('STT vocabulary PUT proxy error:', error);
+  } catch {
     return NextResponse.json(
       { error: 'Failed to proxy STT vocabulary request' },
-      { status: 500 }
+      { status: 500 },
     );
   }
 }
@@ -83,21 +99,18 @@ export async function DELETE(request: NextRequest) {
   try {
     const { searchParams } = new URL(request.url);
     const id = searchParams.get('id');
-
-    if (!id) {
-      return NextResponse.json({ error: 'Missing id parameter' }, { status: 400 });
-    }
+    const error = validateId(id);
+    if (error) return error;
 
     const response = await backendFetch(`/api/stt/vocabulary/${id}`, {
       method: 'DELETE',
     });
 
     return jsonResponse(response.data, response.status);
-  } catch (error) {
-    console.error('STT vocabulary DELETE proxy error:', error);
+  } catch {
     return NextResponse.json(
       { error: 'Failed to proxy STT vocabulary request' },
-      { status: 500 }
+      { status: 500 },
     );
   }
 }

--- a/frontend/src/app/api/admin/stt/route.ts
+++ b/frontend/src/app/api/admin/stt/route.ts
@@ -1,0 +1,103 @@
+import { NextRequest, NextResponse } from 'next/server';
+
+import { backendFetch } from '@/lib/api/backend-proxy';
+
+function jsonResponse(data: unknown, status: number) {
+  return NextResponse.json(data ?? null, { status });
+}
+
+export async function GET(request: NextRequest) {
+  try {
+    const { searchParams } = new URL(request.url);
+    const id = searchParams.get('id');
+    const params: Record<string, string> = {};
+
+    for (const [key, value] of searchParams.entries()) {
+      if (key !== 'id') {
+        params[key] = value;
+      }
+    }
+
+    const response = await backendFetch(
+      id ? `/api/stt/vocabulary/${id}` : '/api/stt/vocabulary',
+      {
+        method: 'GET',
+        params: Object.keys(params).length > 0 ? params : undefined,
+      }
+    );
+
+    return jsonResponse(response.data, response.status);
+  } catch (error) {
+    console.error('STT vocabulary GET proxy error:', error);
+    return NextResponse.json(
+      { error: 'Failed to proxy STT vocabulary request' },
+      { status: 500 }
+    );
+  }
+}
+
+export async function POST(request: NextRequest) {
+  try {
+    const body = await request.json();
+    const response = await backendFetch('/api/stt/vocabulary', {
+      method: 'POST',
+      body,
+    });
+
+    return jsonResponse(response.data, response.status);
+  } catch (error) {
+    console.error('STT vocabulary POST proxy error:', error);
+    return NextResponse.json(
+      { error: 'Failed to proxy STT vocabulary request' },
+      { status: 500 }
+    );
+  }
+}
+
+export async function PUT(request: NextRequest) {
+  try {
+    const { searchParams } = new URL(request.url);
+    const id = searchParams.get('id');
+
+    if (!id) {
+      return NextResponse.json({ error: 'Missing id parameter' }, { status: 400 });
+    }
+
+    const body = await request.json();
+    const response = await backendFetch(`/api/stt/vocabulary/${id}`, {
+      method: 'PUT',
+      body,
+    });
+
+    return jsonResponse(response.data, response.status);
+  } catch (error) {
+    console.error('STT vocabulary PUT proxy error:', error);
+    return NextResponse.json(
+      { error: 'Failed to proxy STT vocabulary request' },
+      { status: 500 }
+    );
+  }
+}
+
+export async function DELETE(request: NextRequest) {
+  try {
+    const { searchParams } = new URL(request.url);
+    const id = searchParams.get('id');
+
+    if (!id) {
+      return NextResponse.json({ error: 'Missing id parameter' }, { status: 400 });
+    }
+
+    const response = await backendFetch(`/api/stt/vocabulary/${id}`, {
+      method: 'DELETE',
+    });
+
+    return jsonResponse(response.data, response.status);
+  } catch (error) {
+    console.error('STT vocabulary DELETE proxy error:', error);
+    return NextResponse.json(
+      { error: 'Failed to proxy STT vocabulary request' },
+      { status: 500 }
+    );
+  }
+}

--- a/frontend/src/app/api/admin/stt/route.ts
+++ b/frontend/src/app/api/admin/stt/route.ts
@@ -36,11 +36,11 @@ export async function GET(request: NextRequest) {
     }
 
     const params: Record<string, string> = {};
-    for (const [key, value] of searchParams.entries()) {
+    searchParams.forEach((value, key) => {
       if (ALLOWED_PARAMS.has(key)) {
         params[key] = value;
       }
-    }
+    });
 
     const response = await backendFetch('/api/stt/vocabulary', {
       method: 'GET',

--- a/frontend/src/lib/api/stt-vocabulary.ts
+++ b/frontend/src/lib/api/stt-vocabulary.ts
@@ -1,6 +1,6 @@
 /**
  * STT Vocabulary API Client
- * FastAPI に直接アクセスする API クライアント関数
+ * Admin proxy 経由で STT vocabulary API にアクセスするクライアント関数
  */
 
 import { VocabularyItem, VocabularyListResponse } from "@/types/vosk";
@@ -8,17 +8,6 @@ import { VocabularyItem, VocabularyListResponse } from "@/types/vosk";
 // ============================================================================
 // API クライアント
 // ============================================================================
-
-function getSttBackendUrl(): string {
-  const url = process.env.NEXT_PUBLIC_BACKEND_API_URL;
-  if (url) return url;
-  if (process.env.NODE_ENV === "development") return "http://localhost:8000/api";
-  throw new Error("NEXT_PUBLIC_BACKEND_API_URL environment variable is required");
-}
-
-function getBackendUrl(): string {
-  return getSttBackendUrl();
-}
 
 /**
  * 語彙一覧取得（URL生成とfetchを統合）
@@ -38,7 +27,7 @@ export async function getVocabularyList(params: {
   if (params.search) query.set("search", params.search);
   query.set("page", String(params.page ?? 1));
   query.set("limit", String(params.limit ?? 20));
-  const url = `${getBackendUrl()}/stt/vocabulary?${query.toString()}`;
+  const url = `/api/admin/stt?${query.toString()}`;
 
   const res = await fetch(url);
   if (!res.ok) throw new Error(`Failed to fetch vocabulary: ${res.status}`);
@@ -49,7 +38,7 @@ export async function getVocabularyList(params: {
  * 語彙削除
  */
 export async function deleteVocabulary(id: string): Promise<void> {
-  const res = await fetch(`${getBackendUrl()}/stt/vocabulary/${id}`, {
+  const res = await fetch(`/api/admin/stt?id=${encodeURIComponent(id)}`, {
     method: "DELETE",
   });
   if (!res.ok) throw new Error(`Failed to delete vocabulary: ${res.status}`);
@@ -59,7 +48,7 @@ export async function deleteVocabulary(id: string): Promise<void> {
  * 語彙詳細取得（編集時に既存データを取得）
  */
 export async function getVocabularyDetail(id: string): Promise<VocabularyItem> {
-  const res = await fetch(`${getBackendUrl()}/stt/vocabulary/${id}`);
+  const res = await fetch(`/api/admin/stt?id=${encodeURIComponent(id)}`);
   if (!res.ok) throw new Error(`Failed to fetch vocabulary detail: ${res.status}`);
   const json = await res.json();
   return json.data;
@@ -74,7 +63,7 @@ export async function createVocabulary(data: {
   category: string;
   priority: number;
 }): Promise<VocabularyItem> {
-  const res = await fetch(`${getBackendUrl()}/stt/vocabulary`, {
+  const res = await fetch("/api/admin/stt", {
     method: "POST",
     headers: {
       "Content-Type": "application/json",
@@ -101,7 +90,7 @@ export async function updateVocabulary(
     priority: number;
   }
 ): Promise<VocabularyItem> {
-  const res = await fetch(`${getBackendUrl()}/stt/vocabulary/${id}`, {
+  const res = await fetch(`/api/admin/stt?id=${encodeURIComponent(id)}`, {
     method: "PUT",
     headers: {
       "Content-Type": "application/json",


### PR DESCRIPTION
## Summary
- Route all STT vocabulary API calls through `/api/admin/stt` instead of direct browser-to-backend calls
- Removes `NEXT_PUBLIC_BACKEND_API_URL` exposure from client-side code
- STT admin routes automatically protected by P0 middleware (`/api/admin/:path*` matcher)

Part of #232

## Changes
- `frontend/src/app/api/admin/stt/route.ts` — **new**: proxy GET/POST/PUT/DELETE to backend via backendFetch
- `frontend/src/lib/api/stt-vocabulary.ts` — changed all 5 functions to use `/api/admin/stt` relative URLs
- `frontend/.env.example` — deprecation note for `NEXT_PUBLIC_BACKEND_API_URL` STT usage

## Test plan
- [x] Backend STT routes already protected by `verify_api_key` (no backend changes needed)
- [x] New proxy route forwards all HTTP methods correctly
- [ ] CI: pnpm lint + typecheck + build
- [ ] Manual: verify STT vocabulary CRUD works via admin UI

🤖 Generated with [Claude Code](https://claude.com/claude-code)