### PR TITLE
fix: Wave 3a — CRITICAL/HIGH production stability fixes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -261,13 +261,15 @@ jobs:
           path: backend/reports/
           retention-days: 30
 
-  # Backend: Deploy to Cloud Run (staging)
+  # Backend: Deploy to Cloud Run
   # Only runs on push to develop after backend tests pass
   # NOTE: This is an optional deploy job - not included in ci-success gate
   #
   # Deployment strategy:
-  #   - develop branch -> staging (Cloud Run, asia-northeast1)
-  #   - main branch -> production (separate environment, not yet configured)
+  #   - develop branch -> Cloud Run (asia-northeast1) with ENVIRONMENT=production
+  #
+  # IMPORTANT: Use --update-secrets (NOT --set-secrets) to avoid destroying
+  # existing secret bindings like API_SECRET_KEY. See CRIT-1 (2026-03-18).
   #
   # TTS services (VoiceVox, Kokoro) are NOT available on Cloud Run.
   # They require dedicated GPU/CPU instances or external API alternatives.
@@ -316,8 +318,8 @@ jobs:
             --cpu 2 \
             --min-instances 0 \
             --max-instances 3 \
-            --update-env-vars "ENVIRONMENT=production,TTS_PROVIDER=voicevox,VOICEVOX_API_URL=https://voicevox-proto-639959525777.asia-northeast2.run.app" \
-            --set-secrets "OPENROUTER_API_KEY=OPENROUTER_API_KEY:latest,SUPABASE_URL=SUPABASE_URL:latest,SUPABASE_KEY=SUPABASE_KEY:latest,SUPABASE_DB_URI=SUPABASE_DB_URI:latest"
+            --update-env-vars "ENVIRONMENT=production,TTS_PROVIDER=voicevox,VOICEVOX_API_URL=https://voicevox-proto-639959525777.asia-northeast2.run.app,ALLOWED_ORIGINS=https://frontend-delta-six-20.vercel.app" \
+            --update-secrets "OPENROUTER_API_KEY=OPENROUTER_API_KEY:latest,SUPABASE_URL=SUPABASE_URL:latest,SUPABASE_KEY=SUPABASE_KEY:latest,SUPABASE_DB_URI=SUPABASE_DB_URI:latest,API_SECRET_KEY=API_SECRET_KEY:latest"
 
       - name: Smoke test deployed service
         run: |
@@ -331,48 +333,9 @@ jobs:
           echo "$HEALTH"
           echo "$HEALTH" | python3 -c "import sys,json; d=json.load(sys.stdin); assert d['status']=='ok', f'Health check failed: {d}'"
 
-  # Frontend: Deploy to Vercel production
-  # Only runs on push to develop after frontend build passes
-  # NOTE: This is an optional deploy job - not included in ci-success gate
-  #
-  # Vercel Production Branch is configured as "main", but this repo promotes
-  # frontend changes from "develop", so CI triggers an explicit production deploy.
-  frontend-deploy-production:
-    needs: [changes, frontend-build]
-    if: needs.changes.outputs.frontend == 'true' && github.event_name == 'push' && github.ref == 'refs/heads/develop'
-    runs-on: ubuntu-latest
-    env:
-      VERCEL_ORG_ID: team_874Dc9xaSKgX5A7meLBjWNvy
-      VERCEL_PROJECT_ID: prj_QUUdYbZBhbQqu3jvhSDNqyqMzgPs
-    steps:
-      - uses: actions/checkout@v4
-
-      - name: Setup Node.js
-        uses: actions/setup-node@v4
-        with:
-          node-version: ${{ env.NODE_VERSION }}
-
-      - name: Check VERCEL_TOKEN secret
-        id: vercel-token
-        env:
-          VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
-        run: |
-          if [ -z "$VERCEL_TOKEN" ]; then
-            echo "::warning::VERCEL_TOKEN is not configured; skipping Vercel production deploy."
-            echo "configured=false" >> "$GITHUB_OUTPUT"
-          else
-            echo "configured=true" >> "$GITHUB_OUTPUT"
-          fi
-
-      - name: Install Vercel CLI
-        if: steps.vercel-token.outputs.configured == 'true'
-        run: npm i -g vercel
-
-      - name: Deploy frontend to Vercel production
-        if: steps.vercel-token.outputs.configured == 'true'
-        env:
-          VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
-        run: vercel deploy --prod --yes --archive=tgz
+  # Frontend: Vercel deploy is handled by Vercel Deploy Hook (auto-deploy on push).
+  # The former CI-based `frontend-deploy-production` job was removed 2026-03-18
+  # because Vercel's Deploy Hook integration is sufficient and more reliable.
 
   # Final status check for branch protection
   ci-success:
@@ -382,12 +345,23 @@ jobs:
     steps:
       - name: Check all jobs passed
         run: |
-          if [[ "${{ needs.frontend-lint.result }}" == "failure" ]] || \
-             [[ "${{ needs.frontend-typecheck.result }}" == "failure" ]] || \
-             [[ "${{ needs.frontend-build.result }}" == "failure" ]] || \
-             [[ "${{ needs.backend-lint.result }}" == "failure" ]] || \
-             [[ "${{ needs.backend-test.result }}" == "failure" ]]; then
-            echo "One or more jobs failed"
+          # Each job result is one of: success, failure, cancelled, skipped.
+          # "skipped" is OK — it means the path-filter determined no changes
+          # in that area (e.g., backend-only PR skips frontend jobs).
+          # We fail on "failure" or "cancelled".
+          FAILED=false
+          for job_result in \
+            "${{ needs.frontend-lint.result }}" \
+            "${{ needs.frontend-typecheck.result }}" \
+            "${{ needs.frontend-build.result }}" \
+            "${{ needs.backend-lint.result }}" \
+            "${{ needs.backend-test.result }}"; do
+            if [[ "$job_result" == "failure" ]] || [[ "$job_result" == "cancelled" ]]; then
+              FAILED=true
+            fi
+          done
+          if [[ "$FAILED" == "true" ]]; then
+            echo "One or more jobs failed or were cancelled"
             exit 1
           fi
