### PR TITLE
fix(backend): stop excluding slide markdown from Docker image

### DIFF
--- a/backend/.dockerignore
+++ b/backend/.dockerignore
@@ -52,8 +52,10 @@ htmlcov/
 .git/
 .gitignore
 
-# Documentation
-*.md
+# Documentation (keep slides/*.md for Marp content)
+README.md
+CHANGELOG.md
+CONTRIBUTING.md
 docs/
 
 # Supabase


### PR DESCRIPTION
## Summary
- `.dockerignore` の `*.md` グロブが `backend/slides/*.md` を Docker イメージから除外していた
- Cloud Run 上で `/api/slides/content` が "Slide file not found" を返し、フロントエンドの `/api/marp` が 500 エラー
- `*.md` を具体的なドキュメントファイル名（README.md, CHANGELOG.md, CONTRIBUTING.md）に変更して、スライドの .md ファイルを含めるようにした

## Root Cause
```
# backend/.dockerignore (Before)
*.md        ← backend/slides/engineer-cafe.md も除外してしまう

# backend/.dockerignore (After)
README.md
CHANGELOG.md
CONTRIBUTING.md   ← スライド .md は除外されない
```

## Impact
- **修正**: `/api/marp` 500 エラー（スライド表示の完全停止）
- **影響ファイル**: `backend/.dockerignore` のみ（1ファイル）
- **リスク**: 低（Docker イメージに .md ファイルが数KB追加されるだけ）

## Test plan
- [ ] `docker build` でスライドファイルが含まれることを確認
- [ ] Cloud Run デプロイ後、`/api/slides/content` が正常応答を返すことを確認
- [ ] フロントエンド `/api/marp` がスライド HTML を正常に返すことを確認

## Related
- Fixes slide rendering failure reported in production (Error Rate 17.7% on Vercel dashboard)
- Related to #282 (CSP issue — separate fix: Vercel Production Branch を develop に変更)

🤖 Generated with [Claude Code](https://claude.com/claude-code)