### PR TITLE
fix(frontend): preserve backend proxy status codes

### DIFF
--- a/frontend/src/__tests__/api-proxy-contract.test.ts
+++ b/frontend/src/__tests__/api-proxy-contract.test.ts
@@ -15,7 +15,7 @@ const originalFetch = global.fetch;
 afterEach(() => {
   process.env.BACKEND_API_URL = originalBackendApiUrl;
   process.env.BACKEND_API_KEY = originalBackendApiKey;
-  process.env.NODE_ENV = originalNodeEnv;
+  (process.env as Record<string, string | undefined>).NODE_ENV = originalNodeEnv;
   global.fetch = originalFetch;
 });
 
@@ -45,7 +45,7 @@ test(
   'createInternalServerErrorResponse exposes details only in development',
   { concurrency: false },
   async () => {
-    process.env.NODE_ENV = 'development';
+    (process.env as Record<string, string | undefined>).NODE_ENV = 'development';
     const response = createInternalServerErrorResponse(new Error('backend timed out'));
 
     assert.equal(response.status, 500);
@@ -61,7 +61,7 @@ test(
   { concurrency: false },
   async () => {
     process.env.BACKEND_API_URL = 'https://backend.example.com';
-    process.env.NODE_ENV = 'test';
+    (process.env as Record<string, string | undefined>).NODE_ENV = 'test';
     mockBackendJsonResponse({ detail: 'validation failed' }, 422);
 
     const { POST } = await import('../app/api/qa/route');
@@ -83,7 +83,7 @@ test(
   { concurrency: false },
   async () => {
     process.env.BACKEND_API_URL = 'https://backend.example.com';
-    process.env.NODE_ENV = 'test';
+    (process.env as Record<string, string | undefined>).NODE_ENV = 'test';
     mockBackendJsonResponse({ error: 'Unsupported action' }, 400);
 
     const { GET } = await import('../app/api/voice/route');

--- a/frontend/src/__tests__/api-proxy-contract.test.ts
+++ b/frontend/src/__tests__/api-proxy-contract.test.ts
@@ -1,0 +1,107 @@
+import assert from 'node:assert/strict';
+import { afterEach, test } from 'node:test';
+import { NextRequest } from 'next/server';
+
+import {
+  createBackendErrorResponse,
+  createInternalServerErrorResponse,
+} from '../app/api/_shared/backend-error-response';
+
+const originalBackendApiUrl = process.env.BACKEND_API_URL;
+const originalBackendApiKey = process.env.BACKEND_API_KEY;
+const originalNodeEnv = process.env.NODE_ENV;
+const originalFetch = global.fetch;
+
+afterEach(() => {
+  process.env.BACKEND_API_URL = originalBackendApiUrl;
+  process.env.BACKEND_API_KEY = originalBackendApiKey;
+  process.env.NODE_ENV = originalNodeEnv;
+  global.fetch = originalFetch;
+});
+
+function mockBackendJsonResponse(body: unknown, status: number) {
+  global.fetch = (async () =>
+    new Response(JSON.stringify(body), {
+      status,
+      headers: { 'Content-Type': 'application/json' },
+    })) as typeof fetch;
+}
+
+test(
+  'createBackendErrorResponse maps backend detail to the standard error payload',
+  { concurrency: false },
+  async () => {
+    const response = createBackendErrorResponse({
+      status: 400,
+      data: { detail: 'Unknown action: ping' },
+    });
+
+    assert.equal(response.status, 400);
+    assert.deepEqual(await response.json(), { error: 'Unknown action: ping' });
+  }
+);
+
+test(
+  'createInternalServerErrorResponse exposes details only in development',
+  { concurrency: false },
+  async () => {
+    process.env.NODE_ENV = 'development';
+    const response = createInternalServerErrorResponse(new Error('backend timed out'));
+
+    assert.equal(response.status, 500);
+    assert.deepEqual(await response.json(), {
+      error: 'Internal server error',
+      details: 'backend timed out',
+    });
+  }
+);
+
+test(
+  'qa POST preserves backend status codes and error payloads',
+  { concurrency: false },
+  async () => {
+    process.env.BACKEND_API_URL = 'https://backend.example.com';
+    process.env.NODE_ENV = 'test';
+    mockBackendJsonResponse({ detail: 'validation failed' }, 422);
+
+    const { POST } = await import('../app/api/qa/route');
+    const response = await POST(
+      new NextRequest('https://example.com/api/qa', {
+        method: 'POST',
+        body: JSON.stringify({ question: 'hello' }),
+        headers: { 'Content-Type': 'application/json' },
+      })
+    );
+
+    assert.equal(response.status, 422);
+    assert.deepEqual(await response.json(), { error: 'validation failed' });
+  }
+);
+
+test(
+  'voice GET preserves backend 4xx responses',
+  { concurrency: false },
+  async () => {
+    process.env.BACKEND_API_URL = 'https://backend.example.com';
+    process.env.NODE_ENV = 'test';
+    mockBackendJsonResponse({ error: 'Unsupported action' }, 400);
+
+    const { GET } = await import('../app/api/voice/route');
+    const response = await GET(
+      new NextRequest('https://example.com/api/voice?action=unsupported')
+    );
+
+    assert.equal(response.status, 400);
+    assert.deepEqual(await response.json(), { error: 'Unsupported action' });
+  }
+);
+
+test(
+  'slides route no longer exports a GET handler',
+  { concurrency: false },
+  async () => {
+    const slidesRoute = await import('../app/api/slides/route');
+
+    assert.equal('GET' in slidesRoute, false);
+  }
+);

--- a/frontend/src/app/api/_shared/backend-error-response.ts
+++ b/frontend/src/app/api/_shared/backend-error-response.ts
@@ -1,0 +1,73 @@
+import { NextResponse } from 'next/server';
+
+import type { BackendProxyResult } from '@/lib/api/backend-proxy';
+
+type ErrorBody = {
+  error: string;
+  details?: string;
+};
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null;
+}
+
+function includeDetails(details?: string): Pick<ErrorBody, 'details'> | Record<string, never> {
+  if (process.env.NODE_ENV !== 'development' || !details) {
+    return {};
+  }
+
+  return { details };
+}
+
+function normalizeBackendError(data: unknown, fallbackError: string): ErrorBody {
+  if (typeof data === 'string' && data.trim()) {
+    return { error: data };
+  }
+
+  if (!isRecord(data)) {
+    return { error: fallbackError };
+  }
+
+  const error =
+    typeof data.error === 'string'
+      ? data.error
+      : typeof data.detail === 'string'
+        ? data.detail
+        : typeof data.message === 'string'
+          ? data.message
+          : fallbackError;
+
+  const details =
+    typeof data.details === 'string'
+      ? data.details
+      : typeof data.error === 'string' && typeof data.detail === 'string'
+        ? data.detail
+        : undefined;
+
+  return {
+    error,
+    ...includeDetails(details),
+  };
+}
+
+export function createBackendErrorResponse(
+  response: Pick<BackendProxyResult<unknown>, 'status' | 'data'>,
+  fallbackError = `Backend API error: ${response.status}`
+) {
+  return NextResponse.json(normalizeBackendError(response.data, fallbackError), {
+    status: response.status,
+  });
+}
+
+export function createInternalServerErrorResponse(
+  error: unknown,
+  fallbackError = 'Internal server error'
+) {
+  return NextResponse.json(
+    {
+      error: fallbackError,
+      ...includeDetails(error instanceof Error ? error.message : 'Unknown error'),
+    },
+    { status: 500 }
+  );
+}

--- a/frontend/src/app/api/alerts/webhook/route.ts
+++ b/frontend/src/app/api/alerts/webhook/route.ts
@@ -2,6 +2,10 @@ import { rollbackManager } from '@/lib/rollback-manager';
 import crypto from 'crypto';
 import { NextRequest, NextResponse } from 'next/server';
 
+import {
+  createBackendErrorResponse,
+  createInternalServerErrorResponse,
+} from '@/app/api/_shared/backend-error-response';
 import { backendFetch } from '@/lib/api/backend-proxy';
 
 /**
@@ -34,7 +38,7 @@ export async function POST(request: NextRequest) {
 
     const response = await backendFetch('/api/alerts', { method: 'POST', body: alert });
     if (!response.ok) {
-      throw new Error(`Backend API error: ${response.status}`);
+      return createBackendErrorResponse(response);
     }
     
     // Process alert based on severity
@@ -44,10 +48,7 @@ export async function POST(request: NextRequest) {
     
   } catch (error) {
     console.error('[Alert Webhook] Error:', error);
-    return NextResponse.json(
-      { error: 'Failed to process alert' },
-      { status: 500 }
-    );
+    return createInternalServerErrorResponse(error, 'Failed to process alert');
   }
 }
 

--- a/frontend/src/app/api/character/route.ts
+++ b/frontend/src/app/api/character/route.ts
@@ -3,6 +3,10 @@ import path from 'node:path';
 
 import { NextRequest, NextResponse } from 'next/server';
 
+import {
+  createBackendErrorResponse,
+  createInternalServerErrorResponse,
+} from '@/app/api/_shared/backend-error-response';
 import { backendFetch } from '@/lib/api/backend-proxy';
 
 const DEFAULT_SUPPORTED_EXPRESSIONS = [
@@ -73,21 +77,13 @@ export async function POST(request: NextRequest) {
     });
 
     if (!response.ok) {
-      throw new Error(`Backend API error: ${response.status}`);
+      return createBackendErrorResponse(response);
     }
 
     return NextResponse.json(response.data);
   } catch (error) {
     console.error('Character API error:', error);
-    return NextResponse.json(
-      {
-        error: 'Internal server error',
-        ...(process.env.NODE_ENV === 'development' && {
-          details: error instanceof Error ? error.message : 'Unknown error',
-        }),
-      },
-      { status: 500 }
-    );
+    return createInternalServerErrorResponse(error);
   }
 }
 

--- a/frontend/src/app/api/marp/route.ts
+++ b/frontend/src/app/api/marp/route.ts
@@ -1,5 +1,9 @@
 import { NextRequest, NextResponse } from 'next/server';
 
+import {
+  createBackendErrorResponse,
+  createInternalServerErrorResponse,
+} from '@/app/api/_shared/backend-error-response';
 import { backendFetch } from '@/lib/api/backend-proxy';
 import { MarpProcessor } from '@/lib/marp-processor';
 
@@ -30,7 +34,7 @@ export async function POST(request: NextRequest) {
     });
 
     if (!backendResponse.ok) {
-      throw new Error(`Backend error: ${backendResponse.status}`);
+      return createBackendErrorResponse(backendResponse, 'Failed to render slides');
     }
 
     const backendData = backendResponse.data;
@@ -69,16 +73,7 @@ export async function POST(request: NextRequest) {
       metadata: backendData.metadata,
     });
   } catch (error) {
-    return NextResponse.json(
-      {
-        success: false,
-        error: 'Failed to render slides',
-        ...(process.env.NODE_ENV === 'development' && {
-          details: error instanceof Error ? error.message : 'Unknown error',
-        }),
-      },
-      { status: 500 }
-    );
+    return createInternalServerErrorResponse(error, 'Failed to render slides');
   }
 }
 

--- a/frontend/src/app/api/qa/route.ts
+++ b/frontend/src/app/api/qa/route.ts
@@ -1,5 +1,9 @@
 import { NextRequest, NextResponse } from 'next/server';
 
+import {
+  createBackendErrorResponse,
+  createInternalServerErrorResponse,
+} from '@/app/api/_shared/backend-error-response';
 import { backendFetch } from '@/lib/api/backend-proxy';
 
 export async function POST(request: NextRequest) {
@@ -21,8 +25,12 @@ export async function POST(request: NextRequest) {
       },
     });
 
-    if (!response.ok || !response.data) {
-      throw new Error(`Backend API error: ${response.status}`);
+    if (!response.ok) {
+      return createBackendErrorResponse(response);
+    }
+
+    if (!response.data) {
+      throw new Error('Backend API returned an empty response');
     }
 
     return NextResponse.json({
@@ -37,15 +45,7 @@ export async function POST(request: NextRequest) {
     });
   } catch (error) {
     console.error('Q&A API error:', error);
-    return NextResponse.json(
-      {
-        error: 'Internal server error',
-        ...(process.env.NODE_ENV === 'development' && {
-          details: error instanceof Error ? error.message : 'Unknown error',
-        }),
-      },
-      { status: 500 }
-    );
+    return createInternalServerErrorResponse(error);
   }
 }
 
@@ -155,14 +155,6 @@ export async function GET(request: NextRequest) {
     }
   } catch (error) {
     console.error('Q&A API GET error:', error);
-    return NextResponse.json(
-      {
-        error: 'Internal server error',
-        ...(process.env.NODE_ENV === 'development' && {
-          details: error instanceof Error ? error.message : 'Unknown error',
-        }),
-      },
-      { status: 500 }
-    );
+    return createInternalServerErrorResponse(error);
   }
 }

--- a/frontend/src/app/api/slides/route.ts
+++ b/frontend/src/app/api/slides/route.ts
@@ -1,5 +1,9 @@
 import { NextRequest, NextResponse } from 'next/server';
 
+import {
+  createBackendErrorResponse,
+  createInternalServerErrorResponse,
+} from '@/app/api/_shared/backend-error-response';
 import { backendFetch } from '@/lib/api/backend-proxy';
 
 export async function POST(request: NextRequest) {
@@ -11,27 +15,12 @@ export async function POST(request: NextRequest) {
     });
 
     if (!response.ok) {
-      throw new Error(`Backend API error: ${response.status}`);
+      return createBackendErrorResponse(response);
     }
 
     return NextResponse.json(response.data);
   } catch (error) {
     console.error('Slides API error:', error);
-    return NextResponse.json(
-      {
-        error: 'Internal server error',
-        ...(process.env.NODE_ENV === 'development' && {
-          details: error instanceof Error ? error.message : 'Unknown error',
-        }),
-      },
-      { status: 500 }
-    );
+    return createInternalServerErrorResponse(error);
   }
-}
-
-export async function GET(request: NextRequest) {
-  return NextResponse.json({
-    status: 'ok',
-    backend: 'connected',
-  });
 }

--- a/frontend/src/app/api/voice/route.ts
+++ b/frontend/src/app/api/voice/route.ts
@@ -1,5 +1,9 @@
 import { NextRequest, NextResponse } from 'next/server';
 
+import {
+  createBackendErrorResponse,
+  createInternalServerErrorResponse,
+} from '@/app/api/_shared/backend-error-response';
 import { backendFetch } from '@/lib/api/backend-proxy';
 
 export async function POST(request: NextRequest) {
@@ -25,21 +29,13 @@ export async function POST(request: NextRequest) {
     });
 
     if (!response.ok) {
-      throw new Error(`Backend API error: ${response.status}`);
+      return createBackendErrorResponse(response);
     }
 
     return NextResponse.json(response.data);
   } catch (error) {
     console.error('Voice API error:', error);
-    return NextResponse.json(
-      {
-        error: 'Internal server error',
-        ...(process.env.NODE_ENV === 'development' && {
-          details: error instanceof Error ? error.message : 'Unknown error',
-        }),
-      },
-      { status: 500 }
-    );
+    return createInternalServerErrorResponse(error);
   }
 }
 
@@ -54,20 +50,12 @@ export async function GET(request: NextRequest) {
     });
 
     if (!response.ok) {
-      throw new Error(`Backend API error: ${response.status}`);
+      return createBackendErrorResponse(response);
     }
 
     return NextResponse.json(response.data);
   } catch (error) {
     console.error('Voice API GET error:', error);
-    return NextResponse.json(
-      {
-        error: 'Internal server error',
-        ...(process.env.NODE_ENV === 'development' && {
-          details: error instanceof Error ? error.message : 'Unknown error',
-        }),
-      },
-      { status: 500 }
-    );
+    return createInternalServerErrorResponse(error);
   }
 }


### PR DESCRIPTION
## Summary

- Fix all frontend API proxy routes that were converting backend 4xx responses to 500 errors
- Add shared `backend-error-response.ts` helper with `createBackendErrorResponse()` and `createInternalServerErrorResponse()` to standardize error handling
- Remove hardcoded `slides GET` handler (backend has no `GET /api/slides` endpoint and frontend never calls it)
- Applied to: qa, voice, slides, character, alerts/webhook, marp routes

## Test plan

- [ ] `pnpm lint && pnpm typecheck && pnpm build` (frontend)
- [ ] Backend 4xx responses are preserved (not converted to 500)
- [ ] `details` field only included in development environment
- [ ] Regression test: `api-proxy-contract.test.ts`

🤖 Generated with [Claude Code](https://claude.com/claude-code)