### PR TITLE
fix(frontend): unlock AudioContext on user interaction for audio playback

### DIFF
--- a/frontend/src/app/components/VoiceInterface.tsx
+++ b/frontend/src/app/components/VoiceInterface.tsx
@@ -258,6 +258,7 @@ export default function VoiceInterface({
     wakeWords: DEFAULT_WAKE_WORDS,
     language: toLocale(currentLanguage),
     onWakeWord: () => {
+      markAudioUserInteraction();
       setError(null);
     },
   });

--- a/frontend/src/app/components/VoiceInterface.tsx
+++ b/frontend/src/app/components/VoiceInterface.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { AudioQueue } from '@/lib/audio-queue';
+import { markAudioUserInteraction } from '@/lib/audio/audio-user-interaction-gate';
 import { MobileAudioService } from '@/lib/audio/mobile-audio-service';
 import { audioStateManager } from '@/lib/audio-state-manager';
 import { cn } from '@/lib/cn';
@@ -616,6 +617,7 @@ export default function VoiceInterface({
   }, [sessionState, startRecorderCapture, stopRecorderCapture, voiceController.shouldListen]);
 
   const startListening = useCallback(() => {
+    markAudioUserInteraction();
     cancelPendingRequest();
     stopPlayback(false);
     setError(null);

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import { markAudioUserInteraction } from '@/lib/audio/audio-user-interaction-gate';
 import { cn } from '@/lib/cn';
 import { ClarificationUtils } from '@/lib/clarification-utils';
 import {
@@ -345,6 +346,7 @@ export default function Home() {
           : { x: 0, y: -0.2, z: 0 };
 
         const submitTextDraft = async () => {
+          markAudioUserInteraction();
           const trimmed = textDraft.trim();
           if (!trimmed) {
             return;

--- a/frontend/src/lib/audio/audio-interaction-manager.ts
+++ b/frontend/src/lib/audio/audio-interaction-manager.ts
@@ -198,9 +198,9 @@ export class AudioInteractionManager {
     document.body.appendChild(this.interactionPromptElement);
     this.isPromptVisible = true;
 
-    // Add click handler
+    // Add click handler to unlock audio
     button.addEventListener('click', () => {
-      // This will trigger the existing interaction handler
+      markAudioUserInteraction();
     });
 
     // Auto-hide after timeout


### PR DESCRIPTION
## Summary
- Fix empty button click handler in `AudioInteractionManager.showInteractionPrompt` — now calls `markAudioUserInteraction()`
- Call `markAudioUserInteraction()` in `VoiceInterface.startListening` (mic button click)
- Call `markAudioUserInteraction()` in `page.tsx` `submitTextDraft` (text send button click)

## Root Cause
`AudioInteractionManager` is lazily initialized (only when `MobileAudioService` is first created during `playAudio`). By that point, the user's initial click interaction (mic button or send button) has already fired and was not captured by the browser's interaction gate. This causes `ensureAudioContext()` to throw "User interaction required" because the gate module's document-level listeners weren't registered early enough.

## Fix Strategy
Instead of restructuring the lazy initialization, we proactively call `markAudioUserInteraction()` at the point of known user interactions (mic click, text send click), ensuring the gate is unlocked before the first `playAudio` attempt.

## Test plan
- [ ] Click mic button → speak → TTS audio plays without "User interaction required" error
- [ ] Type text and click send → TTS audio plays without error
- [ ] If interaction prompt appears, clicking button dismisses and enables audio
- [ ] Subsequent audio playback works without re-prompting

Closes #291

🤖 Generated with [Claude Code](https://claude.com/claude-code)