### PR TITLE
fix(backend): add slowapi to requirements.txt for Docker builds

### DIFF
--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -6,6 +6,7 @@ langsmith>=0.3.12
 pydantic>=2.0.0
 pydantic-settings>=2.0.0
 fastapi>=0.115.0
+slowapi>=0.1.9
 uvicorn[standard]>=0.30.0
 python-dotenv>=1.0.0
 httpx>=0.27.0


### PR DESCRIPTION
## Summary
- Add `slowapi>=0.1.9` to `requirements.txt` — was in `pyproject.toml` but missing from `requirements.txt`
- Docker builds use `requirements.txt`, causing Cloud Run startup failure after PR #234 made slowapi mandatory

Part of #232

## Test plan
- [x] 1-line change, no logic affected
- [ ] CI: backend-lint + backend-test
- [ ] Docker build succeeds with slowapi included

🤖 Generated with [Claude Code](https://claude.com/claude-code)