### PR TITLE
fix(frontend): improve voice error messages and preserve STT transcript on error #373

### DIFF
--- a/frontend/src/app/components/VoiceInterface.tsx
+++ b/frontend/src/app/components/VoiceInterface.tsx
@@ -442,7 +442,11 @@ export default function VoiceInterface({
 
         const qaResult = await qaResponse.json();
         if (!qaResponse.ok || !qaResult.success) {
-          throw new Error(qaResult.error || '質問の送信に失敗しました');
+          const qaError: Error & { status?: number } = new Error(
+            qaResult.error || '質問の送信に失敗しました',
+          );
+          qaError.status = qaResponse.status;
+          throw qaError;
         }
 
         const parsedAnswer = EmotionTagParser.parseEmotionTags(
@@ -469,7 +473,11 @@ export default function VoiceInterface({
 
         const ttsResult = await ttsResponse.json();
         if (!ttsResponse.ok || !ttsResult.success) {
-          throw new Error(ttsResult.error || '音声の生成に失敗しました');
+          const ttsError: Error & { status?: number } = new Error(
+            ttsResult.error || '音声の生成に失敗しました',
+          );
+          ttsError.status = ttsResponse.status;
+          throw ttsError;
         }
 
         if (typeof ttsResult.audioResponse === 'string' && ttsResult.audioResponse.length > 0) {
@@ -529,7 +537,11 @@ export default function VoiceInterface({
 
         const sttResult = await sttResponse.json();
         if (!sttResponse.ok || !sttResult.success || typeof sttResult.transcript !== 'string') {
-          throw new Error(sttResult.error || '音声認識に失敗しました');
+          const sttError: Error & { status?: number } = new Error(
+            sttResult.error || '音声認識に失敗しました',
+          );
+          sttError.status = sttResponse.status;
+          throw sttError;
         }
 
         setTranscript(sttResult.transcript);

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -135,10 +135,13 @@ function KioskVoiceStatusStack({
     if (error) {
       setErrorVisibleUntil(Date.now() + 5000);
     }
+    if (error && transcript.length > 0) {
+      setTranscriptVisibleUntil(Date.now() + 5000);
+    }
     if (error && response.length > 0) {
       setResponseVisibleUntil(Date.now() + 5000);
     }
-  }, [enabled, error, response.length]);
+  }, [enabled, error, response.length, transcript.length]);
 
   useEffect(() => {
     if (!enabled) {
@@ -198,12 +201,6 @@ function KioskVoiceStatusStack({
           <span>{ocrStatus.text}</span>
         </div>
       ) : null}
-      {isErrorVisible ? (
-        <div className="flex w-full items-center gap-2 rounded-xl border border-rose-300/45 bg-rose-700/35 px-4 py-2 text-sm font-medium text-rose-50 shadow-sm backdrop-blur-sm">
-          <XCircle className="size-4 shrink-0" />
-          <span>{error}</span>
-        </div>
-      ) : null}
       {isSttLoading ? (
         <div className="flex w-full items-center gap-2 rounded-xl border border-white/30 bg-black/35 px-4 py-2 text-sm font-medium text-white/95 shadow-sm backdrop-blur-sm">
           <Loader2 className="size-4 shrink-0 animate-spin" />
@@ -216,6 +213,12 @@ function KioskVoiceStatusStack({
           <span>
             {labels.transcriptLabel}: {transcript}
           </span>
+        </div>
+      ) : null}
+      {isErrorVisible ? (
+        <div className="flex w-full items-center gap-2 rounded-xl border border-rose-300/45 bg-rose-700/35 px-4 py-2 text-sm font-medium text-rose-50 shadow-sm backdrop-blur-sm">
+          <XCircle className="size-4 shrink-0" />
+          <span>{error}</span>
         </div>
       ) : null}
       {isTtsSynthesizing ? (

--- a/frontend/src/lib/error-messages.ts
+++ b/frontend/src/lib/error-messages.ts
@@ -71,6 +71,22 @@ export const ERROR_MESSAGES: Record<string, ErrorMessage> = {
   },
   
   // API Errors
+  STT_ERROR: {
+    ja: '音声認識処理でエラーが発生しました。',
+    en: 'Speech recognition processing failed.',
+  },
+  QA_ERROR: {
+    ja: '質問の送信に失敗しました。もう一度お試しください。',
+    en: 'Failed to send question. Please try again.',
+  },
+  TTS_ERROR: {
+    ja: '音声の生成に失敗しました。',
+    en: 'Voice generation failed.',
+  },
+  VALIDATION_ERROR: {
+    ja: 'リクエストの形式が正しくありません。',
+    en: 'Invalid request format.',
+  },
   API_KEY_INVALID: {
     ja: 'APIキーが無効です。設定を確認してください。',
     en: 'Invalid API key. Please check your configuration.',
@@ -117,6 +133,35 @@ export function formatError(
     return getErrorMessage(error.code, language);
   }
   
+  // Check for API-specific error patterns
+  if (error.message) {
+    if (
+      error.message.includes('音声認識に失敗') ||
+      error.message.includes('speech recognition')
+    ) {
+      return getErrorMessage('STT_ERROR', language);
+    }
+    if (
+      error.message.includes('質問の送信に失敗') ||
+      error.message.includes('send question') ||
+      error.message.includes('chat')
+    ) {
+      return getErrorMessage('QA_ERROR', language);
+    }
+    if (
+      error.message.includes('音声の生成に失敗') ||
+      error.message.includes('voice generation') ||
+      error.message.includes('text_to_speech')
+    ) {
+      return getErrorMessage('TTS_ERROR', language);
+    }
+  }
+
+  // Check for 422 validation error
+  if (error.status === 422) {
+    return getErrorMessage('VALIDATION_ERROR', language);
+  }
+
   // Check for specific error messages
   if (error.message) {
     if (error.message.includes('microphone')) {


### PR DESCRIPTION
## Summary
- **error-messages.ts**: `STT_ERROR`, `QA_ERROR`, `TTS_ERROR`, `VALIDATION_ERROR` の4種のバイリンガルエラーメッセージを追加。`formatError()` にAPIエラーパターンマッチングと422ステータス検出を追加
- **page.tsx (KioskVoiceStatusStack)**: エラー発生時もSTTトランスクリプトが見えるよう表示順をトランスクリプト→エラーに変更。エラー時にトランスクリプト表示を5秒延長
- **VoiceInterface.tsx**: API エラー時にHTTPステータスコードを `error.status` に保持し、`formatError()` が422を `VALIDATION_ERROR` として分類可能に

## Test plan
- [ ] STT成功 → QAエラー発生時にトランスクリプトが表示され続けることを確認
- [ ] エラーメッセージが「予期しないエラー」ではなく具体的メッセージ（「質問の送信に失敗しました」等）になることを確認
- [ ] 422レスポンス時に「リクエストの形式が正しくありません」が表示されることを確認
- [ ] `pnpm lint && pnpm typecheck && pnpm build` パス確認

Closes #373

🤖 Generated with [Claude Code](https://claude.com/claude-code)