### PR TITLE
feat(rag): unify ingestion through backend proxy and add document chunking

### DIFF
--- a/backend/api/knowledge.py
+++ b/backend/api/knowledge.py
@@ -9,6 +9,7 @@ NOTE: 認証は別Issueで対応予定。現時点ではCORS制限のみ。
 """
 
 import asyncio
+import json
 import logging
 import os
 import re
@@ -22,7 +23,7 @@ from pydantic import BaseModel, Field
 from supabase import create_client
 
 from backend.utils.embedding_service import generate_embedding
-from backend.utils.file_parser import detect_file_type, parse_markdown, parse_pdf
+from backend.utils.file_parser import chunk_text, detect_file_type, parse_markdown, parse_pdf
 from backend.utils.rate_limit import rate_limit
 
 logger = logging.getLogger(__name__)
@@ -132,6 +133,13 @@ def _is_unique_violation(error: Exception) -> bool:
     """Supabaseエラーがユニーク制約違反かを判定"""
     error_str = str(error).lower()
     return "unique" in error_str or "duplicate" in error_str or "23505" in error_str
+
+
+def _chunk_title(base_title: str, index: int, total_chunks: int) -> str:
+    """チャンク数に応じた保存タイトルを返す"""
+    if total_chunks <= 1:
+        return base_title
+    return f"{base_title} (part {index + 1})"
 
 
 # =============================================================================
@@ -270,6 +278,8 @@ async def upload_knowledge(
     category: str = Form(...),
     language: str = Form(default="ja"),
     title: Optional[str] = Form(default=None),
+    subcategory: Optional[str] = Form(default=None),
+    metadata: Optional[str] = Form(default=None),
 ):
     """ファイルアップロードでナレッジ登録（.md/.pdf → パース → embedding生成）"""
     effective_title = title or (file.filename.rsplit(".", 1)[0] if file.filename else "unknown")
@@ -292,6 +302,18 @@ async def upload_knowledge(
         # title長さバリデーション
         if title and len(title) > 200:
             raise HTTPException(status_code=400, detail="title must be 200 characters or less")
+
+        metadata_payload: Dict[str, Any] = {}
+        if metadata:
+            try:
+                parsed_metadata = json.loads(metadata)
+            except json.JSONDecodeError as exc:
+                raise HTTPException(status_code=400, detail="metadata must be valid JSON") from exc
+
+            if not isinstance(parsed_metadata, dict):
+                raise HTTPException(status_code=400, detail="metadata must be a JSON object")
+
+            metadata_payload = parsed_metadata
 
         file_type = detect_file_type(file.filename)
         if file_type not in ("markdown", "pdf"):
@@ -323,82 +345,118 @@ async def upload_knowledge(
         if not parsed_content.strip():
             raise HTTPException(status_code=400, detail="No text content extracted from file")
 
-        # 50000文字制限（PDF数十ページ分に対応）
-        if len(parsed_content) > 50000:
-            parsed_content = parsed_content[:50000]
-
         # titleが未指定の場合はファイル名から生成
         effective_title = title or file.filename.rsplit(".", 1)[0]
 
         supabase = _get_supabase()
+        chunks = chunk_text(parsed_content)
+        if not chunks:
+            raise HTTPException(status_code=400, detail="No text content extracted from file")
 
-        # 重複titleチェック
-        existing = (
-            supabase.table("knowledge_base").select("id").eq("title", effective_title).execute()
-        )
-        if existing.data:
+        chunk_titles = [
+            _chunk_title(effective_title, index, len(chunks)) for index in range(len(chunks))
+        ]
+        if any(len(chunk_title) > 200 for chunk_title in chunk_titles):
             raise HTTPException(
-                status_code=409,
-                detail=f"Knowledge with title '{effective_title}' already exists",
+                status_code=400,
+                detail="title must be 200 characters or less after chunk suffixes are applied",
             )
 
-        # Embedding生成
-        embedding_text = f"{effective_title}\n{parsed_content}"
-        embedding: List[float] = []
         try:
-            embedding = await generate_embedding(embedding_text)
-            if not embedding:
-                logger.warning(
-                    "Embedding unavailable for upload: filename=%s title=%s file_type=%s "
-                    "content_size=%s",
-                    file.filename,
-                    effective_title,
-                    file_type,
-                    content_size,
+            for chunk_title in chunk_titles:
+                existing = (
+                    supabase.table("knowledge_base").select("id").eq("title", chunk_title).execute()
                 )
-        except httpx.TimeoutException as exc:
-            logger.warning(
-                "Embedding generation timed out for upload: filename=%s title=%s file_type=%s "
-                "content_size=%s error=%s",
-                file.filename,
-                effective_title,
-                file_type,
-                content_size,
-                exc,
-            )
-            embedding = []
-        except Exception as exc:
-            logger.warning(
-                "Embedding generation failed for upload (%s): filename=%s title=%s "
-                "file_type=%s content_size=%s error=%s",
-                type(exc).__name__,
-                file.filename,
-                effective_title,
-                file_type,
-                content_size,
-                exc,
-            )
-            embedding = []
+                if existing.data:
+                    raise HTTPException(
+                        status_code=409,
+                        detail=f"Knowledge with title '{chunk_title}' already exists",
+                    )
 
-        # DB挿入
-        insert_data: Dict[str, Any] = {
-            "title": effective_title,
-            "content": parsed_content,
-            "category": category,
-            "language": language,
-            "source": f"file:{file.filename}",
-            "metadata": {"original_filename": file.filename, "file_type": file_type},
-        }
-        if embedding:
-            insert_data["content_embedding"] = embedding
+            inserted_rows: List[Dict[str, Any]] = []
+            total_chunks = len(chunks)
 
-        try:
-            result = supabase.table("knowledge_base").insert(insert_data).execute()
+            for index, chunk_content in enumerate(chunks):
+                chunk_title = chunk_titles[index]
+                embedding: List[float] = []
+                embedding_input = (
+                    f"{chunk_title}\n{chunk_content}" if total_chunks == 1 else chunk_content
+                )
+                try:
+                    embedding = await generate_embedding(embedding_input)
+                    if not embedding:
+                        logger.warning(
+                            "Embedding unavailable for upload: filename=%s title=%s "
+                            "file_type=%s content_size=%s chunk=%s/%s",
+                            file.filename,
+                            chunk_title,
+                            file_type,
+                            content_size,
+                            index + 1,
+                            total_chunks,
+                        )
+                except httpx.TimeoutException as exc:
+                    logger.warning(
+                        "Embedding generation timed out for upload: filename=%s title=%s "
+                        "file_type=%s content_size=%s chunk=%s/%s error=%s",
+                        file.filename,
+                        chunk_title,
+                        file_type,
+                        content_size,
+                        index + 1,
+                        total_chunks,
+                        exc,
+                    )
+                    embedding = []
+                except Exception as exc:
+                    logger.warning(
+                        "Embedding generation failed for upload (%s): filename=%s title=%s "
+                        "file_type=%s content_size=%s chunk=%s/%s error=%s",
+                        type(exc).__name__,
+                        file.filename,
+                        chunk_title,
+                        file_type,
+                        content_size,
+                        index + 1,
+                        total_chunks,
+                        exc,
+                    )
+                    embedding = []
+
+                insert_data: Dict[str, Any] = {
+                    "title": chunk_title,
+                    "content": chunk_content,
+                    "category": category,
+                    "subcategory": subcategory,
+                    "language": language,
+                    "source": f"file:{file.filename}",
+                    "metadata": {
+                        "original_filename": file.filename,
+                        "file_type": file_type,
+                        "chunk_index": index,
+                        "total_chunks": total_chunks,
+                        **metadata_payload,
+                    },
+                }
+                if embedding:
+                    insert_data["content_embedding"] = embedding
+
+                result = supabase.table("knowledge_base").insert(insert_data).execute()
+                if not result.data:
+                    raise HTTPException(status_code=500, detail="Failed to insert knowledge entry")
+
+                inserted_rows.append(result.data[0])
         except APIError as exc:
             if _is_unique_violation(exc):
+                conflict_title = effective_title
+                if exc.args:
+                    conflict_title = next(
+                        (chunk_title for chunk_title in chunk_titles if chunk_title in str(exc)),
+                        effective_title,
+                    )
                 raise HTTPException(
                     status_code=409,
-                    detail=f"Knowledge with title '{effective_title}' already exists",
+                    detail=f"Knowledge with title '{conflict_title}' already exists",
                 )
             logger.error(
                 "Supabase insert failed: table=knowledge_base title=%s filename=%s error=%s",
@@ -416,12 +474,9 @@ async def upload_knowledge(
             )
             raise HTTPException(status_code=503, detail="Knowledge storage unavailable")
 
-        if not result.data:
-            raise HTTPException(status_code=500, detail="Failed to insert knowledge entry")
-
         return KnowledgeResponse(
             success=True,
-            data=_row_to_item(result.data[0]),
+            data=_row_to_item(inserted_rows[0]),
         )
 
     try:

--- a/backend/api/knowledge.py
+++ b/backend/api/knowledge.py
@@ -32,6 +32,7 @@ router = APIRouter(tags=["knowledge"])
 
 # 10MB upload size limit
 MAX_UPLOAD_SIZE = 10 * 1024 * 1024
+MAX_CHUNKS = 50
 
 
 # =============================================================================
@@ -140,6 +141,15 @@ def _chunk_title(base_title: str, index: int, total_chunks: int) -> str:
     if total_chunks <= 1:
         return base_title
     return f"{base_title} (part {index + 1})"
+
+
+def _rollback_uploaded_chunks(supabase: Any, inserted_ids: List[str]) -> None:
+    """アップロード途中で失敗したチャンクを削除する"""
+    for row_id in inserted_ids:
+        try:
+            supabase.table("knowledge_base").delete().eq("id", row_id).execute()
+        except Exception:
+            logger.error("Failed to rollback chunk %s", row_id)
 
 
 # =============================================================================
@@ -352,6 +362,11 @@ async def upload_knowledge(
         chunks = chunk_text(parsed_content)
         if not chunks:
             raise HTTPException(status_code=400, detail="No text content extracted from file")
+        if len(chunks) > MAX_CHUNKS:
+            raise HTTPException(
+                status_code=400,
+                detail=f"Document too large: {len(chunks)} chunks exceeds limit of {MAX_CHUNKS}",
+            )
 
         chunk_titles = [
             _chunk_title(effective_title, index, len(chunks)) for index in range(len(chunks))
@@ -362,20 +377,21 @@ async def upload_knowledge(
                 detail="title must be 200 characters or less after chunk suffixes are applied",
             )
 
+        existing = (
+            supabase.table("knowledge_base").select("title").in_("title", chunk_titles).execute()
+        )
+        if existing.data:
+            conflicting_title = existing.data[0]["title"]
+            raise HTTPException(
+                status_code=409,
+                detail=f"Knowledge with title '{conflicting_title}' already exists",
+            )
+
+        inserted_rows: List[Dict[str, Any]] = []
+        inserted_ids: List[str] = []
+        total_chunks = len(chunks)
+
         try:
-            for chunk_title in chunk_titles:
-                existing = (
-                    supabase.table("knowledge_base").select("id").eq("title", chunk_title).execute()
-                )
-                if existing.data:
-                    raise HTTPException(
-                        status_code=409,
-                        detail=f"Knowledge with title '{chunk_title}' already exists",
-                    )
-
-            inserted_rows: List[Dict[str, Any]] = []
-            total_chunks = len(chunks)
-
             for index, chunk_content in enumerate(chunks):
                 chunk_title = chunk_titles[index]
                 embedding: List[float] = []
@@ -446,7 +462,9 @@ async def upload_knowledge(
                     raise HTTPException(status_code=500, detail="Failed to insert knowledge entry")
 
                 inserted_rows.append(result.data[0])
+                inserted_ids.append(str(result.data[0]["id"]))
         except APIError as exc:
+            _rollback_uploaded_chunks(supabase, inserted_ids)
             if _is_unique_violation(exc):
                 conflict_title = effective_title
                 if exc.args:
@@ -466,6 +484,7 @@ async def upload_knowledge(
             )
             raise HTTPException(status_code=503, detail="Knowledge storage unavailable")
         except httpx.HTTPError as exc:
+            _rollback_uploaded_chunks(supabase, inserted_ids)
             logger.error(
                 "Supabase insert failed: table=knowledge_base title=%s filename=%s error=%s",
                 effective_title,
@@ -473,10 +492,18 @@ async def upload_knowledge(
                 exc,
             )
             raise HTTPException(status_code=503, detail="Knowledge storage unavailable")
+        except Exception:
+            _rollback_uploaded_chunks(supabase, inserted_ids)
+            raise
+
+        response_row = dict(inserted_rows[0])
+        response_metadata = dict(response_row.get("metadata") or {})
+        response_metadata["chunks_created"] = total_chunks
+        response_row["metadata"] = response_metadata
 
         return KnowledgeResponse(
             success=True,
-            data=_row_to_item(inserted_rows[0]),
+            data=_row_to_item(response_row),
         )
 
     try:

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -17,6 +17,7 @@ dependencies = [
     "langgraph>=0.2.0",
     "langchain>=0.3.0",
     "langchain-openai>=0.2.0",
+    "langchain-text-splitters>=0.3.0",
     "langsmith>=0.3.12",
     "pydantic>=2.0.0",
     "pydantic-settings>=2.0.0",

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -1,6 +1,7 @@
 langgraph>=0.2.0
 langchain>=0.3.0
 langchain-openai>=0.2.0
+langchain-text-splitters>=0.3.0
 langsmith>=0.3.12
 pydantic>=2.0.0
 pydantic-settings>=2.0.0

--- a/backend/tests/api/test_knowledge_api.py
+++ b/backend/tests/api/test_knowledge_api.py
@@ -2,7 +2,7 @@
 
 import asyncio
 import io
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock, call, patch
 
 import httpx
 import pytest
@@ -315,8 +315,7 @@ def test_upload_markdown(mock_get_sb, mock_embed, mock_parse_md):
     mock_sb = _mock_supabase()
     mock_get_sb.return_value = mock_sb
 
-    # 重複チェック → 空
-    mock_sb.table.return_value.select.return_value.eq.return_value.execute.return_value = (
+    mock_sb.table.return_value.select.return_value.in_.return_value.execute.return_value = (
         _mock_table_result([])
     )
     # insert結果
@@ -348,6 +347,7 @@ def test_upload_markdown(mock_get_sb, mock_embed, mock_parse_md):
     assert body["success"] is True
     assert body["data"]["metadata"]["chunk_index"] == 0
     assert body["data"]["metadata"]["total_chunks"] == 1
+    assert body["data"]["metadata"]["chunks_created"] == 1
     mock_parse_md.assert_called_once()
     mock_embed.assert_called_once()
     assert mock_embed.await_args.args == ("test_doc\nParsed markdown content",)
@@ -363,8 +363,7 @@ def test_upload_pdf(mock_get_sb, mock_embed, mock_parse_pdf):
     mock_sb = _mock_supabase()
     mock_get_sb.return_value = mock_sb
 
-    # 重複チェック → 空
-    mock_sb.table.return_value.select.return_value.eq.return_value.execute.return_value = (
+    mock_sb.table.return_value.select.return_value.in_.return_value.execute.return_value = (
         _mock_table_result([])
     )
     # insert結果
@@ -396,6 +395,7 @@ def test_upload_pdf(mock_get_sb, mock_embed, mock_parse_pdf):
     assert body["success"] is True
     assert body["data"]["metadata"]["chunk_index"] == 0
     assert body["data"]["metadata"]["total_chunks"] == 1
+    assert body["data"]["metadata"]["chunks_created"] == 1
     mock_parse_pdf.assert_called_once()
     mock_embed.assert_called_once()
 
@@ -414,10 +414,9 @@ def test_upload_markdown_splits_into_chunks(
     mock_sb = _mock_supabase()
     mock_get_sb.return_value = mock_sb
 
-    mock_sb.table.return_value.select.return_value.eq.return_value.execute.side_effect = [
-        _mock_table_result([]),
-        _mock_table_result([]),
-    ]
+    mock_sb.table.return_value.select.return_value.in_.return_value.execute.return_value = (
+        _mock_table_result([])
+    )
     first_row = {
         **SAMPLE_ROW,
         "title": "multi_doc (part 1)",
@@ -459,6 +458,7 @@ def test_upload_markdown_splits_into_chunks(
     assert body["data"]["title"] == "multi_doc (part 1)"
     assert body["data"]["metadata"]["chunk_index"] == 0
     assert body["data"]["metadata"]["total_chunks"] == 2
+    assert body["data"]["metadata"]["chunks_created"] == 2
     assert mock_embed.await_args_list[0].args == ("Chunk one",)
     assert mock_embed.await_args_list[1].args == ("Chunk two",)
 
@@ -474,19 +474,18 @@ def test_upload_markdown_splits_into_chunks(
 @patch("backend.api.knowledge.chunk_text")
 @patch("backend.api.knowledge.parse_markdown")
 @patch("backend.api.knowledge._get_supabase")
-def test_upload_rejects_duplicate_chunk_title_before_insert(
+def test_upload_rejects_duplicate_chunk_title_from_batch_check(
     mock_get_sb, mock_parse_md, mock_chunk_text
 ):
-    """チャンクタイトル衝突時は挿入前に409を返す"""
+    """チャンクタイトル衝突時は単一INクエリで409を返す"""
     mock_parse_md.return_value = "Parsed markdown content"
     mock_chunk_text.return_value = ["Chunk one", "Chunk two"]
     mock_sb = _mock_supabase()
     mock_get_sb.return_value = mock_sb
 
-    mock_sb.table.return_value.select.return_value.eq.return_value.execute.side_effect = [
-        _mock_table_result([]),
-        _mock_table_result([SAMPLE_ROW]),
-    ]
+    mock_sb.table.return_value.select.return_value.in_.return_value.execute.return_value = (
+        _mock_table_result([{"title": "duplicate_doc (part 2)"}])
+    )
 
     response = client.post(
         "/api/knowledge/upload",
@@ -497,6 +496,10 @@ def test_upload_rejects_duplicate_chunk_title_before_insert(
     assert response.status_code == 409
     assert (
         response.json()["detail"] == "Knowledge with title 'duplicate_doc (part 2)' already exists"
+    )
+    mock_sb.table.return_value.select.return_value.in_.assert_called_once_with(
+        "title",
+        ["duplicate_doc (part 1)", "duplicate_doc (part 2)"],
     )
     mock_sb.table.return_value.insert.assert_not_called()
 
@@ -511,7 +514,7 @@ def test_upload_continues_when_embedding_times_out(mock_get_sb, mock_embed, mock
     mock_sb = _mock_supabase()
     mock_get_sb.return_value = mock_sb
 
-    mock_sb.table.return_value.select.return_value.eq.return_value.execute.return_value = (
+    mock_sb.table.return_value.select.return_value.in_.return_value.execute.return_value = (
         _mock_table_result([])
     )
     uploaded_row = {
@@ -538,6 +541,86 @@ def test_upload_continues_when_embedding_times_out(mock_get_sb, mock_embed, mock
 @patch("backend.api.knowledge.parse_markdown")
 @patch("backend.api.knowledge.generate_embedding", new_callable=AsyncMock)
 @patch("backend.api.knowledge._get_supabase")
+@patch("backend.api.knowledge.chunk_text")
+def test_upload_rejects_when_document_exceeds_max_chunks(
+    mock_chunk_text, mock_get_sb, mock_embed, mock_parse_md
+):
+    """チャンク数上限超過時は400を返す"""
+    mock_embed.return_value = FAKE_EMBEDDING
+    mock_parse_md.return_value = "Parsed markdown content"
+    mock_chunk_text.return_value = [f"Chunk {index}" for index in range(51)]
+    mock_sb = _mock_supabase()
+    mock_get_sb.return_value = mock_sb
+
+    response = client.post(
+        "/api/knowledge/upload",
+        data={"category": "general", "language": "ja"},
+        files={"file": ("too_many_chunks.md", io.BytesIO(b"# Test"), "text/markdown")},
+    )
+
+    assert response.status_code == 400
+    assert response.json()["detail"] == "Document too large: 51 chunks exceeds limit of 50"
+    mock_sb.table.return_value.select.assert_not_called()
+    mock_sb.table.return_value.insert.assert_not_called()
+
+
+@patch("backend.api.knowledge.chunk_text")
+@patch("backend.api.knowledge.parse_markdown")
+@patch("backend.api.knowledge.generate_embedding", new_callable=AsyncMock)
+@patch("backend.api.knowledge._get_supabase")
+def test_upload_rolls_back_inserted_chunks_on_unique_violation(
+    mock_get_sb, mock_embed, mock_parse_md, mock_chunk_text
+):
+    """途中チャンクの一意制約違反時は既存挿入分をロールバックする"""
+    mock_embed.side_effect = [FAKE_EMBEDDING, FAKE_EMBEDDING]
+    mock_parse_md.return_value = "Parsed markdown content"
+    mock_chunk_text.return_value = ["Chunk one", "Chunk two"]
+    mock_sb = _mock_supabase()
+    mock_get_sb.return_value = mock_sb
+
+    mock_sb.table.return_value.select.return_value.in_.return_value.execute.return_value = (
+        _mock_table_result([])
+    )
+    mock_sb.table.return_value.insert.return_value.execute.side_effect = [
+        _mock_table_result(
+            [
+                {
+                    **SAMPLE_ROW,
+                    "id": "first-chunk-id",
+                    "title": "race_doc (part 1)",
+                    "content": "Chunk one",
+                }
+            ]
+        ),
+        APIError(
+            {
+                "message": 'duplicate key value violates unique constraint for "race_doc (part 2)"',
+                "code": "23505",
+                "hint": "",
+                "details": "",
+            }
+        ),
+    ]
+    mock_sb.table.return_value.delete.return_value.eq.return_value.execute.return_value = (
+        _mock_table_result([])
+    )
+
+    response = client.post(
+        "/api/knowledge/upload",
+        data={"category": "general", "language": "ja"},
+        files={"file": ("race_doc.md", io.BytesIO(b"# Test"), "text/markdown")},
+    )
+
+    assert response.status_code == 409
+    assert response.json()["detail"] == "Knowledge with title 'race_doc (part 2)' already exists"
+    assert mock_sb.table.return_value.delete.return_value.eq.call_args_list == [
+        call("id", "first-chunk-id")
+    ]
+
+
+@patch("backend.api.knowledge.parse_markdown")
+@patch("backend.api.knowledge.generate_embedding", new_callable=AsyncMock)
+@patch("backend.api.knowledge._get_supabase")
 def test_upload_returns_503_when_supabase_insert_fails(mock_get_sb, mock_embed, mock_parse_md):
     """Supabase insert失敗時は503を返す"""
     mock_embed.return_value = FAKE_EMBEDDING
@@ -545,7 +628,7 @@ def test_upload_returns_503_when_supabase_insert_fails(mock_get_sb, mock_embed, 
     mock_sb = _mock_supabase()
     mock_get_sb.return_value = mock_sb
 
-    mock_sb.table.return_value.select.return_value.eq.return_value.execute.return_value = (
+    mock_sb.table.return_value.select.return_value.in_.return_value.execute.return_value = (
         _mock_table_result([])
     )
     mock_sb.table.return_value.insert.return_value.execute.side_effect = APIError(

--- a/backend/tests/api/test_knowledge_api.py
+++ b/backend/tests/api/test_knowledge_api.py
@@ -325,6 +325,12 @@ def test_upload_markdown(mock_get_sb, mock_embed, mock_parse_md):
         "title": "test_doc",
         "content": "Parsed markdown content",
         "source": "file:test_doc.md",
+        "metadata": {
+            "original_filename": "test_doc.md",
+            "file_type": "markdown",
+            "chunk_index": 0,
+            "total_chunks": 1,
+        },
     }
     mock_sb.table.return_value.insert.return_value.execute.return_value = _mock_table_result(
         [uploaded_row]
@@ -340,8 +346,11 @@ def test_upload_markdown(mock_get_sb, mock_embed, mock_parse_md):
     assert response.status_code == 201
     body = response.json()
     assert body["success"] is True
+    assert body["data"]["metadata"]["chunk_index"] == 0
+    assert body["data"]["metadata"]["total_chunks"] == 1
     mock_parse_md.assert_called_once()
     mock_embed.assert_called_once()
+    assert mock_embed.await_args.args == ("test_doc\nParsed markdown content",)
 
 
 @patch("backend.api.knowledge.parse_pdf")
@@ -364,6 +373,12 @@ def test_upload_pdf(mock_get_sb, mock_embed, mock_parse_pdf):
         "title": "document",
         "content": "Parsed PDF content",
         "source": "file:document.pdf",
+        "metadata": {
+            "original_filename": "document.pdf",
+            "file_type": "pdf",
+            "chunk_index": 0,
+            "total_chunks": 1,
+        },
     }
     mock_sb.table.return_value.insert.return_value.execute.return_value = _mock_table_result(
         [uploaded_row]
@@ -379,8 +394,111 @@ def test_upload_pdf(mock_get_sb, mock_embed, mock_parse_pdf):
     assert response.status_code == 201
     body = response.json()
     assert body["success"] is True
+    assert body["data"]["metadata"]["chunk_index"] == 0
+    assert body["data"]["metadata"]["total_chunks"] == 1
     mock_parse_pdf.assert_called_once()
     mock_embed.assert_called_once()
+
+
+@patch("backend.api.knowledge.chunk_text")
+@patch("backend.api.knowledge.parse_markdown")
+@patch("backend.api.knowledge.generate_embedding", new_callable=AsyncMock)
+@patch("backend.api.knowledge._get_supabase")
+def test_upload_markdown_splits_into_chunks(
+    mock_get_sb, mock_embed, mock_parse_md, mock_chunk_text
+):
+    """長い.mdは複数チャンクに分割して保存する"""
+    mock_parse_md.return_value = "Parsed markdown content"
+    mock_chunk_text.return_value = ["Chunk one", "Chunk two"]
+    mock_embed.side_effect = [FAKE_EMBEDDING, FAKE_EMBEDDING]
+    mock_sb = _mock_supabase()
+    mock_get_sb.return_value = mock_sb
+
+    mock_sb.table.return_value.select.return_value.eq.return_value.execute.side_effect = [
+        _mock_table_result([]),
+        _mock_table_result([]),
+    ]
+    first_row = {
+        **SAMPLE_ROW,
+        "title": "multi_doc (part 1)",
+        "content": "Chunk one",
+        "source": "file:multi_doc.md",
+        "metadata": {
+            "original_filename": "multi_doc.md",
+            "file_type": "markdown",
+            "chunk_index": 0,
+            "total_chunks": 2,
+        },
+    }
+    second_row = {
+        **SAMPLE_ROW,
+        "title": "multi_doc (part 2)",
+        "content": "Chunk two",
+        "source": "file:multi_doc.md",
+        "metadata": {
+            "original_filename": "multi_doc.md",
+            "file_type": "markdown",
+            "chunk_index": 1,
+            "total_chunks": 2,
+        },
+    }
+    mock_sb.table.return_value.insert.return_value.execute.side_effect = [
+        _mock_table_result([first_row]),
+        _mock_table_result([second_row]),
+    ]
+
+    response = client.post(
+        "/api/knowledge/upload",
+        data={"category": "general", "language": "ja"},
+        files={"file": ("multi_doc.md", io.BytesIO(b"# Test"), "text/markdown")},
+    )
+
+    assert response.status_code == 201
+    body = response.json()
+    assert body["success"] is True
+    assert body["data"]["title"] == "multi_doc (part 1)"
+    assert body["data"]["metadata"]["chunk_index"] == 0
+    assert body["data"]["metadata"]["total_chunks"] == 2
+    assert mock_embed.await_args_list[0].args == ("Chunk one",)
+    assert mock_embed.await_args_list[1].args == ("Chunk two",)
+
+    insert_calls = mock_sb.table.return_value.insert.call_args_list
+    assert len(insert_calls) == 2
+    assert insert_calls[0].args[0]["title"] == "multi_doc (part 1)"
+    assert insert_calls[1].args[0]["title"] == "multi_doc (part 2)"
+    assert insert_calls[0].args[0]["metadata"]["chunk_index"] == 0
+    assert insert_calls[1].args[0]["metadata"]["chunk_index"] == 1
+    assert insert_calls[1].args[0]["metadata"]["total_chunks"] == 2
+
+
+@patch("backend.api.knowledge.chunk_text")
+@patch("backend.api.knowledge.parse_markdown")
+@patch("backend.api.knowledge._get_supabase")
+def test_upload_rejects_duplicate_chunk_title_before_insert(
+    mock_get_sb, mock_parse_md, mock_chunk_text
+):
+    """チャンクタイトル衝突時は挿入前に409を返す"""
+    mock_parse_md.return_value = "Parsed markdown content"
+    mock_chunk_text.return_value = ["Chunk one", "Chunk two"]
+    mock_sb = _mock_supabase()
+    mock_get_sb.return_value = mock_sb
+
+    mock_sb.table.return_value.select.return_value.eq.return_value.execute.side_effect = [
+        _mock_table_result([]),
+        _mock_table_result([SAMPLE_ROW]),
+    ]
+
+    response = client.post(
+        "/api/knowledge/upload",
+        data={"category": "general", "language": "ja"},
+        files={"file": ("duplicate_doc.md", io.BytesIO(b"# Test"), "text/markdown")},
+    )
+
+    assert response.status_code == 409
+    assert (
+        response.json()["detail"] == "Knowledge with title 'duplicate_doc (part 2)' already exists"
+    )
+    mock_sb.table.return_value.insert.assert_not_called()
 
 
 @patch("backend.api.knowledge.parse_markdown")

--- a/backend/tests/utils/test_file_parser_unit.py
+++ b/backend/tests/utils/test_file_parser_unit.py
@@ -9,7 +9,7 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
-from backend.utils.file_parser import detect_file_type, parse_markdown, parse_pdf
+from backend.utils.file_parser import chunk_text, detect_file_type, parse_markdown, parse_pdf
 
 
 # ---------------------------------------------------------------------------
@@ -412,3 +412,29 @@ class TestParsePdf:
                 parse_pdf(b"corrupted pdf")
 
             assert exc_info.value.__cause__ is original_error
+
+
+# ---------------------------------------------------------------------------
+# chunk_text
+# ---------------------------------------------------------------------------
+class TestChunkText:
+    """chunk_text のユニットテスト"""
+
+    def test_returns_empty_list_for_blank_text(self):
+        """空文字や空白のみは空配列を返す"""
+        assert chunk_text("") == []
+        assert chunk_text("   \n\n   ") == []
+
+    def test_returns_single_chunk_when_text_is_short(self):
+        """chunk_size 以下のテキストは単一チャンクを返す"""
+        assert chunk_text("  short text  ", chunk_size=50) == ["short text"]
+
+    def test_splits_long_text_into_multiple_chunks(self):
+        """長文は複数チャンクに分割される"""
+        text = "\n\n".join([f"paragraph {index} " + ("A" * 120) for index in range(12)])
+
+        chunks = chunk_text(text, chunk_size=180, chunk_overlap=20)
+
+        assert len(chunks) > 1
+        assert all(chunk.strip() == chunk for chunk in chunks)
+        assert all(len(chunk) <= 180 for chunk in chunks)

--- a/backend/tests/utils/test_file_parser_unit.py
+++ b/backend/tests/utils/test_file_parser_unit.py
@@ -397,6 +397,24 @@ class TestParsePdf:
 
         mock_doc.close.assert_called_once()
 
+    def test_doc_close_called_when_page_processing_fails(self):
+        """ページ処理中の例外でも doc.close() が呼ばれる"""
+        mock_page = MagicMock()
+        mock_page.get_text.side_effect = RuntimeError("page read failed")
+        mock_doc = self._make_mock_doc([mock_page])
+
+        class FakeFileDataError(Exception):
+            pass
+
+        with patch("backend.utils.file_parser.pymupdf") as mock_pymupdf:
+            mock_pymupdf.open.return_value = mock_doc
+            mock_pymupdf.FileDataError = FakeFileDataError
+
+            with pytest.raises(RuntimeError, match="page read failed"):
+                parse_pdf(b"pdf bytes")
+
+        mock_doc.close.assert_called_once()
+
     def test_valueerror_from_file_data_error_chains_cause(self):
         """FileDataError から変換された ValueError に元の例外が __cause__ として連鎖する"""
 

--- a/backend/utils/file_parser.py
+++ b/backend/utils/file_parser.py
@@ -98,12 +98,14 @@ def parse_pdf(content: bytes) -> str:
     """
     try:
         doc = pymupdf.open(stream=content, filetype="pdf")
