### PR TITLE
refactor(knowledge): proxy admin categories through backend API

### DIFF
--- a/backend/api/knowledge.py
+++ b/backend/api/knowledge.py
@@ -87,6 +87,21 @@ class KnowledgeResponse(BaseModel):
     error: Optional[str] = None
 
 
+class KnowledgeCategoriesStats(BaseModel):
+    totalCategories: int
+    totalSubcategories: int
+    totalSources: int
+    totalLanguages: int
+
+
+class KnowledgeCategoriesResponse(BaseModel):
+    categories: List[str]
+    subcategories: Dict[str, List[str]]
+    sources: List[str]
+    languages: List[str]
+    stats: KnowledgeCategoriesStats
+
+
 # =============================================================================
 # Helper
 # =============================================================================
@@ -155,6 +170,58 @@ def _rollback_uploaded_chunks(supabase: Any, inserted_ids: List[str]) -> None:
 # =============================================================================
 # Endpoints
 # =============================================================================
+
+
+@router.get("/knowledge/categories", response_model=KnowledgeCategoriesResponse)
+@rate_limit("60/minute")
+async def get_knowledge_categories(request: Request):
+    """ナレッジカテゴリ一覧取得"""
+    try:
+        supabase = _get_supabase()
+
+        cat_result = supabase.table("knowledge_base").select("category").execute()
+        categories = sorted(
+            {row["category"] for row in (cat_result.data or []) if row.get("category")}
+        )
+
+        sub_result = supabase.table("knowledge_base").select("category,subcategory").execute()
+        subcategory_sets: Dict[str, set[str]] = {}
+        for row in sub_result.data or []:
+            category = row.get("category")
+            subcategory = row.get("subcategory")
+            if not category or not subcategory:
+                continue
+            subcategory_sets.setdefault(category, set()).add(subcategory)
+
+        subcategories = {
+            category: sorted(values) for category, values in sorted(subcategory_sets.items())
+        }
+
+        src_result = supabase.table("knowledge_base").select("source").execute()
+        sources = sorted({row["source"] for row in (src_result.data or []) if row.get("source")})
+
+        lang_result = supabase.table("knowledge_base").select("language").execute()
+        languages = sorted(
+            {row["language"] for row in (lang_result.data or []) if row.get("language")}
+        )
+
+        return KnowledgeCategoriesResponse(
+            categories=categories,
+            subcategories=subcategories,
+            sources=sources,
+            languages=languages,
+            stats=KnowledgeCategoriesStats(
+                totalCategories=len(categories),
+                totalSubcategories=sum(len(values) for values in subcategories.values()),
+                totalSources=len(sources),
+                totalLanguages=len(languages),
+            ),
+        )
+    except HTTPException:
+        raise
+    except Exception as e:
+        logger.error("Failed to get knowledge categories: %s", e)
+        raise HTTPException(status_code=500, detail="Failed to get knowledge categories")
 
 
 @router.get("/knowledge", response_model=KnowledgeListResponse)

--- a/backend/tests/api/test_knowledge_api.py
+++ b/backend/tests/api/test_knowledge_api.py
@@ -54,6 +54,87 @@ def _mock_table_result(data, count=None):
 
 
 # =============================================================================
+# GET /api/knowledge/categories
+# =============================================================================
+
+
+@patch("backend.api.knowledge._get_supabase")
+def test_get_knowledge_categories(mock_get_sb):
+    """カテゴリ・サブカテゴリ・ソース・言語一覧取得"""
+    mock_sb = _mock_supabase()
+    mock_get_sb.return_value = mock_sb
+
+    table_mock = mock_sb.table.return_value
+
+    category_query = MagicMock()
+    category_query.execute.return_value = _mock_table_result(
+        [
+            {"category": "facility-info"},
+            {"category": "hours"},
+            {"category": "hours"},
+            {"category": None},
+        ]
+    )
+
+    subcategory_query = MagicMock()
+    subcategory_query.execute.return_value = _mock_table_result(
+        [
+            {"category": "hours", "subcategory": "holiday"},
+            {"category": "hours", "subcategory": "weekday"},
+            {"category": "hours", "subcategory": "holiday"},
+            {"category": "facility-info", "subcategory": "equipment"},
+            {"category": "facility-info", "subcategory": None},
+        ]
+    )
+
+    source_query = MagicMock()
+    source_query.execute.return_value = _mock_table_result(
+        [
+            {"source": "manual"},
+            {"source": "web"},
+            {"source": "manual"},
+            {"source": None},
+        ]
+    )
+
+    language_query = MagicMock()
+    language_query.execute.return_value = _mock_table_result(
+        [
+            {"language": "ja"},
+            {"language": "en"},
+            {"language": "ja"},
+            {"language": None},
+        ]
+    )
+
+    table_mock.select.side_effect = [
+        category_query,
+        subcategory_query,
+        source_query,
+        language_query,
+    ]
+
+    response = client.get("/api/knowledge/categories")
+
+    assert response.status_code == 200
+    assert response.json() == {
+        "categories": ["facility-info", "hours"],
+        "subcategories": {
+            "facility-info": ["equipment"],
+            "hours": ["holiday", "weekday"],
+        },
+        "sources": ["manual", "web"],
+        "languages": ["en", "ja"],
+        "stats": {
+            "totalCategories": 2,
+            "totalSubcategories": 3,
+            "totalSources": 2,
+            "totalLanguages": 2,
+        },
+    }
+
+
+# =============================================================================
 # GET /api/knowledge
 # =============================================================================
 

