### PR TITLE
fix(backend): QA返答を口語化しTTS Markdown違和感を解消 #301

### DIFF
--- a/backend/agents/business_info_agent.py
+++ b/backend/agents/business_info_agent.py
@@ -266,6 +266,18 @@ class BusinessInfoAgent:
             language,
         )
 
+        oral_instruction_ja = (
+            "回答は口語（話し言葉）で返してください。"
+            "Markdownの見出し・箇条書き・太字・表などは使わないでください。"
+            "音声で読み上げた時に自然に聞こえるような文章にしてください。"
+        )
+        oral_instruction_en = (
+            "Respond in natural spoken language. "
+            "Do NOT use Markdown formatting such as "
+            "headers, bullet points, bold, or tables. "
+            "Write as if speaking aloud to someone."
+        )
+
         if request_type:
             request_type_prompt = self._get_request_type_prompt(request_type, language)
 
@@ -281,7 +293,8 @@ class BusinessInfoAgent:
                     " Do not include any other information.\n"
                     "IMPORTANT: Start your response with"
                     " [relaxed] for information"
-                    " or [happy] for positive news."
+                    " or [happy] for positive news.\n"
+                    f"{oral_instruction_en}"
                 )
                 return f"""{header}
 
@@ -296,7 +309,8 @@ Information: {context}
 情報: {context}
 
 {request_type_prompt}のみを答えてください。最大1-2文。他の情報は含めないでください。
-重要: 情報提供の場合は[relaxed]、良いニュースの場合は[happy]で回答を始めてください。"""
+重要: 情報提供の場合は[relaxed]、良いニュースの場合は[happy]で回答を始めてください。
+{oral_instruction_ja}"""
 
         else:
             if language == "en":
@@ -311,7 +325,8 @@ Information: {context}
                     "IMPORTANT: Start your response with"
                     " an emotion tag: [relaxed] for"
                     " information, [happy] for positive"
-                    " news, [sad] for unavailable services."
+                    " news, [sad] for unavailable services.\n"
+                    f"{oral_instruction_en}"
                 )
                 return f"""{header}
 
@@ -327,7 +342,8 @@ Information: {context}
                     "関連する情報のみを簡潔に（1-2文）答えてください。\n"
                     "重要: 感情タグで回答を始めてください: "
                     "情報提供は[relaxed]、良いニュースは[happy]、"
-                    "利用できないサービスは[sad]。"
+                    "利用できないサービスは[sad]。\n"
+                    f"{oral_instruction_ja}"
                 )
                 return f"""{header}
 

--- a/backend/agents/general_knowledge_agent.py
+++ b/backend/agents/general_knowledge_agent.py
@@ -375,6 +375,18 @@ class GeneralKnowledgeAgent:
         """プロンプトを構築"""
         source_info = " and ".join(sources) if sources else "available information"
 
+        oral_instruction_ja = (
+            "回答は口語（話し言葉）で返してください。"
+            "Markdownの見出し・箇条書き・太字・表などは使わないでください。"
+            "音声で読み上げた時に自然に聞こえるような文章にしてください。"
+        )
+        oral_instruction_en = (
+            "Respond in natural spoken language. "
+            "Do NOT use Markdown formatting such as "
+            "headers, bullet points, bold, or tables. "
+            "Write as if speaking aloud to someone."
+        )
+
         if language == "en":
             header = (
                 "Answer the following question using"
@@ -398,7 +410,8 @@ Information:
 
 Provide a comprehensive but concise answer.
 If the information is from web search, mention that it's current information.
-Be helpful and informative."""
+Be helpful and informative.
+{oral_instruction_en}"""
         else:
             return f"""{source_info}から提供された情報を使用して、次の質問に答えてください。
 
