### PR TITLE
fix(backend): character GET handler, emotion tag strip, sensor-trigger + Bearer auth #349 #350 #353

### DIFF
--- a/backend/api/reception.py
+++ b/backend/api/reception.py
@@ -303,6 +303,34 @@ class ReceptionStatusResponse(BaseModel):
 # ---------------------------------------------------------------------------
 
 
+class SensorTriggerRequest(BaseModel):
+    sensor_type: str = Field(..., max_length=50)
+    distance_mm: int = Field(..., ge=0)
+    device_id: str = Field(..., max_length=100)
+
+
+class SensorTriggerResponse(BaseModel):
+    success: bool
+    action: str
+    message: Optional[str] = None
+
+
+@reception_router.post("/sensor-trigger", response_model=SensorTriggerResponse)
+async def sensor_trigger(request: SensorTriggerRequest) -> SensorTriggerResponse:
+    """Receive sensor trigger from M5Stack device."""
+    logger.info(
+        "Sensor trigger received: device=%s sensor=%s distance=%dmm",
+        request.device_id,
+        request.sensor_type,
+        request.distance_mm,
+    )
+    return SensorTriggerResponse(
+        success=True,
+        action="trigger_received",
+        message=f"Sensor trigger from {request.device_id} acknowledged",
+    )
+
+
 @reception_router.post("/start", response_model=ReceptionStartResponse)
 async def start_reception(request: ReceptionStartRequest) -> ReceptionStartResponse:
     """Initiate a new reception session.

--- a/backend/main.py
+++ b/backend/main.py
@@ -394,7 +394,12 @@ async def chat(request: Request, body: ChatRequest):
             session_id=session_id,
         )
 
-        answer = result.get("answer", "回答を生成できませんでした。")
+        raw_answer = result.get("answer", "回答を生成できませんでした。")
+
+        # Strip emotion tags (emotion is carried separately in the response)
+        from backend.utils.emotion_utils import strip_emotion_tags
+
+        answer = strip_emotion_tags(raw_answer)
 
         # Output PII scanning
         try:

--- a/backend/main.py
+++ b/backend/main.py
@@ -225,6 +225,10 @@ async def verify_api_key(request: Request) -> None:
             raise HTTPException(status_code=503, detail="Server misconfigured")
         return
     api_key = request.headers.get("X-API-Key")
+    if not api_key:
+        auth_header = request.headers.get("Authorization", "")
+        if auth_header.startswith("Bearer "):
+            api_key = auth_header[7:]
     if not api_key or not hmac.compare_digest(api_key, _API_SECRET_KEY):
         raise HTTPException(status_code=403, detail="Invalid or missing API key")
 

--- a/backend/main.py
+++ b/backend/main.py
@@ -860,6 +860,37 @@ class CharacterResponse(BaseModel):
     error: Optional[str] = None
 
 
+@app.get("/api/character", dependencies=[Depends(verify_api_key)])
+@_rate_limit("20/minute")
+async def character_get_api(request: Request, action: str = ""):
+    """GET handler for character state queries from frontend polling."""
+    if action == "supported_features":
+        from backend.agents.character_control_agent import CharacterControlAgent
+
+        agent = CharacterControlAgent()
+        animations = (
+            agent.get_supported_animations() if hasattr(agent, "get_supported_animations") else []
+        )
+        return {
+            "success": True,
+            "expressions": [
+                "neutral",
+                "happy",
+                "sad",
+                "angry",
+                "relaxed",
+                "surprised",
+            ],
+            "animations": animations,
+        }
+    # Default: return current state
+    return {
+        "success": True,
+        "current_emotion": "neutral",
+        "current_expression": "neutral",
+    }
+
+
 @app.post(
     "/api/character", response_model=CharacterResponse, dependencies=[Depends(verify_api_key)]
 )

--- a/backend/tests/api/test_reception_api.py
+++ b/backend/tests/api/test_reception_api.py
@@ -483,3 +483,54 @@ class TestCompleteReception:
         assert data["purpose_category"] == "facility_use"
         # workflow_state must NOT be in the response (PII leak fix)
         assert "workflow_state" not in data
+
+
+class TestSensorTriggerEndpoint:
+    """Tests for POST /api/reception/sensor-trigger (#353)"""
+
+    def setup_method(self):
+        reception_module._reset_session_storage()
+
+    def test_sensor_trigger_success(self):
+        response = client.post(
+            "/api/reception/sensor-trigger",
+            json={
+                "sensor_type": "tof",
+                "distance_mm": 500,
+                "device_id": "m5stack-001",
+            },
+        )
+        assert response.status_code == 200
+        data = response.json()
+        assert data["success"] is True
+        assert data["action"] == "trigger_received"
+        assert "m5stack-001" in data["message"]
+
+    def test_sensor_trigger_validation_negative_distance(self):
+        response = client.post(
+            "/api/reception/sensor-trigger",
+            json={
+                "sensor_type": "tof",
+                "distance_mm": -1,
+                "device_id": "m5stack-001",
+            },
+        )
+        assert response.status_code == 422
+
+    def test_sensor_trigger_validation_missing_fields(self):
+        response = client.post(
+            "/api/reception/sensor-trigger",
+            json={},
+        )
+        assert response.status_code == 422
+
+    def test_sensor_trigger_validation_device_id_too_long(self):
+        response = client.post(
+            "/api/reception/sensor-trigger",
+            json={
+                "sensor_type": "tof",
+                "distance_mm": 300,
+                "device_id": "x" * 101,
+            },
+        )
+        assert response.status_code == 422

--- a/backend/tests/test_main_endpoints.py
+++ b/backend/tests/test_main_endpoints.py
@@ -344,3 +344,74 @@ class TestCharacterEndpoint:
         assert "neutral" in response["expressions"]
         assert "happy" in response["expressions"]
         assert isinstance(response["animations"], list)
+
+
+class TestBearerAuthSupport:
+    """Tests for Authorization: Bearer support in verify_api_key (#353)"""
+
+    @pytest.mark.asyncio
+    async def test_bearer_token_accepted(self):
+        """verify_api_key should accept Authorization: Bearer header"""
+
+        with patch("backend.main._API_SECRET_KEY", "test-secret-key"):
+            from backend.main import verify_api_key
+
+            scope = {
+                "type": "http",
+                "method": "GET",
+                "path": "/api/character",
+                "query_string": b"",
+                "headers": [
+                    (b"authorization", b"Bearer test-secret-key"),
+                ],
+                "server": ("127.0.0.1", 8000),
+                "client": ("127.0.0.1", 12345),
+            }
+            request = Request(scope)
+            # Should NOT raise
+            await verify_api_key(request)
+
+    @pytest.mark.asyncio
+    async def test_bearer_token_rejected_when_wrong(self):
+        """verify_api_key should reject incorrect Bearer token"""
+        from fastapi import HTTPException
+
+        with patch("backend.main._API_SECRET_KEY", "test-secret-key"):
+            from backend.main import verify_api_key
+
+            scope = {
+                "type": "http",
+                "method": "GET",
+                "path": "/api/character",
+                "query_string": b"",
+                "headers": [
+                    (b"authorization", b"Bearer wrong-key"),
+                ],
+                "server": ("127.0.0.1", 8000),
+                "client": ("127.0.0.1", 12345),
+            }
+            request = Request(scope)
+            with pytest.raises(HTTPException) as exc_info:
+                await verify_api_key(request)
+            assert exc_info.value.status_code == 403
+
+    @pytest.mark.asyncio
+    async def test_x_api_key_still_works(self):
+        """X-API-Key header should still be accepted"""
+        with patch("backend.main._API_SECRET_KEY", "test-secret-key"):
+            from backend.main import verify_api_key
+
+            scope = {
+                "type": "http",
+                "method": "GET",
+                "path": "/api/character",
+                "query_string": b"",
+                "headers": [
+                    (b"x-api-key", b"test-secret-key"),
+                ],
+                "server": ("127.0.0.1", 8000),
+                "client": ("127.0.0.1", 12345),
+            }
+            request = Request(scope)
+            # Should NOT raise
+            await verify_api_key(request)

--- a/backend/tests/test_main_endpoints.py
+++ b/backend/tests/test_main_endpoints.py
@@ -323,3 +323,24 @@ class TestCharacterEndpoint:
             with pytest.raises(HTTPException) as exc_info:
                 await character_api(_mock_request(), body)
             assert "Some internal error" not in exc_info.value.detail
+
+    @pytest.mark.asyncio
+    async def test_character_get_default_state(self):
+        """GET /api/character returns default state (#349)"""
+        from backend.main import character_get_api
+
+        response = await character_get_api(_mock_request())
+        assert response["success"] is True
+        assert response["current_emotion"] == "neutral"
+        assert response["current_expression"] == "neutral"
+
+    @pytest.mark.asyncio
+    async def test_character_get_supported_features(self):
+        """GET /api/character?action=supported_features returns expressions list (#349)"""
+        from backend.main import character_get_api
+
+        response = await character_get_api(_mock_request(), action="supported_features")
+        assert response["success"] is True
+        assert "neutral" in response["expressions"]
+        assert "happy" in response["expressions"]
+        assert isinstance(response["animations"], list)

--- a/backend/tests/test_main_endpoints.py
+++ b/backend/tests/test_main_endpoints.py
@@ -133,6 +133,27 @@ class TestChatEndpoint:
                 session_id="s1",
             )
 
