### PR TITLE
refactor(backend): unify orchestrator policy and extract handler methods #331

### DIFF
--- a/backend/agents/orchestrator_agent.py
+++ b/backend/agents/orchestrator_agent.py
@@ -22,7 +22,6 @@ from typing import Optional
 
 from langchain_core.messages import HumanMessage, SystemMessage
 from langgraph.graph import END
-from langgraph.types import Command
 
 from backend.config.routing_constants import (
     ACCESSIBILITY_KEYWORDS,
@@ -632,42 +631,3 @@ class OrchestratorAgent:
     async def close(self):
         """リソースのクリーンアップ"""
         await self.provider.close()
-
-
-# Supervisor Node用のヘルパー関数
-def create_orchestrator_node(orchestrator: OrchestratorAgent):
-    """
-    LangGraph Supervisor Node を作成するファクトリ関数
-
-    Returns:
-        Command を返すノード関数
-    """
-
-    async def orchestrator_node(state: dict) -> Command[RoutingTarget]:
-        """Supervisor ノード: クエリを適切なエージェントにルーティング"""
-        query = state.get("query", "")
-        session_id = state.get("session_id", "")
-        memory_context = state.get("context", {}).get("memory")
-
-        decision = await orchestrator.decide_next_agent(
-            query=query,
-            session_id=session_id,
-            memory_context=memory_context,
-        )
-
-        return Command(
-            goto=decision.next_agent,
-            update={
-                "language": decision.language,
-                "routing": {
-                    "agent": decision.next_agent,
-                    "category": decision.category,
-                    "request_type": decision.request_type,
-                    "confidence": decision.confidence,
-                    "reasoning": decision.reasoning,
-                    "debug_info": decision.debug_info,
-                },
-            },
-        )
-
-    return orchestrator_node

--- a/backend/workflows/main_workflow.py
+++ b/backend/workflows/main_workflow.py
@@ -30,6 +30,7 @@ from langgraph.types import Command, RetryPolicy
 from backend.agents.character_control_agent import CharacterControlAgent
 from backend.agents.orchestrator_agent import (
     OrchestratorAgent,
+    OrchestratorDecision,
     RoutingTarget,
 )
 
@@ -163,6 +164,13 @@ class MainWorkflow:
         backoff_factor=2.0,
         max_interval=10.0,
         max_attempts=3,
+    )
+    _CLARIFICATION_CATEGORIES = (
+        "cafe-clarification-needed",
+        "meeting-room-clarification-needed",
+        "event-clarification-needed",
+        "space-clarification-needed",
+        "general-clarification-needed",
     )
 
     def _build_graph(self) -> StateGraph:
@@ -559,6 +567,207 @@ class MainWorkflow:
         # normal orchestrator LLM routing.
         return None
 
