### PR TITLE
fix(frontend): increase character API maxDuration to 30s #317

### DIFF
--- a/frontend/vercel.json
+++ b/frontend/vercel.json
@@ -22,7 +22,7 @@
       "maxDuration": 30
     },
     "src/app/api/character/route.ts": {
-      "maxDuration": 10
+      "maxDuration": 30
     },
     "src/app/api/marp/route.ts": {
       "maxDuration": 15


### PR DESCRIPTION
## Summary
- `/api/character` の Vercel `maxDuration` を 10s → 30s に変更
- Cloud Run コールドスタート (12-17s) が Vercel タイムアウト (10s) を超えていた問題を修正
- 他のルート (voice, qa, slides) は既に maxDuration: 30 — character のみ 10 で不整合

## Root Cause
Vercel serverless function の maxDuration: 10 < Cloud Run cold start: 12-17s → 504 Gateway Timeout

## Changes
- `frontend/vercel.json`: `character/route.ts` maxDuration 10 → 30

## Test plan
- [ ] Vercel Preview URL で `/api/character` が 504 にならないことを確認
- [ ] コールドスタート後のレスポンスが 30s 以内に返ることを確認

Closes #317

🤖 Generated with [Claude Code](https://claude.com/claude-code)