### PR TITLE
chore(env): prune frontend vars and sync backend examples

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -40,6 +40,10 @@ PORT=8000
 # Application URL (for OpenRouter tracking)
 APP_URL=http://localhost:3000
 
+# API auth / CORS (optional in local development, required to fail closed outside dev)
+# API_SECRET_KEY=your-api-secret-key
+# ALLOWED_ORIGINS=http://localhost:3000
+
 # Model Selection (Optional - override defaults)
 # See backend/llm/models.py for available models
 # DEFAULT_ROUTER_MODEL=google/gemini-2.5-flash-preview
@@ -49,3 +53,15 @@ APP_URL=http://localhost:3000
 # Must match the dimension of knowledge_base.content_embedding column
 # EMBEDDING_MODEL=text-embedding-3-small
 # EMBEDDING_DIMENSIONS=1536
+
+# TTS Configuration (Optional)
+# TTS_PROVIDER=voicevox
+# VOICEVOX_API_URL=http://localhost:50021
+# KOKORO_API_URL=http://localhost:8880
+
+# LangSmith tracing (Optional)
+# LANGSMITH_API_KEY=
+# LANGSMITH_PROJECT=engineer-cafe-navigator
+
+# Discord alerts (Optional)
+# DISCORD_WEBHOOK_URL=

--- a/backend/README.md
+++ b/backend/README.md
@@ -37,21 +37,26 @@ Notable implementation details:
 
 ## Environment
 
-The exact contract should be validated against code before deploy, but the main backend-side variables currently include:
+Use the checked-in example files as the first source of truth:
 
-- `ENVIRONMENT`
-- `API_SECRET_KEY`
-- `ALLOWED_ORIGINS`
-- `OPENROUTER_API_KEY`
-- `OPENAI_API_KEY`
-- `SUPABASE_URL`
-- `SUPABASE_KEY`
-- `SUPABASE_DB_URI`
-- `TTS_PROVIDER`
-- `VOICEVOX_API_URL`
+- `backend/.env.example`: local development and shared defaults
+- `backend/.env.staging.example`: Cloud Run staging shape
+- `backend/.env.production.example`: production-only additions and hardening
+
+The shared backend contract across those examples includes:
+
+- `ENVIRONMENT`, `PORT`, `APP_URL`
+- `OPENROUTER_API_KEY`, `OPENAI_API_KEY`, `TAVILY_API_KEY`
+- `GOOGLE_CALENDAR_ICAL_URL`, `CONNPASS_API_KEY`
+- `SUPABASE_URL`, `SUPABASE_KEY`, `SUPABASE_DB_URI`
+- `API_SECRET_KEY`, `ALLOWED_ORIGINS` for non-dev fail-closed deployments
+- `TTS_PROVIDER`, `VOICEVOX_API_URL`, `KOKORO_API_URL` for voice runtime selection
+- `LANGSMITH_API_KEY`, `LANGSMITH_PROJECT`, `DISCORD_WEBHOOK_URL` when tracing/alerts are enabled
+
+Additional optional Google voice credentials are still code-backed when using Google-powered STT/TTS paths:
+
 - `GOOGLE_CLOUD_PROJECT_ID`
 - `GOOGLE_CLOUD_CREDENTIALS`
-- `GOOGLE_GENERATIVE_AI_API_KEY`
 
 Do not rely on old migration-era docs for env setup. Use [docs/STATUS.md](../docs/STATUS.md) plus the actual code paths.
 

--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -9,25 +9,18 @@
 #   [REQUIRED]    — App will not function without this
 #   [RECOMMENDED] — Some features degrade without this
 #   [OPTIONAL]    — Graceful degradation; leave blank if unused
+#
+# Note:
+#   This file tracks the manually managed env vars documented for frontend/src.
+#   Platform-managed/runtime flags such as NODE_ENV and VERCEL_DEPLOYMENT_ID are
+#   intentionally excluded.
 # ===========================================================================
-
-# ---------------------------------------------------------------------------
-# [REQUIRED] Google Cloud (Service Account Authentication)
-# ---------------------------------------------------------------------------
-GOOGLE_CLOUD_PROJECT_ID=your-gcp-project-id
-GOOGLE_CLOUD_CREDENTIALS=./config/service-account-key.json
 
 # ---------------------------------------------------------------------------
 # [REQUIRED] Database (Supabase)
 # ---------------------------------------------------------------------------
 NEXT_PUBLIC_SUPABASE_URL=https://project.supabase.co
 NEXT_PUBLIC_SUPABASE_ANON_KEY=your-anon-key