@@ -416,7 +429,8 @@ Be helpful and informative."""
 情報:
 {context}
 
-包括的だが簡潔な回答を提供してください。情報がウェブ検索からのものである場合は、それが最新の情報であることを述べてください。役立つ情報を提供してください。"""
+包括的だが簡潔な回答を提供してください。情報がウェブ検索からのものである場合は、それが最新の情報であることを述べてください。役立つ情報を提供してください。
+{oral_instruction_ja}"""
 
     def _calculate_confidence(self, sources: List[str]) -> float:
         """信頼度を計算"""

--- a/backend/agents/voice_agent.py
+++ b/backend/agents/voice_agent.py
@@ -217,12 +217,20 @@ def clean_text_for_tts(text: str) -> str:
     # Horizontal rules: ---, ***, ___ (3+ chars on their own line)
     t = re.sub(r"^[-\*_]{3,}\s*$", "", t, flags=re.M)
 
-    # HTML tags: <br>, <br/>, <p>, </p>, etc.
-    t = re.sub(r"<[^>]+>", "", t)
+    # HTML tags: only strip common HTML tags that LLMs may emit
+    # (preserves non-HTML angle brackets like vector<int>, 1 < 2)
+    t = re.sub(
+        r"</?(?:br|p|div|span|strong|em|b|i|u|a|h[1-6]"
+        r"|ul|ol|li|table|tr|td|th|hr|img|pre|code|blockquote)(?=[\s>/])[^>]*>",
+        "",
+        t,
+        flags=re.I,
+    )
 
-    # Table syntax: remove pipe characters and separator rows
+    # Table syntax: remove separator rows and table-like lines (2+ pipes)
+    # but preserve single pipes in technical content (e.g. grep foo | sort)
     t = re.sub(r"^\|?[-:]+\|[-:|]+\|?\s*$", "", t, flags=re.M)
-    t = re.sub(r"\|", " ", t)
+    t = re.sub(r"^\s*\|.*\|.*$", "", t, flags=re.M)
 
     # Convert markdown links [text](url) -> text
     t = re.sub(r"\[([^\]]+)\]\([^)]+\)", r"\1", t)

--- a/backend/agents/voice_agent.py
+++ b/backend/agents/voice_agent.py
@@ -195,6 +195,9 @@ def preprocess_tts(text: str, lang: str) -> str:
 def clean_text_for_tts(text: str) -> str:
     t = text
 
+    # Remove fenced code blocks ```...``` (non-greedy, before inline markers)
+    t = re.sub(r"```[\s\S]*?```", "", t)
+
     # Remove markdown emphasis markers
     t = re.sub(r"\*\*", "", t)
     t = re.sub(r"\*", "", t)
@@ -202,17 +205,33 @@ def clean_text_for_tts(text: str) -> str:
     # Numbered list prefixes
     t = re.sub(r"^\d+\.\s*", "", t, flags=re.M)
 
+    # Bullet points: - item or * item at start of line
+    t = re.sub(r"^[-\*]\s+", "", t, flags=re.M)
+
     # Headers (requires # at start of line)
     t = re.sub(r"^#+\s+", "", t, flags=re.M)
 
-    # Convert markdown links [text](url) -> text  ✅ r"\1" が正しい
+    # Blockquotes: > text at start of line
+    t = re.sub(r"^>\s*", "", t, flags=re.M)
+
+    # Horizontal rules: ---, ***, ___ (3+ chars on their own line)
+    t = re.sub(r"^[-\*_]{3,}\s*$", "", t, flags=re.M)
+
+    # HTML tags: <br>, <br/>, <p>, </p>, etc.
+    t = re.sub(r"<[^>]+>", "", t)
+
+    # Table syntax: remove pipe characters and separator rows
+    t = re.sub(r"^\|?[-:]+\|[-:|]+\|?\s*$", "", t, flags=re.M)
+    t = re.sub(r"\|", " ", t)
+
+    # Convert markdown links [text](url) -> text
     t = re.sub(r"\[([^\]]+)\]\([^)]+\)", r"\1", t)
 
-    # Remove fenced code blocks ```...``` (non-greedy)
-    t = re.sub(r"```[\s\S]*?```", "", t)
-
-    # Inline code `code` -> code  ✅ r"\1" が正しい
+    # Inline code `code` -> code
     t = re.sub(r"`([^`]+)`", r"\1", t)
+
+    # Normalize multiple newlines to single space
+    t = re.sub(r"\n{2,}", " ", t)
 
     # Normalize whitespace
     t = re.sub(r"\s+", " ", t).strip()

--- a/backend/config/prompts/event_prompts.py
+++ b/backend/config/prompts/event_prompts.py
@@ -35,6 +35,18 @@ def build_event_prompt(query: str, events_text: str, time_range: str, language: 
     """
     time_range_text = get_time_range_label(time_range, language)
 
+    oral_instruction_ja = (
+        "回答は口語（話し言葉）で返してください。"
+        "Markdownの見出し・箇条書き・太字・表などは使わないでください。"
+        "音声で読み上げた時に自然に聞こえるような文章にしてください。"
+    )
+    oral_instruction_en = (
+        "Respond in natural spoken language. "
+        "Do NOT use Markdown formatting such as "
+        "headers, bullet points, bold, or tables. "
+        "Write as if speaking aloud to someone."
+    )
+
     if language == "en":
         return f"""Based on the following event information \
 for {time_range_text}, answer the question.
@@ -45,7 +57,8 @@ Events {time_range_text}:
 {events_text}
 
 Provide a brief and friendly summary of the events. Start your response with [happy] emotion tag.
-Maximum 2-3 sentences."""
+Maximum 2-3 sentences.
+{oral_instruction_en}"""
     else:
         return f"""{time_range_text}のイベント情報に基づいて、質問に答えてください。
 
@@ -55,4 +68,5 @@ Maximum 2-3 sentences."""
 {events_text}
 
 イベントについて簡潔でフレンドリーな説明を提供してください。[happy]の感情タグで回答を始めてください。
-最大2-3文。"""
+最大2-3文。
+{oral_instruction_ja}"""

--- a/backend/config/prompts/facility_prompts.py
+++ b/backend/config/prompts/facility_prompts.py
@@ -113,6 +113,18 @@ def build_facility_prompt(
     Returns:
         構築されたプロンプト
     """
