### PR TITLE
fix: Wave 3b blockers — ffmpeg, TAVILY CI, setup guide

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -319,7 +319,7 @@ jobs:
             --min-instances 0 \
             --max-instances 3 \
             --update-env-vars "ENVIRONMENT=production,TTS_PROVIDER=voicevox,VOICEVOX_API_URL=https://voicevox-proto-639959525777.asia-northeast2.run.app,ALLOWED_ORIGINS=https://frontend-delta-six-20.vercel.app" \
-            --update-secrets "OPENROUTER_API_KEY=OPENROUTER_API_KEY:latest,SUPABASE_URL=SUPABASE_URL:latest,SUPABASE_KEY=SUPABASE_KEY:latest,SUPABASE_DB_URI=SUPABASE_DB_URI:latest,API_SECRET_KEY=API_SECRET_KEY:latest"
+            --update-secrets "OPENROUTER_API_KEY=OPENROUTER_API_KEY:latest,SUPABASE_URL=SUPABASE_URL:latest,SUPABASE_KEY=SUPABASE_KEY:latest,SUPABASE_DB_URI=SUPABASE_DB_URI:latest,API_SECRET_KEY=API_SECRET_KEY:latest,TAVILY_API_KEY=TAVILY_API_KEY:latest"
 
       - name: Smoke test deployed service
         run: |

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -7,12 +7,13 @@ FROM python:3.11-slim AS base
 # Set working directory
 WORKDIR /app
 
-# Install system dependencies (curl/unzip for Vosk model download)
+# Install system dependencies (curl/unzip for Vosk model download, ffmpeg for pydub audio conversion)
 RUN apt-get update && apt-get install -y \
     gcc \
     g++ \
     curl \
     unzip \
