### PR TITLE
fix(frontend): fix /api/marp 500 — built-in Marp theme crash

### DIFF
--- a/frontend/src/lib/marp-processor.ts
+++ b/frontend/src/lib/marp-processor.ts
@@ -117,9 +117,11 @@ export class MarpProcessor {
       // Parse frontmatter
       const { data: frontmatter, content } = matter(markdown);
 
-      // Apply theme if specified
+      // Apply custom theme if specified (built-in themes like default/gaia/uncover
+      // are already registered in Marp Core — only add genuinely custom CSS)
       const theme = frontmatter.theme;
-      if (theme && this.themes.has(theme)) {
+      const builtinThemes = new Set(['default', 'gaia', 'uncover']);
+      if (theme && this.themes.has(theme) && !builtinThemes.has(theme)) {
         const themeCSS = this.themes.get(theme)!;
         this.marp.themeSet.add(themeCSS);
       }


### PR DESCRIPTION
## Summary
- `/api/marp` が本番で 500 エラーを返していた根本原因の **2つ目** を修正
- 1つ目は PR #286 (.dockerignore) で修正済み — バックエンドのスライドファイルが Cloud Run に含まれるようになった
- 2つ目は `MarpProcessor` が組み込みテーマ (default/gaia/uncover) に対してプレースホルダー CSS を `themeSet.add()` に渡していたこと
- Marp Core はカスタム CSS に `@theme` メタを要求するため、`/* default theme */` という CSS で `Marpit theme CSS requires @theme meta` エラーが発生

## Root Cause
```typescript
// Before: プレースホルダーをthemeSetに追加 → @themeメタがないのでクラッシュ
if (theme && this.themes.has(theme)) {
  this.marp.themeSet.add(themeCSS); // ← "/* default theme */" → Error!
}

// After: 組み込みテーマはスキップ（Marp Coreが既に持ってる）
const builtinThemes = new Set(['default', 'gaia', 'uncover']);
if (theme && this.themes.has(theme) && !builtinThemes.has(theme)) {
  this.marp.themeSet.add(themeCSS);
}
```

## Verification
```
# Before fix:
ERROR: Failed to process markdown: Error: Marpit theme CSS requires @theme meta

# After fix:
SUCCESS — slides: 10, html: 21KB, css: 49KB
```

## Test plan
- [x] ローカルで実際のスライドファイル (backend/slides/ja/engineer-cafe.md) を MarpProcessor で処理 → 成功
- [x] `pnpm lint` → pass
- [x] `pnpm typecheck` → pass
- [ ] Vercel deploy 後、Production で `/api/marp` がスライド HTML を返すことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)