-
-# ---------------------------------------------------------------------------
-# [REQUIRED] Next.js Auth
-# ---------------------------------------------------------------------------
-NEXTAUTH_URL=http://localhost:3000
-NEXTAUTH_SECRET=your-secret-key
 
 # ---------------------------------------------------------------------------
 # [REQUIRED] Backend API Proxy
@@ -54,24 +47,6 @@ SUPABASE_SERVICE_ROLE_KEY=your-service-role-key
 ADMIN_API_SECRET=your-admin-api-secret
 
 # ---------------------------------------------------------------------------
-# [OPTIONAL] Gemini Model Override
-# ---------------------------------------------------------------------------
-GEMINI_MODEL=gemini-2.5-flash-preview-05-20
-# GEMINI_API_KEY=              # Optional Gemini key for server-side model calls
-
-# ---------------------------------------------------------------------------
-# [OPTIONAL] AI / DB Integrations
-# ---------------------------------------------------------------------------
-# OPENAI_API_KEY=your-openai-api-key
-# POSTGRES_URL=postgresql://postgres:password@db.project.supabase.co:5432/postgres
-
-# ---------------------------------------------------------------------------
-# [OPTIONAL] Google Cloud Services
-# ---------------------------------------------------------------------------
-# GOOGLE_SPEECH_API_KEY=       # Only if not using service account for STT
-# GOOGLE_TRANSLATE_API_KEY=    # For translation features
-
-# ---------------------------------------------------------------------------
 # [OPTIONAL] Alerts & Monitoring
 # ---------------------------------------------------------------------------
 # ALERT_WEBHOOK_SECRET=
@@ -82,12 +57,6 @@ GEMINI_MODEL=gemini-2.5-flash-preview-05-20
 # ---------------------------------------------------------------------------
 # UPSTASH_REDIS_URL=
 # UPSTASH_REDIS_TOKEN=
-
-# ---------------------------------------------------------------------------
-# [OPTIONAL] External Integration
-# ---------------------------------------------------------------------------
-# WEBSOCKET_URL=
-# RECEPTION_API_URL=
 
 # ---------------------------------------------------------------------------
 # [OPTIONAL] Feature Toggles

--- a/frontend/CLAUDE.md
+++ b/frontend/CLAUDE.md
@@ -23,6 +23,13 @@ pnpm deploy:dev       # Deploy to Vercel dev environment
 - **Audio**: All playback via Web Audio API (`src/lib/audio/`). No HTMLAudioElement.
 - **Vercel**: Deployed to the Vercel dev environment with the Node.js runtime configured in `vercel.json`.
 
