### PR TITLE
fix: Swagger UIのCSP例外

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -245,18 +245,33 @@ async def add_security_headers(request: Request, call_next):
     response = await call_next(request)
     response.headers["X-Content-Type-Options"] = "nosniff"
     response.headers["X-Frame-Options"] = "DENY"
-    response.headers["Content-Security-Policy"] = (
-        "default-src 'self'; "
-        "script-src 'self' 'unsafe-inline' 'unsafe-eval'; "
-        "style-src 'self' 'unsafe-inline'; "
-        "img-src 'self' data: blob:; "
-        "font-src 'self' data:; "
-        "connect-src 'self' https://*.supabase.co wss://*.supabase.co https://openrouter.ai; "
-        "media-src 'self' blob:; "
-        "frame-src 'none'; "
-        "object-src 'none'; "
-        "base-uri 'self'"
-    )
+    is_docs_path = request.url.path.startswith("/docs") or request.url.path.startswith("/redoc")
+    if is_docs_path:
+        response.headers["Content-Security-Policy"] = (
+            "default-src 'self'; "
+            "script-src 'self' 'unsafe-inline' 'unsafe-eval' https://cdn.jsdelivr.net; "
+            "style-src 'self' 'unsafe-inline' https://cdn.jsdelivr.net; "
+            "img-src 'self' data: blob:; "
+            "font-src 'self' data:; "
+            "connect-src 'self' https://*.supabase.co wss://*.supabase.co https://openrouter.ai; "
+            "media-src 'self' blob:; "
+            "frame-src 'none'; "
+            "object-src 'none'; "
+            "base-uri 'self'"
+        )
+    else:
+        response.headers["Content-Security-Policy"] = (
+            "default-src 'self'; "
+            "script-src 'self' 'unsafe-inline' 'unsafe-eval'; "
+            "style-src 'self' 'unsafe-inline'; "
+            "img-src 'self' data: blob:; "
+            "font-src 'self' data:; "
+            "connect-src 'self' https://*.supabase.co wss://*.supabase.co https://openrouter.ai; "
+            "media-src 'self' blob:; "
+            "frame-src 'none'; "
+            "object-src 'none'; "
+            "base-uri 'self'"
+        )
     response.headers["X-XSS-Protection"] = "0"
     response.headers["Referrer-Policy"] = "strict-origin-when-cross-origin"
     return response


### PR DESCRIPTION
## Summary
- `/docs` と `/redoc` 配下に限り、CSPで `cdn.jsdelivr.net` を許可して Swagger UI / ReDoc を表示可能にします。
- API本体のCSPは従来どおり厳格なままです。

## Related
- Refs #272

## Test plan
- [ ] `http://localhost:8000/docs` を開き、`swagger-ui-bundle.js` / `swagger-ui.css` がブロックされないこと
- [ ] `http://localhost:8000/redoc` が表示されること

Made with [Cursor](https://cursor.com)