### PR TITLE
feat(ocr): wire frontend image requests into chat workflow

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -247,6 +247,7 @@ class ChatRequest(BaseModel):
     language: Optional[str] = Field(default="ja", max_length=10)
     context: Optional[Dict[str, Any]] = None
     visitor_id: Optional[str] = None  # Cross-session visitor identification
+    image_data: str | None = None  # Base64 encoded image
 
 
 class ChatResponse(BaseModel):
@@ -284,6 +285,19 @@ async def _run_workflow_with_tracking(payload: Dict[str, Any], session_id: str) 
     except asyncio.CancelledError:
         logger.info("LLM task cancelled for session %s", session_id)
         raise HTTPException(status_code=409, detail="Request interrupted")
+
+
+def _build_workflow_payload(body: ChatRequest, session_id: str) -> Dict[str, Any]:
+    payload: Dict[str, Any] = {
+        "query": body.query,
+        "session_id": session_id,
+        "language": body.language,
+        "context": body.context or {},
+        "visitor_id": body.visitor_id,
+    }
+    if body.image_data:
+        payload["image_data"] = body.image_data
+    return payload
 
 
 @app.get("/health")
@@ -339,13 +353,7 @@ async def chat(request: Request, body: ChatRequest):
 
     try:
         result = await _run_workflow_with_tracking(
-            payload={
-                "query": body.query,
-                "session_id": session_id,
-                "language": body.language,
-                "context": body.context or {},
-                "visitor_id": body.visitor_id,
-            },
+            payload=_build_workflow_payload(body, session_id),
             session_id=session_id,
         )
 
@@ -403,15 +411,7 @@ async def chat_stream(request: Request, body: ChatRequest):
             workflow = await get_workflow()
 
             # Use astream for streaming
-            async for event in workflow.astream(
-                {
-                    "query": body.query,
-                    "session_id": session_id,
-                    "language": body.language,
-                    "context": body.context or {},
-                    "visitor_id": body.visitor_id,
-                }
-            ):
+            async for event in workflow.astream(_build_workflow_payload(body, session_id)):
                 if interrupt_mgr.is_interrupted(body.session_id):
                     yield f'data: {json.dumps({"type": "interrupted"})}\n\n'
                     break
@@ -447,13 +447,7 @@ async def invoke_agent(request: Request, body: ChatRequest):
 
     try:
         result = await _run_workflow_with_tracking(
-            payload={
-                "query": body.query,
-                "session_id": session_id,
-                "language": body.language,
-                "context": body.context or {},
-                "visitor_id": body.visitor_id,
-            },
+            payload=_build_workflow_payload(body, session_id),
             session_id=session_id,
         )
 

--- a/backend/tests/test_main_endpoints.py
+++ b/backend/tests/test_main_endpoints.py
@@ -81,6 +81,35 @@ class TestChatEndpoint:
             assert "secret" not in exc_info.value.detail
             assert "internal error" in exc_info.value.detail.lower()
 
+    @pytest.mark.asyncio
+    async def test_chat_forwards_image_data_to_workflow(self):
+        with patch(
+            "backend.main._run_workflow_with_tracking",
+            new_callable=AsyncMock,
+            return_value={
+                "answer": "OCR結果です",
+                "emotion": "neutral",
+                "metadata": {},
+            },
+        ) as mock_run:
+            from backend.main import chat, ChatRequest
+
+            body = ChatRequest(query="画像を読んで", session_id="s1", image_data="base64-image")
+            response = await chat(_mock_request(), body)
+
+            assert response.answer == "OCR結果です"
+            mock_run.assert_awaited_once_with(
+                payload={
+                    "query": "画像を読んで",
+                    "session_id": "s1",
+                    "language": "ja",
+                    "context": {},
+                    "visitor_id": None,
+                    "image_data": "base64-image",
+                },
+                session_id="s1",
+            )
+
 
 class TestInvokeEndpoint:
     @pytest.mark.asyncio

--- a/frontend/src/app/api/ocr/route.ts
+++ b/frontend/src/app/api/ocr/route.ts
@@ -1,0 +1,33 @@
+import { NextRequest, NextResponse } from 'next/server';
+
+import { backendFetch } from '@/lib/api/backend-proxy';
+
+export async function POST(request: NextRequest) {
+  try {
+    const body = await request.json();
+
+    if (!body.image_data) {
+      return NextResponse.json(
+        { error: 'Missing image_data field' },
+        { status: 400 },
+      );
+    }
+
+    const response = await backendFetch('/api/chat', {
+      method: 'POST',
+      body: {
+        query: body.query || 'この画像を分析してください',
+        session_id: body.session_id || '',
+        language: body.language || 'ja',
+        image_data: body.image_data,
+      },
+    });
+
+    return NextResponse.json(response.data, { status: response.status });
+  } catch {
+    return NextResponse.json(
+      { error: 'Failed to process image' },
+      { status: 500 },
+    );
+  }
+}


### PR DESCRIPTION
## Summary
Connect VisionAgent (OCR) to frontend by adding image_data support to the chat API.

Part of #244

## Changes
- `backend/main.py`: Added `image_data: str | None` to ChatRequest model, passed to workflow
- `frontend/src/app/api/ocr/route.ts`: New route for image-based queries via /api/chat
- Tests for image_data flow

## How it works
```
Frontend /api/ocr (POST with base64 image_data)
  → backendFetch('/api/chat', { image_data, query })
  → MainWorkflow: _vision_node processes image
  → VisionAgent: OCR/face detection
  → Response with ocr_result
```

## Test plan
- [x] ruff check + black --check pass
- [x] pytest pass
- [ ] CI: backend-test + frontend-typecheck + build

🤖 Generated with [Claude Code](https://claude.com/claude-code)