### PR TITLE
refactor(frontend): expose backend admin proxy routes

### DIFF
--- a/frontend/src/app/api/admin/knowledge/editor-config/route.ts
+++ b/frontend/src/app/api/admin/knowledge/editor-config/route.ts
@@ -1,0 +1,41 @@
+import { NextResponse } from 'next/server';
+
+import { backendFetch } from '@/lib/api/backend-proxy';
+
+function toErrorBody(data: unknown, fallback: string) {
+  if (data && typeof data === 'object') {
+    const payload = data as {
+      detail?: string;
+      error?: string;
+      message?: string;
+    };
+    const error = payload.error || payload.detail || payload.message;
+    if (error) {
+      return { ...payload, error };
+    }
+  }
+
+  return { error: fallback };
+}
+
+export async function GET() {
+  try {
+    const response = await backendFetch('/api/knowledge/editor-config', {
+      method: 'GET',
+    });
+
+    if (!response.ok) {
+      return NextResponse.json(
+        toErrorBody(response.data, 'Failed to fetch knowledge editor config'),
+        { status: response.status },
+      );
+    }
+
+    return NextResponse.json(response.data, { status: response.status });
+  } catch {
+    return NextResponse.json(
+      { error: 'Failed to get knowledge editor config' },
+      { status: 500 },
+    );
+  }
+}

--- a/frontend/src/app/api/admin/stt/route.ts
+++ b/frontend/src/app/api/admin/stt/route.ts
@@ -58,8 +58,10 @@ export async function GET(request: NextRequest) {
 
 export async function POST(request: NextRequest) {
   try {
+    const action = request.nextUrl.searchParams.get('action');
     const body = await request.json();
-    const response = await backendFetch('/api/stt/vocabulary', {
+    const path = action === 'test' ? '/api/stt/vocabulary/test' : '/api/stt/vocabulary';
+    const response = await backendFetch(path, {
       method: 'POST',
       body,
     });

--- a/frontend/src/lib/api/knowledge.ts
+++ b/frontend/src/lib/api/knowledge.ts
@@ -169,24 +169,24 @@ export async function uploadKnowledgeFile(params: {
 }
 
 export async function getKnowledgeEditorConfig(): Promise<KnowledgeEditorConfig> {
-  const [categoriesResponse, templatesResponse] = await Promise.all([
-    fetch('/api/admin/knowledge/categories'),
+  const [editorConfigResponse, templatesResponse] = await Promise.all([
+    fetch('/api/admin/knowledge/editor-config'),
     fetch('/api/admin/knowledge/metadata-templates'),
   ]);
 
-  if (!categoriesResponse.ok) {
-    throw new Error(await getErrorMessage(categoriesResponse, 'Failed to fetch categories'));
+  if (!editorConfigResponse.ok) {
+    throw new Error(await getErrorMessage(editorConfigResponse, 'Failed to fetch editor config'));
   }
 
   if (!templatesResponse.ok) {
     throw new Error(await getErrorMessage(templatesResponse, 'Failed to fetch metadata templates'));
   }
 
-  const categories = (await categoriesResponse.json()) as KnowledgeCategoriesResponse;
+  const editorConfig = (await editorConfigResponse.json()) as KnowledgeCategoriesResponse;
   const templates = (await templatesResponse.json()) as KnowledgeTemplatesResponse;
 
   return {
-    ...categories,
+    ...editorConfig,
     templates: templates.templates,
     availableCategories: templates.availableCategories,
   };


### PR DESCRIPTION
## Summary

- Add `/api/admin/knowledge/editor-config` proxy route → backend `/api/knowledge/editor-config`
- Update `/api/admin/stt` POST to route `?action=test` to backend `/api/stt/vocabulary/test`
- Update `knowledge.ts` client to use new editor-config endpoint instead of categories endpoint
- Calendar route left unchanged — no backend `/api/calendar` endpoint exists yet

## Partially addresses

- #265 (frontend route migration — admin endpoint exposure portion)

## Notes

- Calendar proxy migration deferred until backend `/api/calendar` endpoint is implemented
- `GOOGLE_CALENDAR_ICAL_URL` was already absent from `frontend/.env.example`

## Test plan

- [ ] `pnpm lint && pnpm typecheck && pnpm build` (frontend)
- [ ] Admin knowledge editor config loads correctly
- [ ] STT vocabulary test via `POST /api/admin/stt?action=test` works

🤖 Generated with [Claude Code](https://claude.com/claude-code)