### PR TITLE
fix(frontend): kiosk idle timer recovery bugs #365

### DIFF
--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -362,11 +362,16 @@ export default function Home() {
   }, [clearReturnToIdleTimer]);
 
   const bumpUserActivity = useCallback(() => {
-    if (kioskPhaseRef.current === 'notice' || kioskPhaseRef.current === 'idle') {
+    const phase = kioskPhaseRef.current;
+    if (phase === 'notice' || phase === 'idle') {
       return;
     }
-    clearReturnToIdleTimer();
-  }, [clearReturnToIdleTimer]);
+    if (phase === 'slides') {
+      clearReturnToIdleTimer();
+      return;
+    }
+    scheduleReturnToIdle();
+  }, [clearReturnToIdleTimer, scheduleReturnToIdle]);
 
   useEffect(() => {
     return () => {
@@ -375,7 +380,7 @@ export default function Home() {
   }, [clearReturnToIdleTimer]);
 
   useEffect(() => {
-    if (kioskPhase === 'ocr') {
+    if (kioskPhase === 'ocr' || kioskPhase === 'voice') {
       scheduleReturnToIdle();
     }
   }, [kioskPhase, scheduleReturnToIdle]);
@@ -406,6 +411,7 @@ export default function Home() {
   }, [showSettingsPanel]);
 
   const startPresentation = useCallback((language: 'ja' | 'en') => {
+    clearReturnToIdleTimer();
     setCurrentLanguage(language);
     setKioskPhase('slides');
 
@@ -416,7 +422,7 @@ export default function Home() {
         }),
       );
     }, 150);
-  }, []);
+  }, [clearReturnToIdleTimer]);
 
   const handleCloseSlides = useCallback(() => {
     clearReturnToIdleTimer();


### PR DESCRIPTION
## Summary
- `bumpUserActivity`: reschedule idle timer on user touch, but only clear (not reschedule) in slides phase — slides use `onPresentationComplete` for their own lifecycle
- `startPresentation`: clear pending idle timer before entering slides — prevents premature return to idle during presentation
- voice phase: add fallback timeout via `useEffect` on phase change — prevents kiosk from being stuck if user doesn't speak, but won't interrupt active voice turns since `onAssistantPlaybackEnd` reschedules

Closes #365

## Review
- code-reviewer: APPROVE (no issues found)
- Codex CLI: P2 feedback addressed (slides guard + voice effect-based fallback)

## Test plan
- [ ] `cd frontend && pnpm lint && pnpm typecheck && pnpm build` — all green
- [ ] Browser: welcome screen → tap → wait 90s → returns to idle
- [ ] Browser: voice mode → no speech → wait 90s → returns to idle
- [ ] Browser: voice response → open slides → slides play without interruption
- [ ] Browser: slides auto-play (>90s) — not interrupted by idle timer

🤖 Generated with [Claude Code](https://claude.com/claude-code)