### PR TITLE
feat(frontend): VRM表情・アニメーション統合とエラー時 happy 誤発火を修正

### DIFF
--- a/backend/agents/character_control_agent.py
+++ b/backend/agents/character_control_agent.py
@@ -1095,17 +1095,19 @@ class CharacterControlAgent:
                         }
                     )
 
-                if prev_viseme is not None:
-                    final_time = int(lipsync_data[-1]["time"] * 1000) + 50
-                    final_expressions = dict(base_expressions)
-                    final_expressions[prev_viseme] = 0.0
-                    keyframes.append(
-                        {
-                            "time": final_time,
-                            "bones": {},
-                            "expressions": final_expressions,
-                        }
-                    )
+                final_time = int(lipsync_data[-1]["time"] * 1000) + 50
+                reset_expressions: Dict[str, float] = {}
+                for expression_name in base_expressions.keys():
+                    reset_expressions[expression_name] = 0.0
+                for viseme_name in viseme_names:
+                    reset_expressions[viseme_name] = 0.0
+                keyframes.append(
+                    {
+                        "time": final_time,
+                        "bones": {},
+                        "expressions": reset_expressions,
+                    }
+                )
             else:
                 keyframes.append(
                     {

--- a/frontend/src/app/api/qa/route.ts
+++ b/frontend/src/app/api/qa/route.ts
@@ -10,7 +10,8 @@ export async function POST(request: NextRequest) {
     const response = await backendFetch<{
       answer?: string;
       emotion?: string;
-      metadata?: unknown;
+      metadata?: { vrm_control?: unknown } & Record<string, unknown>;
+      vrm_control?: { name: string; duration: number; keyframes: unknown[] } | null;
     }>('/api/chat', {
       body: {
         query: question || text,
@@ -29,6 +30,10 @@ export async function POST(request: NextRequest) {
       answer: response.data.answer,
       emotion: response.data.emotion,
       metadata: response.data.metadata,
+      vrm_control:
+        response.data.vrm_control ??
+        (response.data.metadata as { vrm_control?: unknown } | undefined)?.vrm_control ??
+        null,
     });
   } catch (error) {
     console.error('Q&A API error:', error);

--- a/frontend/src/app/components/CharacterAvatar.tsx
+++ b/frontend/src/app/components/CharacterAvatar.tsx
@@ -3,7 +3,7 @@
 import { EmotionData, EmotionManager } from '@/lib/emotion-manager';
 import { ExpressionController } from '@/lib/expression-controller';
 import { LipSyncAnalyzer } from '@/lib/lip-sync-analyzer';
-import { VRMBlendShapeController, VRMUtils } from '@/lib/vrm-utils';
+import { VRMBlendShapeController, VRMUtils, getMouthOverrideFactor } from '@/lib/vrm-utils';
 import { VRM, VRMLoaderPlugin } from '@pixiv/three-vrm';
 import { VRMAnimationLoaderPlugin, createVRMAnimationClip } from '@pixiv/three-vrm-animation';
 import { Settings, VolumeX } from 'lucide-react';
@@ -836,10 +836,9 @@ export default function CharacterAvatar({
         }
       }
 
-      // Create viseme control function
+      // Create viseme control function (attenuate intensity when expression uses mouth)
       const setViseme = (viseme: string, intensity: number) => {
         if (blendShapeControllerRef.current) {
-          // Map viseme to VRM expression name
           const visemeMap: Record<string, string> = {
             'A': 'aa',
             'I': 'ih',
@@ -848,9 +847,10 @@ export default function CharacterAvatar({
             'O': 'oh',
             'Closed': 'neutral'
           };
-          
           const vrmExpression = visemeMap[viseme] || 'neutral';
-          blendShapeControllerRef.current.setViseme(vrmExpression, intensity);
+          const { expression, weight } = currentExpressionRef.current;
+          const factor = getMouthOverrideFactor(expression, weight);
+          blendShapeControllerRef.current.setViseme(vrmExpression, intensity * factor);
         }
       };
 

--- a/frontend/src/app/components/VoiceInterface.tsx
+++ b/frontend/src/app/components/VoiceInterface.tsx
@@ -24,6 +24,7 @@ import {
 } from '../hooks/useVoiceSessionController';
 import type { WakeWordMatch } from '../hooks/useWakeWord';
 import { VoiceRecorder } from '@/lib/voice-recorder';
+import type { CharacterAnimationData } from '../utils/character-animation-utils';
 
 export type VoiceSessionState = 'idle' | 'listening' | 'processing' | 'speaking';
 
@@ -35,6 +36,7 @@ export interface VoiceInterfaceMetadata {
   clarification_options?: string[];
   requires_followup?: boolean;
    reception_type?: string;
+  vrm_control?: CharacterAnimationData | null;
   [key: string]: unknown;
 }
 
@@ -77,6 +79,7 @@ interface VoiceInterfaceProps {
   showDefaultUI?: boolean;
   className?: string;
   onMetadataChange?: (metadata: VoiceInterfaceMetadata | null) => void;
+  onAssistantPlaybackStart?: (payload: { metadata: VoiceInterfaceMetadata | null }) => void;
 }
 
 const DEFAULT_WAKE_WORDS = ['すみません', 'hello'];
@@ -177,6 +180,7 @@ export default function VoiceInterface({
   showDefaultUI,
   className,
   onMetadataChange,
+  onAssistantPlaybackStart,
 }: VoiceInterfaceProps) {
   const [currentLanguage, setCurrentLanguage] = useState<'ja' | 'en'>(language);
   const [volume, setVolumeState] = useState(0.8);
@@ -314,9 +318,10 @@ export default function VoiceInterface({
   );
 
   const playAssistantAudio = useCallback(
-    async (audioBase64: string) => {
+    async (audioBase64: string, metadataForPlayback?: VoiceInterfaceMetadata | null) => {
       if (isMuted) {
         voiceController.notifySpeaking();
+        onAssistantPlaybackStart?.({ metadata: metadataForPlayback ?? null });
         window.setTimeout(() => {
           voiceController.notifySpeakingComplete();
         }, 240);
@@ -341,9 +346,13 @@ export default function VoiceInterface({
       setLoadingMessage(LOADING_LABELS[currentLanguage].speaking);
       voiceController.notifySpeaking();
 
-      await applyLipSync(audioBlob).catch(() => {
-        clearLipSyncTimers();
-      });
+      onAssistantPlaybackStart?.({ metadata: metadataForPlayback ?? null });
+
+      if (!metadataForPlayback?.vrm_control) {
+        await applyLipSync(audioBlob).catch(() => {
+          clearLipSyncTimers();
+        });
+      }
 
       audioService.updateEventHandlers({
         onEnded: () => {
@@ -371,6 +380,7 @@ export default function VoiceInterface({
       currentLanguage,
       ensureAudioService,
       isMuted,
+      onAssistantPlaybackStart,
       revokeAudioUrl,
       voiceController,
     ],
@@ -444,7 +454,7 @@ export default function VoiceInterface({
         }
 
         if (typeof ttsResult.audioResponse === 'string' && ttsResult.audioResponse.length > 0) {
-          await playAssistantAudio(ttsResult.audioResponse);
+          await playAssistantAudio(ttsResult.audioResponse, qaResult.metadata ?? null);
         } else {
           voiceController.notifySpeaking();
           window.setTimeout(() => {

--- a/frontend/src/app/components/VoiceInterface.tsx
+++ b/frontend/src/app/components/VoiceInterface.tsx
@@ -333,7 +333,7 @@ export default function VoiceInterface({
         audioBytes = Uint8Array.from(atob(audioBase64), (char) => char.charCodeAt(0));
       } catch (decodeError) {
         console.error('Audio decode failed:', decodeError);
-        voiceController.notifySpeakingComplete();
+        voiceController.notifySpeakingComplete(true);
         return;
       }
       const audioBlob = new Blob([audioBytes], { type: 'audio/mpeg' });
@@ -362,14 +362,14 @@ export default function VoiceInterface({
         onError: (playbackError) => {
           cleanupAudioPlayback();
           setError(formatError(playbackError, currentLanguage));
-          voiceController.notifySpeakingComplete();
+          voiceController.notifySpeakingComplete(true);
         },
       });
 
       const result = await audioService.playAudio(audioUrl);
       if (!result.success) {
         cleanupAudioPlayback();
-        voiceController.notifySpeakingComplete();
+        voiceController.notifySpeakingComplete(true);
         throw result.error ?? new Error('音声再生に失敗しました');
       }
     },
@@ -467,7 +467,7 @@ export default function VoiceInterface({
         }
 
         setError(formatError(sendError, currentLanguage));
-        voiceController.notifySpeakingComplete();
+        voiceController.notifySpeakingComplete(true);
       } finally {
         if (requestAbortRef.current === abortController) {
           requestAbortRef.current = null;
@@ -523,7 +523,7 @@ export default function VoiceInterface({
         }
 
         setError(formatError(recordingError, currentLanguage));
-        voiceController.notifySpeakingComplete();
+        voiceController.notifySpeakingComplete(true);
       } finally {
         if (requestAbortRef.current === abortController) {
           requestAbortRef.current = null;

--- a/frontend/src/app/hooks/useContinuousListening.ts
+++ b/frontend/src/app/hooks/useContinuousListening.ts
@@ -32,7 +32,7 @@ export interface UseContinuousListeningResult {
   beginListening: () => void;
   beginProcessing: () => void;
   beginSpeaking: () => void;
-  completeAssistantTurn: () => void;
+  completeAssistantTurn: (skipAutoResume?: boolean) => void;
   pauseListening: () => void;
   resumeListening: () => void;
 }
@@ -116,29 +116,34 @@ export function useContinuousListening({
     setTurnCount((currentTurnCount) => currentTurnCount + 1);
   }, [clearResumeTimer, updateShouldListen]);
 
-  const completeAssistantTurn = useCallback(() => {
-    clearResumeTimer();
+  const completeAssistantTurn = useCallback(
+    (skipAutoResume = false) => {
+      clearResumeTimer();
 
-    if (!enabled || !isConversationActive) {
-      setMode(enabled ? 'wake-word' : 'idle');
+      if (!enabled || !isConversationActive) {
+        setMode(enabled ? 'wake-word' : 'idle');
+        updateShouldListen(false);
+        return;
+      }
+
+      setMode('idle');
       updateShouldListen(false);
-      return;
-    }
 
-    setMode('idle');
-    updateShouldListen(false);
-
-    resumeTimerRef.current = window.setTimeout(() => {
-      setMode('listening');
-      updateShouldListen(true);
-    }, autoResumeDelayMs);
-  }, [
-    autoResumeDelayMs,
-    clearResumeTimer,
-    enabled,
-    isConversationActive,
-    updateShouldListen,
-  ]);
+      if (!skipAutoResume) {
+        resumeTimerRef.current = window.setTimeout(() => {
+          setMode('listening');
+          updateShouldListen(true);
+        }, autoResumeDelayMs);
+      }
+    },
+    [
+      autoResumeDelayMs,
+      clearResumeTimer,
+      enabled,
+      isConversationActive,
+      updateShouldListen,
+    ],
+  );
 
   const pauseListening = useCallback(() => {
     clearResumeTimer();

--- a/frontend/src/app/hooks/useVoiceSessionController.ts
+++ b/frontend/src/app/hooks/useVoiceSessionController.ts
@@ -45,7 +45,7 @@ export interface UseVoiceSessionControllerResult {
   endManualSession: () => void;
   notifyProcessing: () => void;
   notifySpeaking: () => void;
-  notifySpeakingComplete: () => void;
+  notifySpeakingComplete: (skipAutoResume?: boolean) => void;
   isWakeWordSupported: boolean;
   isWakeWordListening: boolean;
   wakeWordError: string | null;
@@ -221,10 +221,13 @@ export function useVoiceSessionController({
     beginSpeaking();
   }, [beginSpeaking, enabled, isConversationActive, startSession]);
 
-  const notifySpeakingComplete = useCallback(() => {
-    hasDetectedSpeechRef.current = false;
-    completeAssistantTurn();
-  }, [completeAssistantTurn]);
+  const notifySpeakingComplete = useCallback(
+    (skipAutoResume = false) => {
+      hasDetectedSpeechRef.current = false;
+      completeAssistantTurn(skipAutoResume);
+    },
+    [completeAssistantTurn],
+  );
 
   const characterState = useMemo<VoiceCharacterState>(() => {
     if (mode === 'listening') {

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -25,6 +25,7 @@ import {
   type MutableRefObject,
   type SetStateAction,
 } from 'react';
+import type { CharacterAnimationData } from './utils/character-animation-utils';
 import type { BackgroundOption } from './components/BackgroundSelector';
 import CharacterAvatar from './components/CharacterAvatar';
 import ClarificationButtons from './components/ClarificationButtons';
@@ -241,6 +242,8 @@ export default function Home() {
   const [conversationHistory, setConversationHistory] = useState<ConversationHistoryItem[]>([]);
   const [showSettingsPanel, setShowSettingsPanel] = useState(false);
   const settingsPanelPropsRef = useRef<SettingsPanelPropsFromSource | null>(null);
+  const playKeyframeAnimationRef = useRef<((data: CharacterAnimationData) => void) | null>(null);
+  const lastVrmControlPlayedRef = useRef<unknown>(null);
   const lastTranscriptRef = useRef<string>('');
   const lastResponseRef = useRef<string>('');
 
@@ -265,6 +268,14 @@ export default function Home() {
     }
   }, [currentLanguage, latestMetadata, showSlideMode, startPresentation]);
 
+  // Fallback: play vrm_control when metadata arrives (in case onAssistantPlaybackStart ran before ref was set)
+  useEffect(() => {
+    const vc = latestMetadata?.vrm_control;
+    if (!vc || !playKeyframeAnimationRef.current || lastVrmControlPlayedRef.current === vc) return;
+    lastVrmControlPlayedRef.current = vc;
+    playKeyframeAnimationRef.current(vc);
+  }, [latestMetadata?.vrm_control]);
+
   return (
     <VoiceInterface
       language={currentLanguage}
@@ -272,6 +283,13 @@ export default function Home() {
       onVisemeControl={setVisemeFunction}
       showDefaultUI={false}
       onMetadataChange={setLatestMetadata}
+      onAssistantPlaybackStart={({ metadata: playbackMetadata }) => {
+        const vc = playbackMetadata?.vrm_control;
+        if (vc && playKeyframeAnimationRef.current && lastVrmControlPlayedRef.current !== vc) {
+          lastVrmControlPlayedRef.current = vc;
+          playKeyframeAnimationRef.current(vc);
+        }
+      }}
     >
       {(voice) => {
         const labels = overlayLabels[voice.currentLanguage];
@@ -366,6 +384,9 @@ export default function Home() {
                   }}
                   onExpressionControl={(setExpression) => {
                     setSetExpressionFunction(() => setExpression);
+                  }}
+                  onKeyframeAnimationControl={(play) => {
+                    playKeyframeAnimationRef.current = play;
                   }}
                   onBackgroundChange={setCharacterBackground}
                   onLightingChange={setLightingIntensity}

--- a/frontend/src/lib/vrm-utils.ts
+++ b/frontend/src/lib/vrm-utils.ts
@@ -48,6 +48,9 @@ export class VRMUtils {
     'Closed': 'neutral'
   };
 
+  /** Expressions that use mouth (VRM 1.0 emotion presets). When active, lip-sync intensity is attenuated. */
+  public static readonly EXPRESSIONS_THAT_USE_MOUTH = ['happy', 'angry', 'sad', 'relaxed', 'surprised'] as const;
+
   private static humanoidBoneNames = [
     'hips', 'spine', 'chest', 'upperChest', 'neck', 'head',
     'leftShoulder', 'leftUpperArm', 'leftLowerArm', 'leftHand',
@@ -641,6 +644,17 @@ export class VRMAnimationManager {
     this.clips.clear();
     this.currentAction = null;
   }
+}
+
+/**
+ * Returns a factor in [0, 1] to attenuate lip-sync intensity when an expression that uses the mouth is active.
+ * Used for frontend procedural override: intensity' = intensity * getMouthOverrideFactor(expression, weight).
+ */
+export function getMouthOverrideFactor(expression: string, weight: number): number {
+  if (VRMUtils.EXPRESSIONS_THAT_USE_MOUTH.includes(expression as (typeof VRMUtils.EXPRESSIONS_THAT_USE_MOUTH)[number])) {
+    return Math.max(0, 1 - weight);
+  }
+  return 1;
 }
 
 // VRM BlendShape Controller for Lip-sync and Expressions


### PR DESCRIPTION
## Summary

Close #190, Fix #270

- **fix #270**: エラーで1回目のターンが終了した際に自動 resume タイマーを仕掛けないよう `completeAssistantTurn(skipAutoResume: true)` を追加し、2回目入力時に happy:100% が乗る不具合を解消
- **feat #190**: `vrm_control` キーフレームアニメーションを `/api/qa` レスポンスから受け取り、`onAssistantPlaybackStart` コールバックで再生タイミングを音声再生開始に合わせて連携
- **feat**: 表情（happy/sad 等）がアクティブなとき、口を使う表情と lip-sync が競合しないよう `getMouthOverrideFactor` でブレンド係数を調整
- **fix(backend)**: リップシンク終端キーフレームで前の viseme のみリセットしていた箇所を全 viseme + 全 base expression をリセットするよう修正

## Changes

| File | 変更内容 |
|---|---|
| `useContinuousListening.ts` | `completeAssistantTurn(skipAutoResume?)` を追加 |
| `useVoiceSessionController.ts` | `notifySpeakingComplete(skipAutoResume?)` を追加 |
| `VoiceInterface.tsx` | エラー時に `skipAutoResume=true` を渡す / `onAssistantPlaybackStart` コールバックを追加 |
| `page.tsx` | `playKeyframeAnimationRef` を保持し `onAssistantPlaybackStart` で `vrm_control` を再生 |
| `CharacterAvatar.tsx` | `getMouthOverrideFactor` を使って lip-sync 強度をブレンド |
| `vrm-utils.ts` | `EXPRESSIONS_THAT_USE_MOUTH` 定数と `getMouthOverrideFactor` 関数を追加 |
| `api/qa/route.ts` | `vrm_control` をレスポンスに含めて型定義を更新 |
| `character_control_agent.py` | 終端キーフレームで全 viseme + base expression をリセット |

## Test plan

- [ ] C-2: ポジティブな質問で happy 表情になる
- [ ] C-3: エラー系回答で sad 表情になる
- [ ] C-5: TTS 音声再生中に口パクが音声と同期する
- [ ] **#270 再現手順**: 1回目エラー → 会話クリアせず2回目送信 → happy:100% が乗らないことを確認
- [ ] VRM キーフレームアニメーション (`vrm_control`) が音声再生開始とともに再生される

🤖 Generated with [Claude Code](https://claude.com/claude-code)