### PR TITLE
feat(backend): add /api/calendar endpoint + frontend proxy migration (#265)

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -18,6 +18,7 @@ This service is the authoritative runtime for chat, voice, slides, character con
 Current important endpoints:
 
 - `GET /health`
+- `GET /api/calendar`
 - `POST /api/chat`
 - `POST /api/chat/stream`
 - `POST /api/voice`

--- a/backend/main.py
+++ b/backend/main.py
@@ -610,7 +610,8 @@ _CALENDAR_TIME_RANGES = {"today", "thisWeek", "nextWeek", "thisMonth"}
 
 
 @app.get("/api/calendar", dependencies=[Depends(verify_api_key)])
-async def calendar_api(timeRange: str = "thisWeek"):
+@_rate_limit("60/minute")
+async def calendar_api(request: Request, timeRange: str = "thisWeek"):
     """Return calendar events fetched from the backend-managed ICS feed."""
     if timeRange not in _CALENDAR_TIME_RANGES:
         raise HTTPException(status_code=400, detail="Invalid timeRange")

--- a/backend/main.py
+++ b/backend/main.py
@@ -24,6 +24,7 @@ from typing import Optional, Dict, Any, cast
 from starlette.middleware.base import BaseHTTPMiddleware
 from starlette.requests import Request
 
+from backend.tools.calendar_service import CalendarService, TimeRange
 from backend.utils.structured_logging import (
     request_id_var,
     generate_request_id,
@@ -603,6 +604,25 @@ async def voice_get_api(action: str = ""):
             ]
         }
     return {"status": "ok", "actions": ["speech_to_text", "text_to_speech", "supported_languages"]}
+
+
+_CALENDAR_TIME_RANGES = {"today", "thisWeek", "nextWeek", "thisMonth"}
+
+
+@app.get("/api/calendar", dependencies=[Depends(verify_api_key)])
+async def calendar_api(timeRange: str = "thisWeek"):
+    """Return calendar events fetched from the backend-managed ICS feed."""
+    if timeRange not in _CALENDAR_TIME_RANGES:
+        raise HTTPException(status_code=400, detail="Invalid timeRange")
+
+    result = await CalendarService().search_events(cast(TimeRange, timeRange))
+    if not result.get("success"):
+        raise HTTPException(
+            status_code=502,
+            detail=result.get("error", "Failed to fetch calendar events"),
+        )
+
+    return result
 
 
 @app.post("/api/voice", response_model=VoiceResponse, dependencies=[Depends(verify_api_key)])

--- a/backend/tests/api/test_calendar_api.py
+++ b/backend/tests/api/test_calendar_api.py
@@ -1,0 +1,81 @@
+from unittest.mock import AsyncMock, patch
+
+from fastapi.testclient import TestClient
+
+import backend.main as main_mod
+
+client = TestClient(main_mod.app)
+
+
+def test_calendar_get_returns_service_payload(monkeypatch):
+    monkeypatch.setattr(main_mod, "_API_SECRET_KEY", None)
+
+    with patch.object(
+        main_mod.CalendarService,
+        "search_events",
+        new_callable=AsyncMock,
+    ) as mock_search:
+        mock_search.return_value = {
+            "success": True,
+            "data": {
+                "events": [
+                    {
+                        "id": "evt-1",
+                        "title": "Engineer Cafe Meetup",
+                        "start": "2026-03-21T10:00:00Z",
+                        "end": "2026-03-21T12:00:00Z",
+                    }
+                ],
+                "timeRange": "today",
+                "eventCount": 1,
+            },
+        }
+
+        response = client.get("/api/calendar?timeRange=today")
+
+    assert response.status_code == 200
+    assert response.json() == {
+        "success": True,
+        "data": {
+            "events": [
+                {
+                    "id": "evt-1",
+                    "title": "Engineer Cafe Meetup",
+                    "start": "2026-03-21T10:00:00Z",
+                    "end": "2026-03-21T12:00:00Z",
+                }
+            ],
+            "timeRange": "today",
+            "eventCount": 1,
+        },
+    }
+    mock_search.assert_awaited_once_with("today")
+
+
+def test_calendar_get_rejects_invalid_time_range(monkeypatch):
+    monkeypatch.setattr(main_mod, "_API_SECRET_KEY", None)
+
+    response = client.get("/api/calendar?timeRange=invalid")
+
+    assert response.status_code == 400
+    assert response.json() == {"detail": "Invalid timeRange"}
+
+
+def test_calendar_get_surfaces_backend_fetch_failures(monkeypatch):
+    monkeypatch.setattr(main_mod, "_API_SECRET_KEY", None)
+
+    with patch.object(
+        main_mod.CalendarService,
+        "search_events",
+        new_callable=AsyncMock,
+    ) as mock_search:
+        mock_search.return_value = {
+            "success": False,
+            "error": "ICS upstream unavailable",
+        }
+
+        response = client.get("/api/calendar")
+
+    assert response.status_code == 502
+    assert response.json() == {"detail": "ICS upstream unavailable"}
+    mock_search.assert_awaited_once_with("thisWeek")