+    @staticmethod
+    def _build_routing_payload(
+        decision: OrchestratorDecision,
+        *,
+        agent: str,
+        category: Optional[str] = None,
+        request_type: Optional[str] = None,
+    ) -> dict[str, Any]:
+        return {
+            "agent": agent,
+            "category": category or decision.category,
+            "request_type": request_type or decision.request_type,
+            "confidence": decision.confidence,
+            "reasoning": decision.reasoning,
+            "debug_info": decision.debug_info,
+        }
+
+    async def _handle_emergency(
+        self,
+        state: WorkflowStateDict,
+        decision: OrchestratorDecision,
+    ) -> Optional[Command[RoutingTarget]]:
+        if decision.category != "emergency":
+            return None
+
+        from backend.utils.emergency_templates import get_emergency_response
+
+        query = state.get("query", "")
+        logger.info(
+            "Inline emergency: lang=%s, query=%s",
+            decision.language,
+            query[:80],
+        )
+        result = get_emergency_response(query, decision.language)
+        asyncio.create_task(self._notify_discord_emergency(query, result))
+        return Command(
+            goto="format_response",
+            update={
+                "language": decision.language,
+                "routing": self._build_routing_payload(
+                    decision,
+                    agent="orchestrator_inline",
+                    category="emergency",
+                ),
+                "answer": result["response"],
+                "emotion": result["emotion"],
+                "metadata": {
+                    **state.get("metadata", {}),
+                    "emergency": result["metadata"],
+                },
+            },
+        )
+
+    async def _handle_greeting(
+        self,
+        state: WorkflowStateDict,
+        decision: OrchestratorDecision,
+        session_id: str,
+    ) -> Optional[Command[RoutingTarget]]:
+        if decision.category != "greeting":
+            return None
+
+        from backend.config.routing_constants import TIME_GREETING_TEMPLATES
+        from backend.utils.time_utils import get_current_time_period, get_now_jst
+
+        query = state.get("query", "")
+        lang = decision.language or "ja"
+        if lang not in ("ja", "en"):
+            logger.warning("Greeting: unsupported language '%s', falling back to 'ja'", lang)
+            lang = "ja"
+        now = get_now_jst()
+        period = get_current_time_period(now.hour)
+        templates = TIME_GREETING_TEMPLATES.get(period, TIME_GREETING_TEMPLATES["afternoon"])
+        base_greeting = templates.get(lang, templates["ja"])
+
+        if lang == "en":
+            greeting_msg = (
+                f"{base_greeting} "
+                "This is a free coworking space for engineers. "
+                "Feel free to make yourself at home. "
+                "How can I help you?"
+            )
+        else:
+            greeting_msg = (
+                f"{base_greeting}"
+                "ここはエンジニアのための無料コワーキングスペースです。"
+                "お気軽にご利用ください。何かお手伝いできることはありますか？"
+            )
+
+        logger.info(
+            "Inline greeting: lang=%s, period=%s, query=%s",
+            lang,
+            period,
+            query[:80],
+        )
+        await self._store_reception_session(
+            session_id=session_id,
+            stage="greeting",
+            language=lang,
+            metadata={"reception_action": "start_reception"},
+        )
+
+        return Command(
+            goto="format_response",
+            update={
+                "language": lang,
+                "routing": self._build_routing_payload(
+                    decision,
+                    agent="orchestrator_inline",
+                    category="greeting",
+                ),
+                "answer": greeting_msg,
+                "emotion": "happy",
+                "metadata": {
+                    **state.get("metadata", {}),
+                    "agent": "reception",
+                    "reception_stage": "greeting",
+                    "reception_action": "start_reception",
+                },
+            },
+        )
+
+    async def _handle_clarification(
+        self,
+        state: WorkflowStateDict,
+        decision: OrchestratorDecision,
+    ) -> Optional[Command[RoutingTarget]]:
+        if decision.category not in self._CLARIFICATION_CATEGORIES:
+            return None
+
+        from backend.utils.clarification_templates import get_clarification_response
+
+        query = state.get("query", "")
+        logger.info(
+            "Inline clarification: category=%s, lang=%s, query=%s",
+            decision.category,
+            decision.language,
+            query[:80],
+        )
+        result = get_clarification_response(
+            category=decision.category,
+            language=decision.language,
+        )
+        return Command(
+            goto="format_response",
+            update={
+                "language": decision.language,
+                "routing": self._build_routing_payload(
+                    decision,
+                    agent="orchestrator_inline",
+                ),
+                "answer": result["response"],
+                "emotion": result["emotion"],
+                "metadata": {
+                    **state.get("metadata", {}),
+                    "clarification": {
+                        **result["metadata"],
+                        "clarification_type": decision.category,
+                    },
+                    "requires_followup": True,
+                },
+            },
+        )
+
+    async def _handle_topic_guard(
+        self,
+        state: WorkflowStateDict,
+        decision: OrchestratorDecision,
+    ) -> Optional[Command[RoutingTarget]]:
+        query = state.get("query", "")
+        try:
+            from backend.utils.topic_guard import check_topic_adherence
+
+            on_topic, off_topic_response = check_topic_adherence(
+                query=query,
+                routing_category=decision.category,
+                language=decision.language,
+            )
+        except Exception as guard_err:
+            logger.debug("Topic guard skipped: %s", guard_err)
+            return None
+
+        if on_topic:
+            return None
+
+        logger.info("Off-topic query filtered: %.50s", query)
+        return Command(
+            goto="format_response",
+            update={
+                "language": decision.language,
+                "routing": self._build_routing_payload(
+                    decision,
+                    agent="topic_guard",
+                    category="off_topic",
+                    request_type="redirect",
+                ),
+                "answer": off_topic_response,
+                "emotion": "neutral",
+            },
+        )
+
     async def _orchestrator_node(self, state: WorkflowStateDict) -> Command[RoutingTarget]:
         """
         オーケストレーターノード（Supervisor）
@@ -572,7 +781,6 @@ class MainWorkflow:
         session has an active (incomplete) reception flow. If so, short-circuit
         with the appropriate reception stage response.
         """
