### PR TITLE
fix(frontend): validate empty query in /api/qa to prevent 422

### DIFF
--- a/frontend/src/app/api/qa/route.ts
+++ b/frontend/src/app/api/qa/route.ts
@@ -11,6 +11,14 @@ export async function POST(request: NextRequest) {
     const body = await request.json();
     const { action, question, sessionId, language, text, fromLanguage, toLanguage, visitorId } = body;
 
+    const query = (question || text || '').trim();
+    if (!query) {
+      return NextResponse.json(
+        { error: '質問を入力してください', success: false },
+        { status: 400 }
+      );
+    }
+
     const response = await backendFetch<{
       answer?: string;
       emotion?: string;
@@ -18,7 +26,7 @@ export async function POST(request: NextRequest) {
       vrm_control?: { name: string; duration: number; keyframes: unknown[] } | null;
     }>('/api/chat', {
       body: {
-        query: question || text,
+        query,
         session_id: sessionId,
         language: language || 'ja',
         visitor_id: visitorId,


### PR DESCRIPTION
## Summary
- Add early validation in `/api/qa` route to check for empty `query` before forwarding to backend
- Returns 400 with user-friendly message instead of opaque 422 from backend
- Uses the already-trimmed `query` variable in `backendFetch` call

## Root Cause
When both `question` and `text` fields are undefined/empty in the request body, the backend's `ChatRequest.query` validation (required `str` field) returns 422. The frontend showed a generic "予期しないエラー" message.

## Test plan
- [ ] Send empty text input → should see "質問を入力してください" (not "予期しないエラー")
- [ ] Send valid text input → should work as before
- [ ] Voice input with valid transcript → should work as before

Closes #290

🤖 Generated with [Claude Code](https://claude.com/claude-code)