+## Env Notes
+
+- `frontend/.env.example` is pruned to the manually managed vars still documented for `frontend/src`.
+- Keep `BACKEND_API_URL`, `BACKEND_API_KEY`, `NEXT_PUBLIC_SUPABASE_URL`, and `NEXT_PUBLIC_SUPABASE_ANON_KEY` populated in local/dev envs.
+- Runtime-managed vars such as `NODE_ENV` and `VERCEL_DEPLOYMENT_ID` are intentionally not listed in `.env.example`.
+- Additional ad hoc flags still read in `frontend/src` include `GOOGLE_CALENDAR_ICAL_URL`, `NEXT_PUBLIC_SHOW_AVATAR_SETTINGS`, and the `FF_*` rollout flags in `src/lib/feature-flags.ts`.
+
 ## Key Directories
 
 ```

--- a/frontend/src/lib/env.ts
+++ b/frontend/src/lib/env.ts
@@ -1,9 +1,9 @@
 /**
- * Server-side environment variable validation using Zod.
+ * Server-side environment variable validation using Zod for the vars tracked in
+ * frontend/.env.example.
  *
- * This module defines schemas for ALL server-side env vars used across
- * the frontend codebase. It does NOT replace direct process.env usage
- * in individual files yet — that is a separate refactor step.
+ * It does NOT replace direct process.env usage in individual files yet, and it
+ * does not attempt to validate platform-managed/runtime flags such as NODE_ENV.
  *
  * Usage:
  *   import { validateServerEnv } from '@/lib/env';
@@ -26,17 +26,13 @@ const requiredServerEnvSchema = z.object({
     .string()
     .min(1, "NEXT_PUBLIC_SUPABASE_ANON_KEY is required"),
 
-  // Google Cloud
-  GOOGLE_CLOUD_PROJECT_ID: z
+  // Backend proxy
+  BACKEND_API_URL: z
     .string()
-    .min(1, "GOOGLE_CLOUD_PROJECT_ID is required"),
-  GOOGLE_CLOUD_CREDENTIALS: z
+    .url("BACKEND_API_URL must be a valid URL"),
+  BACKEND_API_KEY: z
     .string()
-    .min(1, "GOOGLE_CLOUD_CREDENTIALS path is required"),
-
-  // Next.js auth
-  NEXTAUTH_URL: z.string().url("NEXTAUTH_URL must be a valid URL"),
-  NEXTAUTH_SECRET: z.string().min(1, "NEXTAUTH_SECRET is required"),
+    .min(1, "BACKEND_API_KEY is required"),
 });
 
 // ---------------------------------------------------------------------------
@@ -46,41 +42,20 @@ const requiredServerEnvSchema = z.object({
 const optionalServerEnvSchema = z.object({
   // Server-only admin, alerting, and cron features
   SUPABASE_SERVICE_ROLE_KEY: z.string().optional(),
+  ADMIN_API_SECRET: z.string().optional(),
+  CRON_SECRET: z.string().optional(),
 
-  // Gemini model override
-  GEMINI_MODEL: z.string().optional(),
-  GEMINI_API_KEY: z.string().optional(),
-
-  // AI / DB integrations used by optional server-side workflows
-  OPENAI_API_KEY: z.string().optional(),
-  POSTGRES_URL: z.string().optional(),
-
-  // Google Cloud services
-  GOOGLE_SPEECH_API_KEY: z.string().optional(),
-  GOOGLE_TRANSLATE_API_KEY: z.string().optional(),
-  GOOGLE_APPLICATION_CREDENTIALS: z.string().optional(),
-
-  // Alert / monitoring
+  // Alerting
   ALERT_WEBHOOK_SECRET: z.string().optional(),
   SLACK_WEBHOOK_URL: z.string().optional(),
-
-  // CRON authentication
-  CRON_SECRET: z.string().optional(),
 
   // Redis cache
   UPSTASH_REDIS_URL: z.string().optional(),
   UPSTASH_REDIS_TOKEN: z.string().optional(),
 
-  // External integrations
-  WEBSOCKET_URL: z.string().optional(),
-  RECEPTION_API_URL: z.string().optional(),
-
-  // Vercel
-  VERCEL_URL: z.string().optional(),
-  VERCEL_DEPLOYMENT_ID: z.string().optional(),
-
   // Feature flags
-  FF_NEW_EMBEDDINGS_PERCENTAGE: z.string().optional(),
+  NEXT_PUBLIC_ENABLE_FACIAL_EXPRESSION: z.string().optional(),
+  NEXT_PUBLIC_USE_WEB_SPEECH_API: z.string().optional(),
   NEXT_PUBLIC_SKIP_BACKEND: z.string().optional(),
 });
 
@@ -124,6 +99,7 @@ export function validateServerEnv(): EnvValidationResult {
   // Validate optional vars (collect warnings for missing recommended ones)
   const recommendedOptional = [
     "SUPABASE_SERVICE_ROLE_KEY",
+    "ADMIN_API_SECRET",
     "CRON_SECRET",
   ] as const;
 


### PR DESCRIPTION
## Summary

- Remove unused frontend env placeholders from `.env.example` and `frontend/src/lib/env.ts` (Google Cloud, NextAuth, Gemini, external-integration entries that frontend/src no longer reads via process.env)
- Add missing backend env vars to `backend/.env.example` that existed only in staging/production examples: `API_SECRET_KEY`, `ALLOWED_ORIGINS`, `TTS_PROVIDER`, `VOICEVOX_API_URL`, `KOKORO_API_URL`, `LANGSMITH_API_KEY`, `LANGSMITH_PROJECT`, `DISCORD_WEBHOOK_URL`
- Update env documentation in `frontend/CLAUDE.md` and `backend/README.md`

## Closes

- Closes #261

## Test plan

- [ ] `pnpm lint && pnpm typecheck && pnpm build` (frontend)
- [ ] `ruff check . && black --check .` (backend)
- [ ] Verify no runtime env errors on dev server start

🤖 Generated with [Claude Code](https://claude.com/claude-code)