### PR TITLE
fix(backend): harden checkpointer reconnect on Cloud Run cold starts

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -137,6 +137,15 @@ async def lifespan(app: FastAPI):
     except Exception as e:
         logger.warning("Session task manager setup failed (non-critical): %s", e)
 
+    try:
+        from backend.utils.checkpointer import prewarm_checkpointer
+
+        await prewarm_checkpointer()
+    except ValueError:
+        logger.warning("SUPABASE_DB_URI not set, skipping checkpointer warm-up.")
+    except Exception as e:
+        logger.warning("Checkpointer warm-up failed (non-critical): %s", e)
+
     yield
 
     # Shutdown

--- a/backend/tests/test_main_endpoints.py
+++ b/backend/tests/test_main_endpoints.py
@@ -2,7 +2,7 @@
 
 import pytest
 from httpx import ASGITransport, AsyncClient
-from unittest.mock import AsyncMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 from fastapi.testclient import TestClient
 from starlette.requests import Request
 
@@ -36,6 +36,29 @@ class TestHealthCheck:
         # CI環境ではSupabase/LLM未接続のため "degraded" になりうる
         assert data["status"] in ("ok", "degraded")
         assert data["service"] == "engineer-cafe-navigator-backend"
+
+
+class TestLifespan:
+    @pytest.mark.asyncio
+    async def test_lifespan_prewarms_checkpointer(self):
+        import backend.main as main_mod
+
+        app = MagicMock()
+        session_task_manager = AsyncMock()
+
+        with (
+            patch("backend.utils.env_validator.validate_startup"),
+            patch("backend.utils.checkpoint_cleanup.CheckpointCleanup", return_value=MagicMock()),
+            patch("backend.main.get_session_task_manager", return_value=session_task_manager),
+            patch("backend.utils.checkpointer.prewarm_checkpointer", new=AsyncMock()) as prewarm,
+            patch("backend.utils.checkpointer.close_checkpointer", new=AsyncMock()),
+            patch("backend.utils.store.close_store", new=AsyncMock()),
+        ):
+            async with main_mod.lifespan(app):
+                prewarm.assert_awaited_once()
+                session_task_manager.initialize.assert_awaited_once()
+
+        session_task_manager.shutdown.assert_awaited_once()
 
 
 class TestChatEndpoint:

--- a/backend/tests/utils/test_checkpointer.py
+++ b/backend/tests/utils/test_checkpointer.py
@@ -90,6 +90,76 @@ class TestCheckpointerFactory:
         assert "Failed to connect to Supabase PostgreSQL" in str(exc_info.value)
 
 
+class TestResilientAsyncPostgresSaver:
+    @pytest.mark.asyncio
+    async def test_alist_retries_after_stale_connection(self):
+        initial_pool = MagicMock()
+        initial_pool.close = AsyncMock()
+        recovered_pool = MagicMock()
+        recovered_pool.close = AsyncMock()
+
+        factory = MagicMock()
+        factory.create_pool = AsyncMock(return_value=recovered_pool)
+        factory.prewarm_pool = AsyncMock()
+
+        saver = checkpointer.ResilientAsyncPostgresSaver(factory=factory, pool=initial_pool)
+
+        attempts = 0
+
+        async def mock_alist(_self, config, *, filter=None, before=None, limit=None):
+            nonlocal attempts
+            attempts += 1
+            assert config == {"configurable": {"thread_id": "session-1"}}
+            assert filter == {"topic": "test"}
+            assert before is None
+            assert limit == 2
+            if attempts == 1:
+                raise RuntimeError("connection is closed")
+            yield {"checkpoint_id": "one"}
+            yield {"checkpoint_id": "two"}
+
+        with patch.object(checkpointer.AsyncPostgresSaver, "alist", mock_alist):
+            result = [
+                item
+                async for item in saver.alist(
+                    {"configurable": {"thread_id": "session-1"}},
+                    filter={"topic": "test"},
+                    limit=2,
+                )
+            ]
+
+        assert result == [{"checkpoint_id": "one"}, {"checkpoint_id": "two"}]
+        assert attempts == 2
+        factory.create_pool.assert_awaited_once()
+        factory.prewarm_pool.assert_awaited_once_with(recovered_pool)
+        initial_pool.close.assert_awaited_once()
+        assert saver.pool is recovered_pool
+
+    @pytest.mark.asyncio
+    async def test_recreate_returns_when_pool_already_refreshed(self):
+        initial_pool = MagicMock()
+        initial_pool.close = AsyncMock()
+        refreshed_pool = MagicMock()
+        refreshed_pool.close = AsyncMock()
+
+        factory = MagicMock()
+        factory.create_pool = AsyncMock()
+        factory.prewarm_pool = AsyncMock()
+
+        saver = checkpointer.ResilientAsyncPostgresSaver(factory=factory, pool=initial_pool)
+        saver.conn = refreshed_pool
+
+        await saver.recreate(
+            reason=RuntimeError("connection is closed"),
+            stale_pool=initial_pool,
+        )
+
+        factory.create_pool.assert_not_awaited()
+        factory.prewarm_pool.assert_not_awaited()
+        initial_pool.close.assert_not_awaited()
+        assert saver.pool is refreshed_pool
+
+
 class TestGetCheckpointer:
     @pytest.fixture(autouse=True)
     async def cleanup(self):

--- a/backend/tests/utils/test_checkpointer.py
+++ b/backend/tests/utils/test_checkpointer.py
@@ -1,214 +1,175 @@
-"""Tests for backend.utils.checkpointer — AsyncPostgresSaver checkpointer utilities."""
+"""Tests for backend.utils.checkpointer."""
+
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
-from unittest.mock import AsyncMock, MagicMock, patch
+from psycopg import OperationalError
+from psycopg_pool import PoolClosed
+
 from backend.utils import checkpointer
 
 
 class TestMaskConnectionString:
-    """_mask_connection_string 関数のテスト"""
-
     def test_masks_password_in_connection_string(self):
-        """パスワードが含まれる接続文字列をマスク"""
         db_uri = "postgresql://user:secret_password@host:5432/database"
         result = checkpointer._mask_connection_string(db_uri)
         assert result == "postgresql://user:****@host:5432/database"
         assert "secret_password" not in result
 
     def test_url_without_password_unchanged(self):
-        """パスワードが含まれない接続文字列はそのまま"""
         db_uri = "postgresql://host:5432/database"
-        result = checkpointer._mask_connection_string(db_uri)
-        assert result == db_uri
+        assert checkpointer._mask_connection_string(db_uri) == db_uri
 
     def test_empty_string_returns_empty(self):
