### PR TITLE
fix: wave 3 bugfixes — TTS, character timeout, slide rendering

### DIFF
--- a/backend/agents/voice_agent.py
+++ b/backend/agents/voice_agent.py
@@ -217,17 +217,14 @@ def clean_text_for_tts(text: str) -> str:
     # Horizontal rules: ---, ***, ___ (3+ chars on their own line)
     t = re.sub(r"^[-\*_]{3,}\s*$", "", t, flags=re.M)
 
-    # HTML tags: only strip common HTML tags that LLMs may emit
-    # (preserves non-HTML angle brackets like vector<int>, 1 < 2)
+    # HTML tags: strip common HTML tags that LLMs may emit, replacing with
+    # space to prevent word concatenation (e.g. "</p><p>" won't merge text).
+    # Preserves non-HTML angle brackets like vector<int>, 1 < 2.
     _html_tags = (
         r"(?:br|p|div|span|strong|em|b|i|u|a|h[1-6]"
         r"|ul|ol|li|table|tr|td|th|hr|img|pre|code|blockquote)"
     )
-    # Remove closing tags entirely: </div> -> ""
-    t = re.sub(rf"</(?:{_html_tags})(?=[\s>])[^>]*>", "", t, flags=re.I)
-    # Opening/self-closing tags: keep tag name for readability
-    # <div class="x"> -> "div", <br/> -> "br"
-    t = re.sub(rf"<({_html_tags})(?=[\s>/])[^>]*/?>", r"\1", t, flags=re.I)
+    t = re.sub(rf"</?(?:{_html_tags})(?=[\s>/])[^>]*/?>", " ", t, flags=re.I)
 
     # Table syntax: remove separator rows, convert data rows to plain text
     # Separator rows: |---|---| or |:---:|:---:| etc.

--- a/backend/agents/voice_agent.py
+++ b/backend/agents/voice_agent.py
@@ -217,23 +217,21 @@ def clean_text_for_tts(text: str) -> str:
     # Horizontal rules: ---, ***, ___ (3+ chars on their own line)
     t = re.sub(r"^[-\*_]{3,}\s*$", "", t, flags=re.M)
 
