### PR TITLE
fix(backend): close auth gaps on reception, slides/content, and voice endpoints

### DIFF
--- a/README-EN.md
+++ b/README-EN.md
@@ -29,7 +29,7 @@ Browser
 ## Main Risks Right Now
 
 - Some frontend admin and monitoring routes are still unauthenticated.
-- Backend API-key protection becomes a no-op if `API_SECRET_KEY` is missing in production.
+- Backend API-key protection is a no-op only in local/dev environments without `API_SECRET_KEY`; `staging`, `preview`, and `production` now fail closed.
 - `backend/api/reception.py` keeps reception session state in memory, which is fragile across restarts and multi-instance deployments.
 - Many legacy docs still describe old Mastra-era architecture.
 

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ Browser
 ## 現時点の主要リスク
 
 - フロント側の管理・監視系 endpoint に未認証 route が残っています。
-- バックエンドの API key 保護は `API_SECRET_KEY` 未設定時に無効化されます。
+- バックエンドの API key 保護は local/dev では `API_SECRET_KEY` 未設定時に無効化されますが、`staging` / `preview` / `production` では fail-closed です。
 - `backend/api/reception.py` は受付セッションをメモリ保持しており、再起動や複数インスタンスに弱いです。
 - ドキュメント群には Mastra 前提や古い agent 構成が残っており、文書の現役/履歴の区別が不十分でした。
 

--- a/backend/README.md
+++ b/backend/README.md
@@ -30,7 +30,7 @@ Current important endpoints:
 
 Notable implementation details:
 
-- API-key protection exists, but becomes optional if `API_SECRET_KEY` is missing.
+- API-key protection exists, but becomes optional only in local/dev environments without `API_SECRET_KEY`; `staging`, `preview`, and `production` fail closed.
 - Rate limiting depends on `slowapi`; without it, the decorators become no-ops.
 - Reception session state is currently stored in process memory, not durable storage.
 - Recent STT fixes added WebM-to-WAV conversion, which means ffmpeg/runtime availability matters for some environments.

--- a/backend/api/reception.py
+++ b/backend/api/reception.py
@@ -11,7 +11,7 @@ from collections import OrderedDict
 from datetime import datetime
 from typing import TYPE_CHECKING, Any, Literal, Optional
 
-from fastapi import APIRouter, HTTPException
+from fastapi import APIRouter, HTTPException, Query
 from pydantic import BaseModel, Field
 
 from backend.domain.reception.models import (
@@ -520,7 +520,7 @@ async def complete_reception(
 @reception_router.get("/status/{reception_session_id}", response_model=ReceptionStatusResponse)
 async def get_reception_status(
     reception_session_id: str,
-    session_id: str = "",
+    session_id: str = Query(..., min_length=1, max_length=128),
 ) -> ReceptionStatusResponse:
     """Return the current state of a reception session."""
     session = await _load_session(reception_session_id, allow_completed=True)
@@ -530,7 +530,7 @@ async def get_reception_status(
             detail=f"Reception session not found: {reception_session_id}",
         )
 
-    if session_id and session.session_id != session_id:
+    if session.session_id != session_id:
         raise HTTPException(
             status_code=403,
             detail="Session ID mismatch",

--- a/backend/main.py
+++ b/backend/main.py
@@ -209,9 +209,9 @@ if _ENVIRONMENT == "production" and not _API_SECRET_KEY:
 
 
 async def verify_api_key(request: Request) -> None:
-    """Verify API key, allowing missing keys only outside production."""
+    """Verify API key, allowing missing keys only outside protected environments."""
     if not _API_SECRET_KEY:
-        if _ENVIRONMENT == "production":
+        if _ENVIRONMENT in ("production", "staging", "preview"):
             raise HTTPException(status_code=503, detail="Server misconfigured")
         return
     api_key = request.headers.get("X-API-Key")
@@ -561,6 +561,18 @@ async def _handle_stt(body: VoiceRequest) -> VoiceResponse:
     )
 
 
+@app.get("/api/voice", dependencies=[Depends(verify_api_key)])
+async def voice_get_api(action: str = ""):
+    if action == "supported_languages":
+        return {
+            "languages": [
+                {"code": "ja", "name": "日本語"},
+                {"code": "en", "name": "English"},
+            ]
+        }
+    return {"status": "ok", "actions": ["speech_to_text", "text_to_speech", "supported_languages"]}
+
+
 @app.post("/api/voice", response_model=VoiceResponse, dependencies=[Depends(verify_api_key)])
 @_rate_limit("20/minute")
 async def voice_api(request: Request, body: VoiceRequest):
@@ -677,7 +689,11 @@ class SlideContentResponse(BaseModel):
     error: Optional[str] = None
 
 
-@app.post("/api/slides/content", response_model=SlideContentResponse)
+@app.post(
+    "/api/slides/content",
+    response_model=SlideContentResponse,
+    dependencies=[Depends(verify_api_key)],
+)
 async def slides_content_api(body: SlideContentRequest):
     """Return raw slide markdown and narration data for frontend rendering."""
     try:
@@ -840,7 +856,7 @@ app.include_router(alerts_router, dependencies=[Depends(verify_api_key)])
 # Reception API Router
 from backend.api.reception import reception_router  # noqa: E402
 
-app.include_router(reception_router)
+app.include_router(reception_router, dependencies=[Depends(verify_api_key)])
 
 
 if __name__ == "__main__":

--- a/backend/tests/api/test_reception_api.py
+++ b/backend/tests/api/test_reception_api.py
@@ -253,7 +253,7 @@ class TestReceptionStatus:
         start = _start_session(session_id="s1")
         rid = start["reception_session_id"]
 
-        response = client.get(f"/api/reception/status/{rid}")
+        response = client.get(f"/api/reception/status/{rid}", params={"session_id": "s1"})
         assert response.status_code == 200
         data = response.json()
         assert data["session_id"] == "s1"
@@ -278,14 +278,14 @@ class TestReceptionStatus:
             },
         )
 