-        """空文字列は空文字列を返す"""
-        result = checkpointer._mask_connection_string("")
-        assert result == ""
+        assert checkpointer._mask_connection_string("") == ""
 
 
-def _make_mock_context_manager(mock_saver):
-    """from_conn_string の戻り値をコンテキストマネージャーとしてモック化"""
-    cm = MagicMock()
-    cm.__aenter__ = AsyncMock(return_value=mock_saver)
-    cm.__aexit__ = AsyncMock(return_value=None)
-    return cm
+class TestConnectionErrorDetection:
+    def test_detects_driver_level_connection_errors(self):
+        assert checkpointer.is_checkpointer_connection_error(
+            OperationalError("connection is closed")
+        )
+        assert checkpointer.is_checkpointer_connection_error(PoolClosed("pool is closed"))
+
+    def test_detects_message_only_connection_errors(self):
+        error = RuntimeError("server closed the connection unexpectedly")
+        assert checkpointer.is_checkpointer_connection_error(error)
+
+    def test_ignores_unrelated_errors(self):
+        assert not checkpointer.is_checkpointer_connection_error(ValueError("bad config"))
 
 
-class TestCreateCheckpointer:
-    """create_checkpointer 関数のテスト"""
-
-    @pytest.fixture(autouse=True)
-    async def cleanup(self):
-        """各テスト後にシングルトンをリセット"""
-        yield
-        checkpointer._checkpointer_instance = None
-        checkpointer._checkpointer_cm = None
-
-    async def test_raises_error_without_supabase_db_uri(self, monkeypatch):
-        """SUPABASE_DB_URI が設定されていない場合は ValueError"""
-        monkeypatch.delenv("SUPABASE_DB_URI", raising=False)
-
-        with pytest.raises(ValueError) as exc_info:
-            await checkpointer.create_checkpointer()
-
-        assert "SUPABASE_DB_URI environment variable is not set" in str(exc_info.value)
-
-    async def test_calls_async_postgres_saver_from_conn_string(self, monkeypatch):
-        """SUPABASE_DB_URI が設定されている場合は AsyncPostgresSaver.from_conn_string を呼ぶ"""
-        test_uri = "postgresql://user:pass@localhost:5432/test_db"
-        monkeypatch.setenv("SUPABASE_DB_URI", test_uri)
-
-        mock_saver = AsyncMock()
-        mock_saver.setup = AsyncMock()
-
-        mock_cm = _make_mock_context_manager(mock_saver)
+class TestCheckpointerFactory:
+    @pytest.mark.asyncio
+    async def test_create_pool_uses_resilient_cloud_run_settings(self):
+        mock_pool = AsyncMock()
+        mock_pool.open = AsyncMock()
 
         with patch(
-            "backend.utils.checkpointer.AsyncPostgresSaver.from_conn_string",
-            return_value=mock_cm,
-        ):
+            "backend.utils.checkpointer.AsyncConnectionPool",
+            return_value=mock_pool,
+        ) as pool_cls:
+            factory = checkpointer._CheckpointerFactory("postgresql://user:pass@localhost:5432/db")
+            result = await factory.create_pool()
+
+        assert result is mock_pool
+        mock_pool.open.assert_awaited_once()
+
+        call_kwargs = pool_cls.call_args.kwargs
+        assert call_kwargs["min_size"] == 0
+        assert call_kwargs["max_size"] == 5
+        assert call_kwargs["max_idle"] == 300
+        assert call_kwargs["open"] is False
+        assert callable(call_kwargs["check"])
+        assert call_kwargs["kwargs"]["connect_timeout"] == 10
+        assert call_kwargs["kwargs"]["keepalives"] == 1
+        assert call_kwargs["kwargs"]["keepalives_idle"] == 30
+
+    @pytest.mark.asyncio
+    async def test_create_checkpointer_sets_up_saver(self):
+        mock_factory = MagicMock()
+        mock_factory.db_uri = "postgresql://user:pass@localhost:5432/db"
+        mock_factory.create_checkpointer = AsyncMock(return_value=AsyncMock())
+
+        with patch.object(checkpointer._CheckpointerFactory, "from_env", return_value=mock_factory):
             result = await checkpointer.create_checkpointer()
 
-            mock_cm.__aenter__.assert_called_once()
-            mock_saver.setup.assert_called_once()
-            assert result == mock_saver
+        assert result is mock_factory.create_checkpointer.return_value
+        mock_factory.create_checkpointer.assert_awaited_once()
 
-    async def test_raises_connection_error_on_failure(self, monkeypatch):
-        """データベース接続に失敗した場合は ConnectionError"""
-        monkeypatch.setenv("SUPABASE_DB_URI", "postgresql://invalid")
+    @pytest.mark.asyncio
+    async def test_create_checkpointer_wraps_factory_errors(self):
+        mock_factory = MagicMock()
+        mock_factory.db_uri = "postgresql://user:pass@localhost:5432/db"
+        mock_factory.create_checkpointer = AsyncMock(side_effect=Exception("Connection failed"))
 
-        mock_cm = MagicMock()
-        mock_cm.__aenter__ = AsyncMock(side_effect=Exception("Connection failed"))
-        mock_cm.__aexit__ = AsyncMock(return_value=None)
-
-        with patch(
-            "backend.utils.checkpointer.AsyncPostgresSaver.from_conn_string",
-            return_value=mock_cm,
-        ):
+        with patch.object(checkpointer._CheckpointerFactory, "from_env", return_value=mock_factory):
             with pytest.raises(ConnectionError) as exc_info:
                 await checkpointer.create_checkpointer()
 
-            assert "Failed to connect to Supabase PostgreSQL" in str(exc_info.value)
+        assert "Failed to connect to Supabase PostgreSQL" in str(exc_info.value)
 
 
 class TestGetCheckpointer:
-    """get_checkpointer 関数のテスト（シングルトン）"""
-
     @pytest.fixture(autouse=True)
     async def cleanup(self):
-        """各テスト後にシングルトンをリセット"""
         yield
         checkpointer._checkpointer_instance = None
         checkpointer._checkpointer_cm = None
 
-    async def test_returns_same_instance_on_double_call(self, monkeypatch):
-        """複数回呼び出しても同じインスタンスを返す（シングルトン）"""
-        monkeypatch.setenv("SUPABASE_DB_URI", "postgresql://user:pass@localhost:5432/db")
-
+    @pytest.mark.asyncio
+    async def test_returns_same_instance_on_double_call(self):
         mock_saver = AsyncMock()
-        mock_saver.setup = AsyncMock()
-
-        mock_cm = _make_mock_context_manager(mock_saver)
 
         with patch(
-            "backend.utils.checkpointer.AsyncPostgresSaver.from_conn_string",
-            return_value=mock_cm,
+            "backend.utils.checkpointer.create_checkpointer",
+            AsyncMock(return_value=mock_saver),
         ):
             instance1 = await checkpointer.get_checkpointer()
             instance2 = await checkpointer.get_checkpointer()
 
-            assert instance1 is instance2
+        assert instance1 is instance2
 