--- a/frontend/src/app/api/admin/knowledge/categories/route.ts
+++ b/frontend/src/app/api/admin/knowledge/categories/route.ts
@@ -1,83 +1,24 @@
 import { NextResponse } from 'next/server';
-import { supabaseAdmin } from '@/lib/supabase';
+import { backendFetch } from '@/lib/api/backend-proxy';
 
 export async function GET() {
   try {
-    // Get distinct categories
-    const { data: categories, error: catError } = await supabaseAdmin
-      .from('knowledge_base')
-      .select('category')
-      .not('category', 'is', null)
-      .order('category', { ascending: true });
-
-    if (catError) throw catError;
-
-    // Get distinct subcategories with their categories
-    const { data: subcategories, error: subError } = await supabaseAdmin
-      .from('knowledge_base')
-      .select('category, subcategory')
-      .not('subcategory', 'is', null)
-      .order('category', { ascending: true })
-      .order('subcategory', { ascending: true });
-
-    if (subError) throw subError;
-
-    // Get distinct sources
-    const { data: sources, error: srcError } = await supabaseAdmin
-      .from('knowledge_base')
-      .select('source')
-      .not('source', 'is', null)
-      .order('source', { ascending: true });
-
-    if (srcError) throw srcError;
-
-    // Process the data
-    const uniqueCategories = Array.from(new Set((categories ?? []).map(c => c.category).filter(Boolean)));
-    const uniqueSources = Array.from(new Set((sources ?? []).map(s => s.source).filter(Boolean)));
-    
-    // Group subcategories by category
-    const subcategoryGroups = (subcategories ?? []).reduce((acc, item) => {
-      if (!item.category || !item.subcategory) return acc;
-      
-      if (!acc[item.category]) {
-        acc[item.category] = new Set();
-      }
-      acc[item.category].add(item.subcategory);
-      return acc;
-    }, {} as Record<string, Set<string>>) || {};
-
-    // Convert Sets to Arrays
-    const subcategoryMap = Object.fromEntries(
-      Object.entries(subcategoryGroups).map(([cat, subs]) => [cat, Array.from(subs)])
-    );
-
-    // Get languages
-    const { data: languages, error: langError } = await supabaseAdmin
-      .from('knowledge_base')
-      .select('language')
-      .not('language', 'is', null);
-
-    if (langError) throw langError;
-
-    const uniqueLanguages = Array.from(new Set(languages?.map(l => l.language).filter(Boolean)));
-
-    return NextResponse.json({
-      categories: uniqueCategories,
-      subcategories: subcategoryMap,
-      sources: uniqueSources,
-      languages: uniqueLanguages,
-      stats: {
-        totalCategories: uniqueCategories.length,
-        totalSubcategories: Object.values(subcategoryMap).reduce((sum, subs) => sum + subs.length, 0),
-        totalSources: uniqueSources.length,
-        totalLanguages: uniqueLanguages.length,
-      }
+    const response = await backendFetch('/api/knowledge/categories', {
+      method: 'GET',
     });
-  } catch (error) {
-    console.error('Failed to get categories:', error);
+
+    if (!response.ok) {
+      return NextResponse.json(
+        { error: 'Failed to fetch categories' },
+        { status: response.status },
+      );
+    }
+
+    return NextResponse.json(response.data, { status: 200 });
+  } catch {
     return NextResponse.json(
-      { error: 'Failed to get categories' },
-      { status: 500 }
+      { error: 'Failed to fetch knowledge categories' },
+      { status: 500 },
     );
   }
 }


### PR DESCRIPTION
## Summary
- Add `GET /api/knowledge/categories` backend endpoint with distinct category/subcategory/source/language aggregation
- Frontend `/api/admin/knowledge/categories` now proxies through backendFetch (removes direct Supabase access)
- Part of Mastra→LangGraph migration Phase 2 (#224)

Part of #224

## Changes
- `backend/api/knowledge.py` — new `/knowledge/categories` endpoint with response models
- `frontend/src/app/api/admin/knowledge/categories/route.ts` — replaced supabaseAdmin with backendFetch
- `backend/tests/api/test_knowledge_api.py` — regression test for categories endpoint

## Test plan
- [x] ruff check + black --check pass
- [x] pytest knowledge API tests pass
- [ ] CI: backend-lint + backend-test + frontend-typecheck
- [ ] Manual: admin UI categories dropdown still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)