### PR TITLE
feat: integrate reception workflow into main chat flow #319

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -24,6 +24,7 @@ Current important endpoints:
 - `POST /api/voice`
 - `POST /api/slides`
 - `POST /api/character`
+- `POST /api/ocr` — member card and handwriting OCR; implemented in `backend/api/ocr.py`
 - `POST /api/interrupt`
 - `/api/knowledge/*`
 - `/api/stt-vocabulary/*`
@@ -35,6 +36,10 @@ Notable implementation details:
 - Rate limiting depends on `slowapi`; without it, the decorators become no-ops.
 - Reception session state is currently stored in process memory, not durable storage.
 - Recent STT fixes added WebM-to-WAV conversion, which means ffmpeg/runtime availability matters for some environments.
+- OrchestratorAgent gates on reception status before LLM routing — sessions with an active reception are handled by the reception workflow first.
+- `POST /api/reception/complete` invokes `ainvoke_from_reception()` in the main workflow to generate an agent response using the full visitor context.
+- `POST /api/reception/start` accepts an optional `visitor_identity` field for OCR-pre-identified visitors.
+- `backend/utils/reception_status.py` provides the reception status checker used by the orchestrator gate.
 
 ## Environment
 

--- a/backend/api/reception.py
+++ b/backend/api/reception.py
@@ -308,6 +308,7 @@ class ReceptionStartRequest(BaseModel):
     session_id: str = Field(min_length=1, max_length=128)
     language: Literal["ja", "en", "zh", "ko"] = "ja"
     trigger_type: Literal["face_detection", "button_press", "wake_word", "nfc"] = "button_press"
+    visitor_identity: Optional[dict] = None  # From OCR identification
 
 
 class ReceptionStartResponse(BaseModel):
@@ -357,22 +358,46 @@ class ReceptionStatusResponse(BaseModel):
 
 @reception_router.post("/start", response_model=ReceptionStartResponse)
 async def start_reception(request: ReceptionStartRequest) -> ReceptionStartResponse:
-    """Initiate a new reception session."""
+    """Initiate a new reception session.
+
+    If ``visitor_identity`` is provided (e.g. from OCR identification),
+    the visitor is identified immediately and a personalized greeting
+    is generated.
+    """
     session = ReceptionSession(
         session_id=request.session_id,
         language=request.language,
         trigger_type=request.trigger_type,
     )
-    session.advance_to("greeting")
 
+    # If visitor_identity provided (from OCR), identify immediately
+    if request.visitor_identity and request.visitor_identity.get("user_id"):
+        from backend.utils.reception_templates import get_personalized_greeting
+
+        identity = VisitorIdentity(
+            visitor_type=VisitorType(value="returning"),
+            user_id=request.visitor_identity.get("user_id"),
+            name=request.visitor_identity.get("name"),
+            visit_count=request.visitor_identity.get("visit_count", 0),
+        )
+        session.identify_visitor(identity)
+
+        greeting_result = get_personalized_greeting(
+            language=request.language,
+            name=request.visitor_identity.get("name", ""),
+            last_purpose=request.visitor_identity.get("last_purpose"),
+        )
+    else:
+        greeting_result = get_reception_response(request.language, is_returning=False)
+
+    session.advance_to("greeting")
     await _persist_session(session)
 