-    async def test_reset_clears_singleton(self, monkeypatch):
-        """reset_checkpointer でシングルトンがクリアされる"""
-        monkeypatch.setenv("SUPABASE_DB_URI", "postgresql://user:pass@localhost:5432/db")
-
-        mock_saver1 = AsyncMock()
-        mock_saver1.setup = AsyncMock()
-
-        mock_saver2 = AsyncMock()
-        mock_saver2.setup = AsyncMock()
-
-        mock_cm1 = _make_mock_context_manager(mock_saver1)
-        mock_cm2 = _make_mock_context_manager(mock_saver2)
+    @pytest.mark.asyncio
+    async def test_reset_clears_singleton(self):
+        saver1 = AsyncMock()
+        saver1.aclose = AsyncMock()
+        saver2 = AsyncMock()
+        saver2.aclose = AsyncMock()
 
         with patch(
-            "backend.utils.checkpointer.AsyncPostgresSaver.from_conn_string",
-            side_effect=[mock_cm1, mock_cm2],
+            "backend.utils.checkpointer.create_checkpointer",
+            AsyncMock(side_effect=[saver1, saver2]),
         ):
             instance1 = await checkpointer.get_checkpointer()
             await checkpointer.reset_checkpointer()
             instance2 = await checkpointer.get_checkpointer()
 
-            assert instance1 is not instance2
-            mock_cm1.__aexit__.assert_called_once()
+        assert instance1 is not instance2
+        saver1.aclose.assert_awaited_once()
 
 
 class TestCloseCheckpointer:
-    """close_checkpointer 関数のテスト"""
-
     @pytest.fixture(autouse=True)
     async def cleanup(self):
-        """各テスト後にシングルトンをリセット"""
         yield
         checkpointer._checkpointer_instance = None
         checkpointer._checkpointer_cm = None
 
+    @pytest.mark.asyncio
     async def test_close_with_no_instance_no_error(self):
-        """インスタンスが存在しない場合もエラーなし"""
-        checkpointer._checkpointer_instance = None
-        checkpointer._checkpointer_cm = None
-        await checkpointer.close_checkpointer()  # Should not raise
+        await checkpointer.close_checkpointer()
 
-    async def test_close_calls_aexit_on_context_manager(self):
-        """インスタンスが存在する場合は __aexit__ を呼ぶ"""
+    @pytest.mark.asyncio
+    async def test_close_calls_aclose_on_instance(self):
         mock_saver = AsyncMock()
-        mock_cm = MagicMock()
-        mock_cm.__aexit__ = AsyncMock(return_value=None)
-
+        mock_saver.aclose = AsyncMock()
         checkpointer._checkpointer_instance = mock_saver
-        checkpointer._checkpointer_cm = mock_cm
 
         await checkpointer.close_checkpointer()
 
-        mock_cm.__aexit__.assert_called_once_with(None, None, None)
+        mock_saver.aclose.assert_awaited_once()
         assert checkpointer._checkpointer_instance is None
         assert checkpointer._checkpointer_cm is None
 
 
 class TestCreateMemoryCheckpointer:
-    """create_memory_checkpointer 関数のテスト"""
-
-    @pytest.fixture(autouse=True)
-    async def cleanup(self):
-        """各テスト後にシングルトンをリセット"""
-        yield
-        checkpointer._checkpointer_instance = None
-        checkpointer._checkpointer_cm = None
-
-    async def test_delegates_to_create_checkpointer(self, monkeypatch):
-        """create_checkpointer に委譲する"""
-        monkeypatch.setenv("SUPABASE_DB_URI", "postgresql://user:pass@localhost:5432/db")
-
+    @pytest.mark.asyncio
+    async def test_delegates_to_create_checkpointer(self):
         mock_saver = AsyncMock()
-        mock_saver.setup = AsyncMock()
-
-        mock_cm = _make_mock_context_manager(mock_saver)
 
         with patch(
-            "backend.utils.checkpointer.AsyncPostgresSaver.from_conn_string",
-            return_value=mock_cm,
+            "backend.utils.checkpointer.create_checkpointer",
+            AsyncMock(return_value=mock_saver),
         ):
             result = await checkpointer.create_memory_checkpointer()
-            assert result == mock_saver
+
+        assert result is mock_saver
 
 
 class TestGetCheckpointerContext:
-    """get_checkpointer_context コンテキストマネージャーのテスト"""
-
+    @pytest.mark.asyncio
     async def test_raises_error_without_supabase_db_uri(self, monkeypatch):
-        """SUPABASE_DB_URI が設定されていない場合は ValueError"""
         monkeypatch.delenv("SUPABASE_DB_URI", raising=False)
 
         with pytest.raises(ValueError) as exc_info:
@@ -217,20 +178,38 @@ class TestGetCheckpointerContext:
 
         assert "SUPABASE_DB_URI environment variable is not set" in str(exc_info.value)
 
-    async def test_yields_checkpointer_instance(self, monkeypatch):
-        """正常なコンテキストマネージャーとして動作"""
-        monkeypatch.setenv("SUPABASE_DB_URI", "postgresql://user:pass@localhost:5432/db")
-
+    @pytest.mark.asyncio
+    async def test_yields_checkpointer_instance_and_closes_it(self):
         mock_saver = AsyncMock()
-        mock_saver.setup = AsyncMock()
-
-        mock_context_manager = AsyncMock()
-        mock_context_manager.__aenter__.return_value = mock_saver
-        mock_context_manager.__aexit__.return_value = None
+        mock_saver.aclose = AsyncMock()
 
         with patch(
-            "backend.utils.checkpointer.AsyncPostgresSaver.from_conn_string",
-            return_value=mock_context_manager,
+            "backend.utils.checkpointer.create_checkpointer",
+            AsyncMock(return_value=mock_saver),
         ):
             async with checkpointer.get_checkpointer_context() as cp:
-                assert cp == mock_saver
+                assert cp is mock_saver
+
+        mock_saver.aclose.assert_awaited_once()
+
+
+class TestPrewarmCheckpointer:
+    @pytest.fixture(autouse=True)
+    async def cleanup(self):
+        yield
+        checkpointer._checkpointer_instance = None
+        checkpointer._checkpointer_cm = None
+
+    @pytest.mark.asyncio
+    async def test_prewarm_gets_singleton_and_calls_prewarm(self):
+        mock_saver = AsyncMock()
+        mock_saver.prewarm = AsyncMock()
+
+        with patch(
+            "backend.utils.checkpointer.get_checkpointer",
+            AsyncMock(return_value=mock_saver),
+        ):
+            result = await checkpointer.prewarm_checkpointer()
+
+        assert result is mock_saver
+        mock_saver.prewarm.assert_awaited_once()

--- a/backend/tests/workflows/test_streaming_memory.py
+++ b/backend/tests/workflows/test_streaming_memory.py
@@ -255,15 +255,13 @@ class TestStreamingExecution:
 
     @pytest.mark.asyncio
     @patch("backend.workflows.main_workflow.OrchestratorAgent")
