### PR TITLE
fix(frontend): remove ReceptionPanel overlay to restore single UI #328

### DIFF
--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -40,7 +40,6 @@ import VoiceInterface, {
   type VoiceInterfaceMetadata,
   type VoiceSessionState,
 } from './components/VoiceInterface';
-import { ReceptionPanel } from '@/components/reception/ReceptionPanel';
 
 const overlayLabels = {
   ja: {
@@ -231,7 +230,6 @@ const getStageBackgroundStyle = (background: BackgroundOption): CSSProperties =>
 export default function Home() {
   const [currentLanguage, setCurrentLanguage] = useState<'ja' | 'en'>('ja');
   const [showSlideMode, setShowSlideMode] = useState(false);
-  const [receptionCompleted, setReceptionCompleted] = useState(false);
   const [characterBackground, setCharacterBackground] = useState<BackgroundOption>({
     id: 'engineer-cafe-bg',
     name: 'Engineer Cafe',
@@ -287,12 +285,6 @@ export default function Home() {
       );
     }, 150);
   }, []);
-
-  useEffect(() => {
-    if (!showSlideMode && latestMetadata?.reception_type === 'first_time') {
-      startPresentation(currentLanguage);
-    }
-  }, [currentLanguage, latestMetadata, showSlideMode, startPresentation]);
 
   // Fallback: play vrm_control when metadata arrives (in case onAssistantPlaybackStart ran before ref was set)
   useEffect(() => {
@@ -713,19 +705,7 @@ export default function Home() {
                 </div>
               ) : null}
 
-              {/* Reception overlay — shown until reception is completed */}
-              {!receptionCompleted && !showSlideMode && (
-                <div
-                  className="absolute inset-0 z-40 flex items-center justify-center bg-black/40 backdrop-blur-sm"
-                  style={screenPadding}
-                >
-                  <ReceptionPanel
-                    sessionId={voice.sessionId}
-                    language={voice.currentLanguage}
-                    onReceptionComplete={() => setReceptionCompleted(true)}
-                  />
-                </div>
-              )}
+
             </main>
           </>
         );


### PR DESCRIPTION
## Summary
- Remove ReceptionPanel full-screen overlay that blocked the main VRM + chat UI
- Remove `receptionCompleted` state gating logic  
- Remove reception_type auto-start useEffect
- Restore direct access to VRM character + chat interface on load

Closes #328
Parent Epic: #326

## Review Notes
- code-reviewer: APPROVE (0 CRITICAL, 0 HIGH)
- Codex CLI: P2 device-webhook orphan (tracked in #329)

## Test plan
- [ ] App loads directly to VRM character + chat interface
- [ ] Voice/text chat works normally
- [ ] Slide mode still works
- [ ] No TypeScript/lint errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)