-    greeting_result = get_reception_response(request.language, is_returning=False)
     logger.info(
-        "Reception session started: id=%s session_id=%s language=%s",
+        "Reception session started: id=%s session_id=%s visitor=%s",
         session.id,
         request.session_id,
-        request.language,
+        "identified" if request.visitor_identity else "new",
     )
 
     return ReceptionStartResponse(
@@ -500,6 +525,18 @@ async def complete_reception(
     except ValueError as exc:
         raise HTTPException(status_code=400, detail=str(exc)) from exc
 
+    # Invoke MainWorkflow with the handoff to get an agent response
+    agent_response: Optional[str] = None
+    try:
+        from backend.workflows.main_workflow import MainWorkflow
+
+        workflow = MainWorkflow()
+        agent_result = await workflow.ainvoke_from_reception(result)
+        agent_response = agent_result.get("answer")
+    except Exception as exc:
+        logger.warning("MainWorkflow invocation after reception failed: %s", exc)
+        # Not critical -- the handoff info is still returned
+
     logger.info(
         "Reception completed: id=%s target=%s requires_staff=%s",
         session.id,
@@ -508,7 +545,7 @@ async def complete_reception(
     )
 
     return ReceptionCompleteResponse(
-        response_text=result.purpose_flow.response_text,
+        response_text=agent_response or result.purpose_flow.response_text,
         target_agent=result.target_agent,
         requires_staff=result.requires_staff,
         purpose_category=session.purpose.category,

--- a/backend/api/reception.py
+++ b/backend/api/reception.py
@@ -11,7 +11,7 @@ from collections import OrderedDict
 from datetime import datetime
 from typing import TYPE_CHECKING, Any, Literal, Optional
 
-from fastapi import APIRouter, HTTPException, Query
+from fastapi import APIRouter, HTTPException, Path, Query
 from pydantic import BaseModel, Field
 
 from backend.domain.reception.models import (
@@ -304,11 +304,18 @@ def _classify_purpose(message: str) -> Optional[str]:
 # ---------------------------------------------------------------------------
 
 
+class VisitorIdentityInput(BaseModel):
+    user_id: Optional[int] = None
+    name: Optional[str] = Field(None, max_length=256)
+    visit_count: int = 0
+    last_purpose: Optional[dict] = None
+
+
 class ReceptionStartRequest(BaseModel):
     session_id: str = Field(min_length=1, max_length=128)
     language: Literal["ja", "en", "zh", "ko"] = "ja"
     trigger_type: Literal["face_detection", "button_press", "wake_word", "nfc"] = "button_press"
-    visitor_identity: Optional[dict] = None  # From OCR identification
+    visitor_identity: Optional[VisitorIdentityInput] = None  # From OCR identification
 
 
 class ReceptionStartResponse(BaseModel):
@@ -371,21 +378,21 @@ async def start_reception(request: ReceptionStartRequest) -> ReceptionStartRespo
     )
 
     # If visitor_identity provided (from OCR), identify immediately
-    if request.visitor_identity and request.visitor_identity.get("user_id"):
+    if request.visitor_identity and request.visitor_identity.user_id:
         from backend.utils.reception_templates import get_personalized_greeting
 
         identity = VisitorIdentity(
             visitor_type=VisitorType(value="returning"),
-            user_id=request.visitor_identity.get("user_id"),
-            name=request.visitor_identity.get("name"),
-            visit_count=request.visitor_identity.get("visit_count", 0),
+            user_id=request.visitor_identity.user_id,
+            name=request.visitor_identity.name,
+            visit_count=request.visitor_identity.visit_count,
         )
         session.identify_visitor(identity)
 
         greeting_result = get_personalized_greeting(
             language=request.language,
-            name=request.visitor_identity.get("name", ""),
-            last_purpose=request.visitor_identity.get("last_purpose"),
+            name=request.visitor_identity.name or "",
+            last_purpose=request.visitor_identity.last_purpose,
         )
     else:
         greeting_result = get_reception_response(request.language, is_returning=False)
@@ -414,7 +421,7 @@ async def respond_reception(request: ReceptionRespondRequest) -> ReceptionRespon
     if session is None:
         raise HTTPException(
             status_code=404,
-            detail=f"Reception session not found: {request.reception_session_id}",
+            detail="Reception session not found",
         )
 
     if session.session_id != request.session_id:
@@ -496,7 +503,7 @@ async def complete_reception(
     if session is None:
         raise HTTPException(
             status_code=404,
-            detail=(f"Reception session not found: " f"{request.reception_session_id}"),
+            detail="Reception session not found",
         )
 
     if session.session_id != request.session_id:
@@ -556,7 +563,7 @@ async def complete_reception(
 
 @reception_router.get("/status/{reception_session_id}", response_model=ReceptionStatusResponse)
 async def get_reception_status(
-    reception_session_id: str,
+    reception_session_id: str = Path(..., min_length=1, max_length=128),
     session_id: str = Query(..., min_length=1, max_length=128),
 ) -> ReceptionStatusResponse:
     """Return the current state of a reception session."""
@@ -564,7 +571,7 @@ async def get_reception_status(
     if session is None:
         raise HTTPException(
             status_code=404,
-            detail=f"Reception session not found: {reception_session_id}",
+            detail="Reception session not found",
         )
 
     if session.session_id != session_id:

--- a/backend/api/reception.py
+++ b/backend/api/reception.py
@@ -434,8 +434,10 @@ async def respond_reception(request: ReceptionRespondRequest) -> ReceptionRespon
     current_stage = session.stage
 
     if current_stage == "greeting":
-        identity = VisitorIdentity(visitor_type=VisitorType(value="new"))
-        session.identify_visitor(identity)
+        # Only identify as new if not already identified (e.g., from OCR)
+        if session.visitor_identity is None:
+            identity = VisitorIdentity(visitor_type=VisitorType(value="new"))
+            session.identify_visitor(identity)
         session.advance_to("purpose_hearing")
         await _persist_session(session)
 

--- a/backend/tests/smoke/test_reception_flow.sh
+++ b/backend/tests/smoke/test_reception_flow.sh
@@ -1,0 +1,284 @@
+#!/bin/bash
+# Smoke test: Reception → Agent flow
+# Tests the full reception lifecycle via Live API
+# Usage: bash test_reception_flow.sh [BASE_URL] [API_KEY]
+#
+# Compatible with both the current deployed backend and Wave 2 updates.
+# Steps 1-4 test the reception lifecycle (/api/reception/*).
+# Steps 5-6 test chat integration (/api/chat) and are non-fatal
+# since Wave 2 may not be deployed yet.
+
+set -euo pipefail
+
+BASE_URL="${1:-http://localhost:8000}"
+API_KEY="${2:-${API_SECRET_KEY:-test-api-key}}"
+
+PASS=0
+FAIL=0
+WARN=0
+
+pass() { PASS=$((PASS + 1)); echo "PASS: $1"; }
+fail() { FAIL=$((FAIL + 1)); echo "FAIL: $1"; }
+warn() { WARN=$((WARN + 1)); echo "WARN: $1 (non-fatal)"; }
+
+echo "=== Reception Flow Smoke Test ==="
+echo "Target: $BASE_URL"
+echo ""
+
+# Generate unique session ID
+SESSION_ID="smoke-test-$(date +%s)"
+
+# --------------------------------------------------------------------------
+# Step 1: Start reception
+# --------------------------------------------------------------------------
+echo "--- Step 1: Start Reception ---"
+RESPONSE=$(curl -s -w "\n%{http_code}" -X POST "$BASE_URL/api/reception/start" \
+  -H "Content-Type: application/json" \
+  -H "X-API-Key: $API_KEY" \
+  -d "{
+    \"session_id\": \"$SESSION_ID\",
+    \"language\": \"ja\",
+    \"trigger_type\": \"button_press\"
+  }")
+
+HTTP_CODE=$(echo "$RESPONSE" | tail -1)
+BODY=$(echo "$RESPONSE" | sed '$d')
+
+echo "HTTP: $HTTP_CODE"
+echo "Body: $BODY"
+
+if [ "$HTTP_CODE" != "200" ]; then
+  fail "Start reception: expected 200, got $HTTP_CODE"
+  echo ""
+  echo "=== Smoke Test Aborted (cannot continue without session) ==="
+  exit 1
+fi
+
+RECEPTION_SESSION_ID=$(echo "$BODY" | python3 -c "import sys,json; print(json.load(sys.stdin)['reception_session_id'])" 2>/dev/null)
+STAGE=$(echo "$BODY" | python3 -c "import sys,json; print(json.load(sys.stdin)['stage'])" 2>/dev/null)
+GREETING=$(echo "$BODY" | python3 -c "import sys,json; print(json.load(sys.stdin).get('greeting','')[:80])" 2>/dev/null)
+
+if [ -z "$RECEPTION_SESSION_ID" ]; then
+  fail "Start reception: reception_session_id missing from response"
+  echo ""
+  echo "=== Smoke Test Aborted ==="
+  exit 1
+fi
+
+pass "Start reception (stage=$STAGE, greeting=${GREETING}...)"
+echo "Reception Session ID: $RECEPTION_SESSION_ID"
+echo ""
+
+# --------------------------------------------------------------------------
+# Step 2: Respond — advance from greeting to purpose_hearing
+# --------------------------------------------------------------------------
+echo "--- Step 2: Respond (greeting → purpose_hearing) ---"
+RESPONSE=$(curl -s -w "\n%{http_code}" -X POST "$BASE_URL/api/reception/respond" \
+  -H "Content-Type: application/json" \
+  -H "X-API-Key: $API_KEY" \
+  -d "{
+    \"session_id\": \"$SESSION_ID\",
+    \"reception_session_id\": \"$RECEPTION_SESSION_ID\",
+    \"message\": \"はい\"
+  }")
+
+HTTP_CODE=$(echo "$RESPONSE" | tail -1)
+BODY=$(echo "$RESPONSE" | sed '$d')
+
+echo "HTTP: $HTTP_CODE"
+echo "Body: $BODY"
+
+if [ "$HTTP_CODE" != "200" ]; then
+  fail "Respond (greeting): expected 200, got $HTTP_CODE"
+  echo ""
+  echo "=== Smoke Test Aborted ==="
+  exit 1
+fi
+
+STAGE=$(echo "$BODY" | python3 -c "import sys,json; print(json.load(sys.stdin)['stage'])" 2>/dev/null)
+pass "Respond greeting (stage=$STAGE)"
+echo ""
+
+# --------------------------------------------------------------------------
+# Step 3: Respond — provide purpose to advance to routing
+# --------------------------------------------------------------------------
+echo "--- Step 3: Respond with Purpose (purpose_hearing → routing) ---"
+RESPONSE=$(curl -s -w "\n%{http_code}" -X POST "$BASE_URL/api/reception/respond" \
+  -H "Content-Type: application/json" \
+  -H "X-API-Key: $API_KEY" \
+  -d "{
+    \"session_id\": \"$SESSION_ID\",
+    \"reception_session_id\": \"$RECEPTION_SESSION_ID\",
+    \"message\": \"コワーキングスペースを利用したいです\"
+  }")
+
+HTTP_CODE=$(echo "$RESPONSE" | tail -1)
+BODY=$(echo "$RESPONSE" | sed '$d')
+
+echo "HTTP: $HTTP_CODE"
+echo "Body: $BODY"
+
+if [ "$HTTP_CODE" != "200" ]; then
+  fail "Respond (purpose): expected 200, got $HTTP_CODE"
+  echo ""
+  echo "=== Smoke Test Aborted ==="
+  exit 1
+fi
+
+STAGE=$(echo "$BODY" | python3 -c "import sys,json; print(json.load(sys.stdin)['stage'])" 2>/dev/null)
+PURPOSE=$(echo "$BODY" | python3 -c "import sys,json; p=json.load(sys.stdin).get('purpose'); print(p.get('category','?') if p else 'None')" 2>/dev/null)
+echo "Stage: $STAGE, Purpose: $PURPOSE"
+
+# If still in purpose_hearing (classifier didn't match), try again with simpler input
+if [ "$STAGE" = "purpose_hearing" ]; then
+  echo ""
+  echo "--- Step 3b: Retry purpose (classifier didn't match) ---"
+  RESPONSE=$(curl -s -w "\n%{http_code}" -X POST "$BASE_URL/api/reception/respond" \
+    -H "Content-Type: application/json" \
+    -H "X-API-Key: $API_KEY" \
+    -d "{
+      \"session_id\": \"$SESSION_ID\",
+      \"reception_session_id\": \"$RECEPTION_SESSION_ID\",
+      \"message\": \"施設を利用したい\"
+    }")
+
+  HTTP_CODE=$(echo "$RESPONSE" | tail -1)
+  BODY=$(echo "$RESPONSE" | sed '$d')
+  echo "HTTP: $HTTP_CODE"
+  echo "Body: $BODY"
+  STAGE=$(echo "$BODY" | python3 -c "import sys,json; print(json.load(sys.stdin)['stage'])" 2>/dev/null)
+  PURPOSE=$(echo "$BODY" | python3 -c "import sys,json; p=json.load(sys.stdin).get('purpose'); print(p.get('category','?') if p else 'None')" 2>/dev/null)
+  echo "Stage: $STAGE, Purpose: $PURPOSE"
+fi
+
+if [ "$STAGE" = "routing" ]; then
+  pass "Purpose classified (category=$PURPOSE, stage=routing)"
+else
+  fail "Purpose classification: expected routing stage, got $STAGE"
+fi
+echo ""
+
+# --------------------------------------------------------------------------
+# Step 4: Complete reception (handoff to MainWorkflow)
+# --------------------------------------------------------------------------
+if [ "$STAGE" = "routing" ]; then
+  echo "--- Step 4: Complete Reception ---"
+  RESPONSE=$(curl -s -w "\n%{http_code}" -X POST "$BASE_URL/api/reception/complete" \
+    -H "Content-Type: application/json" \
+    -H "X-API-Key: $API_KEY" \
+    -d "{
+      \"session_id\": \"$SESSION_ID\",
+      \"reception_session_id\": \"$RECEPTION_SESSION_ID\"
+    }")
+
+  HTTP_CODE=$(echo "$RESPONSE" | tail -1)
+  BODY=$(echo "$RESPONSE" | sed '$d')
+
+  echo "HTTP: $HTTP_CODE"
+  echo "Body: $BODY"
+
+  if [ "$HTTP_CODE" = "200" ]; then
+    TARGET=$(echo "$BODY" | python3 -c "import sys,json; print(json.load(sys.stdin).get('target_agent','?'))" 2>/dev/null)
+    ACTION=$(echo "$BODY" | python3 -c "import sys,json; print(json.load(sys.stdin).get('action_type','?'))" 2>/dev/null)
+    pass "Complete reception (target_agent=$TARGET, action_type=$ACTION)"
+  else
+    fail "Complete reception: expected 200, got $HTTP_CODE"
+  fi
+  echo ""
+fi
+
+# --------------------------------------------------------------------------
+# Step 5: Check status
+# --------------------------------------------------------------------------
+echo "--- Step 5: Check Status ---"
+RESPONSE=$(curl -s -w "\n%{http_code}" -X GET \
+  "$BASE_URL/api/reception/status/$RECEPTION_SESSION_ID?session_id=$SESSION_ID" \
+  -H "X-API-Key: $API_KEY")
+
+HTTP_CODE=$(echo "$RESPONSE" | tail -1)
+BODY=$(echo "$RESPONSE" | sed '$d')
+
+echo "HTTP: $HTTP_CODE"
+echo "Body: $BODY"
+
+if [ "$HTTP_CODE" = "200" ]; then
+  STATUS_STAGE=$(echo "$BODY" | python3 -c "import sys,json; print(json.load(sys.stdin).get('stage','?'))" 2>/dev/null)
+  pass "Status check (stage=$STATUS_STAGE)"
+else
+  fail "Status check: expected 200, got $HTTP_CODE"
+fi
+echo ""
+
+# --------------------------------------------------------------------------
+# Step 6: Test /api/chat with the same session (Wave 2 feature)
+# Non-fatal — Wave 2 may not be deployed yet.
+# --------------------------------------------------------------------------
+echo "--- Step 6: Chat with same session (Wave 2 test, non-fatal) ---"
+RESPONSE=$(curl -s -w "\n%{http_code}" --max-time 30 -X POST "$BASE_URL/api/chat" \
+  -H "Content-Type: application/json" \
+  -H "X-API-Key: $API_KEY" \
+  -d "{
+    \"query\": \"エンジニアカフェの営業時間を教えてください\",
+    \"session_id\": \"$SESSION_ID\",
+    \"language\": \"ja\"
+  }")
+
+HTTP_CODE=$(echo "$RESPONSE" | tail -1)
+BODY=$(echo "$RESPONSE" | sed '$d')
+
+echo "HTTP: $HTTP_CODE"
+if [ "$HTTP_CODE" = "200" ]; then
+  ANSWER=$(echo "$BODY" | python3 -c "import sys,json; d=json.load(sys.stdin); print(f'answer={d.get(\"answer\",\"N/A\")[:100]}... agent={d.get(\"metadata\",{}).get(\"agent\",\"N/A\")}')" 2>/dev/null || echo "$BODY" | head -c 200)
+  echo "Body: $ANSWER"
+  pass "Chat with existing session"
+else
+  echo "Body: $(echo "$BODY" | head -c 200)"
+  warn "Chat with existing session: HTTP $HTTP_CODE (Wave 2 may not be deployed)"
+fi
+echo ""
+
+# --------------------------------------------------------------------------
+# Step 7: Test /api/chat with a NEW session (should trigger reception in Wave 2)
+# Non-fatal — Wave 2 may not be deployed yet.
+# --------------------------------------------------------------------------
+echo "--- Step 7: New session chat (Wave 2 reception trigger, non-fatal) ---"
+NEW_SESSION="smoke-new-$(date +%s)"
+RESPONSE=$(curl -s -w "\n%{http_code}" --max-time 30 -X POST "$BASE_URL/api/chat" \
+  -H "Content-Type: application/json" \
+  -H "X-API-Key: $API_KEY" \
+  -d "{
+    \"query\": \"こんにちは\",
+    \"session_id\": \"$NEW_SESSION\",
+    \"language\": \"ja\"
+  }")
+
+HTTP_CODE=$(echo "$RESPONSE" | tail -1)
+BODY=$(echo "$RESPONSE" | sed '$d')
+
+echo "HTTP: $HTTP_CODE"
+if [ "$HTTP_CODE" = "200" ]; then
+  ANSWER=$(echo "$BODY" | python3 -c "import sys,json; d=json.load(sys.stdin); print(f'answer={d.get(\"answer\",\"N/A\")[:100]}... agent={d.get(\"metadata\",{}).get(\"agent\",\"N/A\")}')" 2>/dev/null || echo "$BODY" | head -c 200)
+  echo "Body: $ANSWER"
+  pass "Chat with new session"
+else
+  echo "Body: $(echo "$BODY" | head -c 200)"
+  warn "Chat with new session: HTTP $HTTP_CODE (Wave 2 may not be deployed)"
+fi
+echo ""
+
+# --------------------------------------------------------------------------
+# Summary
+# --------------------------------------------------------------------------
+echo "=== Smoke Test Summary ==="
+echo "PASS: $PASS"
+echo "FAIL: $FAIL"
+echo "WARN: $WARN (non-fatal)"
+echo ""
+
+if [ "$FAIL" -gt 0 ]; then
+  echo "RESULT: FAILED ($FAIL failures)"
+  exit 1
+else
+  echo "RESULT: PASSED"
+  exit 0
+fi

--- a/backend/utils/reception_repository.py
+++ b/backend/utils/reception_repository.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import logging
 from datetime import datetime, timedelta, timezone
-from typing import Any
+from typing import Any, Optional
 from uuid import UUID
 
 from supabase import Client
@@ -80,6 +80,41 @@ class ReceptionRepository:
         if result.data:
             return result.data[0]
         return None
+
+    async def get_active_session_by_conversation_id(
+        self, session_id: str
+    ) -> Optional[dict[str, Any]]:
+        """Look up the most recent active reception session for a conversation session_id.
+
+        Unlike ``get_session_record`` which queries by the reception session's
+        own ``id``, this method queries by the conversation ``session_id`` column.
+
+        Args:
+            session_id: The conversation session ID (UUID string).
+
+        Returns:
+            The most recent active reception session record, or ``None``.
+        """
+        try:
+            client = await self._get_client()
+            parsed = _parse_uuid(session_id)
+            if parsed is None:
+                return None
+            result = (
+                client.table("reception_sessions")
+                .select("*")
+                .eq("session_id", parsed)
+                .eq("status", "active")
+                .order("created_at", desc=True)
+                .limit(1)
+                .execute()
+            )
+            if result.data:
+                return result.data[0]
+            return None
+        except Exception as exc:
+            logger.warning("Failed to look up reception session: %s", exc)
+            return None
 
     async def complete_session(self, session_id: str) -> None:
         client = await self._get_client()

--- a/backend/utils/reception_repository.py
+++ b/backend/utils/reception_repository.py
@@ -5,23 +5,12 @@ from __future__ import annotations
 import logging
 from datetime import datetime, timedelta, timezone
 from typing import Any, Optional
-from uuid import UUID
 
 from supabase import Client
 
 from backend.utils.supabase_helper import get_supabase_client
 
 logger = logging.getLogger(__name__)
-
-
-def _parse_uuid(value: Any) -> str | None:
-    if not isinstance(value, str):
-        return None
-
-    try:
-        return str(UUID(value))
-    except ValueError:
-        return None
 
 
 class ReceptionRepository:
@@ -45,7 +34,7 @@ class ReceptionRepository:
 
         payload = {
             "id": session_id,
-            "session_id": _parse_uuid(data.get("session_id")),
+            "session_id": data.get("session_id"),
             "user_id": visitor_identity.get("user_id"),
             "stage": data.get("stage", "initiated"),
             "purpose": purpose.get("category") if isinstance(purpose, dict) else purpose,
@@ -81,30 +70,31 @@ class ReceptionRepository:
             return result.data[0]
         return None
 
-    async def get_active_session_by_conversation_id(
-        self, session_id: str
-    ) -> Optional[dict[str, Any]]:
-        """Look up the most recent active reception session for a conversation session_id.
+    async def get_session_by_conversation_id(self, session_id: str) -> Optional[dict[str, Any]]:
+        """Look up the most recent reception session for a conversation session_id.
 
         Unlike ``get_session_record`` which queries by the reception session's
         own ``id``, this method queries by the conversation ``session_id`` column.
+        Both active and completed sessions are returned so that the orchestrator
+        can recognise that a session has already finished reception.
 
         Args:
-            session_id: The conversation session ID (UUID string).
+            session_id: The conversation session ID (any string format).
 
         Returns:
-            The most recent active reception session record, or ``None``.
+            The most recent reception session record, or ``None``.
         """
+        if not session_id or not session_id.strip():
+            return None
+        # Do NOT validate as UUID -- session_id can be any string format
+        # (e.g. "voice-session-*" from the browser).
         try:
             client = await self._get_client()
-            parsed = _parse_uuid(session_id)
-            if parsed is None:
-                return None
             result = (
                 client.table("reception_sessions")
                 .select("*")
-                .eq("session_id", parsed)
-                .eq("status", "active")
+                .eq("session_id", session_id)
+                .in_("status", ["active", "completed"])
                 .order("created_at", desc=True)
                 .limit(1)
                 .execute()
@@ -115,6 +105,12 @@ class ReceptionRepository:
         except Exception as exc:
             logger.warning("Failed to look up reception session: %s", exc)
             return None
+
+    async def get_active_session_by_conversation_id(
+        self, session_id: str
+    ) -> Optional[dict[str, Any]]:
+        """Backward-compatible alias for ``get_session_by_conversation_id``."""
+        return await self.get_session_by_conversation_id(session_id)
 
     async def complete_session(self, session_id: str) -> None:
         client = await self._get_client()

--- a/backend/utils/reception_status.py
+++ b/backend/utils/reception_status.py
@@ -1,0 +1,68 @@
+"""Reception status checker for orchestrator integration.
+
+Provides a lightweight check to determine if a session has completed
+the reception flow, used by MainWorkflow to gate agent routing.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any, Optional
+
+logger = logging.getLogger(__name__)
+
+_repository: Optional[Any] = None
+
+
+def _get_repository() -> Any:
+    """Lazy-load ReceptionRepository singleton."""
+    global _repository
+    if _repository is None:
+        from backend.utils.reception_repository import ReceptionRepository
+
+        _repository = ReceptionRepository()
+    return _repository
+
+
+async def check_reception_status(session_id: str) -> dict[str, Any]:
+    """Check if a session has completed reception.
+
+    Used by the orchestrator node as a lightweight pre-check before
+    LLM routing. Fails open (returns completed=True) on errors so
+    that chat continues uninterrupted.
+
+    Args:
+        session_id: The conversation session ID to look up.
+
+    Returns:
+        dict with keys:
+        - completed: bool -- True if reception is done
+        - stage: str -- current reception stage (or "none" if no session)
+        - reception_session_id: Optional[str]
+        - visitor_identity: Optional[dict]
+        - purpose: Optional[dict]
+    """
+    if not session_id:
+        return {"completed": False, "stage": "none"}
+
+    try:
+        repo = _get_repository()
+        record = await repo.get_active_session_by_conversation_id(session_id)
+
+        if record is None:
+            return {"completed": False, "stage": "none"}
+
+        session_data = record.get("session_data", {})
+        stage = session_data.get("stage", record.get("stage", "initiated"))
+
+        return {
+            "completed": stage == "completed",
+            "stage": stage,
+            "reception_session_id": record.get("id"),
+            "visitor_identity": session_data.get("visitor_identity"),
+            "purpose": session_data.get("purpose"),
+        }
+    except Exception as exc:
+        logger.warning("Reception status check failed: %s", exc)
+        # Fail open -- allow chat to proceed without reception
+        return {"completed": True, "stage": "unknown"}

--- a/backend/utils/reception_status.py
+++ b/backend/utils/reception_status.py
@@ -43,14 +43,16 @@ async def check_reception_status(session_id: str) -> dict[str, Any]:
         - purpose: Optional[dict]
     """
     if not session_id:
-        return {"completed": False, "stage": "none"}
+        # No session ID provided -- allow normal chat
+        return {"completed": True, "stage": "none"}
 
     try:
         repo = _get_repository()
-        record = await repo.get_active_session_by_conversation_id(session_id)
+        record = await repo.get_session_by_conversation_id(session_id)
 
         if record is None:
-            return {"completed": False, "stage": "none"}
+            # No reception session exists -- allow normal chat
+            return {"completed": True, "stage": "none"}
 
         session_data = record.get("session_data", {})
         stage = session_data.get("stage", record.get("stage", "initiated"))

--- a/backend/utils/reception_status.py
+++ b/backend/utils/reception_status.py
@@ -65,4 +65,4 @@ async def check_reception_status(session_id: str) -> dict[str, Any]:
     except Exception as exc:
         logger.warning("Reception status check failed: %s", exc)
         # Fail open -- allow chat to proceed without reception
-        return {"completed": True, "stage": "unknown"}
+        return {"completed": True, "stage": "error", "error": str(exc)}

--- a/backend/workflows/main_workflow.py
+++ b/backend/workflows/main_workflow.py
@@ -406,11 +406,14 @@ class MainWorkflow:
         # --- Reception status gate (before LLM call) ---
         reception_status = await check_reception_status(session_id)
 
-        if not reception_status.get("completed"):
+        if not reception_status.get("completed") and reception_status.get("stage") not in (
+            "none",
+            "error",
+        ):
             stage = reception_status.get("stage", "none")
             language = state.get("language", "ja")
 
-            if stage in ("none", "initiated"):
+            if stage == "initiated":
                 # New session -- greet visitor
                 greeting = get_reception_response(language, is_returning=False)
                 return Command(

--- a/backend/workflows/main_workflow.py
+++ b/backend/workflows/main_workflow.py
@@ -387,12 +387,98 @@ class MainWorkflow:
         適切なエージェントにCommand patternでルーティング。
         clarification カテゴリはインラインでテンプレート応答を生成し、
         format_response に直接ルーティングする。
+
+        Reception integration: before the LLM routing call, check if the
+        session has an active (incomplete) reception flow. If so, short-circuit
+        with the appropriate reception stage response.
         """
         from backend.utils.clarification_templates import get_clarification_response
-        from backend.utils.reception_templates import get_reception_response
+        from backend.utils.reception_status import check_reception_status
+        from backend.utils.reception_templates import (
+            get_purpose_followup,
+            get_purpose_hearing_prompt,
+            get_reception_response,
+        )
 
         query = state.get("query", "")
         session_id = state.get("session_id", "")
+
+        # --- Reception status gate (before LLM call) ---
+        reception_status = await check_reception_status(session_id)
+
+        if not reception_status.get("completed"):
+            stage = reception_status.get("stage", "none")
+            language = state.get("language", "ja")
+
+            if stage in ("none", "initiated"):
+                # New session -- greet visitor
+                greeting = get_reception_response(language, is_returning=False)
+                return Command(
+                    goto="format_response",
+                    update={
+                        "answer": greeting.text,
+                        "emotion": "happy",
+                        "metadata": {
+                            **state.get("metadata", {}),
+                            "agent": "reception",
+                            "reception_stage": "greeting",
+                            "reception_action": "start_reception",
+                        },
+                    },
+                )
+
+            if stage == "greeting":
+                # Waiting for purpose -- ask
+                prompt = get_purpose_hearing_prompt(language)
+                return Command(
+                    goto="format_response",
+                    update={
+                        "answer": prompt.text,
+                        "emotion": "neutral",
+                        "metadata": {
+                            **state.get("metadata", {}),
+                            "agent": "reception",
+                            "reception_stage": "purpose_hearing",
+                            "reception_action": "hear_purpose",
+                        },
+                    },
+                )
+
+            if stage == "purpose_hearing":
+                # Classify the purpose from the user's message
+                from backend.utils import purpose_classifier as pc
+
+                try:
+                    category, detail, confidence = await pc.classify_purpose(
+                        query=query, language=language
+                    )
+                except Exception:
+                    category, detail, confidence = "other", None, 0.3
+
+                followup = get_purpose_followup(language, category)
+
+                return Command(
+                    goto="format_response",
+                    update={
+                        "answer": followup.text,
+                        "emotion": "neutral",
+                        "metadata": {
+                            **state.get("metadata", {}),
+                            "agent": "reception",
+                            "reception_stage": "routing",
+                            "reception_action": "classify_purpose",
+                            "purpose": {
+                                "category": category,
+                                "detail": detail,
+                                "confidence": confidence,
+                            },
+                        },
+                    },
+                )
+            # For "routing" or other intermediate stages, fall through to
+            # normal orchestrator LLM routing.
+
+        # --- Normal orchestrator LLM routing ---
         memory_context = state.get("context", {}).get("memory")
 
         decision = await self.orchestrator.decide_next_agent(

--- a/backend/workflows/main_workflow.py
+++ b/backend/workflows/main_workflow.py
@@ -452,7 +452,8 @@ class MainWorkflow:
                     category, detail, confidence = await pc.classify_purpose(
                         query=query, language=language
                     )
-                except Exception:
+                except Exception as classify_exc:
+                    logger.warning("Purpose classification failed: %s", classify_exc)
                     category, detail, confidence = "other", None, 0.3
 
                 followup = get_purpose_followup(language, category)
@@ -1156,6 +1157,7 @@ class MainWorkflow:
             class _RuntimeShim:
                 def __init__(self, ctx: WorkflowContext) -> None:
                     self.context = ctx
+                    self.store = None  # No store available outside graph execution
 
             formatted = await self._format_response_node(merged_state, _RuntimeShim(context))
         except Exception:

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,5 +1,28 @@
 # Changelog
 
+## [Unreleased] - Wave 1-3 (PRs #320, #321, #322)
+
+### Added
+
+- `POST /api/ocr` dedicated endpoint for member card and handwriting OCR (#320)
+  - Supports `member_card` and `handwriting` modes
+  - Backend implementation in `backend/api/ocr.py`, delegates to OCRAgent
+- Reception gate in OrchestratorAgent — all chat queries check reception status before LLM routing (#321)
+- Welcome screen with 3 action buttons: member card scan / handwriting / voice (#321)
+- Device webhook interface for M5Stack and sensor integration (`frontend/src/lib/api/device-webhook.ts`) (#321)
+- `visitor_identity` parameter on `POST /api/reception/start` for OCR-identified visitors (#321)
+- `ainvoke_from_reception()` integration in `POST /api/reception/complete` — main workflow generates agent response using reception context (#321)
+- Smoke test script for reception flow
+
+### Fixed
+
+- HTML tags in TTS output (`clean_text_for_tts`) no longer read out tag names (#322)
+- Table data rows preserved in TTS output — previously deleted by HTML stripping (#322)
+- Slide content white rendering on rapid navigation — fixed with `requestAnimationFrame` and deduplication (#322)
+- `/api/character` 504 timeout — added 10s timeout with proper error response (#322)
+
+---
+
 ## [2026-02-15] - Backend Knowledge Base Complete Expansion (PR #76)
 
 ### Added

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -1,6 +1,6 @@
 # Current Status
 
-Last updated: 2026-03-14
+Last updated: 2026-03-22
 
 ## Summary
 
@@ -9,14 +9,16 @@ Engineer Cafe Navigator is in a stabilization phase, not a finished production p
 Confirmed current-state signals:
 
 - Main frontend routes now proxy to the FastAPI backend.
-- Recent merged PRs focused on hardening, proxy unification, env cleanup, autoplay fixes, VRM compatibility, and WebM-to-WAV conversion.
+- Wave 1 (PR #320): OCR frontend connection — `POST /api/ocr` endpoint and `backend/api/ocr.py` orchestration layer added.
+- Wave 2 (PR #321): Reception workflow integration — orchestrator gates on reception status, `POST /api/reception/start` accepts `visitor_identity`, `POST /api/reception/complete` calls `ainvoke_from_reception()`, Welcome screen with 3-button UI, device webhook interface added.
+- Wave 3 (PR #322): Bug fixes — TTS HTML tag handling, table row preservation, slide white rendering, `/api/character` 504 timeout.
 - Backend tests currently collect `2868` cases with `pytest --collect-only -q`.
 - Repository audit since 2025-12-14 shows `457` commits, `fix/feat = 1.07`, `test ratio = 2.0%`, and a recent fix streak of `5`.
 
 Implication:
 
 - Core functionality exists.
-- Quality pressure is visible.
+- Reception flow is now integrated end-to-end: sensor/button → OCR or voice → reception workflow → main agent.
 - Several high-risk operational gaps remain before production sign-off.
 
 ## Current Architecture
@@ -32,7 +34,9 @@ Implication:
 
 - FastAPI entrypoint in `backend/main.py`
 - LangGraph workflow for chat and domain routing
-- Dedicated APIs for chat, voice, slides, character, knowledge, STT vocabulary, and reception
+- Dedicated APIs for chat, voice, slides, character, knowledge, STT vocabulary, reception, and OCR
+- OrchestratorAgent gates on reception status before LLM routing
+- `ainvoke_from_reception()` in main workflow handles handoff from completed reception sessions
 - Supabase-backed data and external integrations
 
 ### Current GitHub context

--- a/docs/api/API-ja.md
+++ b/docs/api/API-ja.md
@@ -39,7 +39,7 @@ Engineer Cafe Navigator は 2 層構成の API を採用しています。
 
 フロントエンドの `/api/*` route は、そのままバックエンドそのものではありません。
 
-- `/api/voice`、`/api/qa`、`/api/slides`、`/api/character`、`/api/reception/*` はバックエンド route への proxy です。
+- `/api/voice`、`/api/qa`、`/api/slides`、`/api/character`、`/api/ocr`、`/api/reception/*` はバックエンド route への proxy です。
 - `/api/marp` はフロントエンド専用のレンダリング endpoint です。バックエンド `/api/slides/content` から markdown を取得し、`MarpProcessor` で HTML 化します。
 - `/api/admin/*` は edge 保護されたフロントエンド admin route です。バックエンドへ proxy するものと、フロントエンド側の admin utility を使うものがあります。
 
@@ -408,13 +408,52 @@ Authorization: Bearer <ADMIN_API_SECRET>
 - バックエンド `/api/stt/vocabulary` へ proxy します
 - 単一 item 操作の前に `id` 形式を検証します
 
+## OCR API
+
+### POST /api/ocr
+
+バックエンド `POST /api/ocr` への proxy です。カメラ画像から来訪者を識別します。
+
+サポートモード:
+
+- `member_card` — 会員証バーコードまたは ID のスキャン
+- `handwriting` — 手書きフォームからのテキスト抽出
+
+リクエスト例:
+
+```json
+{
+  "mode": "member_card",
+  "imageData": "base64-encoded-image",
+  "sessionId": "session-123"
+}
+```
+
+レスポンス例:
+
+```json
+{
+  "success": true,
+  "visitorIdentity": {
+    "memberId": "M-12345",
+    "name": "Engineer Taro"
+  },
+  "rawText": "M-12345 Engineer Taro",
+  "sessionId": "session-123"
+}
+```
+
+レート制限があります。制限超過時は `429 Too Many Requests` を返します。
+
+OCR バックエンドは `backend/api/ocr.py` に実装され、OCRAgent に処理を委譲します。
+
 ## Reception API
 
 フロントエンド reception route はバックエンド `/api/reception/*` へ proxy します。
 
 ### POST /api/reception/start
 
-reception session を開始します。
+reception session を開始します。OCR などで事前に識別済みの場合は `visitor_identity` フィールドを渡すことができます。
 
 リクエスト例:
 
@@ -422,9 +461,15 @@ reception session を開始します。
 {
   "session_id": "session-123",
   "language": "ja",
-  "trigger_type": "button_press"
+  "trigger_type": "button_press",
+  "visitor_identity": {
+    "memberId": "M-12345",
+    "name": "Engineer Taro"
+  }
 }
 ```
+
+`visitor_identity` は任意です。reception 開始前に身元が確定していない場合は省略してください。
 
 ### POST /api/reception/respond
 
@@ -442,7 +487,7 @@ reception 会話を継続します。
 
 ### POST /api/reception/complete
 
-reception から本体 workflow への handoff を完了します。
+reception を完了し、`ainvoke_from_reception()` 経由でメイン workflow を起動します。reception 中に収集した来訪者コンテキストを使ってエージェントが応答を生成します。
 
 リクエスト例:
 

--- a/docs/api/API.md
+++ b/docs/api/API.md
@@ -39,7 +39,7 @@ Notes:
 
 Frontend `/api/*` routes are not the backend itself. They are a proxy and integration layer:
 
-- `/api/voice`, `/api/qa`, `/api/slides`, `/api/character`, and `/api/reception/*` forward requests to backend routes.
+- `/api/voice`, `/api/qa`, `/api/slides`, `/api/character`, `/api/ocr`, and `/api/reception/*` forward requests to backend routes.
 - `/api/marp` is a frontend-only render endpoint. It fetches backend slide markdown from `/api/slides/content`, then renders it with `MarpProcessor`.
 - Admin routes under `/api/admin/*` are edge-protected frontend routes. Some proxy to backend APIs, and some use frontend-side admin utilities directly.
 
@@ -408,13 +408,52 @@ Current behavior:
 - Proxies to backend `/api/stt/vocabulary`
 - Validates `id` format before proxying single-item requests
 
+## OCR API
+
+### POST /api/ocr
+
+Frontend proxy for backend `POST /api/ocr`. Identifies visitors via camera image.
+
+Supported modes:
+
+- `member_card` — scan a membership card barcode or ID
+- `handwriting` — extract handwritten text from a form
+
+Example request:
+
+```json
+{
+  "mode": "member_card",
+  "imageData": "base64-encoded-image",
+  "sessionId": "session-123"
+}
+```
+
+Example response:
+
+```json
+{
+  "success": true,
+  "visitorIdentity": {
+    "memberId": "M-12345",
+    "name": "Taro Engineer"
+  },
+  "rawText": "M-12345 Taro Engineer",
+  "sessionId": "session-123"
+}
+```
+
+Rate limiting applies. Returns `429 Too Many Requests` when the limit is exceeded.
+
+The OCR backend is implemented in `backend/api/ocr.py` and delegates to OCRAgent for processing.
+
 ## Reception API
 
 Frontend reception routes proxy to backend `/api/reception/*`.
 
 ### POST /api/reception/start
 
-Starts a reception session.
+Starts a reception session. Accepts an optional `visitor_identity` field for pre-identified visitors (e.g. via OCR).
 
 Example request:
 
@@ -422,9 +461,15 @@ Example request:
 {
   "session_id": "session-123",
   "language": "ja",
-  "trigger_type": "button_press"
+  "trigger_type": "button_press",
+  "visitor_identity": {
+    "memberId": "M-12345",
+    "name": "Taro Engineer"
+  }
 }
 ```
+
+`visitor_identity` is optional. Omit it when identity has not been established before reception starts.
 
 ### POST /api/reception/respond
 
@@ -442,7 +487,7 @@ Example request:
 
 ### POST /api/reception/complete
 
-Completes reception handoff.
+Completes reception and invokes the main workflow via `ainvoke_from_reception()`. The backend generates an agent response using the full visitor context collected during reception.
 
 Example request:
 

--- a/docs/architecture/SYSTEM-ARCHITECTURE.md
+++ b/docs/architecture/SYSTEM-ARCHITECTURE.md
@@ -80,10 +80,13 @@ Engineer Cafe Navigator is a multilingual AI navigation system for the Engineer 
 
 ## 📊 Data Flow
 
+### Standard Chat Flow
+
 ```
 User Query → Frontend → FastAPI Backend (Python)
     ↓
 OrchestratorAgent (LLM-based Supervisor Pattern routing)
+  [Reception gate: checks if session has active reception before LLM routing]
     ↓
 [Route to Appropriate Specialized Agent]
     ├─→ BusinessInfoAgent (Enhanced RAG: hours, pricing, consultation, community)
@@ -97,6 +100,28 @@ Response Generation (OpenRouter LLM)
     ↓
 Frontend (Avatar + TTS + UI)
 ```
+
+### Reception Flow
+
+```
+Sensor/Button → Welcome Screen (3 buttons: member card / handwriting / voice)
+    ↓
+[Member card or handwriting path]
+    ↓
+POST /api/ocr → backend/api/ocr.py → OCRAgent → visitor_identity
+    ↓
+POST /api/reception/start (visitor_identity optional)
+    ↓
+Reception Workflow (purpose collection, visitor type classification)
+    ↓
+POST /api/reception/complete → ainvoke_from_reception() → Main Workflow
+    ↓
+OrchestratorAgent routes with visitor context
+    ↓
+Frontend (Avatar + TTS + UI)
+```
+
+Device integration (M5Stack, physical sensors) sends events to `frontend/src/lib/api/device-webhook.ts`, which triggers the Welcome screen.
 
 ### Query Processing Pipeline (LangGraph)
 1. **STT Processing**: Speech recognition with STT corrections (Vosk local / Google Cloud)

--- a/frontend/src/app/components/VoiceInterface.tsx
+++ b/frontend/src/app/components/VoiceInterface.tsx
@@ -43,6 +43,7 @@ export interface VoiceInterfaceMetadata {
 }
 
 export interface VoiceInterfaceRenderProps {
+  sessionId: string;
   sessionState: VoiceSessionState;
   characterState: VoiceCharacterState;
   transcript: string;
@@ -681,6 +682,7 @@ export default function VoiceInterface({
 
   const renderProps = useMemo<VoiceInterfaceRenderProps>(
     () => ({
+      sessionId: sessionIdRef.current,
       sessionState,
       characterState: voiceController.characterState,
       transcript,

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -40,6 +40,7 @@ import VoiceInterface, {
   type VoiceInterfaceMetadata,
   type VoiceSessionState,
 } from './components/VoiceInterface';
+import { ReceptionPanel } from '@/components/reception/ReceptionPanel';
 
 const overlayLabels = {
   ja: {
@@ -227,9 +228,15 @@ const getStageBackgroundStyle = (background: BackgroundOption): CSSProperties =>
   return background.value ? { backgroundColor: background.value } : {};
 };
 
+function createReceptionSessionId(): string {
+  return `reception_${Date.now()}_${Math.random().toString(36).slice(2, 9)}`;
+}
+
 export default function Home() {
   const [currentLanguage, setCurrentLanguage] = useState<'ja' | 'en'>('ja');
   const [showSlideMode, setShowSlideMode] = useState(false);
+  const [receptionCompleted, setReceptionCompleted] = useState(false);
+  const receptionSessionIdRef = useRef(createReceptionSessionId());
   const [characterBackground, setCharacterBackground] = useState<BackgroundOption>({
     id: 'engineer-cafe-bg',
     name: 'Engineer Cafe',
@@ -710,6 +717,20 @@ export default function Home() {
                   </div>
                 </div>
               ) : null}
+
+              {/* Reception overlay — shown until reception is completed */}
+              {!receptionCompleted && !showSlideMode && (
+                <div
+                  className="absolute inset-0 z-40 flex items-center justify-center bg-black/40 backdrop-blur-sm"
+                  style={screenPadding}
+                >
+                  <ReceptionPanel
+                    sessionId={receptionSessionIdRef.current}
+                    language={voice.currentLanguage}
+                    onReceptionComplete={() => setReceptionCompleted(true)}
+                  />
+                </div>
+              )}
             </main>
           </>
         );

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -228,15 +228,10 @@ const getStageBackgroundStyle = (background: BackgroundOption): CSSProperties =>
   return background.value ? { backgroundColor: background.value } : {};
 };
 
-function createReceptionSessionId(): string {
-  return `reception_${Date.now()}_${Math.random().toString(36).slice(2, 9)}`;
-}
-
 export default function Home() {
   const [currentLanguage, setCurrentLanguage] = useState<'ja' | 'en'>('ja');
   const [showSlideMode, setShowSlideMode] = useState(false);
   const [receptionCompleted, setReceptionCompleted] = useState(false);
-  const receptionSessionIdRef = useRef(createReceptionSessionId());
   const [characterBackground, setCharacterBackground] = useState<BackgroundOption>({
     id: 'engineer-cafe-bg',
     name: 'Engineer Cafe',
@@ -725,7 +720,7 @@ export default function Home() {
                   style={screenPadding}
                 >
                   <ReceptionPanel
-                    sessionId={receptionSessionIdRef.current}
+                    sessionId={voice.sessionId}
                     language={voice.currentLanguage}
                     onReceptionComplete={() => setReceptionCompleted(true)}
                   />

--- a/frontend/src/components/reception/ReceptionPanel.tsx
+++ b/frontend/src/components/reception/ReceptionPanel.tsx
@@ -285,9 +285,9 @@ export function ReceptionPanel({
         {(stage === 'camera_ocr' || stage === 'text_input') && (
           <OcrCameraView
             mode={stage === 'camera_ocr' ? 'member_card' : 'handwriting'}
-            language={language}
             onSuccess={handleOcrSuccess}
             onFallback={handleOcrFallback}
+            onSkip={handleOcrFallback}
           />
         )}
 

--- a/frontend/src/components/reception/ReceptionPanel.tsx
+++ b/frontend/src/components/reception/ReceptionPanel.tsx
@@ -1,17 +1,26 @@
 'use client';
 
-import { FormEvent, useEffect, useRef, useState } from 'react';
-import { Loader2, MessageSquare, Sparkles } from 'lucide-react';
+import { FormEvent, useCallback, useEffect, useRef, useState } from 'react';
+import { Camera, Loader2, MessageSquare, Mic, PenLine, Sparkles } from 'lucide-react';
 
 import { cn } from '@/lib/cn';
 import { useReception } from '@/hooks/useReception';
+import { OcrCameraView } from './OcrCameraView';
 import { StageIndicator } from './StageIndicator';
+import type { DeviceDetectionEvent } from '@/lib/api/device-webhook';
+
+// Import side-effects to register the global webhook handler
+import '@/lib/api/device-webhook';
+
+const WELCOME_TIMEOUT_MS = 10_000;
 
 interface ReceptionPanelProps {
   sessionId: string;
   language?: string;
   triggerType?: string;
   className?: string;
+  /** Called when reception is completed and the system should switch to chat mode. */
+  onReceptionComplete?: () => void;
 }
 
 export function ReceptionPanel({
@@ -19,9 +28,12 @@ export function ReceptionPanel({
   language = 'ja',
   triggerType = 'button_press',
   className,
+  onReceptionComplete,
 }: ReceptionPanelProps) {
   const [draft, setDraft] = useState('');
   const hasAutoCompletedRef = useRef(false);
+  const welcomeTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
   const {
     stage,
     error,
@@ -29,6 +41,10 @@ export function ReceptionPanel({
     purpose,
     messages,
     completion,
+    enterWelcome,
+    startOcr,
+    handleOcrSuccess,
+    handleOcrFallback,
     startReception,
     sendMessage,
     completeReception,
@@ -39,6 +55,28 @@ export function ReceptionPanel({
     triggerType,
   });
 
+  // --- 10-second welcome timeout ---
+  const clearWelcomeTimer = useCallback(() => {
+    if (welcomeTimerRef.current) {
+      clearTimeout(welcomeTimerRef.current);
+      welcomeTimerRef.current = null;
+    }
+  }, []);
+
+  useEffect(() => {
+    if (stage !== 'welcome') {
+      clearWelcomeTimer();
+      return;
+    }
+
+    welcomeTimerRef.current = setTimeout(() => {
+      startOcr('member_card');
+    }, WELCOME_TIMEOUT_MS);
+
+    return clearWelcomeTimer;
+  }, [clearWelcomeTimer, stage, startOcr]);
+
+  // --- Auto-complete when routing ---
   useEffect(() => {
     if (stage !== 'routing') {
       hasAutoCompletedRef.current = false;
@@ -55,6 +93,32 @@ export function ReceptionPanel({
     });
   }, [completeReception, isLoading, stage]);
 
+  // --- Notify parent on completion ---
+  useEffect(() => {
+    if (stage === 'completed' && onReceptionComplete) {
+      onReceptionComplete();
+    }
+  }, [onReceptionComplete, stage]);
+
+  // --- Device detection listener (#128) ---
+  useEffect(() => {
+    const handler = (event: Event) => {
+      const detail = (event as CustomEvent<DeviceDetectionEvent>).detail;
+      if (!detail) return;
+
+      // Only auto-trigger when idle
+      if (stage === 'idle') {
+        enterWelcome();
+      }
+    };
+
+    window.addEventListener('device-detection', handler);
+    return () => {
+      window.removeEventListener('device-detection', handler);
+    };
+  }, [enterWelcome, stage]);
+
+  // --- Form submit ---
   const handleSubmit = async (event: FormEvent<HTMLFormElement>) => {
     event.preventDefault();
     const message = draft.trim();
@@ -66,16 +130,35 @@ export function ReceptionPanel({
     await sendMessage(message);
   };
 
-  const isConversationActive = stage !== 'idle';
+  const handleWelcomeAction = (action: 'member_card' | 'handwriting' | 'voice') => {
+    clearWelcomeTimer();
+    if (action === 'member_card') {
+      startOcr('member_card');
+    } else if (action === 'handwriting') {
+      startOcr('handwriting');
+    } else {
+      void startReception();
+    }
+  };
+
+  const isConversationActive =
+    stage === 'greeting' ||
+    stage === 'purpose_hearing' ||
+    stage === 'routing' ||
+    stage === 'completed';
+
+  const showResetButton =
+    stage !== 'idle' && stage !== 'completed';
 
   return (
     <section
       className={cn(
         'w-full max-w-3xl rounded-2xl border border-slate-200 bg-white p-6 shadow-sm',
-        className
+        className,
       )}
     >
       <div className="flex flex-col gap-5">
+        {/* Header */}
         <div className="flex items-start justify-between gap-4">
           <div className="space-y-2">
             <span className="inline-flex items-center gap-2 rounded-full bg-slate-100 px-3 py-1 text-xs font-semibold text-slate-600">
@@ -84,15 +167,17 @@ export function ReceptionPanel({
             </span>
             <div className="space-y-1">
               <h2 className="text-2xl font-semibold text-balance text-slate-950">
-                Front Desk Conversation
+                {stage === 'idle'
+                  ? 'Front Desk'
+                  : stage === 'welcome'
+                    ? 'Welcome'
+                    : stage === 'camera_ocr' || stage === 'text_input'
+                      ? 'Card / Text Recognition'
+                      : 'Front Desk Conversation'}
               </h2>
-              <p className="text-sm text-pretty text-slate-600">
-                Start a guided reception flow, collect the visitor&apos;s purpose, and route them to
-                the right next action.
-              </p>
             </div>
           </div>
-          {isConversationActive && (
+          {showResetButton && (
             <button
               type="button"
               onClick={resetReception}
@@ -103,27 +188,108 @@ export function ReceptionPanel({
           )}
         </div>
 
-        <StageIndicator currentStage={stage} />
+        {/* Stage indicator — visible once past idle */}
+        {stage !== 'idle' && <StageIndicator currentStage={stage} />}
 
-        {!isConversationActive ? (
+        {/* === IDLE state === */}
+        {stage === 'idle' && (
           <div className="rounded-xl border border-dashed border-slate-300 bg-slate-50 p-8 text-center">
             <p className="mx-auto max-w-xl text-sm text-pretty text-slate-600">
-              Start reception when a visitor arrives. The assistant will greet them, ask their
-              purpose, and finalize routing once enough detail is collected.
+              来訪者が到着すると、センサーが自動で受付を開始します。
+              <br />
+              手動で開始することもできます。
             </p>
             <button
               type="button"
-              onClick={() => void startReception()}
+              onClick={() => enterWelcome()}
               disabled={isLoading}
               className="mt-5 inline-flex items-center justify-center rounded-lg bg-slate-900 px-4 py-2.5 text-sm font-semibold text-white transition-colors hover:bg-slate-800 disabled:cursor-not-allowed disabled:bg-slate-400"
             >
-              {isLoading ? <Loader2 className="size-4 animate-spin" aria-hidden="true" /> : null}
-              <span className={cn(isLoading && 'ml-2')}>Start Reception</span>
+              受付を開始
             </button>
-            {error ? <p className="mt-3 text-sm text-red-600">{error}</p> : null}
+            {error && <p className="mt-3 text-sm text-red-600">{error}</p>}
+
+            {/* Debug trigger — development only */}
+            {process.env.NODE_ENV === 'development' && (
+              <button
+                type="button"
+                onClick={() => enterWelcome()}
+                className="mt-4 block w-full text-center text-xs text-gray-400 transition-colors hover:text-gray-600"
+              >
+                Debug: Simulate visitor detection
+              </button>
+            )}
           </div>
-        ) : (
+        )}
+
+        {/* === WELCOME state === */}
+        {stage === 'welcome' && (
+          <div className="rounded-xl border border-slate-200 bg-gradient-to-b from-slate-50 to-white p-8">
+            <h3 className="text-center text-xl font-bold text-slate-900">
+              エンジニアカフェへようこそ！
+            </h3>
+            <p className="mt-2 text-center text-sm text-slate-600">
+              受付方法を選んでください
+            </p>
+
+            <div className="mt-6 flex flex-col gap-3">
+              <button
+                type="button"
+                onClick={() => handleWelcomeAction('member_card')}
+                className="flex items-center gap-3 rounded-xl border border-slate-200 bg-white px-5 py-4 text-left transition-colors hover:border-slate-400 hover:bg-slate-50"
+              >
+                <Camera className="size-6 shrink-0 text-slate-700" />
+                <div>
+                  <p className="font-semibold text-slate-900">会員証読み取り</p>
+                  <p className="text-xs text-slate-500">会員カードをカメラで読み取ります</p>
+                </div>
+              </button>
+
+              <button
+                type="button"
+                onClick={() => handleWelcomeAction('handwriting')}
+                className="flex items-center gap-3 rounded-xl border border-slate-200 bg-white px-5 py-4 text-left transition-colors hover:border-slate-400 hover:bg-slate-50"
+              >
+                <PenLine className="size-6 shrink-0 text-slate-700" />
+                <div>
+                  <p className="font-semibold text-slate-900">筆談</p>
+                  <p className="text-xs text-slate-500">手書きのメッセージを読み取ります</p>
+                </div>
+              </button>
+
+              <button
+                type="button"
+                onClick={() => handleWelcomeAction('voice')}
+                className="flex items-center gap-3 rounded-xl border border-slate-200 bg-white px-5 py-4 text-left transition-colors hover:border-slate-400 hover:bg-slate-50"
+              >
+                <Mic className="size-6 shrink-0 text-slate-700" />
+                <div>
+                  <p className="font-semibold text-slate-900">音声で話す</p>
+                  <p className="text-xs text-slate-500">マイクで直接お話しください</p>
+                </div>
+              </button>
+            </div>
+
+            <p className="mt-5 text-center text-xs text-slate-400">
+              10秒後に自動でカメラが起動します
+            </p>
+          </div>
+        )}
+
+        {/* === CAMERA_OCR / TEXT_INPUT state === */}
+        {(stage === 'camera_ocr' || stage === 'text_input') && (
+          <OcrCameraView
+            mode={stage === 'camera_ocr' ? 'member_card' : 'handwriting'}
+            language={language}
+            onSuccess={handleOcrSuccess}
+            onFallback={handleOcrFallback}
+          />
+        )}
+
+        {/* === Conversation states (greeting / purpose_hearing / routing / completed) === */}
+        {isConversationActive && (
           <>
+            {/* Message thread */}
             <div className="rounded-xl border border-slate-200 bg-slate-50 p-4">
               <div className="flex items-center gap-2 text-sm font-medium text-slate-700">
                 <MessageSquare className="size-4" aria-hidden="true" />
@@ -137,7 +303,7 @@ export function ReceptionPanel({
                       'max-w-[85%] rounded-2xl px-4 py-3 text-sm shadow-sm',
                       message.role === 'assistant'
                         ? 'bg-white text-slate-800'
-                        : 'ml-auto bg-slate-900 text-white'
+                        : 'ml-auto bg-slate-900 text-white',
                     )}
                   >
                     <p className="text-pretty">{message.text}</p>
@@ -146,15 +312,21 @@ export function ReceptionPanel({
               </div>
             </div>
 
-            {purpose ? (
+            {/* Purpose display */}
+            {purpose && (
               <p className="text-sm text-slate-600">
-                Current purpose: <span className="font-medium text-slate-900">{purpose}</span>
+                Current purpose:{' '}
+                <span className="font-medium text-slate-900">{purpose}</span>
               </p>
-            ) : null}
+            )}
 
+            {/* Input form — hidden when completed */}
             {stage !== 'completed' ? (
               <form className="space-y-3" onSubmit={(event) => void handleSubmit(event)}>
-                <label className="block text-sm font-medium text-slate-700" htmlFor="reception-message">
+                <label
+                  className="block text-sm font-medium text-slate-700"
+                  htmlFor="reception-message"
+                >
                   Visitor response
                 </label>
                 <textarea
@@ -173,8 +345,12 @@ export function ReceptionPanel({
                     disabled={isLoading || !draft.trim()}
                     className="inline-flex items-center justify-center rounded-lg bg-slate-900 px-4 py-2.5 text-sm font-semibold text-white transition-colors hover:bg-slate-800 disabled:cursor-not-allowed disabled:bg-slate-400"
                   >
-                    {isLoading ? <Loader2 className="size-4 animate-spin" aria-hidden="true" /> : null}
-                    <span className={cn(isLoading && 'ml-2')}>{stage === 'routing' ? 'Finalizing' : 'Send Response'}</span>
+                    {isLoading && (
+                      <Loader2 className="size-4 animate-spin" aria-hidden="true" />
+                    )}
+                    <span className={cn(isLoading && 'ml-2')}>
+                      {stage === 'routing' ? 'Finalizing' : 'Send Response'}
+                    </span>
                   </button>
                 </div>
               </form>
@@ -182,17 +358,27 @@ export function ReceptionPanel({
               <div className="rounded-xl border border-emerald-200 bg-emerald-50 p-4 text-sm text-slate-700">
                 <p className="font-semibold text-slate-900">Reception completed</p>
                 <p className="mt-1 text-pretty">{completion?.response_text}</p>
-                {completion?.target_agent ? (
+                {completion?.target_agent && (
                   <p className="mt-3">
-                    Route to: <span className="font-medium text-slate-900">{completion.target_agent}</span>
+                    Route to:{' '}
+                    <span className="font-medium text-slate-900">
+                      {completion.target_agent}
+                    </span>
                   </p>
-                ) : null}
-                {completion?.requires_staff ? (
-                  <p className="mt-1 text-slate-600">Staff assistance is required for this visitor.</p>
-                ) : null}
+                )}
+                {completion?.requires_staff && (
+                  <p className="mt-1 text-slate-600">
+                    Staff assistance is required for this visitor.
+                  </p>
+                )}
               </div>
             )}
           </>
+        )}
+
+        {/* Global error (visible in all non-idle states that don't already show it) */}
+        {error && !isConversationActive && stage !== 'idle' && (
+          <p className="text-center text-sm text-red-600">{error}</p>
         )}
       </div>
     </section>

--- a/frontend/src/components/reception/ReceptionPanel.tsx
+++ b/frontend/src/components/reception/ReceptionPanel.tsx
@@ -55,6 +55,12 @@ export function ReceptionPanel({
     triggerType,
   });
 
+  // Wrap resetReception to also clear the auto-complete guard
+  const handleReset = useCallback(() => {
+    hasAutoCompletedRef.current = false;
+    resetReception();
+  }, [resetReception]);
+
   // --- 10-second welcome timeout ---
   const clearWelcomeTimer = useCallback(() => {
     if (welcomeTimerRef.current) {
@@ -79,7 +85,6 @@ export function ReceptionPanel({
   // --- Auto-complete when routing ---
   useEffect(() => {
     if (stage !== 'routing') {
-      hasAutoCompletedRef.current = false;
       return;
     }
 
@@ -89,7 +94,7 @@ export function ReceptionPanel({
 
     hasAutoCompletedRef.current = true;
     void completeReception().catch(() => {
-      hasAutoCompletedRef.current = false;
+      // Don't reset on error — let manual retry handle it
     });
   }, [completeReception, isLoading, stage]);
 
@@ -180,7 +185,7 @@ export function ReceptionPanel({
           {showResetButton && (
             <button
               type="button"
-              onClick={resetReception}
+              onClick={handleReset}
               className="rounded-lg border border-slate-300 px-3 py-2 text-sm font-medium text-slate-700 transition-colors hover:bg-slate-50"
             >
               Reset

--- a/frontend/src/components/reception/StageIndicator.tsx
+++ b/frontend/src/components/reception/StageIndicator.tsx
@@ -6,21 +6,27 @@ import { cn } from '@/lib/cn';
 import type { ReceptionStage } from '@/lib/reception-api';
 
 const STAGES = [
+  { key: 'welcome', label: 'Welcome' },
   { key: 'greeting', label: 'Greeting' },
   { key: 'purpose_hearing', label: 'Purpose' },
   { key: 'routing', label: 'Routing' },
   { key: 'completed', label: 'Complete' },
 ] as const;
 
+/** Maps any stage to the corresponding index in the STAGES array. */
+function resolveActiveIndex(currentStage: ReceptionStage): number {
+  if (currentStage === 'idle') return -1;
+  // camera_ocr and text_input are sub-states of welcome
+  if (currentStage === 'camera_ocr' || currentStage === 'text_input') return 0;
+  return STAGES.findIndex((s) => s.key === currentStage);
+}
+
 interface StageIndicatorProps {
   currentStage: ReceptionStage;
 }
 
 export function StageIndicator({ currentStage }: StageIndicatorProps) {
-  const activeIndex =
-    currentStage === 'idle'
-      ? -1
-      : STAGES.findIndex((stage) => stage.key === currentStage);
+  const activeIndex = resolveActiveIndex(currentStage);
 
   return (
     <ol className="flex items-start gap-3" aria-label="Reception progress">
@@ -36,7 +42,7 @@ export function StageIndicator({ currentStage }: StageIndicatorProps) {
                   'flex size-8 items-center justify-center rounded-full border text-sm font-semibold',
                   isCompleted && 'border-emerald-600 bg-emerald-600 text-white',
                   isCurrent && 'border-slate-900 bg-slate-900 text-white',
-                  !isCompleted && !isCurrent && 'border-slate-300 bg-white text-slate-400'
+                  !isCompleted && !isCurrent && 'border-slate-300 bg-white text-slate-400',
                 )}
               >
                 {isCompleted ? <Check className="size-4" aria-hidden="true" /> : index + 1}
@@ -44,7 +50,7 @@ export function StageIndicator({ currentStage }: StageIndicatorProps) {
               <span
                 className={cn(
                   'text-center text-xs font-medium',
-                  isCompleted || isCurrent ? 'text-slate-900' : 'text-slate-400'
+                  isCompleted || isCurrent ? 'text-slate-900' : 'text-slate-400',
                 )}
               >
                 {stage.label}
@@ -54,7 +60,7 @@ export function StageIndicator({ currentStage }: StageIndicatorProps) {
               <div
                 className={cn(
                   'mt-4 h-px flex-1',
-                  activeIndex > index ? 'bg-emerald-600' : 'bg-slate-200'
+                  activeIndex > index ? 'bg-emerald-600' : 'bg-slate-200',
                 )}
                 aria-hidden="true"
               />

--- a/frontend/src/hooks/useReception.ts
+++ b/frontend/src/hooks/useReception.ts
@@ -121,8 +121,9 @@ export function useReception({
   const handleOcrSuccess = useCallback(
     (result: OcrResponse) => {
       const identity: VisitorIdentity = {
-        user_id: result.member_id ? parseInt(result.member_id, 10) || undefined : undefined,
-        name: result.visitor_name,
+        user_id: result.member_number ?? undefined,
+        name: result.recognized_text ?? undefined,
+        ...(result.visitor_identity as Partial<VisitorIdentity> | undefined),
       };
       void startReception(identity);
     },

--- a/frontend/src/hooks/useReception.ts
+++ b/frontend/src/hooks/useReception.ts
@@ -121,10 +121,8 @@ export function useReception({
   const handleOcrSuccess = useCallback(
     (result: OcrResponse) => {
       const identity: VisitorIdentity = {
-        member_id: result.member_id,
-        visitor_name: result.visitor_name,
-        ocr_text: result.text,
-        ocr_confidence: result.confidence,
+        user_id: result.member_id ? parseInt(result.member_id, 10) || undefined : undefined,
+        name: result.visitor_name,
       };
       void startReception(identity);
     },
@@ -159,7 +157,7 @@ export function useReception({
         startTransition(() => {
           setStage(result.stage);
           setResponseText(result.response);
-          setPurpose(result.purpose);
+          setPurpose(result.purpose?.category ?? null);
           setMessages((currentMessages) => [
             ...currentMessages,
             createMessage('assistant', result.response),

--- a/frontend/src/hooks/useReception.ts
+++ b/frontend/src/hooks/useReception.ts
@@ -1,6 +1,6 @@
 'use client';
 
-import { startTransition, useState } from 'react';
+import { startTransition, useCallback, useState } from 'react';
 
 import {
   completeReception as completeReceptionRequest,
@@ -8,7 +8,9 @@ import {
   startReception as startReceptionRequest,
   type CompleteReceptionResponse,
   type ReceptionStage,
+  type VisitorIdentity,
 } from '@/lib/reception-api';
+import type { OcrResponse } from '@/lib/api/ocr-api';
 
 export interface ReceptionMessage {
   id: string;
@@ -31,7 +33,11 @@ interface UseReceptionResult {
   receptionSessionId: string | null;
   completion: CompleteReceptionResponse | null;
   messages: ReceptionMessage[];
-  startReception: () => Promise<void>;
+  enterWelcome: () => void;
+  startOcr: (mode: 'member_card' | 'handwriting') => void;
+  handleOcrSuccess: (result: OcrResponse) => void;
+  handleOcrFallback: () => void;
+  startReception: (identity?: VisitorIdentity) => Promise<void>;
   sendMessage: (message: string) => Promise<void>;
   completeReception: () => Promise<CompleteReceptionResponse>;
   resetReception: () => void;
@@ -59,7 +65,7 @@ export function useReception({
   const [completion, setCompletion] = useState<CompleteReceptionResponse | null>(null);
   const [messages, setMessages] = useState<ReceptionMessage[]>([]);
 
-  const resetReception = () => {
+  const resetReception = useCallback(() => {
     setStage('idle');
     setResponseText(null);
     setPurpose(null);
@@ -68,68 +74,109 @@ export function useReception({
     setReceptionSessionId(null);
     setCompletion(null);
     setMessages([]);
-  };
+  }, []);
 
-  const startReception = async () => {
-    setIsLoading(true);
+  const enterWelcome = useCallback(() => {
+    setStage('welcome');
     setError(null);
+  }, []);
 
-    try {
-      const result = await startReceptionRequest({
-        session_id: sessionId,
-        language,
-        trigger_type: triggerType,
-      });
-
-      startTransition(() => {
-        setReceptionSessionId(result.reception_session_id);
-        setStage(result.stage);
-        setResponseText(result.greeting);
-        setPurpose(null);
-        setCompletion(null);
-        setMessages([createMessage('assistant', result.greeting)]);
-      });
-    } catch (requestError) {
-      setError(requestError instanceof Error ? requestError.message : 'Failed to start reception');
-    } finally {
-      setIsLoading(false);
-    }
-  };
-
-  const sendMessage = async (message: string) => {
-    const trimmedMessage = message.trim();
-    if (!trimmedMessage || !receptionSessionId) {
-      return;
-    }
-
-    setIsLoading(true);
+  const startOcr = useCallback((mode: 'member_card' | 'handwriting') => {
+    setStage(mode === 'member_card' ? 'camera_ocr' : 'text_input');
     setError(null);
-    setMessages((currentMessages) => [...currentMessages, createMessage('visitor', trimmedMessage)]);
+  }, []);
 
-    try {
-      const result = await respondReception({
-        session_id: sessionId,
-        reception_session_id: receptionSessionId,
-        message: trimmedMessage,
-      });
+  const startReception = useCallback(
+    async (identity?: VisitorIdentity) => {
+      setIsLoading(true);
+      setError(null);
 
-      startTransition(() => {
-        setStage(result.stage);
-        setResponseText(result.response);
-        setPurpose(result.purpose);
-        setMessages((currentMessages) => [
-          ...currentMessages,
-          createMessage('assistant', result.response),
-        ]);
-      });
-    } catch (requestError) {
-      setError(requestError instanceof Error ? requestError.message : 'Failed to send message');
-    } finally {
-      setIsLoading(false);
-    }
-  };
+      try {
+        const result = await startReceptionRequest({
+          session_id: sessionId,
+          language,
+          trigger_type: triggerType,
+          visitor_identity: identity,
+        });
 
-  const completeReception = async (): Promise<CompleteReceptionResponse> => {
+        startTransition(() => {
+          setReceptionSessionId(result.reception_session_id);
+          setStage(result.stage);
+          setResponseText(result.greeting);
+          setPurpose(null);
+          setCompletion(null);
+          setMessages([createMessage('assistant', result.greeting)]);
+        });
+      } catch (requestError) {
+        setError(
+          requestError instanceof Error ? requestError.message : 'Failed to start reception',
+        );
+      } finally {
+        setIsLoading(false);
+      }
+    },
+    [language, sessionId, triggerType],
+  );
+
+  const handleOcrSuccess = useCallback(
+    (result: OcrResponse) => {
+      const identity: VisitorIdentity = {
+        member_id: result.member_id,
+        visitor_name: result.visitor_name,
+        ocr_text: result.text,
+        ocr_confidence: result.confidence,
+      };
+      void startReception(identity);
+    },
+    [startReception],
+  );
+
+  const handleOcrFallback = useCallback(() => {
+    void startReception();
+  }, [startReception]);
+
+  const sendMessage = useCallback(
+    async (message: string) => {
+      const trimmedMessage = message.trim();
+      if (!trimmedMessage || !receptionSessionId) {
+        return;
+      }
+
+      setIsLoading(true);
+      setError(null);
+      setMessages((currentMessages) => [
+        ...currentMessages,
+        createMessage('visitor', trimmedMessage),
+      ]);
+
+      try {
+        const result = await respondReception({
+          session_id: sessionId,
+          reception_session_id: receptionSessionId,
+          message: trimmedMessage,
+        });
+
+        startTransition(() => {
+          setStage(result.stage);
+          setResponseText(result.response);
+          setPurpose(result.purpose);
+          setMessages((currentMessages) => [
+            ...currentMessages,
+            createMessage('assistant', result.response),
+          ]);
+        });
+      } catch (requestError) {
+        setError(
+          requestError instanceof Error ? requestError.message : 'Failed to send message',
+        );
+      } finally {
+        setIsLoading(false);
+      }
+    },
+    [receptionSessionId, sessionId],
+  );
+
+  const completeReception = useCallback(async (): Promise<CompleteReceptionResponse> => {
     if (!receptionSessionId) {
       throw new Error('Reception session has not started');
     }
@@ -163,7 +210,7 @@ export function useReception({
     } finally {
       setIsLoading(false);
     }
-  };
+  }, [receptionSessionId, sessionId]);
 
   return {
     stage,
@@ -174,6 +221,10 @@ export function useReception({
     receptionSessionId,
     completion,
     messages,
+    enterWelcome,
+    startOcr,
+    handleOcrSuccess,
+    handleOcrFallback,
     startReception,
     sendMessage,
     completeReception,

--- a/frontend/src/lib/api/device-webhook.ts
+++ b/frontend/src/lib/api/device-webhook.ts
@@ -1,0 +1,23 @@
+export interface DeviceDetectionEvent {
+  type: 'sensor_triggered' | 'nfc_detected' | 'button_pressed';
+  device_id?: string;
+  timestamp: string;
+  data?: Record<string, unknown>;
+}
+
+/** Dispatch a custom event that ReceptionPanel listens to. */
+export function handleDeviceDetection(event: DeviceDetectionEvent): void {
+  window.dispatchEvent(new CustomEvent('device-detection', { detail: event }));
+}
+
+// Expose globally for external device integration (M5Stack, NFC readers, etc.)
+if (typeof window !== 'undefined') {
+  const win = window as unknown as Record<string, unknown>;
+  const existing =
+    typeof win.__engineerCafe === 'object' ? win.__engineerCafe : {};
+
+  win.__engineerCafe = {
+    ...(existing as Record<string, unknown>),
+    triggerDetection: handleDeviceDetection,
+  };
+}

--- a/frontend/src/lib/reception-api.ts
+++ b/frontend/src/lib/reception-api.ts
@@ -11,10 +11,10 @@ export type ReceptionStage =
 export type ReceptionActiveStage = Exclude<ReceptionStage, 'idle' | 'welcome' | 'camera_ocr' | 'text_input'>;
 
 export interface VisitorIdentity {
-  member_id?: string;
-  visitor_name?: string;
-  ocr_text?: string;
-  ocr_confidence?: number;
+  user_id?: number;
+  name?: string;
+  visit_count?: number;
+  last_purpose?: { category: string; detail?: string };
 }
 
 export interface StartReceptionRequest {
@@ -39,7 +39,7 @@ export interface RespondReceptionRequest {
 export interface RespondReceptionResponse {
   response: string;
   stage: ReceptionActiveStage;
-  purpose: string | null;
+  purpose: { category: string; detail?: string } | null;
   next_action: string | null;
 }
 

--- a/frontend/src/lib/reception-api.ts
+++ b/frontend/src/lib/reception-api.ts
@@ -1,10 +1,27 @@
-export type ReceptionStage = 'idle' | 'greeting' | 'purpose_hearing' | 'routing' | 'completed';
-export type ReceptionActiveStage = Exclude<ReceptionStage, 'idle'>;
+export type ReceptionStage =
+  | 'idle'
+  | 'welcome'
+  | 'camera_ocr'
+  | 'text_input'
+  | 'greeting'
+  | 'purpose_hearing'
+  | 'routing'
+  | 'completed';
+
+export type ReceptionActiveStage = Exclude<ReceptionStage, 'idle' | 'welcome' | 'camera_ocr' | 'text_input'>;
+
+export interface VisitorIdentity {
+  member_id?: string;
+  visitor_name?: string;
+  ocr_text?: string;
+  ocr_confidence?: number;
+}
 
 export interface StartReceptionRequest {
   session_id: string;
   language: string;
   trigger_type: string;
+  visitor_identity?: VisitorIdentity;
 }
 
 export interface StartReceptionResponse {


### PR DESCRIPTION
## Summary

Reception Workflowをメインチャットフロー(/api/chat)に統合し、受付フローが適切にゲーティングされるようにする。

### Backend Changes
- **Orchestrator reception gate**: /api/chat の orchestrator ノードで受付状態をチェック。active な受付セッションが未完了なら受付フローに強制ルーティング（LLM呼び出し前に短絡）。受付セッションが存在しない場合は通常チャットを許可。
- **OCR → Reception injection**: /api/reception/start に VisitorIdentityInput パラメータ追加。OCR識別済みの場合パーソナライズド挨拶。greeting段階でvisitor_identityが上書きされないよう保護。
- **Reception → Agent auto-transition**: complete_reception で ainvoke_from_reception() を呼び出し、専門エージェントの応答を返却。
- **Session lookup改善**: UUID以外のsession_id対応、completed sessionも検索対象に含む。

### Frontend Changes
- **Welcome画面**: 3ボタン（会員証読み取り / 筆談 / 音声で話す）+ 10秒自動タイムアウト
- **OcrCameraView統合**: カメラ→OCR→visitor_identity→受付開始のパイプライン
- **デバイスwebhook (#128)**: window.__engineerCafe.triggerDetection() でM5Stack/センサー連携
- **Reception overlay**: 受付完了まで全画面オーバーレイ、完了後にチャットモード遷移
- **Session ID共有**: ReceptionPanelとVoiceInterfaceが同一session_idを使用

### Security
- VisitorIdentityInput Pydantic model で入力バリデーション
- エラーメッセージからsession_id除去
- reception_session_id Path パラメータバリデーション
- fail-open時にstage="error"で区別可能

### Testing
- Smoke test script: backend/tests/smoke/test_reception_flow.sh

## Review History (3 rounds)
1. code-reviewer: CRITICAL 3 + HIGH 6 → 全修正
2. Codex CLI: P0 1 + P1 2 + P2 2 → 全修正
3. CI: ruff + black + pnpm lint + typecheck + build 全パス

## Relates
- Closes #319
- Partially addresses #117 (自律受付フロー統合)
- Partially addresses #165 (Reception統合境界分析)
- Partially addresses #128 (デバイス検知 — webhookインターフェース)

## Test plan
- [x] Backend: ruff + black ✅
- [x] Frontend: lint + typecheck + build ✅
- [ ] Smoke test: bash backend/tests/smoke/test_reception_flow.sh
- [ ] E2E: OCR camera → reception → agent chat flow

🤖 Generated with [Claude Code](https://claude.com/claude-code)