-        pages_text = []
-        for page in doc:
-            page_text = page.get_text()
-            if page_text.strip():
-                pages_text.append(page_text.strip())
-        doc.close()
+        try:
+            pages_text = []
+            for page in doc:
+                page_text = page.get_text()
+                if page_text.strip():
+                    pages_text.append(page_text.strip())
+        finally:
+            doc.close()
 
         if not pages_text:
             raise ValueError("No text content found in PDF")

--- a/backend/utils/file_parser.py
+++ b/backend/utils/file_parser.py
@@ -10,6 +10,11 @@ from typing import Literal
 
 import pymupdf
 
+try:
+    from langchain.text_splitter import RecursiveCharacterTextSplitter
+except ImportError:  # pragma: no cover - compatibility for newer langchain packages
+    from langchain_text_splitters import RecursiveCharacterTextSplitter
+
 logger = logging.getLogger(__name__)
 
 
@@ -107,3 +112,26 @@ def parse_pdf(content: bytes) -> str:
 
     except pymupdf.FileDataError as e:
         raise ValueError(f"Invalid PDF file: {e}") from e
+
+
+def chunk_text(
+    text: str,
+    chunk_size: int = 1000,
+    chunk_overlap: int = 200,
+) -> list[str]:
+    """Split text into chunks using recursive character splitting."""
+    if not text or not text.strip():
+        return []
+
+    normalized_text = text.strip()
+    if len(normalized_text) <= chunk_size:
+        return [normalized_text]
+
+    splitter = RecursiveCharacterTextSplitter(
+        chunk_size=chunk_size,
+        chunk_overlap=chunk_overlap,
+        length_function=len,
+        separators=["\n\n", "\n", "。", ".", " ", ""],
+    )
+    chunks = splitter.split_text(normalized_text)
+    return [chunk.strip() for chunk in chunks if chunk.strip()]