--- a/frontend/CLAUDE.md
+++ b/frontend/CLAUDE.md
@@ -28,7 +28,7 @@ pnpm deploy:dev       # Deploy to Vercel dev environment
 - `frontend/.env.example` is pruned to the manually managed vars still documented for `frontend/src`.
 - Keep `BACKEND_API_URL`, `BACKEND_API_KEY`, `NEXT_PUBLIC_SUPABASE_URL`, and `NEXT_PUBLIC_SUPABASE_ANON_KEY` populated in local/dev envs.
 - Runtime-managed vars such as `NODE_ENV` and `VERCEL_DEPLOYMENT_ID` are intentionally not listed in `.env.example`.
-- Additional ad hoc flags still read in `frontend/src` include `GOOGLE_CALENDAR_ICAL_URL`, `NEXT_PUBLIC_SHOW_AVATAR_SETTINGS`, and the `FF_*` rollout flags in `src/lib/feature-flags.ts`.
+- Additional ad hoc flags still read in `frontend/src` include `NEXT_PUBLIC_SHOW_AVATAR_SETTINGS` and the `FF_*` rollout flags in `src/lib/feature-flags.ts`.
 
 ## Key Directories
 

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -19,6 +19,7 @@ Main route groups:
 - `src/app/page.tsx`: main kiosk UI
 - `src/app/api/voice/route.ts`: proxy to backend voice API
 - `src/app/api/qa/route.ts`: proxy to backend chat API
+- `src/app/api/calendar/route.ts`: proxy to backend calendar API
 - `src/app/api/slides/route.ts`: proxy to backend slides API
 - `src/app/api/character/route.ts`: proxy to backend character API
 - `src/app/api/reception/*`: proxy to backend reception API

--- a/frontend/scripts/tests/calendar-integration-test.ts
+++ b/frontend/scripts/tests/calendar-integration-test.ts
@@ -1,69 +1,58 @@
 #!/usr/bin/env node
 /**
- * Calendar Integration Test
- * Tests Google Calendar integration and event fetching
+ * Calendar integration smoke test.
+ *
+ * Verifies the backend calendar endpoint through the shared backend proxy
+ * helper so frontend-side calendar access no longer depends on a direct iCal
+ * URL.
  */
 
 import 'dotenv/config';