-        from backend.utils.clarification_templates import get_clarification_response
         from backend.utils.reception_status import check_reception_status
 
         query = state.get("query", "")
@@ -593,145 +801,28 @@ class MainWorkflow:
             memory_context=memory_context,
         )
 
-        # emergency カテゴリをインライン処理（最優先）
-        if decision.category == "emergency":
-            from backend.utils.emergency_templates import get_emergency_response
-
-            logger.info(
-                "Inline emergency: lang=%s, query=%s",
-                decision.language,
-                query[:80],
-            )
-            result = get_emergency_response(query, decision.language)
-            # Discord 通知（fire-and-forget）
-            asyncio.create_task(self._notify_discord_emergency(query, result))
-            return Command(
-                goto="format_response",
-                update={
-                    "language": decision.language,
-                    "routing": {
-                        "agent": "orchestrator_inline",
-                        "category": "emergency",
-                        "request_type": decision.request_type,
-                        "confidence": decision.confidence,
-                        "reasoning": decision.reasoning,
-                        "debug_info": decision.debug_info,
-                    },
-                    "answer": result["response"],
-                    "emotion": result["emotion"],
-                    "metadata": {
-                        **state.get("metadata", {}),
-                        "emergency": result["metadata"],
-                    },
-                },
-            )
-
-        # greeting カテゴリをインライン処理
-        if decision.category == "greeting":
-            from backend.config.routing_constants import TIME_GREETING_TEMPLATES
-            from backend.utils.time_utils import get_current_time_period, get_now_jst
-
-            lang = decision.language or "ja"
-            if lang not in ("ja", "en"):
-                logger.warning("Greeting: unsupported language '%s', falling back to 'ja'", lang)
-                lang = "ja"
-            now = get_now_jst()
-            period = get_current_time_period(now.hour)
-            templates = TIME_GREETING_TEMPLATES.get(period, TIME_GREETING_TEMPLATES["afternoon"])
-            base_greeting = templates.get(lang, templates["ja"])
-
-            if lang == "en":
-                greeting_msg = (
-                    f"{base_greeting} "
-                    "This is a free coworking space for engineers. "
-                    "Feel free to make yourself at home. "
-                    "How can I help you?"
-                )
-            else:
-                greeting_msg = (
-                    f"{base_greeting}"
-                    "ここはエンジニアのための無料コワーキングスペースです。"
-                    "お気軽にご利用ください。何かお手伝いできることはありますか？"
-                )
-
-            logger.info(
-                "Inline greeting: lang=%s, period=%s, query=%s",
-                lang,
-                period,
-                query[:80],
-            )
-            await self._store_reception_session(
-                session_id=session_id,
-                stage="greeting",
-                language=lang,
-                metadata={"reception_action": "start_reception"},
-            )
-
-            return Command(
-                goto="format_response",
-                update={
-                    "language": lang,
-                    "routing": {
-                        "agent": "orchestrator_inline",
-                        "category": "greeting",
-                        "request_type": decision.request_type,
-                        "confidence": decision.confidence,
-                        "reasoning": decision.reasoning,
-                        "debug_info": decision.debug_info,
-                    },
-                    "answer": greeting_msg,
-                    "emotion": "happy",
-                    "metadata": {
-                        **state.get("metadata", {}),
-                        "agent": "reception",
-                        "reception_stage": "greeting",
-                        "reception_action": "start_reception",
-                    },
-                },
-            )
-
-        # clarification カテゴリをインライン処理
-        if decision.category in (
-            "cafe-clarification-needed",
-            "meeting-room-clarification-needed",
-            "event-clarification-needed",
-            "space-clarification-needed",
-            "general-clarification-needed",
+        for handler in (
+            lambda current_state, current_decision: self._handle_emergency(
+                current_state,
+                current_decision,
+            ),
+            lambda current_state, current_decision: self._handle_greeting(
+                current_state,
+                current_decision,
+                session_id,
+            ),
+            lambda current_state, current_decision: self._handle_clarification(
+                current_state,
+                current_decision,
+            ),
+            lambda current_state, current_decision: self._handle_topic_guard(
+                current_state,
+                current_decision,
+            ),
         ):
-            logger.info(
-                "Inline clarification: category=%s, lang=%s, query=%s",
-                decision.category,
-                decision.language,
-                query[:80],
-            )
-            result = get_clarification_response(
-                category=decision.category,
-                language=decision.language,
-            )
-            return Command(
-                goto="format_response",
-                update={
-                    "language": decision.language,
-                    "routing": {
-                        "agent": "orchestrator_inline",
-                        "category": decision.category,
-                        "request_type": decision.request_type,
-                        "confidence": decision.confidence,
-                        "reasoning": decision.reasoning,
-                        "debug_info": decision.debug_info,
-                    },
-                    "answer": result["response"],
-                    "emotion": result["emotion"],
-                    "metadata": {
-                        **state.get("metadata", {}),
-                        "clarification": {
-                            **result["metadata"],
-                            "clarification_type": decision.category,
-                        },
-                        "requires_followup": True,
-                    },
-                },
-            )
+            cmd = await handler(state, decision)
+            if cmd is not None:
+                return cmd
 
         # reception カテゴリをインライン処理
         if decision.request_type == "reception":
@@ -767,14 +858,11 @@ class MainWorkflow:
                 goto="format_response",
                 update={
                     "language": decision.language,
-                    "routing": {
-                        "agent": "orchestrator_inline",
-                        "category": "reception",
-                        "request_type": decision.request_type,
-                        "confidence": decision.confidence,
-                        "reasoning": decision.reasoning,
-                        "debug_info": decision.debug_info,
-                    },
+                    "routing": self._build_routing_payload(
+                        decision,
+                        agent="orchestrator_inline",
+                        category="reception",
+                    ),
                     "answer": result["response"],
                     "emotion": result["emotion"],
                     "metadata": {
@@ -787,48 +875,14 @@ class MainWorkflow:
                 },
             )
 
-        # Topic adherence ガードレール: 明確にoff-topicなクエリをフィルタ
-        try:
-            from backend.utils.topic_guard import check_topic_adherence
-
-            on_topic, off_topic_response = check_topic_adherence(
-                query=query,
-                routing_category=decision.category,
-                language=decision.language,
-            )
-            if not on_topic:
-                logger.info("Off-topic query filtered: %.50s", query)
-                return Command(
-                    goto="format_response",
-                    update={
-                        "language": decision.language,
-                        "routing": {
-                            "agent": "topic_guard",
-                            "category": "off_topic",
-                            "request_type": "redirect",
-                            "confidence": 1.0,
-                            "reasoning": "Query is outside Engineer Cafe scope",
-                            "debug_info": decision.debug_info,
-                        },
-                        "answer": off_topic_response,
-                        "emotion": "neutral",
-                    },
-                )
-        except Exception as guard_err:
-            logger.debug("Topic guard skipped: %s", guard_err)
-
         return Command(
             goto=decision.next_agent,
             update={
                 "language": decision.language,
-                "routing": {
-                    "agent": decision.next_agent,
-                    "category": decision.category,
-                    "request_type": decision.request_type,
-                    "confidence": decision.confidence,
-                    "reasoning": decision.reasoning,
-                    "debug_info": decision.debug_info,
-                },
+                "routing": self._build_routing_payload(
+                    decision,
+                    agent=decision.next_agent,
+                ),
             },
         )
 

--- a/backend/workflows/main_workflow.py
+++ b/backend/workflows/main_workflow.py
@@ -574,13 +574,15 @@ class MainWorkflow:
         agent: str,
         category: Optional[str] = None,
         request_type: Optional[str] = None,
+        confidence: Optional[float] = None,
+        reasoning: Optional[str] = None,
     ) -> dict[str, Any]:
         return {
             "agent": agent,
             "category": category or decision.category,
             "request_type": request_type or decision.request_type,
-            "confidence": decision.confidence,
-            "reasoning": decision.reasoning,
+            "confidence": confidence if confidence is not None else decision.confidence,
+            "reasoning": reasoning or decision.reasoning,
             "debug_info": decision.debug_info,
         }
 
