### PR TITLE
fix(frontend): improve slide mode layout — widen panel

### DIFF
--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -637,13 +637,8 @@ export default function Home() {
                   className="pointer-events-none absolute inset-y-0 right-0 z-30 flex w-full justify-end"
                   style={screenPadding}
                 >
-                  <div className="pointer-events-auto flex h-full w-full max-w-5xl transform-gpu rounded-[32px] bg-white/95 shadow-2xl transition-all duration-300 ease-out">
-                    <div className="hidden h-full flex-[1.05] items-center justify-center border-r border-slate-100/80 bg-gradient-to-br from-white/0 via-white/10 to-white/30 px-4 lg:flex">
-                      <p className="text-sm font-medium text-slate-500">
-                        {labels.guideLabel}
-                      </p>
-                    </div>
-                    <div className="relative flex h-full flex-[1.4] flex-col bg-white">
+                  <div className="pointer-events-auto flex h-full w-full max-w-6xl transform-gpu rounded-[32px] bg-white/95 shadow-2xl transition-all duration-300 ease-out">
+                    <div className="relative flex h-full w-full flex-col bg-white rounded-[32px]">
                       <button
                         type="button"
                         onClick={() => setShowSlideMode(false)}

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -638,7 +638,7 @@ export default function Home() {
                   style={screenPadding}
                 >
                   <div className="pointer-events-auto flex h-full w-full max-w-6xl transform-gpu rounded-[32px] bg-white/95 shadow-2xl transition-all duration-300 ease-out">
-                    <div className="relative flex h-full w-full flex-col bg-white rounded-[32px]">
+                    <div className="relative flex h-full w-full flex-col overflow-hidden rounded-[32px]">
                       <button
                         type="button"
                         onClick={() => setShowSlideMode(false)}


### PR DESCRIPTION
## Summary
- Remove the "音声ガイド" label section that occupied ~43% of the slide panel width
- Give the full panel width to the MarpViewer component
- Increase max-width from `max-w-5xl` to `max-w-6xl` for better slide readability

## Before/After
- **Before**: Slide panel split into guide label (flex-[1.05]) + viewer (flex-[1.4]) with max-w-5xl
- **After**: Full-width viewer with max-w-6xl, no wasted space

## Test plan
- [ ] Open slide mode → slide panel takes full width of the overlay
- [ ] Slide content is more readable with wider panel
- [ ] Close button still visible and functional
- [ ] Non-slide mode layout unchanged

Closes #292

🤖 Generated with [Claude Code](https://claude.com/claude-code)