### PR TITLE
feat(frontend): キャラ設定UIと感情・リップ表現の整理 (Issue #302)

### DIFF
--- a/frontend/src/app/components/CharacterAvatar.tsx
+++ b/frontend/src/app/components/CharacterAvatar.tsx
@@ -321,7 +321,6 @@ export default function CharacterAvatar({
   // Update character state when props change
   useEffect(() => {
     if (charactersRef.current) {
-      void updateCharacterExpressionRef.current(initialExpression);
       void updateCharacterAnimationRef.current(initialAnimation);
     }
   }, [initialExpression, initialAnimation]);
@@ -332,7 +331,6 @@ export default function CharacterAvatar({
     }
 
     const sessionPose = getSessionPoseOffsets(sessionState);
-    void updateCharacterExpressionRef.current(sessionPose.expression);
     void updateCharacterAnimationRef.current(sessionPose.animation);
   }, [sessionState]);
 
@@ -1094,45 +1092,28 @@ export default function CharacterAvatar({
         // Apply expression to VRM model
         const expressionManager = charactersRef.current.expressionManager;
         if (expressionManager) {
-          // Map emotion names to VRM expression names if needed
-          const expressionMapping: Record<string, string> = {
-            'neutral': 'neutral',
-            'happy': 'happy',
-            'sad': 'sad',
-            'angry': 'angry',
-            'surprised': 'happy',
-            'relaxed': 'relaxed',
-            'thinking': 'relaxed',
-            'speaking': 'happy',
-            'listening': 'happy',
-            'greeting': 'happy',
-            'explaining': 'neutral'
-          };
-          
-          const vrmExpression = expressionMapping[expression] || expression;
-          
           // Get available expressions for debugging
           const availableExpressions = Object.keys(expressionManager.expressionMap);
           
           // Reset all expressions with gradual transition
           Object.keys(expressionManager.expressionMap).forEach(name => {
             const currentValue = expressionManager.getValue(name) || 0;
-            if (currentValue > 0 && name !== vrmExpression) {
+            if (currentValue > 0 && name !== expression) {
               // Gradual fade out for smooth transition
               expressionManager.setValue(name, 0);
             }
           });
 
           // Set new expression with full intensity
-          if (expressionManager.expressionMap[vrmExpression]) {
-            expressionManager.setValue(vrmExpression, 1);
+          if (expressionManager.expressionMap[expression]) {
+            expressionManager.setValue(expression, 1);
             // Store current expression for restoration after lip-sync
-            currentExpressionRef.current = { expression: vrmExpression, weight: 1.0 };
+            currentExpressionRef.current = { expression, weight: 1.0 };
           } else {
             // Try to find a similar expression
             const similarExpression = availableExpressions.find(expr => 
-              expr.toLowerCase().includes(vrmExpression.toLowerCase()) ||
-              vrmExpression.toLowerCase().includes(expr.toLowerCase())
+              expr.toLowerCase().includes(expression.toLowerCase()) ||
+              expression.toLowerCase().includes(expr.toLowerCase())
             );
             if (similarExpression) {
               expressionManager.setValue(similarExpression, 1);

--- a/frontend/src/app/components/CharacterAvatar.tsx
+++ b/frontend/src/app/components/CharacterAvatar.tsx
@@ -79,6 +79,8 @@ interface CharacterAvatarProps {
   extraSettingsTab?: { label: string; content: ReactNode };
   /** When set, panel is rendered by parent (e.g. page); this ref is filled with panel props each render */
   settingsPanelPropsRef?: React.MutableRefObject<SettingsPanelPropsFromSource | null>;
+  /** When using settingsPanelPropsRef, notify parent to re-render */
+  onSettingsPanelPropsChange?: (props: SettingsPanelPropsFromSource) => void;
 }
 
 const SETTINGS_TAB_LABELS: Record<
@@ -189,6 +191,7 @@ export default function CharacterAvatar({
   onSettingsClose,
   extraSettingsTab,
   settingsPanelPropsRef,
+  onSettingsPanelPropsChange,
 }: CharacterAvatarProps) {
   const containerRef = useRef<HTMLDivElement>(null);
   const sceneRef = useRef<THREE.Scene | null>(null);
@@ -212,6 +215,9 @@ export default function CharacterAvatar({
   const playKeyframeAnimationInternalRef = useRef<((animation: CharacterAnimationData) => void) | null>(null);
   const setExpressionWeightsRef = useRef<(weights: Record<string, number>) => void>(() => {});
   const expressionWeightsSyncRef = useRef<Record<string, number>>({});
+  const expressionWeightsUiRef = useRef<Record<string, number>>({});
+  const lastManualExpressionUpdateMsRef = useRef<Record<string, number>>({});
+  const lastSettingsPanelEmitMsRef = useRef(0);
   const initializeSceneRef = useRef<() => void | (() => void)>(() => undefined);
   const loadCharacterRef = useRef<() => Promise<void>>(async () => {});
   const cleanupRef = useRef<() => void>(() => {});
@@ -237,7 +243,10 @@ export default function CharacterAvatar({
   const [vrmExpressionNames, setVrmExpressionNames] = useState<string[]>([]);
   const [expressionWeights, setExpressionWeights] = useState<Record<string, number>>({});
 
-  setExpressionWeightsRef.current = setExpressionWeights;
+  setExpressionWeightsRef.current = (weights: Record<string, number>) => {
+    expressionWeightsUiRef.current = { ...weights };
+    setExpressionWeights(weights);
+  };
 
   // Initialize Three.js scene
   useEffect(() => {
@@ -1042,7 +1051,13 @@ export default function CharacterAvatar({
   };
 
   const handle_expression_weight_change = (name: string, weight: number) => {
-    setExpressionWeights((prev) => ({ ...prev, [name]: weight }));
+    const next = { ...expressionWeightsUiRef.current, [name]: weight };
+    expressionWeightsUiRef.current = next;
+    lastManualExpressionUpdateMsRef.current = {
+      ...lastManualExpressionUpdateMsRef.current,
+      [name]: Date.now(),
+    };
+    setExpressionWeights(next);
     blendShapeControllerRef.current?.setExpression(name, weight);
   };
 
@@ -1261,28 +1276,41 @@ export default function CharacterAvatar({
     if (charactersRef.current) {
       charactersRef.current.update(deltaTime);
 
-      // Sync expression weights from VRM to Controls sliders (keyframe, .vrma, lip-sync, etc.)
+      // Sync expression weights from VRM to Character sliders (keyframe, .vrma, lip-sync, etc.)
       const blend_shape = blendShapeControllerRef.current;
       if (blend_shape) {
         const current = blend_shape.getCurrentExpressions();
         const last = expressionWeightsSyncRef.current;
         const current_keys = Object.keys(current);
         const last_keys = Object.keys(last);
+        const EPSILON = 0.0001;
+        const MANUAL_HOLD_MS = 250;
         let changed = current_keys.length !== last_keys.length;
         if (!changed) {
           for (let i = 0; i < current_keys.length; i++) {
             const name = current_keys[i];
             const a = current[name] ?? 0;
             const b = last[name] ?? 0;
-            if (Math.abs(a - b) > 0.001) {
+            // Lip-sync (viseme) weights can change in very small increments; use a tighter epsilon
+            // so the UI sliders track the current VRM state smoothly.
+            if (Math.abs(a - b) > EPSILON) {
               changed = true;
               break;
             }
           }
         }
         if (changed) {
-          setExpressionWeightsRef.current(current);
-          expressionWeightsSyncRef.current = { ...current };
+          const now = Date.now();
+          const manual = lastManualExpressionUpdateMsRef.current;
+          const ui = expressionWeightsUiRef.current;
+          const merged: Record<string, number> = { ...current };
+          for (const [name, ts] of Object.entries(manual)) {
+            if (now - ts < MANUAL_HOLD_MS && typeof ui[name] === 'number') {
+              merged[name] = ui[name];
+            }
+          }
+          setExpressionWeightsRef.current(merged);
+          expressionWeightsSyncRef.current = { ...merged };
         }
       }
 
@@ -1419,7 +1447,7 @@ export default function CharacterAvatar({
       {/* Settings Panel - when settingsPanelPropsRef is set, parent renders the panel; otherwise render locally or via portal */}
       {(() => {
         if (settingsPanelPropsRef) {
-          settingsPanelPropsRef.current = {
+          const next_props: SettingsPanelPropsFromSource = {
             controls_state: characterState,
             vrm_expression_names: vrmExpressionNames,
             expression_weights: expressionWeights,
@@ -1442,6 +1470,15 @@ export default function CharacterAvatar({
             on_run_keyframe: (animation) =>
               playKeyframeAnimationInternalRef.current?.(animation),
           };
+          settingsPanelPropsRef.current = next_props;
+          if (onSettingsPanelPropsChange) {
+            const now = Date.now();
+            const EMIT_INTERVAL_MS = 100;
+            if (now - lastSettingsPanelEmitMsRef.current >= EMIT_INTERVAL_MS) {
+              lastSettingsPanelEmitMsRef.current = now;
+              onSettingsPanelPropsChange(next_props);
+            }
+          }
           return null;
         }
 

--- a/frontend/src/app/components/CharacterAvatar.tsx
+++ b/frontend/src/app/components/CharacterAvatar.tsx
@@ -16,7 +16,7 @@ import SettingsPanel, {
   type SettingsPanelPropsFromSource,
 } from './SettingsPanel';
 import { type BackgroundOption as BackgroundSelectorOption } from './BackgroundSelector';
-import { type VRMAnimationOption } from './ControlsSettings';
+import { type VRMAnimationOption } from './CharacterSettings';
 
 interface CharacterState {
   expression: string;
@@ -85,7 +85,7 @@ const SETTINGS_TAB_LABELS: Record<
   'controls' | 'keyframe' | 'background' | 'lighting' | 'audio',
   string
 > = {
-  controls: 'Controls',
+  controls: 'Character',
   keyframe: 'Keyframe',
   background: 'Background',
   lighting: 'Lighting',

--- a/frontend/src/app/components/CharacterAvatar.tsx
+++ b/frontend/src/app/components/CharacterAvatar.tsx
@@ -3,7 +3,7 @@
 import { EmotionData, EmotionManager } from '@/lib/emotion-manager';
 import { ExpressionController } from '@/lib/expression-controller';
 import { LipSyncAnalyzer } from '@/lib/lip-sync-analyzer';
-import { VRMBlendShapeController, VRMUtils, getMouthOverrideFactor } from '@/lib/vrm-utils';
+import { VRMBlendShapeController, VRMUtils, getLipSyncFactorFromEmotions } from '@/lib/vrm-utils';
 import { VRM, VRMLoaderPlugin } from '@pixiv/three-vrm';
 import { VRMAnimationLoaderPlugin, createVRMAnimationClip } from '@pixiv/three-vrm-animation';
 import { Settings, VolumeX } from 'lucide-react';
@@ -93,6 +93,10 @@ const SETTINGS_TAB_LABELS: Record<
   lighting: 'Lighting',
   audio: 'Audio',
 };
+
+const VISEME_NAMES = ['aa', 'ih', 'ou', 'ee', 'oh'] as const;
+const MIN_LIP_SYNC_UI_FACTOR = 0.2;
+const VISEME_SMOOTHING_ALPHA = 0.35;
 
 const DEFAULT_LOOKAT_TARGET = new THREE.Vector3(0, 1, 1); // 1m ahead, 1m up
 
@@ -214,7 +218,10 @@ export default function CharacterAvatar({
   const keyframeAnimationTimeoutsRef = useRef<NodeJS.Timeout[]>([]);
   const playKeyframeAnimationInternalRef = useRef<((animation: CharacterAnimationData) => void) | null>(null);
   const setExpressionWeightsRef = useRef<(weights: Record<string, number>) => void>(() => {});
-  const expressionWeightsSyncRef = useRef<Record<string, number>>({});
+  // VRM-applied expression weights (includes visemes after attenuation)
+  const expressionWeightsAppliedRef = useRef<Record<string, number>>({});
+  // UI display values (visemes may be shown as estimated raw values)
+  const expressionWeightsDisplayRef = useRef<Record<string, number>>({});
   const expressionWeightsUiRef = useRef<Record<string, number>>({});
   const lastManualExpressionUpdateMsRef = useRef<Record<string, number>>({});
   const lastSettingsPanelEmitMsRef = useRef(0);
@@ -843,7 +850,7 @@ export default function CharacterAvatar({
         }
       }
 
-      // Create viseme control function (attenuate intensity when expression uses mouth)
+      // Create viseme control function (attenuate based on active emotion max)
       const setViseme = (viseme: string, intensity: number) => {
         if (blendShapeControllerRef.current) {
           const visemeMap: Record<string, string> = {
@@ -855,8 +862,7 @@ export default function CharacterAvatar({
             'Closed': 'neutral'
           };
           const vrmExpression = visemeMap[viseme] || 'neutral';
-          const { expression, weight } = currentExpressionRef.current;
-          const factor = getMouthOverrideFactor(expression, weight);
+          const factor = getLipSyncFactorFromEmotions(expressionWeightsAppliedRef.current);
           blendShapeControllerRef.current.setViseme(vrmExpression, intensity * factor);
         }
       };
@@ -982,7 +988,16 @@ export default function CharacterAvatar({
               });
             }
             if (keyframe.expressions && blendShapeControllerRef.current) {
-              blendShapeControllerRef.current.setExpressions(keyframe.expressions);
+              const factor = getLipSyncFactorFromEmotions(keyframe.expressions);
+              const blended = { ...keyframe.expressions };
+              VISEME_NAMES.forEach((name) => {
+                const v = blended[name];
+                if (typeof v === 'number') {
+                  blended[name] = v * factor;
+                }
+              });
+
+              blendShapeControllerRef.current.setExpressions(blended);
               const current = blendShapeControllerRef.current.getCurrentExpressions();
               setExpressionWeightsRef.current(current);
             }
@@ -1049,6 +1064,13 @@ export default function CharacterAvatar({
   };
 
   const handle_expression_weight_change = (name: string, weight: number) => {
+    const is_viseme = (VISEME_NAMES as readonly string[]).includes(name);
+    const factor = is_viseme
+      ? getLipSyncFactorFromEmotions(expressionWeightsAppliedRef.current)
+      : 1;
+    const applied_weight = is_viseme ? weight * factor : weight;
+
+    // UI holds the raw value; attenuation happens only when applying to the VRM.
     const next = { ...expressionWeightsUiRef.current, [name]: weight };
     expressionWeightsUiRef.current = next;
     lastManualExpressionUpdateMsRef.current = {
@@ -1056,7 +1078,7 @@ export default function CharacterAvatar({
       [name]: Date.now(),
     };
     setExpressionWeights(next);
-    blendShapeControllerRef.current?.setExpression(name, weight);
+    blendShapeControllerRef.current?.setExpression(name, applied_weight);
   };
 
   useEffect(() => {
@@ -1261,7 +1283,7 @@ export default function CharacterAvatar({
       const blend_shape = blendShapeControllerRef.current;
       if (blend_shape) {
         const current = blend_shape.getCurrentExpressions();
-        const last = expressionWeightsSyncRef.current;
+        const last = expressionWeightsAppliedRef.current;
         const current_keys = Object.keys(current);
         const last_keys = Object.keys(last);
         const EPSILON = 0.0001;
@@ -1284,14 +1306,49 @@ export default function CharacterAvatar({
           const now = Date.now();
           const manual = lastManualExpressionUpdateMsRef.current;
           const ui = expressionWeightsUiRef.current;
-          const merged: Record<string, number> = { ...current };
+          // Convert VRM-applied viseme (often attenuated) into an estimated raw value for UI display:
+          // raw ≈ applied / factor, where factor is based on active mouth-using emotions.
+          const factor = getLipSyncFactorFromEmotions(current);
+          const display: Record<string, number> = { ...current };
+          if (factor > 0.001) {
+            const effective_factor = Math.max(factor, MIN_LIP_SYNC_UI_FACTOR);
+            VISEME_NAMES.forEach((name) => {
+              const v = display[name];
+              if (typeof v === 'number') {
+                display[name] = Math.max(0, Math.min(1, v / effective_factor));
+              }
+            });
+          } else {
+            // When factor is 0, lip-sync is fully suppressed; display raw as 0 to avoid inf/NaN.
+            VISEME_NAMES.forEach((name) => {
+              if (typeof display[name] === 'number') {
+                display[name] = 0;
+              }
+            });
+          }
+
+          // Smooth viseme sliders to avoid visual jitter and division noise amplification.
+          const prev_display = expressionWeightsDisplayRef.current;
+          VISEME_NAMES.forEach((name) => {
+            const next_value = display[name];
+            const prev_value = prev_display[name];
+            if (typeof next_value === 'number' && typeof prev_value === 'number') {
+              display[name] =
+                prev_value + (next_value - prev_value) * VISEME_SMOOTHING_ALPHA;
+            }
+          });
+
+          // Preserve user's manual slider input briefly to avoid "fight" with VRM updates.
           for (const [name, ts] of Object.entries(manual)) {
             if (now - ts < MANUAL_HOLD_MS && typeof ui[name] === 'number') {
-              merged[name] = ui[name];
+              display[name] = ui[name];
             }
           }
-          setExpressionWeightsRef.current(merged);
-          expressionWeightsSyncRef.current = { ...merged };
+
+          setExpressionWeightsRef.current(display);
+          expressionWeightsDisplayRef.current = { ...display };
+          // Keep this ref as the VRM-applied values (not the UI display values) for stable change detection.
+          expressionWeightsAppliedRef.current = { ...current };
         }
       }
 

--- a/frontend/src/app/components/CharacterSettings.tsx
+++ b/frontend/src/app/components/CharacterSettings.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import React, { useEffect, useState } from 'react';
-import { Play, SlidersHorizontal } from 'lucide-react';
+import { Play, User } from 'lucide-react';
 
 export interface ControlsState {
   expression: string;
@@ -27,7 +27,7 @@ const VISEME_LABELS: Record<string, string> = {
   oh: 'O',
 };
 
-interface ControlsSettingsProps {
+interface CharacterSettingsProps {
   state: ControlsState;
   vrmExpressionNames: string[];
   expressionWeights: Record<string, number>;
@@ -38,7 +38,7 @@ interface ControlsSettingsProps {
   onRotationChange: (rotation: ControlsState['rotation']) => void;
 }
 
-export default function ControlsSettings({
+export default function CharacterSettings({
   state,
   vrmExpressionNames,
   expressionWeights,
@@ -47,7 +47,7 @@ export default function ControlsSettings({
   onPlayVRMAnimation,
   onPositionChange,
   onRotationChange,
-}: ControlsSettingsProps) {
+}: CharacterSettingsProps) {
   const [selected_vrm_animation, set_selected_vrm_animation] = useState<string>(DEFAULT_VRM_ANIMATION);
   const [vrm_animation_loop, set_vrm_animation_loop] = useState(true);
 
@@ -63,8 +63,8 @@ export default function ControlsSettings({
   return (
     <div className="bg-white rounded-lg p-4 shadow-sm">
       <h3 className="text-sm font-semibold mb-3 flex items-center gap-2">
-        <SlidersHorizontal className="w-4 h-4" />
-        Controls
+        <User className="w-4 h-4" />
+        Character
       </h3>
 
       {vrmExpressionNames.length > 0 && (
@@ -244,3 +244,4 @@ export default function ControlsSettings({
     </div>
   );
 }
+

--- a/frontend/src/app/components/SettingsPanel.tsx
+++ b/frontend/src/app/components/SettingsPanel.tsx
@@ -6,7 +6,7 @@ import {
   MessageSquare,
   Palette,
   Presentation,
-  SlidersHorizontal,
+  User,
   Volume2,
   X,
 } from 'lucide-react';
@@ -16,10 +16,10 @@ import AudioSettings from './AudioSettings';
 import BackgroundSelector, {
   type BackgroundOption as BackgroundSelectorOption,
 } from './BackgroundSelector';
-import ControlsSettings, {
+import CharacterSettings, {
   type ControlsState,
   type VRMAnimationOption,
-} from './ControlsSettings';
+} from './CharacterSettings';
 import EnvironmentSettings from './EnvironmentSettings';
 import KeyframeSettings from './KeyframeSettings';
 
@@ -27,7 +27,7 @@ const SETTINGS_TAB_LABELS: Record<
   'controls' | 'keyframe' | 'background' | 'lighting' | 'audio' | 'slides',
   string
 > = {
-  controls: 'Controls',
+  controls: 'Character',
   keyframe: 'Keyframe',
   background: 'Background',
   lighting: 'Lighting',
@@ -48,7 +48,7 @@ export interface SettingsPanelProps {
   show_close_button?: boolean;
   on_close?: () => void;
   extra_tab?: { label: string; content: ReactNode };
-  /** Controls tab (uses ControlsSettings component) */
+  /** Character tab (uses CharacterSettings component) */
   controls_state: ControlsState;
   vrm_expression_names: string[];
   expression_weights: Record<string, number>;
@@ -170,7 +170,7 @@ export default function SettingsPanel({
           >
             {tab === 'conversation' && <MessageSquare className="size-4" />}
             {tab === 'slides' && <Presentation className="size-4" />}
-            {tab === 'controls' && <SlidersHorizontal className="size-4" />}
+            {tab === 'controls' && <User className="size-4" />}
             {tab === 'keyframe' && <Film className="size-4" />}
             {tab === 'background' && <Palette className="size-4" />}
             {tab === 'lighting' && <Lightbulb className="size-4" />}
@@ -212,7 +212,7 @@ export default function SettingsPanel({
 
       {active_tab === 'controls' ? (
         <div className="mb-4">
-          <ControlsSettings
+          <CharacterSettings
             state={controls_state}
             vrmExpressionNames={vrm_expression_names}
             expressionWeights={expression_weights}

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -251,6 +251,25 @@ export default function Home() {
 
   const showAvatarControls = process.env.NEXT_PUBLIC_SHOW_AVATAR_SETTINGS === 'true';
 
+  const handleSettingsPanelPropsChange = useCallback(
+    (props: SettingsPanelPropsFromSource) => {
+      settingsPanelPropsRef.current = props;
+      // Avoid re-rendering the whole page when settings panel is closed.
+      if (showSettingsPanel) {
+        setSettingsPanelProps(props);
+      }
+    },
+    [showSettingsPanel],
+  );
+
+  useEffect(() => {
+    if (showSettingsPanel) {
+      setSettingsPanelProps(settingsPanelPropsRef.current);
+    } else {
+      setSettingsPanelProps(null);
+    }
+  }, [showSettingsPanel]);
+
   const startPresentation = useCallback((language: 'ja' | 'en') => {
     setCurrentLanguage(language);
     setShowSlideMode(true);
@@ -393,7 +412,7 @@ export default function Home() {
                   onBackgroundChange={setCharacterBackground}
                   onLightingChange={setLightingIntensity}
                   settingsPanelPropsRef={settingsPanelPropsRef}
-                  onSettingsPanelPropsChange={setSettingsPanelProps}
+                  onSettingsPanelPropsChange={handleSettingsPanelPropsChange}
                 />
               </div>
 

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -242,6 +242,8 @@ export default function Home() {
   const [conversationHistory, setConversationHistory] = useState<ConversationHistoryItem[]>([]);
   const [showSettingsPanel, setShowSettingsPanel] = useState(false);
   const settingsPanelPropsRef = useRef<SettingsPanelPropsFromSource | null>(null);
+  const [settingsPanelProps, setSettingsPanelProps] =
+    useState<SettingsPanelPropsFromSource | null>(null);
   const playKeyframeAnimationRef = useRef<((data: CharacterAnimationData) => void) | null>(null);
   const lastVrmControlPlayedRef = useRef<unknown>(null);
   const lastTranscriptRef = useRef<string>('');
@@ -391,6 +393,7 @@ export default function Home() {
                   onBackgroundChange={setCharacterBackground}
                   onLightingChange={setLightingIntensity}
                   settingsPanelPropsRef={settingsPanelPropsRef}
+                  onSettingsPanelPropsChange={setSettingsPanelProps}
                 />
               </div>
 
@@ -563,7 +566,7 @@ export default function Home() {
                   </div>
                 </div>
 
-                {showSettingsPanel && settingsPanelPropsRef.current ? (
+                {showSettingsPanel && settingsPanelProps ? (
                   <div
                     className="absolute inset-0 z-30 pointer-events-none"
                     aria-hidden={!showSettingsPanel}
@@ -576,7 +579,7 @@ export default function Home() {
                       }}
                     >
                       <SettingsPanel
-                        {...settingsPanelPropsRef.current}
+                        {...settingsPanelProps}
                         show_close_button
                         on_close={() => setShowSettingsPanel(false)}
                         extra_tab={{

--- a/frontend/src/lib/vrm-utils.ts
+++ b/frontend/src/lib/vrm-utils.ts
@@ -678,13 +678,10 @@ export class VRMBlendShapeController {
     }
 
     try {
-      const expression = this.vrm.expressionManager.getExpression(expressionName);
-      if (expression) {
-        const clampedWeight = Math.max(0, Math.min(1, weight));
-        expression.weight = clampedWeight;
-      } else {
-        console.warn(`Expression "${expressionName}" not found in VRM model`);
-      }
+      const clampedWeight = Math.max(0, Math.min(1, weight));
+      // Use expressionManager.setValue() as the single source of truth.
+      // Reading via expression objects' .weight can drift from the actual applied value depending on VRM version.
+      this.vrm.expressionManager.setValue(expressionName, clampedWeight);
     } catch (error) {
       console.warn(`Error setting expression "${expressionName}":`, error);
     }
@@ -868,8 +865,8 @@ export class VRMBlendShapeController {
     if (!this.vrm.expressionManager) return {};
     
     const current: Record<string, number> = {};
-    this.vrm.expressionManager.expressions.forEach(expr => {
-      current[expr.expressionName] = expr.weight;
+    this.vrm.expressionManager.expressions.forEach((expr) => {
+      current[expr.expressionName] = this.vrm.expressionManager?.getValue(expr.expressionName) ?? 0;
     });
     
     return current;

--- a/frontend/src/lib/vrm-utils.ts
+++ b/frontend/src/lib/vrm-utils.ts
@@ -646,15 +646,14 @@ export class VRMAnimationManager {
   }
 }
 
-/**
- * Returns a factor in [0, 1] to attenuate lip-sync intensity when an expression that uses the mouth is active.
- * Used for frontend procedural override: intensity' = intensity * getMouthOverrideFactor(expression, weight).
- */
-export function getMouthOverrideFactor(expression: string, weight: number): number {
-  if (VRMUtils.EXPRESSIONS_THAT_USE_MOUTH.includes(expression as (typeof VRMUtils.EXPRESSIONS_THAT_USE_MOUTH)[number])) {
-    return Math.max(0, 1 - weight);
-  }
-  return 1;
+export function getLipSyncFactorFromEmotions(
+  weights: Record<string, number>,
+): number {
+  const max_emotion = VRMUtils.EXPRESSIONS_THAT_USE_MOUTH.reduce((acc, name) => {
+    const v = weights[name] ?? 0;
+    return v > acc ? v : acc;
+  }, 0);
+  return Math.max(0, 1 - max_emotion);
 }
 
 // VRM BlendShape Controller for Lip-sync and Expressions


### PR DESCRIPTION
## 概要

VRM のキャラクター設定 UI の整理と、感情・リップシンク表現の一貫性向上を行います。設定パネルとモデル表示の同期を改善し、口形に効く感情ウェイトに基づいてリップシンク強度を調整するよう変更しています。

Closes #302

## 変更内容

- `ControlsSettings` を `CharacterSettings` に改名し、タブ・アイコン文言を「Character」に統一
- 設定パネル用 props を `Home` 側で state 化し、`CharacterAvatar` から `onSettingsPanelPropsChange` で同期（パネル表示中のみ再レンダー、通知は 100ms 間引き）
- フロント専用の感情→VRM 名マッピングを削除し、`/api/character` 経由の表情は **バックエンドが返す名前をそのまま**適用（類似名フォールバックは維持）
- リップシンク強度を `getLipSyncFactorFromEmotions` に集約（口を使う感情シェイプの最大ウェイトで減衰）
- `VRMBlendShapeController` で `expressionManager.setValue` / `getValue` を正として参照し、スライダー同期用の `getCurrentExpressions` の読み取りを整合
- viseme の UI 表示は適用値から逆算しつつ、スムージング・手動スライダー短時間ホールドで「VRM 更新と UI の喧嘩」を抑制
- `initialExpression` およびセッション姿勢に紐づく **表情の自動適用**を外し、アニメーションのみ更新（誤った表情が残るケースへの対処として意図的な挙動変更）

## レビュー・マージ前に確認してほしいこと

### 機能・回帰

- [ ] 設定タブ「Character」でスライダーが **開いた直前の VRM 状態**（リップ・キーフレーム等を含む）と概ね一致する
- [ ] 会話・音声再生時、口を使う感情が強いときも **リップと表情の見た目**が破綻していない
- [ ] **待受 / 処理中 / 発話**など、セッションに応じた見た目が意図どおりか（`sessionState` / `initialExpression` から **表情の自動更新を外した**ため、以前と差が出る場合は仕様として許容か判断したい）

### 契約・整合性

- [ ] バックエンド／API が返す `expression`（感情タグ）が、利用中 VRM の **プリセット名と揃っている**、または類似名フォールバックで許容範囲か（フロントの固定マッピングをやめたため、**名前の契約**がより表に出ます）
- [ ] `EmotionManager.applyEmotionToVRM` 系と `updateCharacterExpression` 系で **入力経路が混在**していないか、または混在しても見た目上問題ないか

### パフォーマンス（任意）

- [ ] 低スペック環境で `requestAnimationFrame` 内の表情同期が重くないか（問題あれば別 Issue で間引き検討）

## 既知のメモ（フォローアップ可）

- 型名 `ControlsState` はファイル内で継続利用。リネームは別 PR でも可。
- `VRMBlendShapeController.setExpressions` の内部 `currentExpression` と実機の完全一致は、必要なら `getCurrentExpressions` で確定させる余地あり。

## 動作確認の目安

- `make dev` または frontend + backend を起動し、**Character タブ**と音声会話で目視確認

（スクリーンショットや短い録画があるとレビューが速いです）

## 録画
https://github.com/user-attachments/assets/c72fa191-3efa-409c-8d66-54131b2a6b8f

※髪が荒ぶっているのはSettingsPanelを出したときのみ