### PR TITLE
fix(frontend): Wave 1 — production integration fixes

### DIFF
--- a/frontend/src/__tests__/api-character-route.test.ts
+++ b/frontend/src/__tests__/api-character-route.test.ts
@@ -1,0 +1,68 @@
+import assert from 'node:assert/strict';
+import { mkdtemp, mkdir, rm, writeFile } from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import { afterEach, test } from 'node:test';
+import { NextRequest } from 'next/server';
+
+import { GET } from '../app/api/character/route';
+
+const originalCwd = process.cwd();
+let tempDir: string | null = null;
+
+afterEach(async () => {
+  process.chdir(originalCwd);
+
+  if (tempDir) {
+    await rm(tempDir, { recursive: true, force: true });
+    tempDir = null;
+  }
+});
+
+test('returns supported feature arrays when manifest is missing', async () => {
+  const response = await GET(
+    new NextRequest('https://example.com/api/character?action=supported_features')
+  );
+
+  assert.equal(response.status, 200);
+  assert.deepEqual(await response.json(), {
+    success: true,
+    expressions: ['neutral', 'happy', 'sad', 'angry', 'relaxed', 'surprised', 'thinking'],
+    animations: ['idle', 'greeting', 'explaining', 'thinking', 'listening', 'speaking'],
+  });
+});
+
+test('returns manifest animations when a character animation manifest exists', async () => {
+  tempDir = await mkdtemp(path.join(os.tmpdir(), 'character-route-'));
+  await mkdir(path.join(tempDir, 'public', 'characters', 'animations'), { recursive: true });
+  await writeFile(
+    path.join(tempDir, 'public', 'characters', 'animations', 'manifest.json'),
+    JSON.stringify({
+      animations: ['wave', 'bow'],
+    })
+  );
+
+  process.chdir(tempDir);
+
+  const response = await GET(
+    new NextRequest('https://example.com/api/character?action=supported_features')
+  );
+
+  assert.equal(response.status, 200);
+  assert.deepEqual(await response.json(), {
+    success: true,
+    expressions: ['neutral', 'happy', 'sad', 'angry', 'relaxed', 'surprised', 'thinking'],
+    animations: ['wave', 'bow'],
+  });
+});
+
+test('keeps the default GET health payload for other actions', async () => {
+  const response = await GET(
+    new NextRequest('https://example.com/api/character?action=current_state')
+  );
+
+  assert.equal(response.status, 200);
+  assert.deepEqual(await response.json(), {
+    status: 'ok',
+  });
+});

--- a/frontend/src/app/api/admin/knowledge/templates/[filename]/route.ts
+++ b/frontend/src/app/api/admin/knowledge/templates/[filename]/route.ts
@@ -1,6 +1,9 @@
 import { NextRequest, NextResponse } from 'next/server';
 
