### PR TITLE
fix(backend): Wave 5A — format_response answer fix, sensor rate limit, Docker Vosk #354 #356 #357

### DIFF
--- a/backend/api/reception.py
+++ b/backend/api/reception.py
@@ -7,6 +7,7 @@ Handles session lifecycle: start -> respond -> complete -> status.
 from __future__ import annotations
 
 import logging
+import time
 from collections import OrderedDict
 from datetime import datetime
 from typing import TYPE_CHECKING, Any, Literal, Optional
@@ -88,6 +89,7 @@ def _reset_session_storage() -> None:
     global _session_repository
     _session_repository = None
     _active_sessions.clear()
+    _sensor_trigger_cooldowns.clear()
 
 
 def _serialize_session(session: ReceptionSession, *, status: str = "active") -> dict[str, Any]:
@@ -315,9 +317,27 @@ class SensorTriggerResponse(BaseModel):
     message: Optional[str] = None
 
 
+# ---------------------------------------------------------------------------
+# Per-device rate limiting for sensor triggers
+# ---------------------------------------------------------------------------
+
+_sensor_trigger_cooldowns: dict[str, float] = {}
+SENSOR_TRIGGER_RATE_LIMIT_SECONDS = 5
+
+
 @reception_router.post("/sensor-trigger", response_model=SensorTriggerResponse)
 async def sensor_trigger(request: SensorTriggerRequest) -> SensorTriggerResponse:
     """Receive sensor trigger from M5Stack device."""
+    now = time.time()
+    last_trigger = _sensor_trigger_cooldowns.get(request.device_id, 0)
+    if now - last_trigger < SENSOR_TRIGGER_RATE_LIMIT_SECONDS:
+        return SensorTriggerResponse(
+            success=False,
+            action="rate_limited",
+            message=f"Device {request.device_id} is rate limited",
+        )
+    _sensor_trigger_cooldowns[request.device_id] = now
+
     logger.info(
         "Sensor trigger received: device=%s sensor=%s distance=%dmm",
         request.device_id,

--- a/backend/tests/api/test_reception_api.py
+++ b/backend/tests/api/test_reception_api.py
@@ -534,3 +534,45 @@ class TestSensorTriggerEndpoint:
             },
         )
         assert response.status_code == 422
+
+    def test_sensor_trigger_rate_limited(self):
+        """Rapid duplicate requests from the same device should be rate-limited (#357)."""
+        payload = {
+            "sensor_type": "tof",
+            "distance_mm": 500,
+            "device_id": "m5stack-ratelimit-test",
+        }
+
+        # First request should succeed
+        resp1 = client.post("/api/reception/sensor-trigger", json=payload)
+        assert resp1.status_code == 200
+        assert resp1.json()["success"] is True
+        assert resp1.json()["action"] == "trigger_received"
+
+        # Immediate second request from same device should be rate-limited
+        resp2 = client.post("/api/reception/sensor-trigger", json=payload)
+        assert resp2.status_code == 200
+        assert resp2.json()["success"] is False
+        assert resp2.json()["action"] == "rate_limited"
+
+    def test_sensor_trigger_rate_limit_different_devices(self):
+        """Different devices should NOT be rate-limited by each other (#357)."""
+        payload_a = {
+            "sensor_type": "tof",
+            "distance_mm": 500,
+            "device_id": "m5stack-device-a",
+        }
+        payload_b = {
+            "sensor_type": "tof",
+            "distance_mm": 500,
+            "device_id": "m5stack-device-b",
+        }
+
+        resp_a = client.post("/api/reception/sensor-trigger", json=payload_a)
+        assert resp_a.status_code == 200
+        assert resp_a.json()["success"] is True
+
+        # Different device should still succeed
+        resp_b = client.post("/api/reception/sensor-trigger", json=payload_b)
+        assert resp_b.status_code == 200
+        assert resp_b.json()["success"] is True

--- a/backend/tests/workflows/test_error_propagation.py
+++ b/backend/tests/workflows/test_error_propagation.py
@@ -273,6 +273,33 @@ class TestFormatResponseErrorPropagation:
             assert "[happy" not in result["messages"][1].content
             assert "I am great!" in result["messages"][1].content
 
+    @pytest.mark.asyncio
+    async def test_format_response_returns_stripped_answer_in_dict(self):
+        """format_response must include stripped answer in return dict (#356).
+
+        Without this, state['answer'] retains emotion-tagged text and the
+        reception invoke path returns raw tags to the client.
+        """
+        workflow = _create_workflow()
+
+        with patch("backend.utils.memory_helper.get_memory_helper") as mock_get_helper:
+            mock_helper = AsyncMock()
+            mock_helper.store_message = AsyncMock()
+            mock_get_helper.return_value = mock_helper
+
+            state = {
+                "query": "What are the hours?",
+                "answer": "[happy]We are open 9 to 22.[/happy]",
+                "session_id": "test-session",
+            }
+
+            result = await workflow._format_response_node(state, _mock_runtime())
+
+            # The return dict must contain "answer" with stripped text
+            assert "answer" in result
+            assert "[happy]" not in result["answer"]
+            assert "We are open 9 to 22." in result["answer"]
+
 
 # ===========================================================================
 # 3. Orchestrator Failure Handling

--- a/backend/workflows/main_workflow.py
+++ b/backend/workflows/main_workflow.py
@@ -1290,6 +1290,7 @@ class MainWorkflow:
             logger.warning("Time period/closing warning processing failed: %s", time_err)
 
         return {
+            "answer": answer,
             "metadata": metadata,
             "messages": windowed
             + [

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -48,6 +48,8 @@ services:
       # Hot reload support
       - ./backend:/app
       - /app/__pycache__
+      # Persist Vosk models built into the image (bind mount overwrites them)
+      - backend-vosk-models:/app/models
     environment:
       - PYTHONUNBUFFERED=1
     env_file:
@@ -116,3 +118,4 @@ volumes:
   frontend-next:
   backend-pycache:
   voicevox-cache:
+  backend-vosk-models:


### PR DESCRIPTION
## Summary
Wave 5A バグ修正3件。全てPR #355 code-reviewerフォローアップまたはチームメンバー報告のバグ。

- **#356**: `_format_response_node` が `state["answer"]` を更新しないため reception 経路で感情タグ残存 → return dict に `"answer": answer` 追加
- **#357**: `/api/reception/sensor-trigger` にデバイス別レート制限追加（5秒クールダウン）
- **#354**: Docker dev 環境で Vosk モデルがボリュームマウントで上書きされる → named volume で永続化

## Test plan
- [x] 89 tests pass (workflows + reception + main_endpoints)
- [x] `ruff check .` — パス
- [x] `black --check .` — パス

## Related Issues
Closes #354, Closes #356, Closes #357

🤖 Generated with [Claude Code](https://claude.ai/code)