-    # HTML tags: strip common HTML tags that LLMs may emit, replacing with
-    # space to prevent word concatenation (e.g. "</p><p>" won't merge text).
-    # Preserves non-HTML angle brackets like vector<int>, 1 < 2.
-    _html_tags = (
-        r"(?:br|p|div|span|strong|em|b|i|u|a|h[1-6]"
-        r"|ul|ol|li|table|tr|td|th|hr|img|pre|code|blockquote)"
+    # HTML tags: replace with space to prevent word concatenation
+    # (preserves non-HTML angle brackets like vector<int>, 1 < 2)
+    t = re.sub(
+        r"</?(?:br|p|div|span|strong|em|b|i|u|a|h[1-6]"
+        r"|ul|ol|li|table|tr|td|th|hr|img|pre|code|blockquote)(?=[\s>/])[^>]*>",
+        " ",
+        t,
+        flags=re.I,
     )
-    t = re.sub(rf"</?(?:{_html_tags})(?=[\s>/])[^>]*/?>", " ", t, flags=re.I)
 
     # Table syntax: remove separator rows, convert data rows to plain text
-    # Separator rows: |---|---| or |:---:|:---:| etc.
     t = re.sub(r"^\|?[-:]+\|[-:|]+\|?\s*$", "", t, flags=re.M)
-    # Data rows: remove pipe characters but keep cell content as plain text
-    # Only match lines with 2+ pipes (preserves single pipe in e.g. grep foo | sort)
     t = re.sub(
-        r"^(\s*\|.*\|.*)$",
-        lambda m: re.sub(r"\|", " ", m.group(1)).strip(),
+        r"^\s*\|(.+\|.+)\s*$",
+        lambda m: m.group(1).replace("|", " ").strip(),
         t,
         flags=re.M,
     )

--- a/backend/agents/voice_agent.py
+++ b/backend/agents/voice_agent.py
@@ -219,18 +219,27 @@ def clean_text_for_tts(text: str) -> str:
 
     # HTML tags: only strip common HTML tags that LLMs may emit
     # (preserves non-HTML angle brackets like vector<int>, 1 < 2)
-    t = re.sub(
-        r"</?(?:br|p|div|span|strong|em|b|i|u|a|h[1-6]"
-        r"|ul|ol|li|table|tr|td|th|hr|img|pre|code|blockquote)(?=[\s>/])[^>]*>",
-        "",
-        t,
-        flags=re.I,
+    _html_tags = (
+        r"(?:br|p|div|span|strong|em|b|i|u|a|h[1-6]"
+        r"|ul|ol|li|table|tr|td|th|hr|img|pre|code|blockquote)"
     )
+    # Remove closing tags entirely: </div> -> ""
+    t = re.sub(rf"</(?:{_html_tags})(?=[\s>])[^>]*>", "", t, flags=re.I)
+    # Opening/self-closing tags: keep tag name for readability
+    # <div class="x"> -> "div", <br/> -> "br"
+    t = re.sub(rf"<({_html_tags})(?=[\s>/])[^>]*/?>", r"\1", t, flags=re.I)
 
-    # Table syntax: remove separator rows and table-like lines (2+ pipes)
-    # but preserve single pipes in technical content (e.g. grep foo | sort)
+    # Table syntax: remove separator rows, convert data rows to plain text
+    # Separator rows: |---|---| or |:---:|:---:| etc.
     t = re.sub(r"^\|?[-:]+\|[-:|]+\|?\s*$", "", t, flags=re.M)
-    t = re.sub(r"^\s*\|.*\|.*$", "", t, flags=re.M)
+    # Data rows: remove pipe characters but keep cell content as plain text
+    # Only match lines with 2+ pipes (preserves single pipe in e.g. grep foo | sort)
+    t = re.sub(
+        r"^(\s*\|.*\|.*)$",
+        lambda m: re.sub(r"\|", " ", m.group(1)).strip(),
+        t,
+        flags=re.M,
+    )
 
     # Convert markdown links [text](url) -> text
     t = re.sub(r"\[([^\]]+)\]\([^)]+\)", r"\1", t)

--- a/backend/main.py
+++ b/backend/main.py
@@ -868,16 +868,25 @@ async def character_api(request: Request, body: CharacterRequest):
         from backend.agents.character_control_agent import CharacterControlAgent
 
         agent = CharacterControlAgent()
-        result = await agent.process(
-            emotion=body.emotion or "neutral",
-            text=None,
-            context={"action": body.action, "animation": body.animation},
+        result = await asyncio.wait_for(
+            agent.process(
+                emotion=body.emotion or "neutral",
+                text=None,
+                context={"action": body.action, "animation": body.animation},
+            ),
+            timeout=10.0,
         )
         return CharacterResponse(
             success=True,
             message=(
                 json.dumps(result, ensure_ascii=False) if isinstance(result, dict) else str(result)
             ),
+        )
+    except asyncio.TimeoutError:
+        logger.warning("CharacterControlAgent timed out after 10s")
+        return CharacterResponse(
+            success=True,
+            message="Character action timed out",
         )
     except Exception as e:
         logger.exception("Endpoint error: %s", e)

--- a/backend/main.py
+++ b/backend/main.py
@@ -17,7 +17,7 @@ from io import BytesIO
 
 from fastapi import Depends, FastAPI, HTTPException
 from fastapi.middleware.cors import CORSMiddleware
-from fastapi.responses import JSONResponse, StreamingResponse
+from fastapi.responses import StreamingResponse
 from pydantic import BaseModel, Field
 from typing import Optional, Dict, Any, cast
 
@@ -884,9 +884,9 @@ async def character_api(request: Request, body: CharacterRequest):
         )
     except asyncio.TimeoutError:
         logger.warning("CharacterControlAgent timed out after 10s")
-        return JSONResponse(
+        raise HTTPException(
             status_code=504,
-            content={"success": False, "error": "Character action timed out"},
+            detail="Character action timed out",
         )
     except Exception as e:
         logger.exception("Endpoint error: %s", e)

--- a/backend/main.py
+++ b/backend/main.py
@@ -17,7 +17,7 @@ from io import BytesIO
 
 from fastapi import Depends, FastAPI, HTTPException
 from fastapi.middleware.cors import CORSMiddleware
-from fastapi.responses import StreamingResponse
+from fastapi.responses import JSONResponse, StreamingResponse
 from pydantic import BaseModel, Field
 from typing import Optional, Dict, Any, cast
 
@@ -884,9 +884,9 @@ async def character_api(request: Request, body: CharacterRequest):
         )
     except asyncio.TimeoutError:
         logger.warning("CharacterControlAgent timed out after 10s")
-        return CharacterResponse(
-            success=True,
-            message="Character action timed out",
+        return JSONResponse(
+            status_code=504,
+            content={"success": False, "error": "Character action timed out"},
         )
     except Exception as e:
         logger.exception("Endpoint error: %s", e)

--- a/backend/tests/agents/test_voice_agent.py
+++ b/backend/tests/agents/test_voice_agent.py
@@ -79,8 +79,9 @@ def test_clean_text_for_tts_preserves_technical_symbols_and_single_pipes():
     assert "</p>" not in cleaned
     assert "vector<int>" in cleaned
     assert "1 < 2" in cleaned
-    assert "name" not in cleaned
-    assert "value" not in cleaned
+    # Table data rows are converted to plain text (pipes removed, content kept)
+    assert "name" in cleaned
+    assert "value" in cleaned
     assert "grep foo | sort" in cleaned
 
 

--- a/frontend/src/app/components/MarpViewer.tsx
+++ b/frontend/src/app/components/MarpViewer.tsx
@@ -141,6 +141,7 @@ export default function MarpViewer({
   const stopAutoPlayRef = useRef<() => void>(() => {});
   const previousSlideRef = useRef<() => Promise<void>>(async () => {});
   const updateIframeSlideRef = useRef<(slideNumber: number, retryCount?: number) => void>(() => {});
+  const lastRenderedSlideRef = useRef<number>(0);
   const isNarratingRef = useRef(isNarrating);
   const isNarrationInProgressRef = useRef(isNarrationInProgress);
   const isPlayingRef = useRef(isPlaying);
@@ -1041,25 +1042,28 @@ export default function MarpViewer({
   };
 
   const updateIframeSlide = (slideNumber: number, retryCount = 0) => {
+    // Early return if slide hasn't changed (skip for retries finding DOM elements)
+    if (retryCount === 0 && slideNumber === lastRenderedSlideRef.current) return;
+
     if (iframeRef.current && iframeRef.current.contentWindow) {
       try {
         const iframeDoc = iframeRef.current.contentDocument || iframeRef.current.contentWindow.document;
-        
+
         // Try multiple selectors for better compatibility
         let slides = iframeDoc.querySelectorAll('section[data-marpit-fragment]');
-        
+
         if (slides.length === 0) {
           slides = iframeDoc.querySelectorAll('.marpit > svg');
         }
-        
+
         if (slides.length === 0) {
           slides = iframeDoc.querySelectorAll('[data-marpit-svg]');
         }
-        
+
         if (slides.length === 0) {
           slides = iframeDoc.querySelectorAll('div.marpit > svg');
         }
-        
+
         // If still no slides and haven't retried too many times, retry after delay
         if (slides.length === 0 && retryCount < 10) {
           setTimeout(() => {
@@ -1067,35 +1071,39 @@ export default function MarpViewer({
           }, 200);
           return;
         }
-        
+
         if (slides.length === 0) {
           console.error('No slides found after multiple attempts');
           return;
         }
-        
-        
-        // Hide all slides
-        slides.forEach((slide) => {
-          const el = slide as HTMLElement;
-          el.style.display = 'none';
-          el.style.visibility = 'hidden';
+
+        lastRenderedSlideRef.current = slideNumber;
+
+        // Use requestAnimationFrame to batch DOM mutations and avoid blank frames
+        requestAnimationFrame(() => {
+          // Hide all slides
+          slides.forEach((slide) => {
+            const el = slide as HTMLElement;
+            el.style.display = 'none';
+            el.style.visibility = 'hidden';
+          });
+
+          // Show only the current slide
+          if (slides[slideNumber - 1]) {
+            const currentSlide = slides[slideNumber - 1] as HTMLElement;
+            currentSlide.style.display = 'block';
+            currentSlide.style.visibility = 'visible';
+            currentSlide.style.position = 'relative';
+            currentSlide.style.width = '100%';
+            currentSlide.style.height = '100%';
+          }
+
+          // Update counter
+          const slideCounter = iframeDoc.getElementById('slideCounter');
+          if (slideCounter) {
+            slideCounter.textContent = `Slide ${slideNumber} of ${slides.length}`;
+          }
         });
-        
-        // Show only the current slide
-        if (slides[slideNumber - 1]) {
-          const currentSlide = slides[slideNumber - 1] as HTMLElement;
-          currentSlide.style.display = 'block';
-          currentSlide.style.visibility = 'visible';
-          currentSlide.style.position = 'relative';
-          currentSlide.style.width = '100%';
-          currentSlide.style.height = '100%';
-        }
-        
-        // Update counter
-        const slideCounter = iframeDoc.getElementById('slideCounter');
-        if (slideCounter) {
-          slideCounter.textContent = `Slide ${slideNumber} of ${slides.length}`;
-        }
       } catch (error) {
         console.error('Error updating slide visibility:', error);
       }


### PR DESCRIPTION
## Summary

4つのオープンバグを一括修正。

| Issue | Bug | Fix |
|-------|-----|-----|
| #311 | clean_text_for_tts がHTMLタグ名を削除 | HTMLタグをスペースに置換（タグ名を読まない） |
| #312 | clean_text_for_tts がテーブル行を全削除 | パイプ記号除去でプレーンテキスト化 |
| #317 | /api/character が504タイムアウト | asyncio.wait_for(timeout=10.0) + 504レスポンス |
| #316 | スライドコンテンツが白表示 | 同一スライド早期リターン + requestAnimationFrame |

Fixes #311, #312, #316, #317

## Review History
- Codex CLI: P1 (HTML tag regression) + P2 (timeout success flag) → 修正済み

## Test plan
- [x] Backend: ruff + black ✅
- [x] Frontend: lint + typecheck + build ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)