### PR TITLE
fix(security): add Content-Security-Policy headers and fix deprecated X-XSS-Protection

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -236,7 +236,19 @@ async def add_security_headers(request: Request, call_next):
     response = await call_next(request)
     response.headers["X-Content-Type-Options"] = "nosniff"
     response.headers["X-Frame-Options"] = "DENY"
-    response.headers["X-XSS-Protection"] = "1; mode=block"
+    response.headers["Content-Security-Policy"] = (
+        "default-src 'self'; "
+        "script-src 'self' 'unsafe-inline' 'unsafe-eval'; "
+        "style-src 'self' 'unsafe-inline'; "
+        "img-src 'self' data: blob:; "
+        "font-src 'self' data:; "
+        "connect-src 'self' https://*.supabase.co wss://*.supabase.co https://openrouter.ai; "
+        "media-src 'self' blob:; "
+        "frame-src 'none'; "
+        "object-src 'none'; "
+        "base-uri 'self'"
+    )
+    response.headers["X-XSS-Protection"] = "0"
     response.headers["Referrer-Policy"] = "strict-origin-when-cross-origin"
     return response
 

--- a/frontend/next.config.js
+++ b/frontend/next.config.js
@@ -66,6 +66,21 @@ const nextConfig = {
         source: "/(.*)",
         headers: [
           {
+            key: "Content-Security-Policy",
+            value: [
+              "default-src 'self'",
+              "script-src 'self' 'unsafe-inline' 'unsafe-eval'",
+              "style-src 'self' 'unsafe-inline'",
+              "img-src 'self' data: blob:",
+              "font-src 'self' data:",
+              "connect-src 'self' https://*.supabase.co wss://*.supabase.co",
+              "media-src 'self' blob:",
+              "frame-src 'none'",
+              "object-src 'none'",
+              "base-uri 'self'",
+            ].join("; "),
+          },
+          {
             key: "Cross-Origin-Embedder-Policy",
             value: "unsafe-none",
           },


### PR DESCRIPTION
## Summary
Add CSP headers to backend and frontend. Fix deprecated X-XSS-Protection.

Part of #245

## Changes
- `backend/main.py`: Added CSP header in SecurityHeadersMiddleware, changed X-XSS-Protection to '0'
- `frontend/next.config.js`: Added CSP header in security headers config

## CSP Policy
```
default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval';
style-src 'self' 'unsafe-inline'; img-src 'self' data: blob:;
connect-src 'self' https://*.supabase.co wss://*.supabase.co https://openrouter.ai;
media-src 'self' blob:; frame-src 'none'; object-src 'none'; base-uri 'self'
```

Note: 'unsafe-inline'/'unsafe-eval' required for Next.js SSR. Can be tightened with nonce-based CSP later.

## Test plan
- [x] ruff check + black --check pass
- [ ] CI: backend-test + frontend-build
- [ ] Manual: verify CSP header in response headers

🤖 Generated with [Claude Code](https://claude.com/claude-code)