+    ffmpeg \
     && rm -rf /var/lib/apt/lists/*
 
 # Copy requirements

--- a/docs/plans/production-integration-2026-03-16.md
+++ b/docs/plans/production-integration-2026-03-16.md
@@ -90,8 +90,9 @@
 
 ---
 
-## Wave 3a: プロダクション安定化 — CRITICAL/HIGH修正 (2026-03-18開始)
+## Wave 3a: プロダクション安定化 — CRITICAL/HIGH修正 ✅ COMPLETE
 
+**完了日**: 2026-03-18 (PR #278 マージ)
 **目標**: プロダクトレビューで発見されたCRITICAL/HIGH問題を修正し、CI/CDパイプラインを安全にする
 **開始日**: 2026-03-18
 **根拠**: code-explorer全体レビュー (2026-03-18実施)
@@ -99,60 +100,85 @@
 ### Task 3a.0: CI frontend-deploy-production ジョブ削除 ✅ DONE
 - [x] Vercel Git連携に移行 → CIジョブ不要化
 - [x] ci.yml から削除 (2026-03-18)
-- [ ] Vercel Dashboard で Production Branch = `develop` に変更 (先輩アクション)
+- [x] Vercel Dashboard で Production Branch = `develop` に設定 (Deploy Hook)
 
-### Task 3a.1: CI `--set-secrets` → `--update-secrets` 修正 [CRIT-1]
-**担当**: Claude Code（即対応）
-**根本原因**: `--set-secrets` が全secret bindingを置換 → `API_SECRET_KEY`が消える → 新revision起動失敗 → trafficが旧revに固定
-- [ ] `ci.yml` の `--set-secrets` → `--update-secrets` に変更
-- [ ] `API_SECRET_KEY` を Secret Manager に移行し `--update-secrets` リストに追加
-- [ ] CORS `ALLOWED_ORIGINS` を `--update-env-vars` に追加（CRIT-2も同時修正）
-- [ ] CI deploy後のsmoke testを認証付き（`X-API-Key`ヘッダー）に変更
-- [ ] 手動deploy → traffic切替 → ブラウザからのCORS確認
+### Task 3a.1: CI `--set-secrets` → `--update-secrets` 修正 [CRIT-1] ✅ DONE
+- [x] `ci.yml` の `--set-secrets` → `--update-secrets` に変更
+- [x] `API_SECRET_KEY` を Secret Manager に移行し `--update-secrets` リストに追加
+- [x] CORS `ALLOWED_ORIGINS` を `--update-env-vars` に追加（CRIT-2も同時修正）
+- [x] CI deploy後のsmoke testを認証付き（`X-API-Key`ヘッダー）に変更
+- [x] 手動deploy → traffic切替 → ブラウザからのCORS確認
 
-### Task 3a.2: CORS デフォルトオリジン修正 [CRIT-2]
-**担当**: Claude Code（3a.1と同時）
-- [ ] `backend/main.py` ALLOWED_ORIGINS のデフォルトを Vercel URL に変更
-- [ ] Cloud Run env vars に `ALLOWED_ORIGINS` を追加
+### Task 3a.2: CORS デフォルトオリジン修正 [CRIT-2] ✅ DONE
+- [x] `backend/main.py` ALLOWED_ORIGINS のデフォルトを Vercel URL に変更
+- [x] Cloud Run env vars に `ALLOWED_ORIGINS` を追加
 
-### Task 3a.3: `backendFetch` タイムアウト追加 [HIGH-1]
-**担当**: Codex CLI（経路C）
-- [ ] `frontend/src/lib/api/backend-proxy.ts` に `AbortSignal.timeout(25_000)` 追加
-- [ ] `backend/workflows/main_workflow.py` の `ainvoke` を `asyncio.wait_for(..., timeout=30)` でラップ
-- [ ] テスト追加
+### Task 3a.3: `backendFetch` タイムアウト追加 [HIGH-1] ✅ DONE
+- [x] `frontend/src/lib/api/backend-proxy.ts` に `AbortSignal.timeout(35_000)` 追加
+- [x] `backend/workflows/main_workflow.py` の `ainvoke` を `asyncio.wait_for(..., timeout=30)` でラップ
+- [x] テスト追加
 
-### Task 3a.4: admin editor-config N+4クエリ最適化 [HIGH-2]
-**担当**: Codex CLI（経路C）
-- [ ] `backend/api/knowledge.py` の4連続SELECT → `SELECT DISTINCT` 1クエリに統合
-- [ ] `asyncio.to_thread()` でevent loop非ブロック化（MED-3も同時修正）
+### Task 3a.4: admin editor-config N+4クエリ最適化 [HIGH-2] ✅ DONE
+- [x] `backend/api/knowledge.py` の4連続SELECT → `SELECT DISTINCT` 1クエリに統合
+- [x] `asyncio.to_thread()` でevent loop非ブロック化（MED-3も同時修正）
 
-### Task 3a.5: `invoke_agent` session_id null-guard [HIGH-3]
-**担当**: Codex CLI（経路C）
-- [ ] `backend/main.py` invoke_agent: `cast(str, body.session_id)` → `body.session_id or str(uuid4())`
+### Task 3a.5: `invoke_agent` session_id null-guard [HIGH-3] ✅ DONE
+- [x] `backend/main.py` invoke_agent: `body.session_id or str(uuid4())`
 
-### Task 3a.6: `BACKEND_API_KEY` 起動時検証 [HIGH-4]
-**担当**: Codex CLI（経路C）
-- [ ] `frontend/instrumentation.ts` で `validateServerEnv()` を呼び出し、未設定時はfail-fast
+### Task 3a.6: `BACKEND_API_KEY` 起動時検証 [HIGH-4] ✅ DONE
+- [x] `frontend/instrumentation.ts` で `validateServerEnv()` を呼び出し、未設定時はfail-fast
 
-### Task 3a.7: `ci-success` ゲート修正 [HIGH-5]
-**担当**: Claude Code（3a.1と同時）
-- [ ] `ci-success` のconditionを修正: `skipped` を許容しつつ、変更があるのにskippedの場合はfail
-- [ ] または frontend/backend それぞれの `ci-success-*` ジョブに分離
+### Task 3a.7: `ci-success` ゲート修正 [HIGH-5] ✅ DONE
+- [x] `ci-success` のconditionを修正: `skipped` 許容、`failure`/`cancelled` でfail
 
-### Task 3a.8: Alert webhook Zod検証 [MED-2]
-**担当**: Codex CLI（経路C）
-- [ ] `frontend/src/app/api/alerts/webhook/route.ts` に Zod schema追加
-- [ ] `processAlert` 呼び出し前にバリデーション
+### Task 3a.8: Alert webhook Zod検証 [MED-2] ✅ DONE
+- [x] `frontend/src/app/api/alerts/webhook/route.ts` に Zod schema追加
+- [x] `processAlert` 呼び出し前にバリデーション
 
 ---
 
-## Wave 3b: P1改善 — 品質・テスト・多言語 + route完了
+## Wave 3b: プロダクション品質修正 + P1改善 (2026-03-21 開始)
 
-**目標**: プロダクション品質を担保するテスト基盤、RAG改善、残route移行
-**Issue**: #139 (E2E), #141/#137 (RAG), #138 (多言語), #140 (負荷テスト), #265 (calendar proxy残)
-**Wave 3a完了後に開始**
+**目標**: 本番ブロッカー修正（embedding/ffmpeg/TAVILY）→ P1品質改善
+**Issue**: #279 (RAG一貫性), #189 (音声テスト), #265 (calendar), #139 (E2E), #141/#137 (RAG品質), #138 (多言語), #140 (負荷テスト)
+**開始日**: 2026-03-21
 
-### Task 3b.0: calendar backend endpoint + proxy (#265 残)
+### Wave 3b-0: 本番ブロッカー修正（独立・並列実行）
+
+#### Task 3b-0a: knowledge_base embedding 80件一括再生成 (#279 根本修正)
+**担当**: Claude Code（本番API操作）
+**根本原因**: migration `20260214000001` が content_embedding カラムを DROP→再CREATE したため全80件のembeddingがNULLに
+- [ ] バッチスクリプトで PUT /api/knowledge/{id} → embedding自動再生成
+- [ ] 再生成後に search_knowledge_base RPC が正常動作することを検証
+- [ ] #279 の根本原因（embedding NULL）を解消
+
+#### Task 3b-0b: Dockerfile に ffmpeg 追加 (#189 blocker)
+**担当**: Agent Team (worktree)
+**根本原因**: pydub の WebM→WAV変換が ffprobe/ffmpeg に依存するが Dockerfile に未インストール
+- [ ] `backend/Dockerfile` の apt-get install に `ffmpeg` 追加
+- [ ] CI/CD で新イメージビルド・デプロイ
+
+#### Task 3b-0c: TAVILY_API_KEY を Cloud Run に追加
+**担当**: Claude Code（GCP操作）
+- [x] GCP Secret Manager に TAVILY_API_KEY 作成
+- [x] Cloud Run service account に secretAccessor 付与
+- [x] `gcloud run services update --update-secrets` で追加 → rev 00038 稼働
+- [ ] CI deploy コマンドにも `TAVILY_API_KEY=TAVILY_API_KEY:latest` 追加
+
+#### Task 3b-0d: Cloudflare 残骸削除 + Vercel 重複プロジェクト整理
+**担当**: Agent Team + 先輩（Vercelダッシュボード手動操作）
+- [ ] `frontend/.open-next/` ディレクトリ削除（ローカルビルド残骸）
+- [ ] Vercel 重複プロジェクト (`engineer-cafe-navigator2025`, `engineer-cafe-navigator`) 削除
+- [ ] 手順書: `~/Desktop/vercel-cleanup-guide.md` に作成済み
+
+#### Task 3b-0e: 開発環境セットアップガイド (#189 チームサポート)
+**担当**: Agent Team
+- [ ] `docs/setup-guide.md` 作成（日本語）
+- [ ] 前提条件、backend/frontend セットアップ、env vars、トラブルシューティング
+
+### Wave 3b-1: route移行 + 品質改善
+
+#### Task 3b.0: calendar backend endpoint + proxy (#265 残)
 **担当**: Codex CLI（経路C）
 - [ ] backend に `/api/calendar` GET エンドポイント実装（既存 `calendar_service.py` を活用）
 - [ ] frontend `/api/calendar/route.ts` を `backendFetch('/api/calendar')` にプロキシ化
@@ -194,7 +220,7 @@
 
 ---
 
-## Issue Status Map
+## Issue Status Map (2026-03-21 更新)
 
 | Issue | Wave | Status | 備考 |
 |-------|------|--------|------|
@@ -204,22 +230,25 @@
 | #261 | W2 | ✅ Closed | PR #274 env深層最適化 |
 | #263 | W1 | ✅ Closed | PR #266 API契約不一致（3件） |
 | #264 | W1 | ✅ Closed | PR #266 Vercel→Cloud Run認証 |
-| #265 | W2→W3b | 🔧 Open | route移行（admin完了、calendar保留→W3b Task 3b.0） |
+| #265 | W3b | 🔧 Open | route移行（admin完了、calendar→Codex CLI実行中） |
 | #270 | W2 | ✅ Closed | PR #271 happy誤発火 |
 | #272 | W2 | ✅ Closed | PR #273 Swagger CSP |
-| — | W3a | 🔧 NEW | CI `--set-secrets`→`--update-secrets` [CRIT-1] |
-| — | W3a | 🔧 NEW | CORS デフォルトオリジン修正 [CRIT-2] |
-| — | W3a | 🔧 NEW | backendFetch/ainvoke タイムアウト [HIGH-1] |
-| — | W3a | 🔧 NEW | editor-config N+4クエリ [HIGH-2] |
-| — | W3a | 🔧 NEW | invoke_agent session_id null-guard [HIGH-3] |
-| — | W3a | 🔧 NEW | BACKEND_API_KEY 起動時検証 [HIGH-4] |
-| — | W3a | 🔧 NEW | ci-success ゲート修正 [HIGH-5] |
-| — | W3a | 🔧 NEW | Alert webhook Zod検証 [MED-2] |
+| #279 | W3b | 🔧 NEW | RAG Knowledge Base 検索・保存の一貫性問題（embedding NULL→再生成中） |
+| — | W3a | ✅ PR#278 | CI `--set-secrets`→`--update-secrets` [CRIT-1] |
+| — | W3a | ✅ PR#278 | CORS デフォルトオリジン修正 [CRIT-2] |
+| — | W3a | ✅ PR#278 | backendFetch/ainvoke タイムアウト [HIGH-1] |
+| — | W3a | ✅ PR#278 | editor-config N+4クエリ [HIGH-2] |
+| — | W3a | ✅ PR#278 | invoke_agent session_id null-guard [HIGH-3] |
+| — | W3a | ✅ PR#278 | BACKEND_API_KEY 起動時検証 [HIGH-4] |
+| — | W3a | ✅ PR#278 | ci-success ゲート修正 [HIGH-5] |
+| — | W3a | ✅ PR#278 | Alert webhook Zod検証 [MED-2] |
+| — | W3b | 🔧 進行中 | Dockerfile ffmpeg追加（#189 blocker） |
+| — | W3b | ✅ DONE | TAVILY_API_KEY Cloud Run追加（rev 00038） |
 | #209 | — | ⏳ Backlog | テキストバブル表示 |
 | #211 | — | ⏳ Backlog | 対応VRMAの追加（PR #260で部分完了） |
-| #192-189 | W3b | ⏳ 統合テスト | E2E整備後 |
+| #192-189 | W3b | ⏳ テスト中 | 統合テスト（Jun #189テスト報告あり） |
 | #165 | — | ⏳ Backlog | Reception境界分析 |
-| #141 | W3b | 📋 P1 | RAG precision |
+| #141 | W3b | 📋 P1 | RAG precision（embedding再生成後に着手） |
 | #140 | W3b | 📋 P1 | 負荷テスト |
 | #139 | W3b | 📋 P1 | E2Eテスト |
 | #138 | W3b | 📋 P1 | 多言語対応 |

--- a/docs/setup-guide.md
+++ b/docs/setup-guide.md
@@ -1,0 +1,501 @@
+# ローカル開発環境セットアップガイド
+
+対象読者: プロジェクトに参加するすべての開発者 (takegawa, Jun ほか)
+所要時間: 約30〜45分 (ネットワーク速度による)
+
+---
+
+## このガイドで達成できること
+
+- フロントエンド (Next.js) とバックエンド (FastAPI) を両方ローカルで起動する
+- ブラウザで `http://localhost:3000` を開き、音声エージェントが動作する状態にする
+- テストとLintをパスさせ、PR が出せる状態にする
+
+---
+
+## 目次
+
+1. [前提条件](#1-前提条件)
+2. [リポジトリのクローン](#2-リポジトリのクローン)
+3. [バックエンドのセットアップ](#3-バックエンドのセットアップ)
+4. [フロントエンドのセットアップ](#4-フロントエンドのセットアップ)
+5. [起動して動作確認](#5-起動して動作確認)
+6. [Dockerを使ったフルスタック起動（任意）](#6-dockerを使ったフルスタック起動任意)
+7. [テストとLint](#7-テストとlint)
+8. [プロジェクト構成の概要](#8-プロジェクト構成の概要)
+9. [本番環境URL一覧](#9-本番環境url一覧)
+10. [よくあるエラーと対処法](#10-よくあるエラーと対処法)
+
+---
+
+## 1. 前提条件
+
+以下をインストールしてから作業を開始してください。
+
+### 必須ツール
+
+| ツール | 最低バージョン | インストール方法 |
+|--------|--------------|----------------|
+| Node.js | 20以上 | [nodejs.org](https://nodejs.org/) または `mise install node` |
+| pnpm | 10以上 | `npm install -g pnpm` または `mise install pnpm` |
+| Python | 3.11以上 | [python.org](https://www.python.org/) または `mise install python` |
+| ffmpeg | 任意のバージョン | `brew install ffmpeg` (macOS) |
+
+### ffmpeg が必要な理由
+
+音声機能 (STT) でブラウザから送られてくる WebM 形式の音声を変換するために ffmpeg が必要です。インストールしていないと STT が動作しません。
+
+```bash
+# macOS
+brew install ffmpeg
+
+# 確認
+ffprobe -version
+```
+
+### アクセスが必要なAPIキー
+
+セットアップ前にチームから以下のキーを受け取ってください。
+
+| サービス | 用途 | 取得先 |
+|----------|------|--------|
+| OpenRouter | LLM (Gemini など) | チームリーダーに確認 |
+| OpenAI | ベクトル埋め込み | チームリーダーに確認 |
+| Supabase | データベース | チームリーダーに確認 |
+| Google Cloud | STT / TTS | チームリーダーに確認 |
+| Tavily | Web検索 (省略可) | https://tavily.com |
+
+---
+
+## 2. リポジトリのクローン
+
+```bash
+git clone https://github.com/EngineerCafeJP/engineer-cafe-navigator2025.git
+cd engineer-cafe-navigator2025
+```
+
+ブランチ戦略: `main <- develop <- feat/*`。作業は必ず `develop` から新しいブランチを切ってください。
+
+```bash
+git checkout develop
+git pull
+git checkout -b feat/あなたの作業名
+```
+
+---
+
+## 3. バックエンドのセットアップ
+
+### 3-1. 仮想環境を作成して有効化する
+
+```bash
+cd backend
+python -m venv .venv
+source .venv/bin/activate   # Windows: .venv\Scripts\activate
+```
+
+ターミナルのプロンプトに `(.venv)` が表示されれば有効化できています。
+
+### 3-2. 依存パッケージをインストールする
+
+```bash
+pip install -e ".[dev]"
+```
+
+`[dev]` を付けることで pytest / black / ruff など開発ツールも一緒にインストールされます。
+
+### 3-3. 環境変数ファイルを作成する
+
+```bash
+cp .env.example .env
+```
+
+`.env` をテキストエディタで開き、以下の項目を設定してください。
+
+#### 必須の環境変数
+
+```dotenv
+# LLM プロバイダー (OpenRouter)
+OPENROUTER_API_KEY=sk-or-v1-xxxxxxxx
+
+# OpenAI (ベクトル埋め込み専用)
+OPENAI_API_KEY=sk-xxxxxxxx
+
+# Supabase
+SUPABASE_URL=https://xxxxxxxxxx.supabase.co
+SUPABASE_KEY=your-service-role-key
+SUPABASE_DB_URI=postgresql://postgres:password@db.xxxxxxxxxx.supabase.co:5432/postgres
+```
+
+#### 推奨の環境変数
+
+```dotenv
+# Web検索エージェント (なくても起動するが一部機能が低下する)
+TAVILY_API_KEY=tvly-xxxxxxxx
+
+# Google Calendar イベント情報取得
+GOOGLE_CALENDAR_ICAL_URL=https://calendar.google.com/calendar/ical/YOUR_CALENDAR_ID/public/basic.ics
+```
+
+#### ローカル開発では省略できる環境変数
+
+```dotenv
+# ローカルでは認証なしで動作する (省略可)
+# API_SECRET_KEY=your-api-secret-key
+# ALLOWED_ORIGINS=http://localhost:3000
+```
+
+> **注意**: `API_SECRET_KEY` を設定した場合、フロントエンドの `BACKEND_API_KEY` に同じ値を設定する必要があります。ローカル開発では両方とも空のままにしておくのが簡単です。
+
+### 3-4. Google Cloud サービスアカウントキーを配置する (STT/TTS を使う場合)
+
+音声機能を使う場合のみ必要です。
+
+1. チームリーダーからサービスアカウントキー (JSON) を受け取る
+2. `backend/config/service-account-key.json` として保存する
+
+```bash
+# ファイルが正しい場所にあるか確認
+ls backend/config/service-account-key.json
+```
+
+### 3-5. バックエンドを起動する
+
+```bash
+# backend/ ディレクトリで実行
+python -m uvicorn main:app --reload --host 0.0.0.0 --port 8000
+```
+
+起動に成功すると以下のようなログが表示されます。
+
+```
+INFO:     Uvicorn running on http://0.0.0.0:8000 (Press CTRL+C to quit)
+INFO:     Started reloader process
+```
+
+ブラウザで `http://localhost:8000/docs` を開くと API ドキュメントが確認できます。
+
+---
+
+## 4. フロントエンドのセットアップ
+
+バックエンドとは別のターミナルウィンドウで作業してください。
+
+### 4-1. 依存パッケージをインストールする
+
+```bash
+cd frontend
+pnpm install
+```
+
+### 4-2. 環境変数ファイルを作成する
+
+```bash
+cp .env.example .env.local
+```
+
+`.env.local` を開き、以下の項目を設定してください。
+
+#### 必須の環境変数
+
+```dotenv
+# バックエンドAPIへの接続先 (ローカル起動時はこのまま)
+BACKEND_API_URL=http://localhost:8000
+
+# バックエンドと同じ API_SECRET_KEY を設定 (ローカルでは空でも可)
+BACKEND_API_KEY=
+
+# Supabase (フロントエンド用 anon key を使用)
+NEXT_PUBLIC_SUPABASE_URL=https://xxxxxxxxxx.supabase.co
+NEXT_PUBLIC_SUPABASE_ANON_KEY=your-anon-key
+```
+
+#### 推奨の環境変数
+
+```dotenv
+# サーバーサイドの管理機能で使用
+SUPABASE_SERVICE_ROLE_KEY=your-service-role-key
+
+# 管理API / cron ルート保護
+ADMIN_API_SECRET=your-admin-api-secret
+```
+
+> **Supabase の anon key と service role key の違い**:
+> - `NEXT_PUBLIC_SUPABASE_ANON_KEY`: ブラウザに公開されるキー。RLS で行レベルアクセス制御される
+> - `SUPABASE_SERVICE_ROLE_KEY`: サーバーサイド専用。RLS をバイパスするため、ブラウザに公開しない
+
+### 4-3. フロントエンドを起動する
+
+```bash
+# frontend/ ディレクトリで実行
+pnpm dev
+```
+
+起動に成功すると以下のようなログが表示されます。
+
+```
+  ▲ Next.js 15.x.x
+  - Local:        http://localhost:3000
+  - Ready in xxxms
+```
+
+ブラウザで `http://localhost:3000` を開いてください。
+
+---
+
+## 5. 起動して動作確認
+
+バックエンド (ポート 8000) とフロントエンド (ポート 3000) の両方が起動している状態で確認します。
+
+### 確認項目チェックリスト
+
+- [ ] `http://localhost:3000` がブラウザで表示される
+- [ ] `http://localhost:8000/docs` で API ドキュメントが表示される
+- [ ] ブラウザのコンソールに CORS エラーが出ていない
+- [ ] (音声機能を使う場合) マイクのアクセス許可ダイアログが表示される
+
+### 簡易動作確認コマンド
+
+```bash
+# バックエンドのヘルスチェック
+curl http://localhost:8000/health
+
+# 期待するレスポンス: {"status": "ok"} または類似のJSON
+```
+
+---
+
+## 6. Dockerを使ったフルスタック起動（任意）
+
+Docker を使うとフロントエンドとバックエンドを一括で起動できます。ただし初回ビルドに時間がかかります。
+
+```bash
+# リポジトリルートで実行
+make setup   # 初回のみ: mise install + deps + Docker イメージビルド
+make dev     # frontend:3000 + backend:8000 を起動
+```
+
+> **Apple Silicon (M1/M2/M3) ユーザーへ**: GCP Cloud Run 向けにビルドする場合は `--platform linux/amd64` が必要です。ローカル開発では不要です。
+
+---
+
+## 7. テストとLint
+
+PR を出す前に以下がすべてパスすることを確認してください。
+
+### バックエンド
+
+```bash
+cd backend
+source .venv/bin/activate
+
+# 高速テスト (ragas と slow を除外)
+pytest -m "not ragas and not slow" --tb=short -q
+
+# Lint チェック
+ruff check .
+
+# フォーマットチェック
+black --check .
+
+# フォーマット自動修正
+black .
+```
+
+### フロントエンド
+
+```bash
+cd frontend
+
+# Lint
+pnpm lint
+
+# 型チェック
+pnpm typecheck
+
+# ビルド確認
+pnpm build
+
+# テスト
+pnpm test
+```
+
+### 特定エージェントのテスト
+
+```bash
+# リポジトリルートで実行
+make test-agent AGENT=business_info QUERY='営業時間は？'
+make debug-agent   # インタラクティブなエージェントデバッガー
+```
+
+---
+
+## 8. プロジェクト構成の概要
+
+開発を始める前に理解しておくべき重要な構成です。
+
+```
+engineer-cafe-navigator2025/
+├── frontend/          Next.js 15 (App Router) + TypeScript
+│   ├── src/app/       ページと API ルート
+│   ├── src/app/api/   APIルートハンドラ (voice, slides, marp, qa など)
+│   ├── src/lib/       共通ライブラリ (audio, memory, STT補正 など)
+│   └── src/mastra/    Mastra マルチエージェント (バックエンドへ移行中)
+│
+├── backend/           FastAPI + LangGraph + Python 3.11
+│   ├── main.py        FastAPI エントリーポイント
+│   ├── agents/        エージェント実装 (13エージェント)
+│   ├── workflows/     LangGraph ワークフロー定義
+│   ├── config/        ルーティング定数、プロンプトテンプレート
+│   └── tests/         pytest テストスイート
+│
+└── supabase/          DBマイグレーションと設定
+```
+
+### 重要: 2つのAIエージェント層について
+
+このプロジェクトには AIエージェントが **2箇所** あります。混乱しやすいので注意してください。
+
+| 層 | 場所 | 状態 | 技術 |
+|----|------|------|------|
+| フロントエンド Mastra | `frontend/src/mastra/` | 移行中 (現在も稼働) | Gemini + OpenAI embeddings |
+| バックエンド LangGraph | `backend/agents/` | 新実装 (主体) | OpenRouter + LangChain |
+
+移行方向: フロントエンド Mastra → バックエンド LangGraph。フロントエンドは純粋なUIレイヤーへ薄化中です。
+
+### 重要: APIエンドポイントの混同に注意
+
+| エンドポイント | 場所 | 目的 |
+|--------------|------|------|
+| `/api/marp` | フロントエンド | Markdown → HTML レンダリング (スライド表示) |
+| `/api/slides` | バックエンド | ナレーション / ナビゲーション |
+
+この2つは別物です。混同しないように注意してください。
+
+### データフローの概要
+
+```
+音声: ブラウザ → /api/voice (FE) → Google Cloud STT → AIエージェント → Google Cloud TTS → ブラウザ
+Q&A:  ブラウザ → /api/qa (FE) → Mastraエージェント → Supabase RAG → レスポンス
+バックエンドAPI: フロントエンド → http://localhost:8000/api/... → FastAPI → LangGraph
+```
+
+---
+
+## 9. 本番環境URL一覧
+
+| サービス | URL |
+|----------|-----|
+| フロントエンド (Vercel) | https://frontend-delta-six-20.vercel.app |
+| バックエンド (Cloud Run) | https://engineer-cafe-backend-639959525777.asia-northeast1.run.app |
+| VoiceVox (Cloud Run) | https://voicevox-proto-639959525777.asia-northeast2.run.app |
+
+ローカル開発では本番環境を直接操作しないでください。
+
+---
+
+## 10. よくあるエラーと対処法
+
+### APIコールで 403 エラーが返ってくる
+
+**原因**: フロントエンドの `BACKEND_API_KEY` とバックエンドの `API_SECRET_KEY` が一致していない。
+
+**対処**:
+- ローカル開発では両方を空にする (`.env.local` の `BACKEND_API_KEY=` と `.env` の `# API_SECRET_KEY=...` をコメントアウト)
+- または、両方に同じ値を設定する
+
+### `ffprobe: command not found` または STT が動作しない
+
+**原因**: ffmpeg がインストールされていない。
+
+**対処**:
+```bash
+brew install ffmpeg
+ffprobe -version  # 動作確認
+```
+
+### `WebM` 形式の音声変換に失敗する
+
+**原因**: ffmpeg が必要。上記と同じ対処をしてください。
+
+### TAVILY に関するエラーが出る
+
+**原因**: `TAVILY_API_KEY` が未設定。
+
+**対処**: https://tavily.com でアカウントを作成してキーを取得し、`backend/.env` に設定してください。Tavily がなくてもエージェントは起動しますが、Web検索機能が低下します。
+
+### `ModuleNotFoundError` または `ImportError` が出る
+
+**原因**: 仮想環境が有効化されていない、またはパッケージが未インストール。
+
+**対処**:
+```bash
+cd backend
+source .venv/bin/activate  # 仮想環境を有効化
+pip install -e ".[dev]"    # 再インストール
+```
+
+### `pnpm install` でエラーが出る
+
+**原因**: Node.js のバージョンが古い可能性がある。
+
+**対処**:
+```bash
+node --version   # 20以上であることを確認
+pnpm --version   # 10以上であることを確認
+```
+
+バージョンが古い場合は mise や nvm でバージョンを切り替えてください。
+
+### Supabase への接続エラーが出る
+
+**原因**: `SUPABASE_URL` / `SUPABASE_KEY` / `SUPABASE_DB_URI` の設定ミス。
+
+**対処**:
+1. Supabase ダッシュボード → Settings → API でキーを確認する
+2. `SUPABASE_KEY` には **service role key** (anon key ではない) を使用する
+3. `SUPABASE_DB_URI` は Supabase ダッシュボード → Settings → Database → Connection string (URI) から取得する
+
+### Google Cloud STT が動作しない
+
+**原因**: サービスアカウントキーが配置されていない。
+
+**対処**:
+```bash
+# ファイルの存在を確認
+ls -la backend/config/service-account-key.json
+```
+
+ファイルがなければチームリーダーに連絡してください。
+
+### `pnpm typecheck` で型エラーが出る
+
+**原因**: TypeScript の型エラー。修正してからコミットしてください。
+
+**対処**:
+```bash
+pnpm typecheck  # エラー箇所を確認
+# エラーを修正してから再実行
+```
+
+### `ruff check .` で Lint エラーが出る
+
+**原因**: Python コードのスタイル違反。
+
+**対処**:
+```bash
+ruff check . --fix  # 自動修正できるものを修正
+black .              # フォーマット統一
+```
+
+---
+
+## 困ったときは
+
+1. まずこのガイドの「よくあるエラーと対処法」を確認する
+2. `backend/` で `pytest -m "not ragas and not slow" --tb=short -q` を実行してエラーメッセージを確認する
+3. チームの Slack チャンネルで質問する (エラーメッセージ全文を貼り付けること)
+
+---
+
+*最終更新: 2026-03-21*


### PR DESCRIPTION
## Summary
- **Dockerfile ffmpeg追加** (#189 blocker): Cloud RunでWebM→WAV音声変換が失敗していた問題を修正。pydubがffprobe/ffmpegに依存
- **CI TAVILY_API_KEY追加**: deploy時に`--update-secrets`でTAVILY_API_KEYバインディングを含めるよう修正
- **セットアップガイド新規作成**: `docs/setup-guide.md` — チームメンバーの環境構築支援（日本語）
- **Plans.md更新**: Wave 3a全タスクを✅完了、Wave 3b新タスク追記

## 背景
- Junさんの#189テスト結果でffmpeg未インストールがブロッカーと判明
- TAVILY_API_KEYは本番Cloud Runに手動追加済み（rev 00038）、CIにも反映が必要
- takegawaさん/Junさんが環境構築に苦戦しているためガイド作成

## Test plan
- [ ] CI green（backend lint + frontend build）
- [ ] Dockerfile変更はCloud Runデプロイ後にWebM音声変換テスト
- [ ] setup-guide.mdの内容をチームメンバーで検証

🤖 Generated with [Claude Code](https://claude.com/claude-code)