--- a/frontend/src/app/api/admin/knowledge/route.ts
+++ b/frontend/src/app/api/admin/knowledge/route.ts
@@ -22,9 +22,9 @@ export async function GET(request: NextRequest) {
     const { searchParams } = new URL(request.url);
     const params: Record<string, string> = {};
 
-    for (const [key, value] of searchParams.entries()) {
+    searchParams.forEach((value, key) => {
       params[key] = value;
-    }
+    });
 
     if (params.search && !params.keyword) {
       params.keyword = params.search;
@@ -43,8 +43,7 @@ export async function GET(request: NextRequest) {
     }
 
     return NextResponse.json(response.data, { status: response.status });
-  } catch (error) {
-    console.error('Failed to get knowledge entries:', error);
+  } catch {
     return NextResponse.json(
       { error: 'Failed to get knowledge entries' },
       { status: 500 }
@@ -76,8 +75,7 @@ export async function POST(request: NextRequest) {
     }
 
     return NextResponse.json(response.data, { status: response.status });
-  } catch (error) {
-    console.error('Failed to create knowledge entry:', error);
+  } catch {
     return NextResponse.json(
       { error: 'Failed to create knowledge entry' },
       { status: 500 }

--- a/frontend/src/app/api/admin/knowledge/route.ts
+++ b/frontend/src/app/api/admin/knowledge/route.ts
@@ -1,24 +1,48 @@
 import { NextRequest, NextResponse } from 'next/server';
-import { knowledgeBaseUtils, KnowledgeBaseEntry } from '@/lib/knowledge-base-utils';
+import { backendFetch } from '@/lib/api/backend-proxy';
+
+function toErrorBody(data: unknown, fallback: string) {
+  if (data && typeof data === 'object') {
+    const payload = data as {
+      detail?: string;
+      error?: string;
+      message?: string;
+    };
+    const error = payload.error || payload.detail || payload.message;
+    if (error) {
+      return { ...payload, error };
+    }
+  }
+
+  return { error: fallback };
+}
 
 export async function GET(request: NextRequest) {
   try {
     const { searchParams } = new URL(request.url);
-    const page = parseInt(searchParams.get('page') || '1');
-    const limit = parseInt(searchParams.get('limit') || '20');
-    const language = searchParams.get('language') as any;
-    const category = searchParams.get('category') || undefined;
-    const search = searchParams.get('search') || undefined;
+    const params: Record<string, string> = {};
 
-    const result = await knowledgeBaseUtils.getAll({
-      page,
-      limit,
-      language,
-      category,
-      search,
+    for (const [key, value] of searchParams.entries()) {
+      params[key] = value;
+    }
+
+    if (params.search && !params.keyword) {
+      params.keyword = params.search;
+    }
+
+    const response = await backendFetch('/api/knowledge', {
+      method: 'GET',
+      params,
     });
 
-    return NextResponse.json(result);
+    if (!response.ok) {
+      return NextResponse.json(
+        toErrorBody(response.data, 'Failed to fetch knowledge entries'),
+        { status: response.status }
+      );
+    }
+
+    return NextResponse.json(response.data, { status: response.status });
   } catch (error) {
     console.error('Failed to get knowledge entries:', error);
     return NextResponse.json(
@@ -30,21 +54,32 @@ export async function GET(request: NextRequest) {
 
 export async function POST(request: NextRequest) {
   try {
-    const entry: KnowledgeBaseEntry = await request.json();
-    const result = await knowledgeBaseUtils.addEntry(entry);
+    const body = await request.json();
+    const response = await backendFetch('/api/knowledge', {
+      method: 'POST',
+      body: {
+        title: body.title,
+        content: body.content,
+        category: body.category,
+        subcategory: body.subcategory,
+        language: body.language || 'ja',
+        source: body.source || 'admin-ui',
+        metadata: body.metadata || {},
+      },
+    });
 
-    if (result.success) {
-      return NextResponse.json({ id: result.id, success: true });
-    } else {
+    if (!response.ok) {
       return NextResponse.json(
-        { error: result.error || 'Failed to create entry' },
-        { status: 400 }
+        toErrorBody(response.data, 'Failed to create entry'),
+        { status: response.status }
       );
     }
+
+    return NextResponse.json(response.data, { status: response.status });
   } catch (error) {
     console.error('Failed to create knowledge entry:', error);
     return NextResponse.json(
-      { error: error instanceof Error ? error.message : 'Unknown error' },
+      { error: 'Failed to create knowledge entry' },
       { status: 500 }
     );
   }


### PR DESCRIPTION
## Summary
- Frontend admin knowledge route now proxies through `backendFetch` instead of direct Supabase insert with Google embeddings
- Embeddings now use OpenAI text-embedding-3-small (native 1536-dim) via backend, eliminating the 768→1536 padding hack
- Uploaded documents (PDF/Markdown) are automatically chunked using `RecursiveCharacterTextSplitter`
- Each chunk is stored as a separate knowledge_base entry with chunk metadata

Part of #232

## Changes
### Frontend
- `frontend/src/app/api/admin/knowledge/route.ts` — POST/GET now proxy through backendFetch

### Backend
- `backend/utils/file_parser.py` — added `chunk_text()` function using langchain's RecursiveCharacterTextSplitter
- `backend/api/knowledge.py` — upload handler now chunks documents, inserts one row per chunk with `title (part N)` unique titles
- `backend/tests/api/test_knowledge_api.py` — regression tests for chunked upload
- `backend/tests/utils/test_file_parser_unit.py` — unit tests for chunk_text

## Chunking strategy
- chunk_size: 1000 chars, overlap: 200 chars
- Separators: `\n\n`, `\n`, `。`, `.`, ` `, `` (Japanese-aware)
- Single-chunk documents behave identically to before (backward compatible)
- Metadata includes `chunk_index` and `total_chunks` for reconstruction

## Test plan
- [x] ruff check + black --check pass
- [x] Backend unit tests pass (chunk_text, knowledge_api)
- [ ] CI: full backend test suite + frontend build
- [ ] Manual: upload a multi-page PDF, verify multiple knowledge_base entries created

🤖 Generated with [Claude Code](https://claude.com/claude-code)