+    @pytest.mark.asyncio
+    async def test_chat_strips_emotion_tags_from_answer(self):
+        """Emotion tags in answer text should be stripped (#350)"""
+        with patch(
+            "backend.main._run_workflow_with_tracking",
+            new_callable=AsyncMock,
+            return_value={
+                "answer": "[relaxed]営業時間は9時からです[/relaxed]",
+                "emotion": "relaxed",
+                "metadata": {},
+            },
+        ):
+            from backend.main import chat, ChatRequest
+
+            body = ChatRequest(query="営業時間は？", session_id="s1")
+            response = await chat(_mock_request(), body)
+            assert "[relaxed]" not in response.answer
+            assert "[/relaxed]" not in response.answer
+            assert "営業時間は9時からです" in response.answer
+            assert response.emotion == "relaxed"
+
 
 class TestInvokeEndpoint:
     @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- **#350**: `/api/chat` のanswerテキストから感情タグ `[relaxed]` 等を除去
- **#349**: `GET /api/character` ハンドラ追加（405解消）
- **#353**: `/api/reception/sensor-trigger` エンドポイント + `Authorization: Bearer` 認証対応

## ADR-005 準拠
ロジックをバックエンド側に集約する方針に基づく変更。

## Test plan
- [x] `pytest tests/test_main_endpoints.py` — 22件パス
- [x] `ruff check .` — パス
- [x] `black --check .` — パス
- [x] Codex CLI review: 0 CRITICAL, 0 HIGH

## Codex Review Findings (MEDIUM, follow-up)
- `GET /api/character?action=supported_features` の animations が空配列（`get_supported_animations()` 未実装）
- `GET /api/character` の current_state が常にneutral（ランタイム状態未反映）

## Related Issues
Closes #349, Closes #350, Closes #353

🤖 Generated with [Claude Code](https://claude.ai/code)