+    oral_instruction_ja = (
+        "回答は口語（話し言葉）で返してください。"
+        "Markdownの見出し・箇条書き・太字・表などは使わないでください。"
+        "音声で読み上げた時に自然に聞こえるような文章にしてください。"
+    )
+    oral_instruction_en = (
+        "Respond in natural spoken language. "
+        "Do NOT use Markdown formatting such as "
+        "headers, bullet points, bold, or tables. "
+        "Write as if speaking aloud to someone."
+    )
+
     if request_type:
         prompt_info = FACILITY_REQUEST_TYPE_PROMPTS.get(
             request_type, {"en": "requested information", "ja": "要求された情報"}
@@ -132,7 +144,8 @@ def build_facility_prompt(
                 f"Answer in 2-3 sentences with specific, relevant "
                 f"details. Do not include unrelated information.\n"
                 f"IMPORTANT: Start your response with [relaxed] "
-                f"for information or [happy] for positive news."
+                f"for information or [happy] for positive news.\n"
+                f"{oral_instruction_en}"
             )
         else:
             return (
@@ -147,7 +160,8 @@ def build_facility_prompt(
                 f"質問と無関係な情報は含めないでください。\n"
                 f"重要: 情報提供の場合は[relaxed]、"
                 f"良いニュースの場合は[happy]で回答を始めてください。\n"
-                f"必ず日本語で回答してください。"
+                f"必ず日本語で回答してください。\n"
+                f"{oral_instruction_ja}"
             )
     else:
         if language == "en":
@@ -160,7 +174,8 @@ def build_facility_prompt(
                 f"relevant information.\n"
                 f"IMPORTANT: Start your response with an emotion "
                 f"tag: [relaxed] for information, [happy] for "
-                f"positive news, [sad] for unavailable services."
+                f"positive news, [sad] for unavailable services.\n"
+                f"{oral_instruction_en}"
             )
         else:
             return (
@@ -173,5 +188,6 @@ def build_facility_prompt(
                 f"重要: 感情タグで回答を始めてください: "
                 f"情報提供は[relaxed]、良いニュースは[happy]、"
                 f"利用できないサービスは[sad]。\n"
-                f"必ず日本語で回答してください。"
+                f"必ず日本語で回答してください。\n"
+                f"{oral_instruction_ja}"
             )

--- a/backend/tests/agents/test_voice_agent.py
+++ b/backend/tests/agents/test_voice_agent.py
@@ -66,6 +66,24 @@ def test_clean_text_for_tts_strips_markdown_links_code():
     assert "print(" not in cleaned
 
 
+def test_clean_text_for_tts_preserves_technical_symbols_and_single_pipes():
+    text = """
+    <p>Use vector<int> when 1 < 2.</p>
+    | name | value |
+    grep foo | sort
+    """
+
+    cleaned = clean_text_for_tts(text)
+
+    assert "<p>" not in cleaned
+    assert "</p>" not in cleaned
+    assert "vector<int>" in cleaned
+    assert "1 < 2" in cleaned
+    assert "name" not in cleaned
+    assert "value" not in cleaned
+    assert "grep foo | sort" in cleaned
+
+
 def test_truncate_by_bytes_over_limit():
     """5000 bytes 制限を超える入力が 5000 bytes 以下に収まること"""
     text = "あ" * 3000


### PR DESCRIPTION
## Summary
- エージェントプロンプトに口語指示を追加（5ファイル、日英対応）
- clean_text_for_tts() を強化（箇条書き、引用、水平線、HTMLタグ、テーブル構文の除去追加）
- P1レビュー指摘を修正（HTMLタグ除去をホワイトリスト化、パイプ除去をテーブル行限定に）

## Changes

### Commit 1: TTS テキストクリーニング強化 (voice_agent.py)
- 箇条書き、引用、水平線、HTMLタグ、テーブル構文の除去追加

### Commit 2: エージェントプロンプト口語指示追加
- business_info_agent.py, general_knowledge_agent.py, event_prompts.py, facility_prompts.py
- 日英両方に「口語で返答、Markdown不使用」の指示を追加

### Commit 3: P1レビュー指摘修正
- HTMLタグ除去: 全角括弧除去 → 一般的HTMLタグのみホワイトリスト除去
- パイプ除去: 全置換 → テーブル行（2+パイプ）のみ除去
- リグレッションテスト追加

## Review pipeline
- code-reviewer: Approve (0 CRITICAL, 0 HIGH, 2 MEDIUM: DRY違反、803行)
- Codex CLI: P2x2 検出 → follow-up issues として記録
  - #311: HTMLタグ名リテラルの誤除去
  - #312: テーブル行データの保持

## Test plan
- [x] backend: black --check, ruff check — PASS
- [x] pytest tests/agents/test_voice_agent.py — 12/12 PASS
- [ ] QA質問を送り、返答にMarkdown記号が含まれないことを確認
- [ ] TTS再生で自然な口語として聞こえることを確認

Closes #301

🤖 Generated with [Claude Code](https://claude.com/claude-code)