### PR TITLE
fix(backend): validate empty image data before cv2.imdecode #368

### DIFF
--- a/backend/api/ocr.py
+++ b/backend/api/ocr.py
@@ -203,6 +203,11 @@ def _decode_image(image_data: str) -> np.ndarray:
         ) from exc
 
     arr = np.frombuffer(image_bytes, dtype=np.uint8)
+    if arr.size == 0:
+        raise HTTPException(
+            status_code=400,
+            detail="Empty image data",
+        )
     image = cv2.imdecode(arr, cv2.IMREAD_COLOR)
     if image is None:
         raise HTTPException(

--- a/backend/tests/api/test_ocr_api.py
+++ b/backend/tests/api/test_ocr_api.py
@@ -95,6 +95,16 @@ class TestDecodeImage:
         assert exc_info.value.status_code == 400
         assert "Could not decode image" in exc_info.value.detail
 
+    def test_raises_400_for_empty_image_payload(self):
+        """base64 デコード結果が空バイトの場合は 400 を返す。"""
+        import base64 as _base64
+
+        empty_payload = _base64.b64encode(b"").decode("utf-8")
+        with pytest.raises(HTTPException) as exc_info:
+            ocr_module._decode_image(empty_payload)
+        assert exc_info.value.status_code == 400
+        assert "Empty image data" in exc_info.value.detail
+
 
 class TestDetectLanguage:
     """_detect_language のテスト。"""


### PR DESCRIPTION
## Summary
- Add `arr.size == 0` check in `_decode_image()` before `cv2.imdecode` call
- Returns 400 "Empty image data" instead of crashing with cv2.error 500
- Add test `test_raises_400_for_empty_image_payload`

## Related Issue
Closes #368

## Review
- code-reviewer: APPROVE (no issues)
- Codex CLI: No bugs identified

## Verification
- [x] `ruff check .` — passed
- [x] `black --check .` — 2 files unchanged
- [x] `pytest tests/api/test_ocr_api.py -v` — 29/29 passed

## Test plan
- [ ] `curl -X POST /api/ocr` with empty image_data → 400 response
- [ ] Existing OCR tests still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)