### PR TITLE
fix(frontend): WAV MIME type - merge gate test v3

### DIFF
--- a/frontend/src/app/components/VoiceInterface.tsx
+++ b/frontend/src/app/components/VoiceInterface.tsx
@@ -338,7 +338,7 @@ export default function VoiceInterface({
         voiceController.notifySpeakingComplete(true);
         return;
       }
-      const audioBlob = new Blob([audioBytes], { type: 'audio/mpeg' });
+      const audioBlob = new Blob([audioBytes], { type: 'audio/wav' });
       const audioUrl = URL.createObjectURL(audioBlob);
       const audioService = ensureAudioService();
 
@@ -368,7 +368,7 @@ export default function VoiceInterface({
         },
       });
 
-      const result = await audioService.playAudio(audioUrl);
+      const result = await audioService.playAudio(audioBlob);
       if (!result.success) {
         cleanupAudioPlayback();
         voiceController.notifySpeakingComplete(true);

--- a/frontend/src/app/components/VoiceInterface.tsx
+++ b/frontend/src/app/components/VoiceInterface.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { AudioQueue } from '@/lib/audio-queue';
+import { AudioDataProcessor } from '@/lib/audio/audio-data-processor';
 import { markAudioUserInteraction } from '@/lib/audio/audio-user-interaction-gate';
 import { MobileAudioService } from '@/lib/audio/mobile-audio-service';
 import { audioStateManager } from '@/lib/audio-state-manager';
@@ -338,7 +339,8 @@ export default function VoiceInterface({
         voiceController.notifySpeakingComplete(true);
         return;
       }
-      const audioBlob = new Blob([audioBytes], { type: 'audio/wav' });
+      const detectedFormat = AudioDataProcessor.detectAudioFormat(audioBytes.buffer as ArrayBuffer);
+      const audioBlob = new Blob([audioBytes], { type: detectedFormat });
       const audioUrl = URL.createObjectURL(audioBlob);
       const audioService = ensureAudioService();
 


### PR DESCRIPTION
## Summary
- Correct WAV MIME type from `audio/mpeg` to `audio/wav` in VoiceInterface.tsx
- Fix `playAudio` call to pass `audioBlob` instead of `audioUrl` for proper audio playback

Re-land of the WAV MIME fix (follow-up to previous PRs which were reverted during hook testing).

Closes #300

## Test plan
- [ ] Verify voice playback works correctly with WAV audio format
- [ ] Confirm no regressions in audio playback flow

🤖 Generated with [Claude Code](https://claude.com/claude-code)