-    async def test_ainvoke_retries_after_stale_checkpointer_probe(self, mock_orch_cls):
-        """stale connection を検知したら pool refresh 後に ainvoke を続行する"""
+    async def test_ainvoke_probes_checkpointer_before_invoke(self, mock_orch_cls):
+        """checkpointer の readiness probe を ainvoke 前に実行する"""
         mock_orch_cls.return_value = AsyncMock()
         workflow = MainWorkflow()
 
         mock_checkpointer = AsyncMock()
-        mock_checkpointer.aget_tuple = AsyncMock(
-            side_effect=[RuntimeError("the connection is closed"), None]
-        )
+        mock_checkpointer.aget_tuple = AsyncMock(return_value=None)
         mock_checkpointer.recreate = AsyncMock()
         workflow.checkpointer = mock_checkpointer
 
@@ -275,8 +273,10 @@ class TestStreamingExecution:
         result = await workflow.ainvoke(_default_input(session_id="reconnect-session"))
 
         assert result["answer"] == "recovered"
-        assert mock_checkpointer.aget_tuple.await_count == 2
-        mock_checkpointer.recreate.assert_awaited_once()
+        mock_checkpointer.aget_tuple.assert_awaited_once_with(
+            {"configurable": {"thread_id": "reconnect-session"}}
+        )
+        mock_checkpointer.recreate.assert_not_called()
         workflow.graph.ainvoke.assert_awaited_once()
 
 

--- a/backend/tests/workflows/test_streaming_memory.py
+++ b/backend/tests/workflows/test_streaming_memory.py
@@ -45,7 +45,7 @@ def _build_patches():
         "vision_agent": "backend.agents.ocr_agent.VisionAgent",
         "rag": "backend.tools.enhanced_rag.EnhancedRAGSearch",
         "classifier": "backend.utils.query_classifier.QueryClassifier",
-        "checkpointer": "backend.utils.checkpointer.create_checkpointer",
+        "checkpointer": "backend.utils.checkpointer.get_checkpointer",
         "clarification": "backend.utils.clarification_templates.get_clarification_response",
         "priority_engine": "backend.utils.context_priority.ContextPriorityEngine",
     }
@@ -252,6 +252,32 @@ class TestStreamingExecution:
 
         assert captured_kwargs.get("config") is not None
         assert captured_kwargs["config"]["configurable"]["thread_id"] == "cfg-test"
+
+    @pytest.mark.asyncio
+    @patch("backend.workflows.main_workflow.OrchestratorAgent")
+    async def test_ainvoke_retries_after_stale_checkpointer_probe(self, mock_orch_cls):
+        """stale connection を検知したら pool refresh 後に ainvoke を続行する"""
+        mock_orch_cls.return_value = AsyncMock()
+        workflow = MainWorkflow()
+
+        mock_checkpointer = AsyncMock()
+        mock_checkpointer.aget_tuple = AsyncMock(
+            side_effect=[RuntimeError("the connection is closed"), None]
+        )
+        mock_checkpointer.recreate = AsyncMock()
+        workflow.checkpointer = mock_checkpointer
+
+        workflow.graph = MagicMock()
+        workflow.graph.ainvoke = AsyncMock(
+            return_value={"answer": "recovered", "emotion": "neutral", "metadata": {}}
+        )
+
+        result = await workflow.ainvoke(_default_input(session_id="reconnect-session"))
+
+        assert result["answer"] == "recovered"
+        assert mock_checkpointer.aget_tuple.await_count == 2
+        mock_checkpointer.recreate.assert_awaited_once()
+        workflow.graph.ainvoke.assert_awaited_once()
 
 
 # ===========================================================================
@@ -583,11 +609,11 @@ class TestGetWorkflowSingleton:
 
     @pytest.mark.asyncio
     @patch("backend.workflows.main_workflow.OrchestratorAgent")
-    @patch("backend.utils.checkpointer.create_checkpointer", new_callable=AsyncMock)
-    async def test_get_workflow_returns_same_instance(self, mock_create_cp, mock_orch_cls):
+    @patch("backend.utils.checkpointer.get_checkpointer", new_callable=AsyncMock)
+    async def test_get_workflow_returns_same_instance(self, mock_get_cp, mock_orch_cls):
         """get_workflow() を 2 回呼ぶと同一インスタンスが返る"""
         mock_orch_cls.return_value = AsyncMock()
-        mock_create_cp.side_effect = ValueError("No SUPABASE_DB_URI")
+        mock_get_cp.side_effect = ValueError("No SUPABASE_DB_URI")
 
         wf1 = await get_workflow()
         wf2 = await get_workflow()
@@ -596,11 +622,11 @@ class TestGetWorkflowSingleton:
 
     @pytest.mark.asyncio
     @patch("backend.workflows.main_workflow.OrchestratorAgent")
-    @patch("backend.utils.checkpointer.create_checkpointer", new_callable=AsyncMock)
-    async def test_get_workflow_thread_safe(self, mock_create_cp, mock_orch_cls):
+    @patch("backend.utils.checkpointer.get_checkpointer", new_callable=AsyncMock)
+    async def test_get_workflow_thread_safe(self, mock_get_cp, mock_orch_cls):
         """複数タスクから同時に get_workflow() を呼んでもシングルトンが保証される"""
         mock_orch_cls.return_value = AsyncMock()
-        mock_create_cp.side_effect = ValueError("No SUPABASE_DB_URI")
+        mock_get_cp.side_effect = ValueError("No SUPABASE_DB_URI")
 
         results = await asyncio.gather(*[get_workflow() for _ in range(5)])
 
@@ -611,11 +637,11 @@ class TestGetWorkflowSingleton:
 
     @pytest.mark.asyncio
     @patch("backend.workflows.main_workflow.OrchestratorAgent")
-    @patch("backend.utils.checkpointer.create_checkpointer", new_callable=AsyncMock)
-    async def test_reset_workflow_clears_instance(self, mock_create_cp, mock_orch_cls):
+    @patch("backend.utils.checkpointer.get_checkpointer", new_callable=AsyncMock)
+    async def test_reset_workflow_clears_instance(self, mock_get_cp, mock_orch_cls):
         """reset_workflow() 後の get_workflow() は新しいインスタンスを返す"""
         mock_orch_cls.return_value = AsyncMock()
-        mock_create_cp.side_effect = ValueError("No SUPABASE_DB_URI")
+        mock_get_cp.side_effect = ValueError("No SUPABASE_DB_URI")
 
         wf1 = await get_workflow()
         reset_workflow()
@@ -625,11 +651,11 @@ class TestGetWorkflowSingleton:
 
     @pytest.mark.asyncio
     @patch("backend.workflows.main_workflow.OrchestratorAgent")