-        response = client.get(f"/api/reception/status/{rid}")
+        response = client.get(f"/api/reception/status/{rid}", params={"session_id": "s1"})
         assert response.status_code == 200
         data = response.json()
         assert data["stage"] == "routing"
         assert data["purpose"] == "event_participation"
 
     def test_status_404_for_nonexistent_session(self):
-        response = client.get("/api/reception/status/no-such-id")
+        response = client.get("/api/reception/status/no-such-id", params={"session_id": "s1"})
         assert response.status_code == 404
 
     def test_status_with_different_languages(self):
@@ -294,7 +294,7 @@ class TestReceptionStatus:
             start = _start_session(session_id="s1", language=lang)
             rid = start["reception_session_id"]
 
-            response = client.get(f"/api/reception/status/{rid}")
+            response = client.get(f"/api/reception/status/{rid}", params={"session_id": "s1"})
             assert response.status_code == 200
             assert response.json()["stage"] == "greeting"
 

--- a/backend/tests/test_security_audit.py
+++ b/backend/tests/test_security_audit.py
@@ -1,0 +1,136 @@
+from __future__ import annotations
+
+import pytest
+from fastapi.testclient import TestClient
+from starlette.requests import Request
+
+import backend.api.reception as reception_module
+import backend.main as main_mod
+
+client = TestClient(main_mod.app)
+
+
+def _make_request(api_key: str | None = None) -> Request:
+    headers: list[tuple[bytes, bytes]] = []
+    if api_key is not None:
+        headers.append((b"x-api-key", api_key.encode()))
+
+    scope = {
+        "type": "http",
+        "method": "POST",
+        "path": "/api/chat",
+        "query_string": b"",
+        "headers": headers,
+        "server": ("127.0.0.1", 8000),
+        "client": ("127.0.0.1", 12345),
+    }
+    return Request(scope)
+
+
+@pytest.fixture
+def api_key_guard(monkeypatch: pytest.MonkeyPatch) -> dict[str, str]:
+    monkeypatch.setattr(main_mod, "_API_SECRET_KEY", "expected-key")
+    monkeypatch.setattr(main_mod, "_ENVIRONMENT", "test")
+    return {"X-API-Key": "expected-key"}
+
+
+@pytest.fixture(autouse=True)
+def reset_reception_sessions() -> None:
+    reception_module._reset_session_storage()
+
+
+def _start_reception(headers: dict[str, str], session_id: str = "session-001") -> dict:
+    response = client.post(
+        "/api/reception/start",
+        json={
+            "session_id": session_id,
+            "language": "ja",
+            "trigger_type": "button_press",
+        },
+        headers=headers,
+    )
+    assert response.status_code == 200, response.text
+    return response.json()
+
+
+def test_reception_endpoints_require_api_key(api_key_guard: dict[str, str]) -> None:
+    start_without_key = client.post(
+        "/api/reception/start",
+        json={
+            "session_id": "session-001",
+            "language": "ja",
+            "trigger_type": "button_press",
+        },
+    )
+    assert start_without_key.status_code == 403
+
+    started = _start_reception(api_key_guard)
+    reception_session_id = started["reception_session_id"]
+
+    respond_without_key = client.post(
+        "/api/reception/respond",
+        json={
+            "session_id": "session-001",
+            "reception_session_id": reception_session_id,
+            "message": "こんにちは",
+        },
+    )
+    assert respond_without_key.status_code == 403
+
+    status_without_key = client.get(
+        f"/api/reception/status/{reception_session_id}",
+        params={"session_id": "session-001"},
+    )
+    assert status_without_key.status_code == 403
+
+    complete_without_key = client.post(
+        "/api/reception/complete",
+        json={
+            "session_id": "session-001",
+            "reception_session_id": reception_session_id,
+        },
+    )
+    assert complete_without_key.status_code == 403
+
+
+def test_slides_content_requires_api_key(api_key_guard: dict[str, str]) -> None:
+    response = client.post("/api/slides/content", json={"language": "ja"})
+    assert response.status_code == 403
+
+    authorized = client.post(
+        "/api/slides/content",
+        json={"language": "ja"},
+        headers=api_key_guard,
+    )
+    assert authorized.status_code == 200
+    assert authorized.json()["success"] is True
+
+
+def test_voice_get_supported_languages(api_key_guard: dict[str, str]) -> None:
+    response = client.get(
+        "/api/voice",
+        params={"action": "supported_languages"},
+        headers=api_key_guard,
+    )
+
+    assert response.status_code == 200
+    assert response.json() == {
+        "languages": [
+            {"code": "ja", "name": "日本語"},
+            {"code": "en", "name": "English"},
+        ]
+    }
+
+
+@pytest.mark.asyncio
+async def test_verify_api_key_rejects_staging_without_secret(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(main_mod, "_API_SECRET_KEY", None)
+    monkeypatch.setattr(main_mod, "_ENVIRONMENT", "staging")
+
+    with pytest.raises(main_mod.HTTPException) as exc_info:
+        await main_mod.verify_api_key(_make_request())
+
+    assert exc_info.value.status_code == 503
+    assert exc_info.value.detail == "Server misconfigured"

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -52,9 +52,9 @@ The FastAPI backend enforces an `API_SECRET_KEY` requirement at two points:
 
 1. **Startup gate**: If `ENVIRONMENT=production` and `API_SECRET_KEY` is absent or empty, the process calls `sys.exit(1)` and refuses to start. This prevents a misconfigured deployment from silently exposing write-capable endpoints.
 
-2. **Per-request dependency**: Protected endpoints declare `verify_api_key` as a FastAPI dependency. The function reads the `X-API-Key` request header and compares it against `_API_SECRET_KEY` using `hmac.compare_digest`, which provides constant-time comparison in CPython. If the key is missing or incorrect, the endpoint returns `403 Forbidden`. If somehow a production instance is running without a key (defence in depth), it returns `503 Service Unavailable` rather than permitting access.
+2. **Per-request dependency**: Protected endpoints declare `verify_api_key` as a FastAPI dependency. The function reads the `X-API-Key` request header and compares it against `_API_SECRET_KEY` using `hmac.compare_digest`, which provides constant-time comparison in CPython. If the key is missing or incorrect, the endpoint returns `403 Forbidden`. If a `production`, `staging`, or `preview` instance is running without a key (defence in depth), it returns `503 Service Unavailable` rather than permitting access.
 
-**Required environment variable**: `API_SECRET_KEY` — must be set as a Cloud Run secret before deploying to production.
+**Required environment variable**: `API_SECRET_KEY` — must be set as a Cloud Run secret before deploying to production, and should also be set for any staging or preview environment that is expected to remain protected.
 
 ### Defense-in-Depth Summary
 


### PR DESCRIPTION
## Summary
Fix 3 CRITICAL + 2 HIGH backend security issues from pre-deployment audit.

Closes part of #243

## Changes
### C1: Reception API auth
- Added `dependencies=[Depends(verify_api_key)]` to reception_router registration

### C2: /api/slides/content auth
- Added `dependencies=[Depends(verify_api_key)]` to slides_content_api endpoint

### C3: GET /api/voice
- Added GET handler returning supported languages and available actions

### H4: verify_api_key staging/preview
- Extended fail-closed to `staging` and `preview` environments (not just `production`)

### H5: Reception session_id required
- Made `session_id` a required query parameter on reception status endpoint

## Test plan
- [x] ruff check + black --check pass
- [x] pytest pass
- [ ] CI: backend-lint + backend-test
- [ ] Manual: verify 403 on unauthenticated reception/slides/content requests

🤖 Generated with [Claude Code](https://claude.com/claude-code)