@@ -762,6 +764,8 @@ class MainWorkflow:
                     agent="topic_guard",
                     category="off_topic",
                     request_type="redirect",
+                    confidence=1.0,
+                    reasoning="Query is outside Engineer Cafe scope",
                 ),
                 "answer": off_topic_response,
                 "emotion": "neutral",

--- a/backend/workflows/main_workflow.py
+++ b/backend/workflows/main_workflow.py
@@ -733,6 +733,65 @@ class MainWorkflow:
             },
         )
 
+    async def _handle_reception_inline(
+        self,
+        state: WorkflowStateDict,
+        decision: OrchestratorDecision,
+    ) -> Optional[Command[RoutingTarget]]:
+        """Handle reception category inline (before topic_guard)."""
+        if decision.request_type != "reception":
+            return None
+
+        from backend.utils.reception_templates import get_reception_response
+
+        query = state.get("query", "")
+        logger.info(
+            "Inline reception: lang=%s, query=%s",
+            decision.language,
+            query[:80],
+        )
+        # first_time / returning / general の判定
+        long_term_memory = state.get("context", {}).get("long_term_memory")
+        lower_query = query.lower()
+        first_time_keywords = [
+            "初めて",
+            "はじめて",
+            "初回",
+            "first time",
+            "first visit",
+        ]
+        if any(kw in lower_query for kw in first_time_keywords):
+            reception_type = "first_time"
+        elif long_term_memory:
+            reception_type = "returning"
+        else:
+            reception_type = "general"
+
+        result = get_reception_response(
+            language=decision.language,
+            reception_type=reception_type,
+        )
+        return Command(
+            goto="format_response",
+            update={
+                "language": decision.language,
+                "routing": self._build_routing_payload(
+                    decision,
+                    agent="orchestrator_inline",
+                    category="reception",
+                ),
+                "answer": result["response"],
+                "emotion": result["emotion"],
+                "metadata": {
+                    **state.get("metadata", {}),
+                    "reception": {
+                        **result["metadata"],
+                        "reception_type": reception_type,
+                    },
+                },
+            },
+        )
+
     async def _handle_topic_guard(
         self,
         state: WorkflowStateDict,
@@ -819,6 +878,10 @@ class MainWorkflow:
                 current_state,
                 current_decision,
             ),