-    @patch("backend.utils.checkpointer.create_checkpointer", new_callable=AsyncMock)
-    async def test_get_workflow_without_checkpointer(self, mock_create_cp, mock_orch_cls):
-        """create_checkpointer が ValueError を投げても永続化なしで動作する"""
+    @patch("backend.utils.checkpointer.get_checkpointer", new_callable=AsyncMock)
+    async def test_get_workflow_without_checkpointer(self, mock_get_cp, mock_orch_cls):
+        """get_checkpointer が ValueError を投げても永続化なしで動作する"""
         mock_orch_cls.return_value = AsyncMock()
-        mock_create_cp.side_effect = ValueError("SUPABASE_DB_URI environment variable is not set.")
+        mock_get_cp.side_effect = ValueError("SUPABASE_DB_URI environment variable is not set.")
 
         wf = await get_workflow()
 
@@ -639,11 +665,11 @@ class TestGetWorkflowSingleton:
 
     @pytest.mark.asyncio
     @patch("backend.workflows.main_workflow.OrchestratorAgent")
-    @patch("backend.utils.checkpointer.create_checkpointer", new_callable=AsyncMock)
-    async def test_get_workflow_with_checkpointer_failure(self, mock_create_cp, mock_orch_cls):
-        """create_checkpointer が一般例外を投げても永続化なしで動作する"""
+    @patch("backend.utils.checkpointer.get_checkpointer", new_callable=AsyncMock)
+    async def test_get_workflow_with_checkpointer_failure(self, mock_get_cp, mock_orch_cls):
+        """get_checkpointer が一般例外を投げても永続化なしで動作する"""
         mock_orch_cls.return_value = AsyncMock()
-        mock_create_cp.side_effect = ConnectionError("DB unreachable")
+        mock_get_cp.side_effect = ConnectionError("DB unreachable")
 
         wf = await get_workflow()
 

--- a/backend/utils/checkpointer.py
+++ b/backend/utils/checkpointer.py
@@ -1,10 +1,8 @@
 """
-Checkpointer基盤実装
+Checkpointer utilities for LangGraph persistence.
 
-LangGraphの永続化機能を有効化するための AsyncPostgresSaver 実装。
-Supabase PostgreSQL を使用した langgraph-checkpoint-postgres 統合。
-
-参考: https://langchain-ai.github.io/langgraph/concepts/persistence/
+Uses a small psycopg async pool so Cloud Run cold starts do not keep serving
+through stale PostgreSQL connections after idle scale-to-zero periods.
 """
 
 import asyncio
@@ -12,186 +10,333 @@ import logging
 import os
 import re
 from contextlib import asynccontextmanager
-from typing import AsyncGenerator, Optional
+from dataclasses import dataclass
+from typing import Any, AsyncGenerator, Awaitable, Callable, Optional, TypeVar, cast
 
+from langgraph.checkpoint.base import (
+    ChannelVersions,
+    Checkpoint,
+    CheckpointMetadata,
+    RunnableConfig,
+)
 from langgraph.checkpoint.postgres.aio import AsyncPostgresSaver
+from psycopg import AsyncConnection, InterfaceError, OperationalError
+from psycopg.rows import dict_row
+from psycopg_pool import AsyncConnectionPool, PoolClosed
 
 logger = logging.getLogger(__name__)
 
-# 非同期シングルトン用ロック
-_checkpointer_lock = asyncio.Lock()
+_T = TypeVar("_T")
 
-# コンテキストマネージャー参照（store.py と同パターン）
+_POOL_MIN_SIZE = 0
+_POOL_MAX_SIZE = 5
+_POOL_MAX_IDLE_SECONDS = 300
+_CONNECT_TIMEOUT_SECONDS = 10
+_KEEPALIVES_IDLE_SECONDS = 30
+
+_CONNECTION_ERROR_MESSAGES = (
+    "connection is closed",
+    "connection closed",
+    "pool is closed",
+    "server closed the connection unexpectedly",
+    "terminating connection",
+    "broken pipe",
+    "ssl connection has been closed unexpectedly",
+    "consuming input failed",
+)
+
+# Non-async types in tests still expect these module globals to exist.
+_checkpointer_lock = asyncio.Lock()
 _checkpointer_cm = None
+_checkpointer_instance: Optional[AsyncPostgresSaver] = None
 
 
 def _mask_connection_string(db_uri: str) -> str:
-    """
-    接続文字列から認証情報を安全にマスク
+    """Mask credentials in a PostgreSQL connection string for logs."""
+    return re.sub(r"(://[^:]+:)[^@]+(@)", r"\1****\2", db_uri)
 
-    Args:
-        db_uri: PostgreSQL接続文字列
 
-    Returns:
-        パスワードがマスクされた接続文字列
-    """
-    # パスワード部分をマスク: postgresql://user:password@host -> postgresql://user:****@host
-    masked = re.sub(r"(://[^:]+:)[^@]+(@)", r"\1****\2", db_uri)
-    return masked
+def is_checkpointer_connection_error(error: Exception) -> bool:
+    """Return True when the exception indicates a dead/closed DB connection."""
+    if isinstance(error, (OperationalError, InterfaceError, PoolClosed)):
+        return True
+
+    error_message = str(error).lower()
+    return any(message in error_message for message in _CONNECTION_ERROR_MESSAGES)
+
+
+async def _health_check_connection(conn: AsyncConnection[Any]) -> None:
+    """Fallback pool health check for psycopg versions without check_connection."""
+    async with conn.cursor() as cur:
+        await cur.execute("SELECT 1")
+
+
+def _pool_check_callback() -> Callable[[AsyncConnection[Any]], Awaitable[None]]:
+    callback = getattr(AsyncConnectionPool, "check_connection", None)
+    if callable(callback):
+        return cast(Callable[[AsyncConnection[Any]], Awaitable[None]], callback)
+    return _health_check_connection
+
+
+@dataclass(frozen=True)
+class _CheckpointerFactory:
+    """Factory for creating and re-creating resilient checkpointers."""
+
+    db_uri: str
+
+    @classmethod
+    def from_env(cls) -> "_CheckpointerFactory":
+        db_uri = os.getenv("SUPABASE_DB_URI")
+        if not db_uri:
+            error_msg = (
+                "SUPABASE_DB_URI environment variable is not set. "
+                "Please set it to your Supabase PostgreSQL connection string."
+            )
+            logger.error(error_msg)
+            raise ValueError(error_msg)
+
+        return cls(db_uri=db_uri)
+
+    async def create_pool(self) -> AsyncConnectionPool:
+        pool = AsyncConnectionPool(
+            conninfo=self.db_uri,
+            open=False,
+            min_size=_POOL_MIN_SIZE,
+            max_size=_POOL_MAX_SIZE,
+            max_idle=_POOL_MAX_IDLE_SECONDS,
+            check=_pool_check_callback(),
+            kwargs={
+                "autocommit": True,
+                "prepare_threshold": 0,
+                "row_factory": dict_row,
+                "connect_timeout": _CONNECT_TIMEOUT_SECONDS,
+                "keepalives": 1,
+                "keepalives_idle": _KEEPALIVES_IDLE_SECONDS,
+            },
+        )
+        await pool.open()
+        return pool
+
+    async def create_checkpointer(self) -> "ResilientAsyncPostgresSaver":
+        pool = await self.create_pool()
+        saver = ResilientAsyncPostgresSaver(factory=self, pool=pool)
+        await saver.setup()
+        return saver
+
+    async def prewarm_pool(self, pool: AsyncConnectionPool) -> None:
+        async with pool.connection() as conn:
+            await _pool_check_callback()(conn)
+
+
+class ResilientAsyncPostgresSaver(AsyncPostgresSaver):
+    """AsyncPostgresSaver that can replace its own pool after connection loss."""
+
+    def __init__(self, factory: _CheckpointerFactory, pool: AsyncConnectionPool) -> None:
+        super().__init__(conn=pool)
+        self._factory = factory
+        self._pool_refresh_lock = asyncio.Lock()
+
+    @property
+    def pool(self) -> AsyncConnectionPool:
+        return cast(AsyncConnectionPool, self.conn)
+
+    async def prewarm(self) -> None:
+        await self._factory.prewarm_pool(self.pool)
+
+    async def recreate(self, reason: Exception | None = None) -> None:
+        async with self._pool_refresh_lock:
+            previous_pool = self.pool
+            new_pool = await self._factory.create_pool()
+            try:
+                await self._factory.prewarm_pool(new_pool)
+            except Exception:
+                await new_pool.close()
+                raise
+
+            async with self.lock:
+                self.conn = new_pool
+
+            try:
+                await previous_pool.close()
+            except Exception as close_error:
+                logger.warning(
+                    "Error closing previous checkpointer pool: %s",
+                    close_error,
+                    exc_info=True,
+                )
+
+            if reason is None:
+                logger.info("Recreated checkpointer connection pool")
+            else:
+                logger.warning(
+                    "Recreated checkpointer connection pool after failure: %s",
+                    reason,
+                )
+
+    async def aclose(self) -> None:
+        await self.pool.close()
+
+    async def _run_with_connection_retry(
+        self,
+        operation_name: str,
+        operation: Callable[..., Awaitable[_T]],
+        *args: Any,
+        **kwargs: Any,
+    ) -> _T:
+        try:
+            return await operation(*args, **kwargs)
+        except Exception as error:
+            if not is_checkpointer_connection_error(error):
+                raise
+
+            logger.warning(
+                "Checkpointer %s failed because the PostgreSQL connection is stale. "
+                "Recreating the pool and retrying once.",
+                operation_name,
+                exc_info=True,
+            )
+            await self.recreate(reason=error)
+            return await operation(*args, **kwargs)
+
+    async def aget_tuple(self, config: RunnableConfig) -> Any:
+        return await self._run_with_connection_retry("aget_tuple", super().aget_tuple, config)
+
+    async def alist(
+        self,
+        config: RunnableConfig | None,
+        *,
+        filter: dict[str, Any] | None = None,
+        before: RunnableConfig | None = None,
+        limit: int | None = None,
+    ) -> Any:
+        return await self._run_with_connection_retry(
+            "alist",
+            super().alist,
+            config,
+            filter=filter,
+            before=before,
+            limit=limit,
+        )
+
+    async def aput(
+        self,
+        config: RunnableConfig,
+        checkpoint: Checkpoint,
+        metadata: CheckpointMetadata,
+        new_versions: ChannelVersions,
+    ) -> RunnableConfig:
+        return await self._run_with_connection_retry(
+            "aput",
+            super().aput,
+            config,
+            checkpoint,
+            metadata,
+            new_versions,
+        )
+
+    async def aput_writes(
+        self,
+        config: RunnableConfig,
+        writes: Any,
+        task_id: str,
+        task_path: str = "",
+    ) -> None:
+        await self._run_with_connection_retry(
+            "aput_writes",
+            super().aput_writes,
+            config,
+            writes,
+            task_id,
+            task_path,
+        )
+
+    async def adelete_thread(self, thread_id: str) -> None:
+        await self._run_with_connection_retry("adelete_thread", super().adelete_thread, thread_id)
 
 
 async def create_checkpointer() -> AsyncPostgresSaver:
     """
-    AsyncPostgresSaverを作成（Supabase PostgreSQL使用）
-
-    環境変数 SUPABASE_DB_URI から PostgreSQL 接続文字列を取得し、
-    langgraph-checkpoint-postgres の AsyncPostgresSaver を初期化します。
-
-    環境変数:
-        SUPABASE_DB_URI: PostgreSQL接続文字列
-            例: postgresql://user:password@host:port/database
+    Create an AsyncPostgresSaver backed by a resilient AsyncConnectionPool.
 
     Returns:
-        AsyncPostgresSaver: LangGraph用のCheckpointerインスタンス
-
-    Raises:
-        ValueError: SUPABASE_DB_URI が設定されていない場合
-        ConnectionError: データベース接続に失敗した場合
-
-    Example:
-        >>> checkpointer = await create_checkpointer()
-        >>> # LangGraph workflow で使用
-        >>> workflow = StateGraph(WorkflowState).compile(checkpointer=checkpointer)
+        AsyncPostgresSaver: LangGraph checkpointer instance
     """
-    db_uri = os.getenv("SUPABASE_DB_URI")
-
-    if not db_uri:
-        error_msg = (
-            "SUPABASE_DB_URI environment variable is not set. "
-            "Please set it to your Supabase PostgreSQL connection string."
-        )
-        logger.error(error_msg)
-        raise ValueError(error_msg)
-
-    # 接続文字列をマスクしてログ出力（パスワード漏洩防止）
-    masked_uri = _mask_connection_string(db_uri)
-    logger.info("Creating AsyncPostgresSaver with connection: %s", masked_uri)
-
-    global _checkpointer_cm
+    factory = _CheckpointerFactory.from_env()
+    logger.info(
+        "Creating AsyncPostgresSaver with pooled connection: %s",
+        _mask_connection_string(factory.db_uri),
+    )
 
     try:
-        # from_conn_string は @asynccontextmanager でラップされているため、
-        # 呼び出すとコンテキストマネージャーが返される。
-        # シングルトンパターンのため、コンテキストマネージャーを保持し、__aenter__() で取得する。
-        _checkpointer_cm = AsyncPostgresSaver.from_conn_string(db_uri)
-        checkpointer = await _checkpointer_cm.__aenter__()
-        await checkpointer.setup()
+        checkpointer = await factory.create_checkpointer()
         logger.info("AsyncPostgresSaver created and initialized successfully")
         return checkpointer