-import { CalendarServiceTool } from '../../src/mastra/tools/calendar-service';
+import { backendFetch } from '../../src/lib/api/backend-proxy';
 
 export async function testCalendarIntegration() {
-  console.log('📅 Testing Google Calendar Integration\n');
+  console.log('📅 Testing calendar backend proxy integration\n');
 
-  const calendarTool = new CalendarServiceTool();
-  
-  // Test 1: Check if calendar URL is configured
-  const calendarUrl = process.env.GOOGLE_CALENDAR_ICAL_URL;
-  
-  if (!calendarUrl) {
-    console.log('❌ GOOGLE_CALENDAR_ICAL_URL is not configured in environment');
-    console.log('   Calendar integration will not work without this URL');
+  if (!process.env.BACKEND_API_URL) {
+    console.log('❌ BACKEND_API_URL is not configured in environment');
     return {
       success: false,
-      error: 'Calendar URL not configured'
+      error: 'Backend URL not configured',
     };
-  } else {
-    console.log('✅ Calendar URL is configured');
-    console.log(`   URL: ${calendarUrl.substring(0, 50)}...`);
   }
 
-  // Test 2: Try to fetch calendar data
-  console.log('\n🔄 Attempting to fetch calendar events...');
-  
   try {
-    const result = await calendarTool.execute({
-      useProxy: false, // Direct fetch for testing
-      daysAhead: 30,
-      maxEvents: 5
+    const result = await backendFetch('/api/calendar', {
+      method: 'GET',
     });
 
-    if (result.success) {
-      console.log('✅ Calendar fetch successful!');
-      console.log('\nCalendar events:');
-      console.log(result.events);
+    if (result.ok) {
+      console.log('✅ Calendar proxy request successful!');
+      console.log('\nCalendar response:');
+      console.log(result.data);
       return {
         success: true,
-        events: result.events
-      };
-    } else {
-      console.log('❌ Calendar fetch failed');
-      console.log(`   Error: ${result.error}`);
-      return {
-        success: false,
-        error: result.error
+        data: result.data,
       };
     }
+
+    console.log('❌ Calendar proxy request failed');
+    console.log(`   Status: ${result.status}`);
+    console.log(`   Error: ${JSON.stringify(result.data)}`);
+    return {
+      success: false,
+      error: result.data,
+    };
   } catch (error) {
-    console.log('❌ Exception during calendar fetch');
+    console.log('❌ Exception during calendar proxy request');
     console.log(`   Error: ${error instanceof Error ? error.message : 'Unknown error'}`);
     return {
       success: false,
-      error: error instanceof Error ? error.message : 'Unknown error'
+      error: error instanceof Error ? error.message : 'Unknown error',
     };
   }
 }
 
-// Run the test if called directly
 if (require.main === module) {
   testCalendarIntegration().catch(console.error);
 }

--- a/frontend/src/__tests__/api-calendar-route.test.ts
+++ b/frontend/src/__tests__/api-calendar-route.test.ts
@@ -1,0 +1,85 @@
+import assert from 'node:assert/strict';
+import { afterEach, test } from 'node:test';
+import { NextRequest } from 'next/server';
+
+const originalBackendApiUrl = process.env.BACKEND_API_URL;
+const originalBackendApiKey = process.env.BACKEND_API_KEY;
+const originalFetch = global.fetch;
+let lastFetchRequest: { url: string; method: string } | null = null;
+
+afterEach(() => {
+  process.env.BACKEND_API_URL = originalBackendApiUrl;
+  process.env.BACKEND_API_KEY = originalBackendApiKey;
+  global.fetch = originalFetch;
+  lastFetchRequest = null;
+});
+
+function mockBackendJsonResponse(body: unknown, status: number) {
+  global.fetch = (async (input: RequestInfo | URL, init?: RequestInit) => {
+    const url = typeof input === 'string' ? input : input.toString();
+    lastFetchRequest = {
+      url,
+      method: init?.method ?? 'GET',
+    };
+
+    return new Response(JSON.stringify(body), {
+      status,
+      headers: {
+        'Content-Type': 'application/json',
+      },
+    });
+  }) as typeof fetch;
+}
+
+test(
+  'calendar GET proxies to backend GET /api/calendar',
+  { concurrency: false },
+  async () => {
+    process.env.BACKEND_API_URL = 'https://backend.example.com';
+    process.env.BACKEND_API_KEY = 'test-backend-key';
+    mockBackendJsonResponse(
+      {
+        success: true,
+        data: {
+          events: [{ id: 'event-1', title: 'Calendar Event' }],
+        },
+      },
+      200
+    );
+
+    const { GET } = await import('../app/api/calendar/route');
+    const response = await GET(new NextRequest('https://example.com/api/calendar'));
+
+    assert.equal(response.status, 200);
+    assert.deepEqual(lastFetchRequest, {
+      url: 'https://backend.example.com/api/calendar',
+      method: 'GET',
+    });
+    assert.deepEqual(await response.json(), {
+      success: true,
+      data: {
+        events: [{ id: 'event-1', title: 'Calendar Event' }],
+      },
+    });
+  }
+);
+
+test(
+  'calendar GET preserves backend error responses',
+  { concurrency: false },
+  async () => {
+    process.env.BACKEND_API_URL = 'https://backend.example.com';
+    process.env.BACKEND_API_KEY = 'test-backend-key';
+    mockBackendJsonResponse({ detail: 'calendar unavailable' }, 503);
+
+    const { GET } = await import('../app/api/calendar/route');
+    const response = await GET(new NextRequest('https://example.com/api/calendar'));
+
+    assert.equal(response.status, 503);
+    assert.deepEqual(lastFetchRequest, {
+      url: 'https://backend.example.com/api/calendar',
+      method: 'GET',
+    });
+    assert.deepEqual(await response.json(), { error: 'calendar unavailable' });
+  }
+);

--- a/frontend/src/app/api/calendar/route.ts
+++ b/frontend/src/app/api/calendar/route.ts
@@ -1,47 +1,24 @@
 import { NextRequest, NextResponse } from 'next/server';
 
-export async function GET(request: NextRequest) {
-  try {
-    // Get iCal URL from environment variables
-    const icalUrl = process.env.GOOGLE_CALENDAR_ICAL_URL;
-    
-    if (!icalUrl) {
-      return NextResponse.json(
-        { error: 'Calendar URL not configured' },
-        { status: 500 }
-      );
-    }
+import {
+  createBackendErrorResponse,
+  createInternalServerErrorResponse,
+} from '@/app/api/_shared/backend-error-response';
+import { backendFetch } from '@/lib/api/backend-proxy';
 
-    // Fetch the iCal data from Google Calendar
-    const response = await fetch(icalUrl, {
-      headers: {
-        'Accept': 'text/calendar',
-      },
+export async function GET(_request: NextRequest) {
+  try {
+    const response = await backendFetch('/api/calendar', {
+      method: 'GET',
     });
 
     if (!response.ok) {
-      return NextResponse.json(
-        { error: 'Failed to fetch calendar data' },
-        { status: response.status }
-      );
+      return createBackendErrorResponse(response, 'Failed to fetch calendar data');
     }
 
-    // Get the response as text (iCal format)
-    const icalData = await response.text();
-
-    // Return the iCal data with proper headers
-    return new NextResponse(icalData, {
-      status: 200,
-      headers: {
-        'Content-Type': 'text/calendar; charset=utf-8',
-        'Cache-Control': 'no-cache, no-store, must-revalidate',
-      },
-    });
+    return NextResponse.json(response.data, { status: response.status });
   } catch (error) {
     console.error('Calendar API error:', error);
-    return NextResponse.json(
-      { error: 'Internal server error' },
-      { status: 500 }
-    );
+    return createInternalServerErrorResponse(error, 'Failed to fetch calendar data');
   }
 }

--- a/frontend/src/app/api/calendar/route.ts
+++ b/frontend/src/app/api/calendar/route.ts
@@ -6,10 +6,17 @@ import {
 } from '@/app/api/_shared/backend-error-response';
 import { backendFetch } from '@/lib/api/backend-proxy';
 
-export async function GET(_request: NextRequest) {
+export async function GET(request: NextRequest) {
   try {
+    const timeRange = request.nextUrl.searchParams.get('timeRange');
+    const params: Record<string, string> = {};
+    if (timeRange) {
+      params.timeRange = timeRange;
+    }
+
     const response = await backendFetch('/api/calendar', {
       method: 'GET',
+      params,
     });
 
     if (!response.ok) {
@@ -18,7 +25,6 @@ export async function GET(_request: NextRequest) {
 
     return NextResponse.json(response.data, { status: response.status });
   } catch (error) {
-    console.error('Calendar API error:', error);
     return createInternalServerErrorResponse(error, 'Failed to fetch calendar data');
   }
 }


### PR DESCRIPTION
## Summary
- Backend `/api/calendar` GET エンドポイント新規実装（既存`calendar_service.py`活用）
- Frontend `/api/calendar/route.ts` を`backendFetch`プロキシに切替
- `GOOGLE_CALENDAR_ICAL_URL` をfrontendから削除（backend側で管理）

## Closes
- Closes #265 (calendar proxy部分)

## Test plan
- [ ] CI green
- [ ] Backend: `pytest backend/tests/api/test_calendar_api.py`
- [ ] Frontend: calendar route integration test
- [ ] 本番デプロイ後: `GOOGLE_CALENDAR_ICAL_URL` をCloud Run env varsに追加が必要

## 注意事項
- 本番デプロイ時に`GOOGLE_CALENDAR_ICAL_URL`環境変数をCloud Runに追加する必要あり
- frontend側のGoogle Calendar iCal直接フェッチは削除済み

🤖 Generated with [Claude Code](https://claude.com/claude-code)