+            lambda current_state, current_decision: self._handle_reception_inline(
+                current_state,
+                current_decision,
+            ),
             lambda current_state, current_decision: self._handle_topic_guard(
                 current_state,
                 current_decision,
@@ -827,57 +890,6 @@ class MainWorkflow:
             cmd = await handler(state, decision)
             if cmd is not None:
                 return cmd
-
-        # reception カテゴリをインライン処理
-        if decision.request_type == "reception":
-            from backend.utils.reception_templates import get_reception_response
-
-            logger.info(
-                "Inline reception: lang=%s, query=%s",
-                decision.language,
-                query[:80],
-            )
-            # first_time / returning / general の判定
-            long_term_memory = state.get("context", {}).get("long_term_memory")
-            lower_query = query.lower()
-            first_time_keywords = [
-                "初めて",
-                "はじめて",
-                "初回",
-                "first time",
-                "first visit",
-            ]
-            if any(kw in lower_query for kw in first_time_keywords):
-                reception_type = "first_time"
-            elif long_term_memory:
-                reception_type = "returning"
-            else:
-                reception_type = "general"
-
-            result = get_reception_response(
-                language=decision.language,
-                reception_type=reception_type,
-            )
-            return Command(
-                goto="format_response",
-                update={
-                    "language": decision.language,
-                    "routing": self._build_routing_payload(
-                        decision,
-                        agent="orchestrator_inline",
-                        category="reception",
-                    ),
-                    "answer": result["response"],
-                    "emotion": result["emotion"],
-                    "metadata": {
-                        **state.get("metadata", {}),
-                        "reception": {
-                            **result["metadata"],
-                            "reception_type": reception_type,
-                        },
-                    },
-                },
-            )
 
         return Command(
             goto=decision.next_agent,


### PR DESCRIPTION
## Summary
- Remove unused `create_orchestrator_node()` from orchestrator_agent.py (-40 lines)
- Extract inline policy handlers into named methods: `_handle_emergency`, `_handle_greeting`, `_handle_clarification`, `_handle_reception_inline`, `_handle_topic_guard`
- Extract `_build_routing_payload` helper to DRY routing dict construction
- Handler chain: emergency > greeting > clarification > reception_inline > topic_guard

No functional changes — pure refactoring. `_orchestrator_node` reduced from 273 to ~100 lines.

Closes #331
Parent Epic: #326

## Review Notes
- code-reviewer: APPROVE (topic_guard confidence fix + handler order verified)
- Codex CLI: P2 handler order → fixed (reception before topic_guard)

## Test plan
- [ ] All existing tests pass
- [ ] Routing behavior unchanged
- [ ] Handler priority order preserved

🤖 Generated with [Claude Code](https://claude.com/claude-code)