-    except Exception as e:
-        logger.exception("Failed to create AsyncPostgresSaver: %s", e)
-        raise ConnectionError(f"Failed to connect to Supabase PostgreSQL: {e}") from e
+    except Exception as error:
+        logger.exception("Failed to create AsyncPostgresSaver: %s", error)
+        raise ConnectionError(f"Failed to connect to Supabase PostgreSQL: {error}") from error
 
 
 @asynccontextmanager
 async def get_checkpointer_context() -> AsyncGenerator[AsyncPostgresSaver, None]:
-    """
-    Checkpointerのコンテキストマネージャー
-
-    async with文で使用することで、接続の自動クリーンアップを保証します。
-
-    Yields:
-        AsyncPostgresSaver: Checkpointerインスタンス
-
-    Example:
-        >>> async with get_checkpointer_context() as checkpointer:
-        ...     graph = builder.compile(checkpointer=checkpointer)
-        ...     result = await graph.ainvoke(input_data)
-    """
-    db_uri = os.getenv("SUPABASE_DB_URI")
-
-    if not db_uri:
-        error_msg = (
-            "SUPABASE_DB_URI environment variable is not set. "
-            "Please set it to your Supabase PostgreSQL connection string."
-        )
-        logger.error(error_msg)
-        raise ValueError(error_msg)
-
-    async with AsyncPostgresSaver.from_conn_string(db_uri) as checkpointer:
-        await checkpointer.setup()
+    """Yield a one-off resilient checkpointer and close its pool afterwards."""
+    checkpointer = await create_checkpointer()
+    try:
         logger.info("AsyncPostgresSaver context created successfully")
         yield checkpointer
+    finally:
+        aclose = getattr(checkpointer, "aclose", None)
+        if callable(aclose):
+            await aclose()
 
 
 async def create_memory_checkpointer() -> AsyncPostgresSaver:
-    """
-    メモリ専用のCheckpointerを作成
-
-    メモリエージェント用に最適化されたCheckpointerインスタンスを作成します。
-    現在は通常のCheckpointerと同じ実装ですが、将来的に異なる設定を適用可能。
-
-    Returns:
-        AsyncPostgresSaver: メモリエージェント用のCheckpointerインスタンス
-    """
+    """Create the memory-specific checkpointer instance."""
     logger.info("Creating memory-specific checkpointer")
     return await create_checkpointer()
 
 
-# シングルトンインスタンス
-_checkpointer_instance: Optional[AsyncPostgresSaver] = None
-
-
 async def get_checkpointer() -> AsyncPostgresSaver:
-    """
-    Checkpointerのシングルトンインスタンスを取得（スレッドセーフ）
-
-    アプリケーション全体で単一のCheckpointerインスタンスを共有します。
-    複数のワークフローで同じCheckpointerを使用する場合に便利。
-    asyncio.Lockを使用してrace conditionを防止。
-
-    Returns:
-        AsyncPostgresSaver: Checkpointerのシングルトンインスタンス
-
-    Example:
-        >>> checkpointer = await get_checkpointer()
-        >>> workflow1 = StateGraph(State1).compile(checkpointer=checkpointer)
-        >>> workflow2 = StateGraph(State2).compile(checkpointer=checkpointer)
-    """
+    """Return the process-wide resilient checkpointer singleton."""
     global _checkpointer_instance
+
     if _checkpointer_instance is None:
         async with _checkpointer_lock:
-            # Double-check after acquiring lock
             if _checkpointer_instance is None:
                 _checkpointer_instance = await create_checkpointer()
                 logger.info("Checkpointer singleton instance created")
+
     return _checkpointer_instance
 
 
-async def close_checkpointer() -> None:
-    """
-    シングルトンCheckpointerをクローズ
+async def prewarm_checkpointer() -> AsyncPostgresSaver:
+    """Open and validate a pooled connection during application startup."""
+    checkpointer = await get_checkpointer()
+    prewarm = getattr(checkpointer, "prewarm", None)
+    if callable(prewarm):
+        await prewarm()
+        logger.info("Checkpointer connection pool pre-warmed")
+    return checkpointer
 
-    アプリケーション終了時に呼び出して、接続をクリーンアップします。
-    """
+
+async def close_checkpointer() -> None:
+    """Close the singleton checkpointer and drop the cached instance."""
     global _checkpointer_instance, _checkpointer_cm
-    if _checkpointer_instance is not None:
-        try:
-            # コンテキストマネージャーの __aexit__() を呼び出してクリーンアップ
-            if _checkpointer_cm is not None:
-                await _checkpointer_cm.__aexit__(None, None, None)
-            logger.info("Checkpointer singleton instance closed")
-        except Exception as e:
-            logger.warning("Error closing checkpointer: %s", e, exc_info=True)
-        finally:
-            _checkpointer_instance = None
-            _checkpointer_cm = None
+
+    if _checkpointer_instance is None:
+        return
+
+    try:
+        aclose = getattr(_checkpointer_instance, "aclose", None)
+        if callable(aclose):
+            await aclose()
+        logger.info("Checkpointer singleton instance closed")
+    except Exception as error:
+        logger.warning("Error closing checkpointer: %s", error, exc_info=True)
+    finally:
+        _checkpointer_instance = None
+        _checkpointer_cm = None
 
 
 async def reset_checkpointer() -> None:
-    """
-    Checkpointerインスタンスをリセット（テスト用）
-
-    既存の接続を適切にクローズしてからリセットします。
-    """
+    """Reset the singleton checkpointer instance for tests."""
     await close_checkpointer()

--- a/backend/utils/checkpointer.py
+++ b/backend/utils/checkpointer.py
@@ -143,8 +143,15 @@ class ResilientAsyncPostgresSaver(AsyncPostgresSaver):
     async def prewarm(self) -> None:
         await self._factory.prewarm_pool(self.pool)
 
-    async def recreate(self, reason: Exception | None = None) -> None:
+    async def recreate(
+        self,
+        reason: Exception | None = None,
+        stale_pool: AsyncConnectionPool | None = None,
+    ) -> None:
         async with self._pool_refresh_lock:
+            if stale_pool is not None and self.pool is not stale_pool:
+                return
+
             previous_pool = self.pool
             new_pool = await self._factory.create_pool()
             try:
@@ -183,6 +190,7 @@ class ResilientAsyncPostgresSaver(AsyncPostgresSaver):
         *args: Any,
         **kwargs: Any,
     ) -> _T:
+        stale_pool = self.pool
         try:
             return await operation(*args, **kwargs)
         except Exception as error:
@@ -195,7 +203,7 @@ class ResilientAsyncPostgresSaver(AsyncPostgresSaver):
                 operation_name,
                 exc_info=True,
             )
-            await self.recreate(reason=error)
+            await self.recreate(reason=error, stale_pool=stale_pool)
             return await operation(*args, **kwargs)
 
     async def aget_tuple(self, config: RunnableConfig) -> Any:
@@ -208,15 +216,33 @@ class ResilientAsyncPostgresSaver(AsyncPostgresSaver):
         filter: dict[str, Any] | None = None,
         before: RunnableConfig | None = None,
         limit: int | None = None,
-    ) -> Any:
-        return await self._run_with_connection_retry(
-            "alist",
-            super().alist,
-            config,
-            filter=filter,
-            before=before,
-            limit=limit,
-        )
+    ) -> AsyncGenerator[Any, None]:
+        stale_pool = self.pool
+        try:
+            async for item in super().alist(
+                config,
+                filter=filter,
+                before=before,
+                limit=limit,
+            ):
+                yield item
+        except Exception as error:
+            if not is_checkpointer_connection_error(error):
+                raise
+
+            logger.warning(
+                "Checkpointer alist failed because the PostgreSQL connection is stale. "
+                "Recreating the pool and retrying once.",
+                exc_info=True,
+            )
+            await self.recreate(reason=error, stale_pool=stale_pool)
+            async for item in super().alist(
+                config,
+                filter=filter,
+                before=before,
+                limit=limit,
+            ):
+                yield item
 
     async def aput(
         self,

--- a/backend/workflows/main_workflow.py
+++ b/backend/workflows/main_workflow.py
@@ -1000,26 +1000,7 @@ class MainWorkflow:
         if not callable(aget_tuple):
             return
 
-        try:
-            await aget_tuple(config)
-        except Exception as error:
-            from backend.utils.checkpointer import is_checkpointer_connection_error
-
-            if not is_checkpointer_connection_error(error):
-                raise
-
-            recreate = getattr(self.checkpointer, "recreate", None)
-            if not callable(recreate):
-                raise
-
-            logger.warning(
-                "Checkpoint probe failed for session %s due to a stale PostgreSQL connection. "
-                "Refreshing the pool and retrying once.",
-                session_id,
-                exc_info=True,
-            )
-            await recreate(reason=error)
-            await aget_tuple(config)
+        await aget_tuple(config)
 
     _AGENT_NODE_MAP: dict[str, str] = {
         "facility": "_facility_node",

--- a/backend/workflows/main_workflow.py
+++ b/backend/workflows/main_workflow.py
@@ -15,7 +15,7 @@ import os
 import time
 import uuid
 from dataclasses import dataclass
-from typing import Annotated, Any, Optional, TypedDict
+from typing import Annotated, Any, Optional, TypedDict, cast
 
 from langchain_core.messages import AIMessage, BaseMessage, HumanMessage
 from langgraph.graph import END, START, StateGraph
@@ -991,6 +991,36 @@ class MainWorkflow:
 
         return state, config
 
+    async def _ensure_checkpointer_ready(self, config: dict | None, session_id: str) -> None:
+        """Cold-start後の切断済み接続を graph 実行前に一度だけ張り直す。"""
+        if not self.checkpointer or not config:
+            return
+
+        aget_tuple = getattr(self.checkpointer, "aget_tuple", None)
+        if not callable(aget_tuple):
+            return
+
+        try:
+            await aget_tuple(config)
+        except Exception as error:
+            from backend.utils.checkpointer import is_checkpointer_connection_error
+
+            if not is_checkpointer_connection_error(error):
+                raise
+
+            recreate = getattr(self.checkpointer, "recreate", None)
+            if not callable(recreate):
+                raise
+
+            logger.warning(
+                "Checkpoint probe failed for session %s due to a stale PostgreSQL connection. "
+                "Refreshing the pool and retrying once.",
+                session_id,
+                exc_info=True,
+            )
+            await recreate(reason=error)
+            await aget_tuple(config)
+
     _AGENT_NODE_MAP: dict[str, str] = {
         "facility": "_facility_node",
         "event": "_event_node",
@@ -1029,7 +1059,7 @@ class MainWorkflow:
         agent_result = await agent_node(state)
 
         # Merge agent output into state for format_response
-        merged_state = {**state, **agent_result}
+        merged_state = cast(WorkflowStateDict, {**state, **agent_result})
 
         # format_response expects Runtime context — call directly with a
         # lightweight shim since we're outside the graph execution.
@@ -1058,6 +1088,7 @@ class MainWorkflow:
     async def ainvoke(self, input_data: dict) -> dict:
         """ワークフローを非同期実行"""
         state, config = self._prepare_state(input_data)
+        await self._ensure_checkpointer_ready(config, state["session_id"])
         visitor_id = input_data.get("visitor_id") or input_data.get("session_id", "anonymous")
         context = WorkflowContext(user_id=visitor_id)
         result = await self.graph.ainvoke(state, config=config, context=context)
@@ -1082,6 +1113,7 @@ class MainWorkflow:
             dict: {"type": "token", "content": str} or {"type": "complete", "data": dict}
         """
         state, config = self._prepare_state(input_data)
+        await self._ensure_checkpointer_ready(config, state["session_id"])
         visitor_id = input_data.get("visitor_id") or input_data.get("session_id", "anonymous")
         context = WorkflowContext(user_id=visitor_id)
         event_stream = self.graph.astream_events(
@@ -1147,9 +1179,9 @@ async def get_workflow() -> MainWorkflow:
                 store = None
 
                 try:
-                    from backend.utils.checkpointer import create_checkpointer
+                    from backend.utils.checkpointer import get_checkpointer
 
-                    checkpointer = await create_checkpointer()
+                    checkpointer = await get_checkpointer()
                     logger.info("Workflow initialized with AsyncPostgresSaver")
                 except ValueError:
                     logger.warning("SUPABASE_DB_URI not set, running without persistence.")


### PR DESCRIPTION
## Summary

- Harden LangGraph PostgreSQL checkpointer for Cloud Run cold starts
- `AsyncConnectionPool` with `min_size=0`, `max_size=5`, `max_idle=300`, health checks
- Connection kwargs: `connect_timeout=10`, `keepalives=1`, `keepalives_idle=30`
- Factory pattern: recreates pool on stale connection failures
- `aget_tuple()` probe with retry before graph execution
- Pre-warm pool during FastAPI startup lifespan

## Root Cause

Cloud Run `min-instances=0` causes instances to scale down. On cold start, `AsyncPostgresSaver` held stale DB connections from previous instance lifecycle, causing `psycopg.OperationalError: the connection is closed` on every `/api/chat` and `/api/slides` request.

## Closes

- Closes #267

## Test plan

- [x] `ruff check .` — pass
- [x] `black --check .` — pass
- [x] `pytest` — 2612 passed, 47 skipped, 169 deselected
- [x] New tests in `test_checkpointer.py`
- [ ] Deploy to Cloud Run and verify cold start recovery
- [ ] Verify `/api/chat` works after 10+ min idle

🤖 Generated with [Claude Code](https://claude.com/claude-code)