-          echo "All CI checks passed!"
+          echo "All CI checks passed (skipped jobs are OK — no changes in that area)"

--- a/backend/api/knowledge.py
+++ b/backend/api/knowledge.py
@@ -167,39 +167,54 @@ def _rollback_uploaded_chunks(supabase: Any, inserted_ids: List[str]) -> None:
 
 
 def _build_knowledge_categories_response(supabase: Any) -> KnowledgeCategoriesResponse:
-    """カテゴリ関連の編集設定データを構築する"""
-    cat_result = supabase.table("knowledge_base").select("category").execute()
-    categories = sorted({row["category"] for row in (cat_result.data or []) if row.get("category")})
+    """カテゴリ関連の編集設定データを構築する
 
-    sub_result = supabase.table("knowledge_base").select("category,subcategory").execute()
+    単一クエリで必要な4カラムのみ取得し、Python側で重複排除する。
+    Supabase REST APIはSELECT DISTINCTを直接サポートしないため、
+    カラム指定 + Python setで代替する。
+    """
+    result = (
+        supabase.table("knowledge_base").select("category, subcategory, source, language").execute()
+    )
+    rows = result.data or []
+
+    categories: set[str] = set()
     subcategory_sets: Dict[str, set[str]] = {}
-    for row in sub_result.data or []:
-        category = row.get("category")
-        subcategory = row.get("subcategory")
-        if not category or not subcategory:
-            continue
-        subcategory_sets.setdefault(category, set()).add(subcategory)
+    sources: set[str] = set()
+    languages: set[str] = set()
 
