### PR TITLE
chore(backend): pin langgraph version range to >=1.0,<1.2 #332

### DIFF
--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -14,7 +14,7 @@ authors = [
     { name = "EngineerCafeJP" }
 ]
 dependencies = [
-    "langgraph>=0.2.0",
+    "langgraph>=1.0,<1.2",
     "langchain>=0.3.0",
     "langchain-openai>=0.2.0",
     "langchain-text-splitters>=0.3.0",
@@ -70,7 +70,7 @@ readme = "README.md"
 
 [tool.poetry.dependencies]
 python = "^3.11"
-langgraph = "^0.2.0"
+langgraph = ">=1.0,<1.2"
 langchain = "^0.3.0"
 langchain-openai = "^0.2.0"
 langsmith = "^0.3.12"

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -732,7 +732,7 @@ requires-dist = [
     { name = "httpx", specifier = ">=0.27.0" },
     { name = "langchain", specifier = ">=0.3.0" },
     { name = "langchain-openai", specifier = ">=0.2.0" },
-    { name = "langgraph", specifier = ">=0.2.0" },
+    { name = "langgraph", specifier = ">=1.0,<1.2" },
     { name = "langgraph-checkpoint-postgres", specifier = ">=2.0.0" },
     { name = "langsmith", specifier = ">=0.3.12" },
     { name = "mypy", marker = "extra == 'dev'", specifier = ">=1.10.0" },


### PR DESCRIPTION
## Summary
- Pin langgraph from `>=0.2.0` to `>=1.0,<1.2` in pyproject.toml
- Sync uv.lock specifier
- No code changes — config only

The lockfile resolves langgraph==1.0.8 but the declaration implied 0.2-era compatibility.

Closes #332
Parent Epic: #326

## Review Notes
- code-reviewer: APPROVE (config-only, no code changes)
- Codex CLI: N/A (LIGHT tier — config/docs changes only)

## Test plan
- [ ] `uv lock` resolves successfully
- [ ] All tests pass unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)