-const BACKEND_API_URL = (process.env.BACKEND_API_URL || 'http://localhost:8000').replace(/\/+$/, '');
+const BACKEND_API_URL = process.env.BACKEND_API_URL?.replace(/\/+$/, '') ?? '';
+if (!BACKEND_API_URL) {
+  console.warn('BACKEND_API_URL is not set. Template requests will fail.');
+}
 const ALLOWED_FILENAMES = new Set(['knowledge-template.md', 'knowledge-pdf-template-guide.md']);
 
 function backendUrl(path: string): string {

--- a/frontend/src/app/api/admin/knowledge/upload/route.ts
+++ b/frontend/src/app/api/admin/knowledge/upload/route.ts
@@ -1,6 +1,9 @@
 import { NextRequest, NextResponse } from 'next/server';
 
-const BACKEND_API_URL = (process.env.BACKEND_API_URL || 'http://localhost:8000').replace(/\/+$/, '');
+const BACKEND_API_URL = process.env.BACKEND_API_URL?.replace(/\/+$/, '') ?? '';
+if (!BACKEND_API_URL) {
+  console.warn('BACKEND_API_URL is not set. Upload requests will fail.');
+}
 
 function backendUrl(path: string): string {
   const normalizedPath = path.startsWith('/') ? path : `/${path}`;

--- a/frontend/src/app/api/character/route.ts
+++ b/frontend/src/app/api/character/route.ts
@@ -1,6 +1,69 @@
+import { readFile } from 'node:fs/promises';
+import path from 'node:path';
+
 import { NextRequest, NextResponse } from 'next/server';
 
 import { backendFetch } from '@/lib/api/backend-proxy';
+
+const DEFAULT_SUPPORTED_EXPRESSIONS = [
+  'neutral',
+  'happy',
+  'sad',
+  'angry',
+  'relaxed',
+  'surprised',
+  'thinking',
+];
+
+const DEFAULT_SUPPORTED_ANIMATIONS = [
+  'idle',
+  'greeting',
+  'explaining',
+  'thinking',
+  'listening',
+  'speaking',
+];
+
+const isStringArray = (value: unknown): value is string[] =>
+  Array.isArray(value) && value.every((entry) => typeof entry === 'string');
+
+async function getSupportedAnimations() {
+  const manifestPath = path.join(
+    process.cwd(),
+    'public',
+    'characters',
+    'animations',
+    'manifest.json'
+  );
+
+  try {
+    const manifestContent = await readFile(manifestPath, 'utf-8');
+    const manifest = JSON.parse(manifestContent) as unknown;
+
+    if (isStringArray(manifest)) {
+      return manifest;
+    }
+
+    if (
+      manifest &&
+      typeof manifest === 'object' &&
+      'animations' in manifest &&
+      isStringArray(manifest.animations)
+    ) {
+      return manifest.animations;
+    }
+
+    console.warn('[character route] Unsupported animation manifest format:', manifestPath);
+  } catch (error) {
+    const code = error && typeof error === 'object' && 'code' in error ? error.code : null;
+
+    if (code !== 'ENOENT') {
+      console.warn('[character route] Failed to load animation manifest:', error);
+    }
+  }
+
+  return DEFAULT_SUPPORTED_ANIMATIONS;
+}
 
 export async function POST(request: NextRequest) {
   try {
@@ -30,6 +93,18 @@ export async function POST(request: NextRequest) {
 }
 
 export async function GET(request: NextRequest) {
+  const action = request.nextUrl.searchParams.get('action');
+
+  if (action === 'supported_features') {
+    const animations = await getSupportedAnimations();
+
+    return NextResponse.json({
+      success: true,
+      expressions: DEFAULT_SUPPORTED_EXPRESSIONS,
+      animations,
+    });
+  }
+
   return NextResponse.json({
     status: 'ok',
   });

--- a/frontend/src/app/components/MarpViewer.tsx
+++ b/frontend/src/app/components/MarpViewer.tsx
@@ -14,6 +14,16 @@ interface SlideData {
   notes?: string;
 }
 
+interface SlidesApiResponse {
+  success?: boolean;
+  slideNumber?: number;
+  answer?: string;
+  error?: string;
+  transitionMessage?: string;
+  characterAction?: string;
+  audioResponse?: string | null;
+}
+
 interface NarrationData {
   metadata: {
     title: string;
@@ -147,6 +157,42 @@ export default function MarpViewer({
   const resetNarrationFlags = () => {
     setIsNarrating(false);
     setIsNarrationInProgress(false);
+  };
+
+  const advancePresentation = (delayMs = 0) => {
+    const advance = () => {
+      autoPlayTimerRef.current = null;
+      resetNarrationFlags();
+
+      if (!isPlaying) {
+        return;
+      }
+
+      if (currentSlide < totalSlides) {
+        setCurrentSlide(prev => {
+          const nextSlide = prev + 1;
+          onSlideChange?.(nextSlide);
+          return nextSlide;
+        });
+        return;
+      }
+
+      setIsPlaying(false);
+      trackPresentationEvent('presentation_completed', {
+        totalDuration: presentationStartTimeRef.current ? Date.now() - presentationStartTimeRef.current : 0
+      });
+    };
+
+    if (delayMs <= 0) {
+      advance();
+      return;
+    }
+
+    if (autoPlayTimerRef.current) {
+      clearTimeout(autoPlayTimerRef.current);
+    }
+
+    autoPlayTimerRef.current = setTimeout(advance, delayMs);
   };
 
   // Error recovery with retry logic
@@ -563,7 +609,7 @@ export default function MarpViewer({
     setIsNarrating(true);
     
     try {
-      let result: any = null;
+      let result: SlidesApiResponse | null = null;
       
       // Create new AbortController for this narration
       narrationAbortControllerRef.current = new AbortController();
@@ -600,9 +646,12 @@ export default function MarpViewer({
         throw new Error('Invalid response format - expected JSON');
       }
       
-      result = await response.json();
-      
-      
+      result = await response.json() as SlidesApiResponse;
+
+      if (result?.characterAction) {
+        updateCharacterAction(result.characterAction);
+      }
+
       if (result.audioResponse) {
         try {
           // Starting audio playback
@@ -611,22 +660,7 @@ export default function MarpViewer({
           await playAudioWithLipSync(result.audioResponse);
           
           // Audio playback completed
-          resetNarrationFlags();
-          
-          // Advance to next slide only after audio completion
-          if (isPlaying && currentSlide < totalSlides) {
-            setCurrentSlide(prev => {
-              const nextSlide = prev + 1;
-              onSlideChange?.(nextSlide);
-              return nextSlide;
-            });
-          } else if (currentSlide >= totalSlides) {
-            // Presentation completed
-            setIsPlaying(false);
-            trackPresentationEvent('presentation_completed', {
-              totalDuration: presentationStartTime ? Date.now() - presentationStartTime : 0
-            });
-          }
+          advancePresentation();
         } catch (error: any) {
           // Error during audio playback
           
@@ -644,25 +678,12 @@ export default function MarpViewer({
           }
           
           // Continue to next slide even if audio fails (for other errors)
-          if (isPlaying && currentSlide < totalSlides) {
-            setTimeout(() => {
-              resetNarrationFlags();
-              setCurrentSlide(prev => {
-                const nextSlide = prev + 1;
-                onSlideChange?.(nextSlide);
-                return nextSlide;
-              });
-            }, 1000);
+          if (isPlaying) {
+            advancePresentation(1000);
           }
         }
-        
-        // Note: Expressions disabled for slide mode - only lip sync is used
-        // This provides natural presentation without distracting facial expressions
-        if (result?.characterAction) {
-          updateCharacterAction(result.characterAction);
-        }
       } else {
-        resetNarrationFlags();
+        advancePresentation(300);
       }
     } catch (error) {
       // Check if the error is due to abort
@@ -792,7 +813,7 @@ export default function MarpViewer({
         throw new Error(`HTTP error! status: ${response.status}`);
       }
 
-      const result = await response.json();
+      const result = await response.json() as SlidesApiResponse;
 
       if (result.success && result.slideNumber) {
         // Only update if we got a valid slide number
@@ -1076,7 +1097,7 @@ export default function MarpViewer({
         throw new Error('Invalid response format - expected JSON');
       }
 
-      const result = await response.json();
+      const result = await response.json() as SlidesApiResponse;
       
       if (process.env.NODE_ENV !== 'production') {
       }

--- a/frontend/src/components/reception/ReceptionPanel.tsx
+++ b/frontend/src/components/reception/ReceptionPanel.tsx
@@ -17,7 +17,7 @@ interface ReceptionPanelProps {
 export function ReceptionPanel({
   sessionId,
   language = 'ja',
-  triggerType = 'manual',
+  triggerType = 'button_press',
   className,
 }: ReceptionPanelProps) {
   const [draft, setDraft] = useState('');

--- a/frontend/src/hooks/useReception.ts
+++ b/frontend/src/hooks/useReception.ts
@@ -48,7 +48,7 @@ function createMessage(role: ReceptionMessage['role'], text: string): ReceptionM
 export function useReception({
   sessionId,
   language = 'ja',
-  triggerType = 'manual',
+  triggerType = 'button_press',
 }: UseReceptionOptions): UseReceptionResult {
   const [stage, setStage] = useState<ReceptionStage>('idle');
   const [responseText, setResponseText] = useState<string | null>(null);

--- a/frontend/src/lib/api/backend-proxy.ts
+++ b/frontend/src/lib/api/backend-proxy.ts
@@ -5,8 +5,13 @@
  * and attaches the X-API-Key header to every outgoing request.
  */
 
-const BACKEND_API_URL =
-  process.env.BACKEND_API_URL || "http://localhost:8000";
+const BACKEND_API_URL = process.env.BACKEND_API_URL;
+
+if (!BACKEND_API_URL) {
+  console.warn(
+    "BACKEND_API_URL is not set. Backend proxy requests will fail.",
+  );
+}
 
 export interface BackendProxyOptions {
   /** HTTP method (defaults to POST). */
@@ -79,6 +84,11 @@ function buildUrl(
   path: string,
   params?: Readonly<Record<string, string>>,
 ): string {
+  if (!BACKEND_API_URL) {
+    throw new Error(
+      "BACKEND_API_URL environment variable is not set. Cannot proxy to backend.",
+    );
+  }
   const base = BACKEND_API_URL.replace(/\/+$/, "");
   const normalizedPath = path.startsWith("/") ? path : `/${path}`;
   const url = new URL(`${base}${normalizedPath}`);


### PR DESCRIPTION
## Summary

- Remove `localhost:8000` fallback from all backend proxy code — throw clear error when `BACKEND_API_URL` is not set
- Fix `/api/character` GET to return `{success, expressions, animations}` matching `CharacterAvatar.tsx` contract
- Fix reception `triggerType` from `'manual'` to `'button_press'` (backend only accepts `button_press|face_detection|wake_word|nfc`)
- Make `audioResponse` optional in `MarpViewer.tsx` — graceful degradation when backend doesn't include narration audio

## Context

Codex CLI static audit identified 3 BROKEN API contract mismatches and 1 auth/connection issue between Vercel frontend and Cloud Run backend. This PR fixes all 4.

## Closes

- Closes #264 (Vercel→Cloud Run auth)
- Partially addresses #263 (API contract mismatches — all 3 fixed)

## Test plan

- [x] `pnpm lint` — pass
- [x] `pnpm typecheck` — pass
- [x] Character route regression test added
- [ ] Verify Vercel env vars set: `BACKEND_API_URL`, `BACKEND_API_KEY`
- [ ] Test frontend→backend chat proxy on deployed preview
- [ ] Test reception start flow
- [ ] Test slide navigation without audioResponse

🤖 Generated with [Claude Code](https://claude.com/claude-code)