-    subcategories = {
+    for row in rows:
+        cat = row.get("category")
+        sub = row.get("subcategory")
+        src = row.get("source")
+        lang = row.get("language")
+
+        if cat:
+            categories.add(cat)
+            if sub:
+                subcategory_sets.setdefault(cat, set()).add(sub)
+        if src:
+            sources.add(src)
+        if lang:
+            languages.add(lang)
+
+    sorted_categories = sorted(categories)
+    sorted_subcategories = {
         category: sorted(values) for category, values in sorted(subcategory_sets.items())
     }
-
-    src_result = supabase.table("knowledge_base").select("source").execute()
-    sources = sorted({row["source"] for row in (src_result.data or []) if row.get("source")})
-
-    lang_result = supabase.table("knowledge_base").select("language").execute()
-    languages = sorted({row["language"] for row in (lang_result.data or []) if row.get("language")})
+    sorted_sources = sorted(sources)
+    sorted_languages = sorted(languages)
 
     return KnowledgeCategoriesResponse(
-        categories=categories,
-        subcategories=subcategories,
-        sources=sources,
-        languages=languages,
+        categories=sorted_categories,
+        subcategories=sorted_subcategories,
+        sources=sorted_sources,
+        languages=sorted_languages,
         stats=KnowledgeCategoriesStats(
-            totalCategories=len(categories),
-            totalSubcategories=sum(len(values) for values in subcategories.values()),
-            totalSources=len(sources),
-            totalLanguages=len(languages),
+            totalCategories=len(sorted_categories),
+            totalSubcategories=sum(len(values) for values in sorted_subcategories.values()),
+            totalSources=len(sorted_sources),
+            totalLanguages=len(sorted_languages),
         ),
     )
 
@@ -214,7 +229,7 @@ def _build_knowledge_categories_response(supabase: Any) -> KnowledgeCategoriesRe
 async def get_knowledge_categories(request: Request):
     """ナレッジカテゴリ一覧取得"""
     try:
-        return _build_knowledge_categories_response(_get_supabase())
+        return await asyncio.to_thread(_build_knowledge_categories_response, _get_supabase())
     except HTTPException:
         raise
     except Exception as e:
@@ -227,7 +242,7 @@ async def get_knowledge_categories(request: Request):
 async def get_editor_config(request: Request):
     """エディタ起動時の設定データを取得"""
     try:
-        return _build_knowledge_categories_response(_get_supabase())
+        return await asyncio.to_thread(_build_knowledge_categories_response, _get_supabase())
     except HTTPException:
         raise
     except Exception as e:

--- a/backend/main.py
+++ b/backend/main.py
@@ -228,9 +228,9 @@ async def verify_api_key(request: Request) -> None:
         raise HTTPException(status_code=403, detail="Invalid or missing API key")
 
 
-ALLOWED_ORIGINS = os.getenv(
-    "ALLOWED_ORIGINS", "https://engineer-cafe-navigator.company-997.workers.dev"
-).split(",")
+ALLOWED_ORIGINS = os.getenv("ALLOWED_ORIGINS", "https://frontend-delta-six-20.vercel.app").split(
+    ","
+)
 app.add_middleware(
     CORSMiddleware,
     allow_origins=ALLOWED_ORIGINS,
@@ -476,9 +476,11 @@ async def invoke_agent(request: Request, body: ChatRequest):
     """
     LangGraphエージェントの直接実行エンドポイント
     """
+    import uuid as _uuid
+
     from backend.utils.interrupt_manager import get_interrupt_manager
 
-    session_id = cast(str, body.session_id)
+    session_id = body.session_id or str(_uuid.uuid4())
     get_interrupt_manager().clear_interrupt(session_id)
 
     try:

--- a/backend/tests/api/test_knowledge_api.py
+++ b/backend/tests/api/test_knowledge_api.py
@@ -66,53 +66,50 @@ def test_get_knowledge_categories(mock_get_sb):
 
     table_mock = mock_sb.table.return_value
 
-    category_query = MagicMock()
-    category_query.execute.return_value = _mock_table_result(
+    # Single query returns all 4 columns; Python-side deduplication handles the rest
+    combined_query = MagicMock()
+    combined_query.execute.return_value = _mock_table_result(
         [
-            {"category": "facility-info"},
-            {"category": "hours"},
-            {"category": "hours"},
-            {"category": None},
+            {
+                "category": "facility-info",
+                "subcategory": "equipment",
+                "source": "manual",
+                "language": "ja",
+            },
+            {
+                "category": "hours",
+                "subcategory": "holiday",
+                "source": "web",
+                "language": "en",
+            },
+            {
+                "category": "hours",
+                "subcategory": "weekday",
+                "source": "manual",
+                "language": "ja",
+            },
+            {
+                "category": "hours",
+                "subcategory": "holiday",
+                "source": "manual",
+                "language": "ja",
+            },
+            {
+                "category": "facility-info",
+                "subcategory": None,
+                "source": None,
+                "language": None,
+            },
+            {
+                "category": None,
+                "subcategory": None,
+                "source": None,
+                "language": None,
+            },
         ]
     )
 
-    subcategory_query = MagicMock()
-    subcategory_query.execute.return_value = _mock_table_result(
-        [
-            {"category": "hours", "subcategory": "holiday"},
-            {"category": "hours", "subcategory": "weekday"},
-            {"category": "hours", "subcategory": "holiday"},
-            {"category": "facility-info", "subcategory": "equipment"},
-            {"category": "facility-info", "subcategory": None},
-        ]
-    )
-
-    source_query = MagicMock()
-    source_query.execute.return_value = _mock_table_result(
-        [
-            {"source": "manual"},
-            {"source": "web"},
-            {"source": "manual"},
-            {"source": None},
-        ]
-    )
-
-    language_query = MagicMock()
-    language_query.execute.return_value = _mock_table_result(
-        [
-            {"language": "ja"},
-            {"language": "en"},
-            {"language": "ja"},
-            {"language": None},
-        ]
-    )
-
-    table_mock.select.side_effect = [
-        category_query,
-        subcategory_query,
-        source_query,
-        language_query,
-    ]
+    table_mock.select.return_value = combined_query
 
     response = client.get("/api/knowledge/categories")
 

--- a/backend/tests/e2e/test_http_endpoint_e2e.py
+++ b/backend/tests/e2e/test_http_endpoint_e2e.py
@@ -439,7 +439,7 @@ class TestMiddleware:
 
     async def test_cors_headers_on_preflight(self, client: httpx.AsyncClient):
         """OPTIONS リクエストで CORS ヘッダーが設定されること"""
-        production_origin = "https://engineer-cafe-navigator.company-997.workers.dev"
+        production_origin = "https://frontend-delta-six-20.vercel.app"
         response = await client.options(
             "/api/chat",
             headers={
@@ -457,7 +457,7 @@ class TestMiddleware:
 
     async def test_cors_allows_configured_origin(self, client: httpx.AsyncClient):
         """設定済みのオリジンが CORS で許可されること"""
-        production_origin = "https://engineer-cafe-navigator.company-997.workers.dev"
+        production_origin = "https://frontend-delta-six-20.vercel.app"
         response = await client.options(
             "/api/chat",
             headers={

--- a/backend/tests/test_main_endpoints.py
+++ b/backend/tests/test_main_endpoints.py
@@ -269,7 +269,7 @@ class TestCORSConfiguration:
 
         importlib.reload(backend.main)
         assert (
-            "https://engineer-cafe-navigator.company-997.workers.dev"
+            "https://frontend-delta-six-20.vercel.app"
             in backend.main.ALLOWED_ORIGINS
         )
 

--- a/backend/tests/test_main_endpoints.py
+++ b/backend/tests/test_main_endpoints.py
@@ -268,10 +268,7 @@ class TestCORSConfiguration:
         import backend.main
 
         importlib.reload(backend.main)
-        assert (
-            "https://frontend-delta-six-20.vercel.app"
-            in backend.main.ALLOWED_ORIGINS
-        )
+        assert "https://frontend-delta-six-20.vercel.app" in backend.main.ALLOWED_ORIGINS
 
     def test_cors_custom_origins(self, monkeypatch):
         """With ALLOWED_ORIGINS set, custom origins are used"""

--- a/backend/tests/workflows/test_streaming_memory.py
+++ b/backend/tests/workflows/test_streaming_memory.py
@@ -558,18 +558,19 @@ class TestConcurrentInvocations:
 
             call_count = 0
 
-            async def mock_answer(query, **kwargs):
+            async def mock_graph_ainvoke(state, *, config=None, context=None):
                 nonlocal call_count
                 call_count += 1
                 # asyncio.sleep で並行性をシミュレート
                 await asyncio.sleep(0.01)
                 return {
-                    "answer": f"Response to: {query}",
+                    **state,
+                    "answer": f"Response to: {state.get('query', '')}",
                     "emotion": "neutral",
                     "metadata": {},
                 }
 
-            workflow._general_knowledge_agent.answer_query = AsyncMock(side_effect=mock_answer)
+            workflow.graph.ainvoke = AsyncMock(side_effect=mock_graph_ainvoke)
 
             tasks = [
                 workflow.ainvoke(

--- a/backend/workflows/main_workflow.py
+++ b/backend/workflows/main_workflow.py
@@ -1072,7 +1072,22 @@ class MainWorkflow:
         await self._ensure_checkpointer_ready(config, state["session_id"])
         visitor_id = input_data.get("visitor_id") or input_data.get("session_id", "anonymous")
         context = WorkflowContext(user_id=visitor_id)
-        result = await self.graph.ainvoke(state, config=config, context=context)
+
+        try:
+            result = await asyncio.wait_for(
+                self.graph.ainvoke(state, config=config, context=context),
+                timeout=30,
+            )
+        except asyncio.TimeoutError:
+            logger.error(
+                "Workflow timed out after 30s for session %s",
+                state["session_id"],
+            )
+            return {
+                "answer": "申し訳ございません。処理がタイムアウトしました。",
+                "emotion": "neutral",
+                "metadata": {"error": "Request timed out after 30 seconds"},
+            }
 
         return {
             "answer": result.get("answer", ""),

--- a/docs/plans/production-integration-2026-03-16.md
+++ b/docs/plans/production-integration-2026-03-16.md
@@ -1,0 +1,289 @@
+# Production Integration Plan — 2026-03-16
+
+## Goal
+
+フロントエンド（Vercel）→バックエンド（Cloud Run）のプロキシ統合を完全に機能させ、
+デプロイ済みUIから全機能が動作する状態にする。
+
+---
+
+## Wave 1: BROKEN修正 — プロダクション動作の復旧 ✅ COMPLETE
+
+**完了日**: 2026-03-16
+**PRs**: #262, #266, #268, #269
+**Issues Closed**: #257, #258, #263, #264, #267
+
+### Task 1.1: Vercel環境変数設定 (#264) ✅
+- [x] `BACKEND_API_URL` / `BACKEND_API_KEY` Vercelに設定
+- [x] localhost fallback 削除（PR #266）
+- [x] Vercel CI/CD prod deploy 追加（PR #268）
+- [x] VERCEL_TOKEN GitHub Secrets 登録
+- [x] 疎通確認: Chat API, Character API, Knowledge API 全OK
+
+### Task 1.2: /api/character GET 契約修正 (#263-1) ✅
+- [x] supported_features action追加、manifest.json読み込み + fallback
+- [x] regression test追加
+
+### Task 1.3: 受付フロー triggerType 修正 (#263-2) ✅ (PR #266)
+
+### Task 1.4: Marp audioResponse 修正 (#263-3) ✅ (PR #266)
+
+### Task 1.5: DB接続プール修正 (#267) ✅ (PR #269)
+- [x] ResilientAsyncPostgresSaver with AsyncConnectionPool
+- [x] alist async generator retry (CRITICAL code review fix)
+- [x] stale_pool race condition guard
+- [x] Cloud Run cold start verified
+
+### Task 1.3: 受付フロー triggerType 修正 (#263-2)
+- [ ] `useReception.ts` の `triggerType='manual'` → backend許可値に変更
+  - `button_press` が最も近い代替
+- [ ] `ReceptionPanel.tsx` のdefault triggerTypeも修正
+- [ ] 動作確認: 受付開始→応答→完了の一連フロー
+
+### Task 1.4: Marp audioResponse 契約修正 (#263-3)
+- [ ] `MarpViewer.tsx` の `audioResponse` 参照を修正
+  - backend `/api/slides` のレスポンス構造に合わせる
+  - またはナレーション再生を別経路（TTS API直接呼び出し）に変更
+- [ ] 動作確認: スライド表示 + ナレーション
+
+---
+
+## Wave 2: 安定化 — 契約整合性 + env最適化
+
+**目標**: WARNING級の不整合をゼロにし、env管理を完全に整理
+**Issue**: #261 (env最適化), #259 (VRM Animation), #265 (route移行), #272 (CSP)
+**開始日**: 2026-03-17
+**PRマージ済み**: #260 (VRM修正), #271 (VRM表情統合+happy誤発火), #273 (Swagger CSP)
+
+### Task 2.1: env深層最適化 (#261) ✅ DONE
+**完了**: PR #274 (2026-03-18)
+- [x] frontend全ファイルをgrepし、実際に使用されているenv変数を特定
+- [x] `frontend/.env.example` から未使用変数を削除（Google Cloud, NextAuth, Gemini, OPENAI等）
+- [x] `frontend/src/lib/env.ts` required→BACKEND_API_URL/KEY、未使用optional削除
+- [x] `backend/.env.example` に不足変数を追加（API_SECRET_KEY, ALLOWED_ORIGINS, TTS, LangSmith, Discord）
+- [x] README/docsにenv変更を記載（backend/README.md, frontend/CLAUDE.md）
+
+### Task 2.2: VRM Animation プルダウン修正 (#259) ✅ DONE
+**完了**: PR #260 (2026-03-17) + PR #271 (VRM表情統合)
+- [x] VRMAファイル差し替え（Mixamoアニメーション5種追加）
+- [x] プルダウン表示修正（APIレスポンス正規化）
+- [x] VRM表情・リップシンク統合
+- [x] エラー時 happy 誤発火修正
+
+### Task 2.3+2.4: route移行 + 未露出endpoint露出 (#265) ✅ DONE
+**完了**: PR #276 (2026-03-18)
+- [x] `/api/admin/knowledge/editor-config` proxy route追加
+- [x] `/api/admin/stt/vocabulary/test` proxy route追加（`?action=test`でルーティング）
+- [x] `knowledge.ts` client をeditor-config endpointに切り替え
+- [ ] `/api/calendar` → backend endpoint未実装のため保留（将来対応）
+
+### Task 2.5: voice/slides/qa GET契約修正 ✅ DONE
+**完了**: PR #275 (2026-03-18)
+- [x] 共通ヘルパー `backend-error-response.ts` 追加（6 route適用）
+- [x] backend 4xx→500変換を修正（元のステータスコードを保持）
+- [x] `/api/slides` GET ハードコード削除（backend GETなし確認済み）
+- [x] regression test追加（`api-proxy-contract.test.ts`）
+
+### Task 2.6: Swagger UI CSP修正 (#272) ✅ DONE
+**完了**: PR #273 (2026-03-17)
+- [x] `/docs` `/redoc` 限定でCSP緩和（cdn.jsdelivr.net許可）
+
+---
+
+## Wave 3a: プロダクション安定化 — CRITICAL/HIGH修正 (2026-03-18開始)
+
+**目標**: プロダクトレビューで発見されたCRITICAL/HIGH問題を修正し、CI/CDパイプラインを安全にする
+**開始日**: 2026-03-18
+**根拠**: code-explorer全体レビュー (2026-03-18実施)
+
+### Task 3a.0: CI frontend-deploy-production ジョブ削除 ✅ DONE
+- [x] Vercel Git連携に移行 → CIジョブ不要化
+- [x] ci.yml から削除 (2026-03-18)
+- [ ] Vercel Dashboard で Production Branch = `develop` に変更 (先輩アクション)
+
+### Task 3a.1: CI `--set-secrets` → `--update-secrets` 修正 [CRIT-1]
+**担当**: Claude Code（即対応）
+**根本原因**: `--set-secrets` が全secret bindingを置換 → `API_SECRET_KEY`が消える → 新revision起動失敗 → trafficが旧revに固定
+- [ ] `ci.yml` の `--set-secrets` → `--update-secrets` に変更
+- [ ] `API_SECRET_KEY` を Secret Manager に移行し `--update-secrets` リストに追加
+- [ ] CORS `ALLOWED_ORIGINS` を `--update-env-vars` に追加（CRIT-2も同時修正）
+- [ ] CI deploy後のsmoke testを認証付き（`X-API-Key`ヘッダー）に変更
+- [ ] 手動deploy → traffic切替 → ブラウザからのCORS確認
+
+### Task 3a.2: CORS デフォルトオリジン修正 [CRIT-2]
+**担当**: Claude Code（3a.1と同時）
+- [ ] `backend/main.py` ALLOWED_ORIGINS のデフォルトを Vercel URL に変更
+- [ ] Cloud Run env vars に `ALLOWED_ORIGINS` を追加
+
+### Task 3a.3: `backendFetch` タイムアウト追加 [HIGH-1]
+**担当**: Codex CLI（経路C）
+- [ ] `frontend/src/lib/api/backend-proxy.ts` に `AbortSignal.timeout(25_000)` 追加
+- [ ] `backend/workflows/main_workflow.py` の `ainvoke` を `asyncio.wait_for(..., timeout=30)` でラップ
+- [ ] テスト追加
+
+### Task 3a.4: admin editor-config N+4クエリ最適化 [HIGH-2]
+**担当**: Codex CLI（経路C）
+- [ ] `backend/api/knowledge.py` の4連続SELECT → `SELECT DISTINCT` 1クエリに統合
+- [ ] `asyncio.to_thread()` でevent loop非ブロック化（MED-3も同時修正）
+
+### Task 3a.5: `invoke_agent` session_id null-guard [HIGH-3]
+**担当**: Codex CLI（経路C）
+- [ ] `backend/main.py` invoke_agent: `cast(str, body.session_id)` → `body.session_id or str(uuid4())`
+
+### Task 3a.6: `BACKEND_API_KEY` 起動時検証 [HIGH-4]
+**担当**: Codex CLI（経路C）
+- [ ] `frontend/instrumentation.ts` で `validateServerEnv()` を呼び出し、未設定時はfail-fast
+
+### Task 3a.7: `ci-success` ゲート修正 [HIGH-5]
+**担当**: Claude Code（3a.1と同時）
+- [ ] `ci-success` のconditionを修正: `skipped` を許容しつつ、変更があるのにskippedの場合はfail
+- [ ] または frontend/backend それぞれの `ci-success-*` ジョブに分離
+
+### Task 3a.8: Alert webhook Zod検証 [MED-2]
+**担当**: Codex CLI（経路C）
+- [ ] `frontend/src/app/api/alerts/webhook/route.ts` に Zod schema追加
+- [ ] `processAlert` 呼び出し前にバリデーション
+
+---
+
+## Wave 3b: P1改善 — 品質・テスト・多言語 + route完了
+
+**目標**: プロダクション品質を担保するテスト基盤、RAG改善、残route移行
+**Issue**: #139 (E2E), #141/#137 (RAG), #138 (多言語), #140 (負荷テスト), #265 (calendar proxy残)
+**Wave 3a完了後に開始**
+
+### Task 3b.0: calendar backend endpoint + proxy (#265 残)
+**担当**: Codex CLI（経路C）
+- [ ] backend に `/api/calendar` GET エンドポイント実装（既存 `calendar_service.py` を活用）
+- [ ] frontend `/api/calendar/route.ts` を `backendFetch('/api/calendar')` にプロキシ化
+- [ ] `GOOGLE_CALENDAR_ICAL_URL` を frontend から完全削除（backend側で管理）
+- [ ] #265 クローズ
+
+### Task 3b.1: Playwright E2E テスト整備 (#139)
+**担当**: Codex CLI（経路C）— テスト作成 / Claude Code — テスト実行
+- [ ] 基本シナリオ: ページ表示 → チャット → 応答表示
+- [ ] VRMキャラクター表示確認
+- [ ] スライド表示・ナビゲーション
+- [ ] admin ナレッジ管理CRUD
+- [ ] CI統合（playwright.yml）
+
+### Task 3b.2: RAG precision 改善 (#141)
+**担当**: Claude Code（対話的）
+- [ ] context_precision ベースライン測定
+- [ ] ばらつき原因分析（検索クエリ、embedding品質、チャンク戦略）
+- [ ] RAGAS評価パイプライン実行
+- [ ] 改善パラメータ適用
+
+### Task 3b.3: answer_correctness 0.7+ (#137)
+**担当**: Claude Code（対話的）
+- [ ] ベースライン測定
+- [ ] プロンプト・検索パラメータ調整
+- [ ] RAGAS再評価で0.7+確認
+
+### Task 3b.4: 多言語対応改善 (#138)
+**担当**: Claude Code（対話的）
+- [ ] 英語応答品質の現状測定
+- [ ] 言語検出精度の確認
+- [ ] プロンプト多言語対応
+
+### Task 3b.5: 負荷テスト (#140)
+**担当**: Codex CLI（経路C）
+- [ ] k6/locust スクリプト作成
+- [ ] チャットAPI、音声API の同時接続テスト
+- [ ] ボトルネック特定・レポート
+
+---
+
+## Issue Status Map
+
+| Issue | Wave | Status | 備考 |
+|-------|------|--------|------|
+| #257 | W1 | ✅ Closed | バックエンドデプロイ完了 |
+| #258 | W1 | ✅ Closed | #262で部分完了、残は#261で完了 |
+| #259 | W2 | ✅ Closed | PR #260 VRM Animation |
+| #261 | W2 | ✅ Closed | PR #274 env深層最適化 |
+| #263 | W1 | ✅ Closed | PR #266 API契約不一致（3件） |
+| #264 | W1 | ✅ Closed | PR #266 Vercel→Cloud Run認証 |
+| #265 | W2→W3b | 🔧 Open | route移行（admin完了、calendar保留→W3b Task 3b.0） |
+| #270 | W2 | ✅ Closed | PR #271 happy誤発火 |
+| #272 | W2 | ✅ Closed | PR #273 Swagger CSP |
+| — | W3a | 🔧 NEW | CI `--set-secrets`→`--update-secrets` [CRIT-1] |
+| — | W3a | 🔧 NEW | CORS デフォルトオリジン修正 [CRIT-2] |
+| — | W3a | 🔧 NEW | backendFetch/ainvoke タイムアウト [HIGH-1] |
+| — | W3a | 🔧 NEW | editor-config N+4クエリ [HIGH-2] |
+| — | W3a | 🔧 NEW | invoke_agent session_id null-guard [HIGH-3] |
+| — | W3a | 🔧 NEW | BACKEND_API_KEY 起動時検証 [HIGH-4] |
+| — | W3a | 🔧 NEW | ci-success ゲート修正 [HIGH-5] |
+| — | W3a | 🔧 NEW | Alert webhook Zod検証 [MED-2] |
+| #209 | — | ⏳ Backlog | テキストバブル表示 |
+| #211 | — | ⏳ Backlog | 対応VRMAの追加（PR #260で部分完了） |
+| #192-189 | W3b | ⏳ 統合テスト | E2E整備後 |
+| #165 | — | ⏳ Backlog | Reception境界分析 |
+| #141 | W3b | 📋 P1 | RAG precision |
+| #140 | W3b | 📋 P1 | 負荷テスト |
+| #139 | W3b | 📋 P1 | E2Eテスト |
+| #138 | W3b | 📋 P1 | 多言語対応 |
+| #137 | W3b | 📋 P1 | answer_correctness |
+| #128 | — | ⏳ P1 研究 | デバイス検知 |
+| #117 | — | ⏳ P0 | 自律受付フロー（W1で部分対応） |
+| #114 | — | ⏳ P2 | 満足度フィードバック |
+| #113 | — | ⏳ P2 | イベント登録ガイド |
+
+## 並列実行戦略
+
+```
+Wave 1 (BROKEN修正) ✅ COMPLETE
+Wave 2 (安定化)     ✅ COMPLETE
+
+Wave 3a (プロダクション安定化) ── 2026-03-18 開始
+├── Task 3a.0 (CI cleanup)        ─── ✅ DONE
+├── Task 3a.1 (--set-secrets fix) ─── Claude Code（CRIT-1+CRIT-2、即対応）
+├── Task 3a.3 (timeout)           ─── Codex CLI（並列）
+├── Task 3a.4 (N+4 query)         ─── Codex CLI（並列）
+├── Task 3a.5 (session_id guard)  ─── Codex CLI（並列）
+├── Task 3a.6 (env validation)    ─── Codex CLI（並列）
+├── Task 3a.7 (ci-success gate)   ─── Claude Code（3a.1と同時）
+└── Task 3a.8 (webhook Zod)       ─── Codex CLI（並列）
+
+Wave 3b (P1改善) ── Wave 3a完了後
+├── Task 3b.0 (calendar proxy)    ─── Codex CLI（独立、先行可）
+├── Task 3b.1 (E2E)               ─── Codex CLI + Claude Code
+├── Task 3b.2 (RAG precision)     ─── Claude Code (対話的)
+├── Task 3b.3 (correctness)       ─── Claude Code (対話的、3b.2と直列)
+├── Task 3b.4 (多言語)            ─── Claude Code (対話的)
+└── Task 3b.5 (負荷テスト)        ─── Codex CLI（3b.1完了後）
+```
+
+## プロダクトレビュー追跡 (2026-03-18実施)
+
+レビュー手法: code-explorer エージェントによるフルスキャン
+
+### 全指摘一覧
+
+| ID | 深刻度 | 領域 | 説明 | Wave | 対応状況 |
+|---|---|---|---|---|---|
+| CRIT-1 | CRITICAL | CI/CD | `--set-secrets` が `API_SECRET_KEY` を消す | 3a.1 | 📋 |
+| CRIT-2 | CRITICAL | CORS | デフォルトオリジンが workers.dev (旧CF) | 3a.2 | 📋 |
+| HIGH-1 | HIGH | Integration | backendFetch/ainvoke にタイムアウトなし | 3a.3 | 📋 |
+| HIGH-2 | HIGH | Database | editor-config N+4 unbounded クエリ | 3a.4 | 📋 |
+| HIGH-3 | HIGH | Backend | invoke_agent: nullable session_id の unsafe cast | 3a.5 | 📋 |
+| HIGH-4 | HIGH | Security | BACKEND_API_KEY 未設定時サイレント失敗 | 3a.6 | 📋 |
+| HIGH-5 | HIGH | CI/CD | ci-success が skipped を pass 扱い | 3a.7 | 📋 |
+| MED-1 | MEDIUM | Observability | console.error 17箇所、構造化ログなし | Backlog | ⏳ |
+| MED-2 | MEDIUM | Security | Alert webhook 未検証で emergencyShutdown | 3a.8 | 📋 |
+| MED-3 | MEDIUM | Performance | sync Supabase calls blocking event loop | 3a.4 | 📋 (HIGH-2と同時) |
+| MED-4 | MEDIUM | Reliability | Upload proxy タイムアウトなし | Backlog | ⏳ |
+| MED-5 | MEDIUM | Reliability | Calendar proxy タイムアウト・Content-Type未検証 | 3b.0 | 📋 (calendar移行時) |
+| MED-6 | MEDIUM | Config | ENVIRONMENT=production だがコメントは staging | 3a.1 | 📋 (コメント修正) |
+| MED-7 | MEDIUM | Security | local toErrorBody が payload spread で内部漏洩 | Backlog | ⏳ |
+| LOW-1 | LOW | CI/CD | Deploy失敗が未通知 | Backlog | ⏳ |
+| LOW-2 | LOW | UX | Reception start body 未検証 | Backlog | ⏳ |
+| LOW-3 | LOW | Correctness | ocr/route.ts response.ok 未チェック | Backlog | ⏳ |
+| LOW-4 | LOW | Config | BACKEND_API_KEY required in schema but optional in usage | 3a.6 | 📋 (同時修正) |
+| LOW-5 | LOW | Security | /health が infra state を無認証公開 | Backlog | ⏳ (意図的) |
+| LOW-6 | LOW | Reliability | Reception session store 非レプリケーション | Backlog | ⏳ |
+
+### アーキテクチャ観察（将来対応）
+- Mastra agents (`frontend/src/mastra/`) はdead weight — 本番バンドルから除外推奨
+- `should_continue_or_end` は常にEND — no-opプレースホルダー
+- keyword-based fast routing (200行超) はデータ駆動に移行推奨

--- a/frontend/src/app/api/alerts/webhook/route.ts
+++ b/frontend/src/app/api/alerts/webhook/route.ts
@@ -1,12 +1,29 @@
 import { rollbackManager } from '@/lib/rollback-manager';
 import crypto from 'crypto';
 import { NextRequest, NextResponse } from 'next/server';
+import { z } from 'zod';
 
 import {
   createBackendErrorResponse,
   createInternalServerErrorResponse,
 } from '@/app/api/_shared/backend-error-response';
 import { backendFetch } from '@/lib/api/backend-proxy';
+
+/**
+ * Strict Zod schema for alert webhook payloads.
+ * Only known alert types and severity levels are accepted.
+ * This prevents crafted payloads from triggering emergencyShutdown().
+ */
+const AlertPayloadSchema = z.object({
+  id: z.string().max(256).optional(),
+  type: z.enum(['error_rate', 'response_time', 'cache_hit_rate', 'api_failure', 'memory_usage']),
+  severity: z.enum(['info', 'warning', 'critical']),
+  metric: z.string().min(1).max(256),
+  value: z.number().finite(),
+  threshold: z.number().finite(),
+  source: z.string().min(1).max(256),
+  metadata: z.record(z.string(), z.unknown()).optional(),
+});
 
 /**
  * Webhook endpoint for production alerts
@@ -34,7 +51,21 @@ export async function POST(request: NextRequest) {
       );
     }
     
-    const alert = await request.json();
+    const rawBody = await request.json();
+    const parsed = AlertPayloadSchema.safeParse(rawBody);
+    if (!parsed.success) {
+      return NextResponse.json(
+        {
+          error: 'Invalid alert payload',
+          details: parsed.error.issues.map((i) => ({
+            path: i.path.join('.'),
+            message: i.message,
+          })),
+        },
+        { status: 400 }
+      );
+    }
+    const alert = parsed.data;
 
     const response = await backendFetch('/api/alerts', { method: 'POST', body: alert });
     if (!response.ok) {
@@ -172,17 +203,8 @@ export async function GET(request: NextRequest) {
   }
 }
 
-// Type definitions
-interface AlertPayload {
-  id?: string;
-  type: 'error_rate' | 'response_time' | 'cache_hit_rate' | 'api_failure' | 'memory_usage';
-  severity: 'info' | 'warning' | 'critical';
-  metric: string;
-  value: number;
-  threshold: number;
-  source: string;
-  metadata?: Record<string, any>;
-}
+// Type definitions (derived from Zod schema)
+type AlertPayload = z.infer<typeof AlertPayloadSchema>;
 
 interface AlertResponse {
   received: boolean;

--- a/frontend/src/instrumentation.ts
+++ b/frontend/src/instrumentation.ts
@@ -1,0 +1,30 @@
+/**
+ * Next.js Instrumentation — runs once on server startup.
+ * https://nextjs.org/docs/app/building-your-application/optimizing/instrumentation
+ *
+ * Validates required server environment variables and fails fast
+ * if critical configuration is missing in production.
+ */
+export async function register(): Promise<void> {
+  if (process.env.NEXT_RUNTIME === "nodejs") {
+    const { validateServerEnv } = await import("@/lib/env");
+    const result = validateServerEnv();
+
+    if (!result.success) {
+      for (const err of result.errors) {
+        console.error(`[instrumentation] ${err}`);
+      }
+
+      if (process.env.NODE_ENV === "production") {
+        throw new Error(
+          `Server startup blocked: ${result.errors.length} missing env var(s). ` +
+            `See logs above for details.`
+        );
+      }
+
+      console.warn(
+        "[instrumentation] Non-production mode: continuing despite missing env vars."
+      );
+    }
+  }
+}

--- a/frontend/src/lib/api/backend-proxy.ts
+++ b/frontend/src/lib/api/backend-proxy.ts
@@ -58,10 +58,12 @@ export async function backendFetch<T = unknown>(
     mergedHeaders["X-API-Key"] = apiKey;
   }
 
+  const effectiveSignal = signal ?? AbortSignal.timeout(25_000);
+
   const fetchInit: RequestInit = {
     method,
     headers: mergedHeaders,
-    signal,
+    signal: effectiveSignal,
   };
 
   if (body !== undefined && method !== "GET") {

--- a/frontend/src/lib/api/backend-proxy.ts
+++ b/frontend/src/lib/api/backend-proxy.ts
@@ -58,7 +58,9 @@ export async function backendFetch<T = unknown>(
     mergedHeaders["X-API-Key"] = apiKey;
   }
 
-  const effectiveSignal = signal ?? AbortSignal.timeout(25_000);
+  // 35s > backend's 30s workflow timeout, so the backend can return its
+  // graceful timeout response before the frontend aborts the connection.
+  const effectiveSignal = signal ?? AbortSignal.timeout(35_000);
 
   const fetchInit: RequestInit = {
     method,


### PR DESCRIPTION
## Summary

Production readiness review (2026-03-18) で発見された CRITICAL 2件 + HIGH 5件 + MED 1件を修正。

### CRITICAL fixes
- **CRIT-1**: CI deploy `--set-secrets` → `--update-secrets` に変更。旧コマンドは全secret bindingを置換し `API_SECRET_KEY` が消える → 新revision起動失敗 → traffic が rev 00021 に固定されていた根本原因
- **CRIT-2**: CORS デフォルトオリジンを `workers.dev` (旧Cloudflare) → `frontend-delta-six-20.vercel.app` に修正

### HIGH fixes
- **HIGH-1**: `backendFetch` に25秒タイムアウト、`workflow.ainvoke` に30秒タイムアウト追加
- **HIGH-2**: editor-config の N+4 unbounded クエリを1クエリに最適化 + `asyncio.to_thread` でevent loop非ブロック化
- **HIGH-3**: `invoke_agent` の nullable `session_id` unsafe cast を修正
- **HIGH-4**: `instrumentation.ts` で `BACKEND_API_KEY` の起動時バリデーション (本番: fail-fast, 開発: warn)
- **HIGH-5**: `ci-success` ゲートが `cancelled` ジョブも検出するよう修正

### MEDIUM fixes
- **MED-2**: Alert webhook に Zod スキーマ検証追加 (crafted payload による `emergencyShutdown` 防止)

### Infrastructure changes
- `frontend-deploy-production` CIジョブ削除 (Vercel Deploy Hook に移行)
- `API_SECRET_KEY` を GCP Secret Manager に移行 (平文env var → secret ref)
- `ALLOWED_ORIGINS` を Cloud Run env vars に追加
- Cloud Run traffic → LATEST に切替済み (rev 00036)

## Test plan
- [x] `pnpm typecheck` — pass
- [x] `pnpm lint` — pass
- [x] `ruff check` + `black --check` — pass
- [x] `pytest tests/test_auth_fail_closed.py` — 5 passed
- [x] `pytest tests/test_security_audit.py` — 4 passed
- [x] Cloud Run health check — OK (rev 00036)
- [x] CORS preflight — `access-control-allow-origin: https://frontend-delta-six-20.vercel.app`
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)