### PR TITLE
chore(frontend): override transitive npm audit vulnerabilities

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -103,6 +103,10 @@
     "wrangler": "4.69.0"
   },
   "pnpm": {
+    "overrides": {
+      "fast-xml-parser": "5.4.1",
+      "undici": "7.24.2"
+    },
     "onlyBuiltDependencies": [
       "esbuild",
       "sharp",

--- a/frontend/pnpm-lock.yaml
+++ b/frontend/pnpm-lock.yaml
@@ -4,6 +4,10 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
+overrides:
+  fast-xml-parser: 5.4.1
+  undici: 7.24.2
+
 importers:
 
   .:
@@ -7476,7 +7480,7 @@ snapshots:
       '@smithy/smithy-client': 4.4.1
       '@smithy/types': 4.3.1
       '@smithy/util-middleware': 4.0.4
-      fast-xml-parser: 4.4.1
+      fast-xml-parser: 5.4.1
       tslib: 2.8.1
 
   '@aws-sdk/core@3.973.18':
@@ -13780,7 +13784,7 @@ snapshots:
     dependencies:
       '@cspotcode/source-map-support': 0.8.1
       sharp: 0.34.5
-      undici: 7.18.2
+      undici: 7.24.2
       workerd: 1.20260305.0
       ws: 8.18.0
       youch: 4.1.0-beta.10


### PR DESCRIPTION
## Summary
Add pnpm overrides for transitive dependency vulnerabilities found in pre-deployment audit.

Part of #245

## Changes
- `package.json`: Added `pnpm.overrides` for `fast-xml-parser` (→5.4.1) and `undici` (→7.24.2)
- `pnpm-lock.yaml`: Updated lockfile with overridden versions

## Remaining
- `hono@4.7.11` (HIGH via `@mastra/core`) — requires `@mastra/core` update to resolve, tracked in #245
- This PR reduces CRITICAL vulnerabilities but cannot fully eliminate HIGH due to transitive `@mastra/core` dependency

## Test plan
- [ ] CI: pnpm install + lint + typecheck + build (validates overrides don't break)
- [ ] Post-merge: re-run `pnpm audit` to confirm reduction

🤖 Generated with [Claude Code](https://claude.com/claude-code)