### PR TITLE
docs: Wave 7 planning — ADR-006, migration guides, scenario tests #376

### DIFF
--- a/backend/tests/scenarios/test_engineer_cafe_reception_scenarios.py
+++ b/backend/tests/scenarios/test_engineer_cafe_reception_scenarios.py
@@ -1,0 +1,1448 @@
+"""
+Engineer Cafe Reception Scenario Tests
+=======================================
+TDD: These tests define the expected behavior BEFORE implementation.
+They should FAIL on the current codebase and PASS after Wave 7 implementation.
+
+Scenarios are derived from:
+- Existing knowledge base markdown documents
+- routing_constants.py keyword patterns (real user query patterns)
+- RAGAS evaluation test data (e2e_scenarios.json)
+- Discord logs of actual kiosk usage (2026-03-25, 2026-03-28)
+
+Each scenario represents a real visitor interaction at Engineer Cafe Fukuoka.
+"""
+
+from __future__ import annotations
+
+from contextlib import contextmanager
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from langgraph.checkpoint.memory import MemorySaver
+
+from backend.agents.orchestrator_agent import OrchestratorDecision
+from backend.config.routing_constants import extract_request_type
+
+# Mark all tests as scenario tests (can be run with pytest -m scenario)
+pytestmark = [pytest.mark.scenario, pytest.mark.slow]
+
+
+# =============================================================================
+# Shared test helpers (same pattern as test_multi_agent_scenarios.py)
+# =============================================================================
+
+
+def _make_memory_helper_mock(context_return=None):
+    helper = AsyncMock()
+    if context_return is None:
+        context_return = {"recent_messages": [], "context_string": ""}
+    helper.get_context = AsyncMock(return_value=context_return)
+    helper.store_message = AsyncMock()
+    return helper
+
+
+def _make_rag_mock(context=""):
+    rag = AsyncMock()
+    rag.search = AsyncMock(
+        return_value={
+            "success": True,
+            "data": {"results": [], "context": context},
+        }
+    )
+    return rag
+
+
+def _make_classifier_mock(category="general"):
+    class _Classification:
+        def __init__(self, cat):
+            self.category = cat
+
+    classification = _Classification(category)
+    classifier = MagicMock()
+    classifier.classify_with_details = AsyncMock(return_value=classification)
+    return classifier
+
+
+def _make_context_priority_mock():
+    mock_engine = MagicMock()
+    mock_engine.extract_signals_from_context.return_value = {
+        "has_memory": False,
+        "has_knowledge": False,
+    }
+    return mock_engine
+
+
+@contextmanager
+def _patch_memory_loader_deps(category="general"):
+    with (
+        patch(
+            "backend.tools.enhanced_rag.EnhancedRAGSearch",
+            return_value=_make_rag_mock(),
+        ),
+        patch(
+            "backend.utils.query_classifier.QueryClassifier",
+            return_value=_make_classifier_mock(category),
+        ),
+        patch(
+            "backend.utils.context_priority.ContextPriorityEngine",
+            return_value=_make_context_priority_mock(),
+        ),
+    ):
+        yield
+
+
+def _build_decision(
+    next_agent,
+    language="ja",
+    category="general",
+    request_type="general",
+    confidence=0.9,
+    reasoning="test routing",
+):
+    return OrchestratorDecision(
+        next_agent=next_agent,
+        language=language,
+        category=category,
+        request_type=request_type,
+        confidence=confidence,
+        reasoning=reasoning,
+        debug_info={},
+    )
+
+
+async def _run_workflow(query, session_id, language, mock_decision, agent_attr, agent_response):
+    """Run MainWorkflow with standard mocks and return the result."""
+    from backend.workflows.main_workflow import MainWorkflow
+
+    mock_orchestrator = AsyncMock()
+    mock_orchestrator.decide_next_agent = AsyncMock(return_value=mock_decision)
+
+    mock_helper = _make_memory_helper_mock()
+
+    with (
+        patch(
+            "backend.workflows.main_workflow.OrchestratorAgent",
+            return_value=mock_orchestrator,
+        ),
+        patch("backend.utils.memory_helper.get_memory_helper", return_value=mock_helper),
+    ):
+        checkpointer = MemorySaver()
+        category = mock_decision.category if mock_decision.category else "general"
+
+        with _patch_memory_loader_deps(category):
+            workflow = MainWorkflow(checkpointer=checkpointer)
+
+            agent = getattr(workflow, agent_attr)
+            if agent_attr == "_business_info_agent":
+                agent.answer_business_query = AsyncMock(return_value=agent_response)
+            elif agent_attr == "_facility_agent":
+                agent.answer_facility_query = AsyncMock(return_value=agent_response)
+            elif agent_attr == "_event_agent":
+                agent.answer_event_query = AsyncMock(return_value=agent_response)
+            elif agent_attr == "_general_knowledge_agent":
+                agent.answer_general_query = AsyncMock(return_value=agent_response)
+            elif agent_attr == "_slide_agent":
+                agent.handle_slide_request = AsyncMock(return_value=agent_response)
+            elif agent_attr == "_farewell_agent":
+                agent.handle_farewell = AsyncMock(return_value=agent_response)
+
+            result = await workflow.ainvoke(
+                {"query": query, "session_id": session_id, "language": language}
+            )
+
+    return result
+
+
+# =============================================================================
+# A. Japanese Regular User (エンジニアカフェ利用客)
+# =============================================================================
+
+
+class TestJapaneseRegularUser:
+    """日本語の一般利用者シナリオ。エンジニアカフェで最も頻出する質問パターン。"""
+
+    @pytest.mark.asyncio
+    async def test_a01_wifi_password(self):
+        """A01: "WiFiのパスワードを教えてください" -> facility agent -> WiFi password
+
+        Most common question at the kiosk. Visitors need WiFi immediately.
+        """
+        assert extract_request_type("WiFiのパスワードを教えてください") == "wifi"
+
+        result = await _run_workflow(
+            query="WiFiのパスワードを教えてください",
+            session_id="scenario-a01",
+            language="ja",
+            mock_decision=_build_decision(
+                next_agent="facility",
+                category="facility-info",
+                request_type="wifi",
+                confidence=0.98,
+                reasoning="WiFi keyword detected",
+            ),
+            agent_attr="_facility_agent",
+            agent_response={
+                "answer": "Wi-Fiは無料でご利用いただけます。SSID: EngineerCafe_WiFi",
+                "emotion": "happy",
+                "metadata": {"agent": "FacilityAgent", "status": "success"},
+            },
+        )
+
+        assert "Wi-Fi" in result["answer"] or "wifi" in result["answer"].lower()
+
+    @pytest.mark.asyncio
+    async def test_a02_business_hours(self):
+        """A02: "営業時間は何時までですか？" -> business_info agent -> hours
+
+        Hours: Weekdays/Sat 9:00-22:00, Sun/Holidays 9:00-20:00.
+        """
+        assert extract_request_type("営業時間は何時までですか？") == "hours"
+
+        result = await _run_workflow(
+            query="営業時間は何時までですか？",
+            session_id="scenario-a02",
+            language="ja",
+            mock_decision=_build_decision(
+                next_agent="business_info",
+                category="business-hours",
+                request_type="hours",
+                confidence=0.97,
+            ),
+            agent_attr="_business_info_agent",
+            agent_response={
+                "answer": "平日・土曜は9:00〜22:00、日曜・祝日は9:00〜20:00です。",
+                "emotion": "neutral",
+                "metadata": {"agent": "BusinessInfoAgent", "status": "success"},
+            },
+        )
+
+        assert "9:00" in result["answer"]
+        assert "22:00" in result["answer"] or "20:00" in result["answer"]
+
+    @pytest.mark.asyncio
+    async def test_a03_todays_events(self):
+        """A03: "今日のイベントはありますか？" -> event agent -> calendar check
+
+        Visitors checking if there's a meetup/seminar today.
+        """
+        assert extract_request_type("今日のイベントはありますか？") == "event"
+
+        result = await _run_workflow(
+            query="今日のイベントはありますか？",
+            session_id="scenario-a03",
+            language="ja",
+            mock_decision=_build_decision(
+                next_agent="event",
+                category="events",
+                request_type="event",
+                confidence=0.95,
+            ),
+            agent_attr="_event_agent",
+            agent_response={
+                "answer": "本日はPython勉強会が19:00から開催されます。",
+                "emotion": "happy",
+                "metadata": {"agent": "EventAgent", "status": "success"},
+            },
+        )
+
+        assert result["answer"] is not None
+
+    @pytest.mark.asyncio
+    async def test_a04_basement_space(self):
+        """A04: "地下のスペースを使いたいのですが" -> facility agent -> basement info
+
+        Engineer Cafe has B1 with meeting/focus/makers spaces.
+        """
+        assert extract_request_type("地下のスペースを使いたいのですが") == "basement"
+
+        result = await _run_workflow(
+            query="地下のスペースを使いたいのですが",
+            session_id="scenario-a04",
+            language="ja",
+            mock_decision=_build_decision(
+                next_agent="facility",
+                category="facility-info",
+                request_type="basement",
+                confidence=0.93,
+            ),
+            agent_attr="_facility_agent",
+            agent_response={
+                "answer": "地下にはMTGスペース、集中スペース、MAKER'sスペースがあります。",
+                "emotion": "neutral",
+                "metadata": {"agent": "FacilityAgent", "status": "success"},
+            },
+        )
+
+        assert result["answer"] is not None
+
+    @pytest.mark.asyncio
+    async def test_a05_meeting_room_booking(self):
+        """A05: "会議室の予約方法を教えてください" -> facility agent -> meeting room"""
+        assert extract_request_type("会議室の予約方法を教えてください") == "meeting-room"
+
+        result = await _run_workflow(
+            query="会議室の予約方法を教えてください",
+            session_id="scenario-a05",
+            language="ja",
+            mock_decision=_build_decision(
+                next_agent="facility",
+                category="facility-info",
+                request_type="meeting-room",
+                confidence=0.92,
+            ),
+            agent_attr="_facility_agent",
+            agent_response={
+                "answer": "会議室は事前予約で利用できます。受付でお申し込みください。",
+                "emotion": "neutral",
+                "metadata": {"agent": "FacilityAgent", "status": "success"},
+            },
+        )
+
+        assert result["answer"] is not None
+
+    @pytest.mark.asyncio
+    async def test_a06_pricing_free(self):
+        """A06: "料金はいくらですか？" -> business_info -> pricing (free!)
+
+        Engineer Cafe is free to use. Visitors often don't believe it.
+        """
+        assert extract_request_type("料金はいくらですか？") == "price"
+
+        result = await _run_workflow(
+            query="料金はいくらですか？",
+            session_id="scenario-a06",
+            language="ja",
+            mock_decision=_build_decision(
+                next_agent="business_info",
+                category="pricing",
+                request_type="price",
+                confidence=0.96,
+            ),
+            agent_attr="_business_info_agent",
+            agent_response={
+                "answer": "エンジニアカフェは無料でご利用いただけます。",
+                "emotion": "happy",
+                "metadata": {"agent": "BusinessInfoAgent", "status": "success"},
+            },
+        )
+
+        assert "無料" in result["answer"]
+
+    @pytest.mark.asyncio
+    async def test_a07_power_outlets(self):
+        """A07: "電源はどこにありますか？" -> facility agent -> power outlets
+
+        Engineers need to charge laptops. Power outlets at most desks.
+        """
+        assert extract_request_type("電源はどこにありますか？") == "facility"
+
+        result = await _run_workflow(
+            query="電源はどこにありますか？",
+            session_id="scenario-a07",
+            language="ja",
+            mock_decision=_build_decision(
+                next_agent="facility",
+                category="facilities",
+                request_type="facility",
+                confidence=0.90,
+            ),
+            agent_attr="_facility_agent",
+            agent_response={
+                "answer": "各デスクに電源コンセントが設置されています。",
+                "emotion": "neutral",
+                "metadata": {"agent": "FacilityAgent", "status": "success"},
+            },
+        )
+
+        assert result["answer"] is not None
+
+    @pytest.mark.asyncio
+    async def test_a08_printer_available(self):
+        """A08: "プリンターは使えますか？" -> facility agent -> printing"""
+        assert extract_request_type("プリンターは使えますか？") == "facility"
+
+        result = await _run_workflow(
+            query="プリンターは使えますか？",
+            session_id="scenario-a08",
+            language="ja",
+            mock_decision=_build_decision(
+                next_agent="facility",
+                category="facilities",
+                request_type="facility",
+                confidence=0.90,
+            ),
+            agent_attr="_facility_agent",
+            agent_response={
+                "answer": "プリンターをご利用いただけます。受付にお声がけください。",
+                "emotion": "neutral",
+                "metadata": {"agent": "FacilityAgent", "status": "success"},
+            },
+        )
+
+        assert result["answer"] is not None
+
+    @pytest.mark.asyncio
+    async def test_a09_what_is_engineer_cafe(self):
+        """A09: "エンジニアカフェって何ですか？" -> business_info -> about
+
+        From e2e_scenarios.json scn-001: first-time visitor at kiosk.
+        """
+        result = await _run_workflow(
+            query="エンジニアカフェって何ですか？",
+            session_id="scenario-a09",
+            language="ja",
+            mock_decision=_build_decision(
+                next_agent="business_info",
+                category="general",
+                request_type="general",
+                confidence=0.85,
+            ),
+            agent_attr="_business_info_agent",
+            agent_response={
+                "answer": (
+                    "エンジニアカフェは、福岡市の赤煉瓦文化館にある"
+                    "エンジニア向けの無料コワーキングスペースです。"
+                ),
+                "emotion": "happy",
+                "metadata": {"agent": "BusinessInfoAgent", "status": "success"},
+            },
+        )
+
+        assert "エンジニアカフェ" in result["answer"] or "コワーキング" in result["answer"]
+
+    @pytest.mark.asyncio
+    async def test_a10_community_lab(self):
+        """A10: "コミュニティラボについて教えてください" -> business_info -> community
+
+        EC Lab is a membership community for startups. From scn-007.
+        """
+        assert extract_request_type("エンジニアカフェラボについて教えてください") == "community"
+
+        result = await _run_workflow(
+            query="コミュニティラボについて教えてください",
+            session_id="scenario-a10",
+            language="ja",
+            mock_decision=_build_decision(
+                next_agent="business_info",
+                category="community",
+                request_type="community",
+                confidence=0.92,
+            ),
+            agent_attr="_business_info_agent",
+            agent_response={
+                "answer": (
+                    "Engineer Cafe Labは会員制のコミュニティです。"
+                    "起業やスタートアップの支援を行っています。"
+                ),
+                "emotion": "happy",
+                "metadata": {"agent": "BusinessInfoAgent", "status": "success"},
+            },
+        )
+
+        assert result["answer"] is not None
+
+
+# =============================================================================
+# B. English Tourist (外国人観光客)
+# =============================================================================
+
+
+class TestEnglishTourist:
+    """English-speaking visitor scenarios. Engineer Cafe is in a historic
+    building in Fukuoka and attracts international visitors."""
+
+    @pytest.mark.asyncio
+    async def test_b11_opening_hours_english(self):
+        """B11: "What are the opening hours?" -> business_info -> hours (English)
+
+        From e2e_scenarios.json scn-004.
+        """
+        assert extract_request_type("What are the opening hours?") == "hours"
+
+        result = await _run_workflow(
+            query="What are the opening hours?",
+            session_id="scenario-b11",
+            language="en",
+            mock_decision=_build_decision(
+                next_agent="business_info",
+                language="en",
+                category="business-hours",
+                request_type="hours",
+                confidence=0.95,
+            ),
+            agent_attr="_business_info_agent",
+            agent_response={
+                "answer": (
+                    "We are open weekdays and Saturdays from 9:00 to 22:00, "
+                    "Sundays and holidays from 9:00 to 20:00."
+                ),
+                "emotion": "neutral",
+                "metadata": {"agent": "BusinessInfoAgent", "status": "success"},
+            },
+        )
+
+        assert "9:00" in result["answer"]
+
+    @pytest.mark.asyncio
+    async def test_b12_is_it_free_english(self):
+        """B12: "Is it free to use?" -> business_info -> pricing (English)"""
+        assert extract_request_type("Is it free to use?") == "price"
+
+        result = await _run_workflow(
+            query="Is it free to use?",
+            session_id="scenario-b12",
+            language="en",
+            mock_decision=_build_decision(
+                next_agent="business_info",
+                language="en",
+                category="pricing",
+                request_type="price",
+                confidence=0.95,
+            ),
+            agent_attr="_business_info_agent",
+            agent_response={
+                "answer": "Yes, Engineer Cafe is completely free to use!",
+                "emotion": "happy",
+                "metadata": {"agent": "BusinessInfoAgent", "status": "success"},
+            },
+        )
+
+        assert "free" in result["answer"].lower()
+
+    @pytest.mark.asyncio
+    async def test_b13_wifi_password_english(self):
+        """B13: "What's the WiFi password?" -> facility -> WiFi (English)"""
+        assert extract_request_type("What's the WiFi password?") == "wifi"
+
+        result = await _run_workflow(
+            query="What's the WiFi password?",
+            session_id="scenario-b13",
+            language="en",
+            mock_decision=_build_decision(
+                next_agent="facility",
+                language="en",
+                category="facility-info",
+                request_type="wifi",
+                confidence=0.97,
+            ),
+            agent_attr="_facility_agent",
+            agent_response={
+                "answer": "Free WiFi is available. SSID: EngineerCafe_WiFi",
+                "emotion": "happy",
+                "metadata": {"agent": "FacilityAgent", "status": "success"},
+            },
+        )
+
+        assert "WiFi" in result["answer"] or "wifi" in result["answer"].lower()
+
+    @pytest.mark.asyncio
+    async def test_b14_directions_from_hakata(self):
+        """B14: "How do I get here from Hakata Station?" -> facility -> access
+
+        Hakata Station is the main JR station in Fukuoka.
+        """
+        assert extract_request_type("How do I get here from Hakata Station?") == "access"
+
+        result = await _run_workflow(
+            query="How do I get here from Hakata Station?",
+            session_id="scenario-b14",
+            language="en",
+            mock_decision=_build_decision(
+                next_agent="facility",
+                language="en",
+                category="access",
+                request_type="access",
+                confidence=0.92,
+            ),
+            agent_attr="_facility_agent",
+            agent_response={
+                "answer": (
+                    "From Hakata Station, take the subway to Gion Station. "
+                    "It's a 5-minute walk from there."
+                ),
+                "emotion": "neutral",
+                "metadata": {"agent": "FacilityAgent", "status": "success"},
+            },
+        )
+
+        assert result["answer"] is not None
+
+    @pytest.mark.asyncio
+    async def test_b15_tour_request(self):
+        """B15: "I'd like a tour of the building" -> slide agent -> tour slides
+
+        The building (Akarenga Cultural Hall) is a registered Important
+        Cultural Property from 1909. Tourists want a tour.
+        """
+        result = await _run_workflow(
+            query="I'd like a tour of the building",
+            session_id="scenario-b15",
+            language="en",
+            mock_decision=_build_decision(
+                next_agent="slide",
+                language="en",
+                category="slide",
+                request_type="slide",
+                confidence=0.88,
+            ),
+            agent_attr="_slide_agent",
+            agent_response={
+                "answer": "Let me show you around! This building was built in 1909.",
+                "emotion": "happy",
+                "metadata": {"agent": "SlideAgent", "status": "success"},
+            },
+        )
+
+        assert result["answer"] is not None
+
+    @pytest.mark.asyncio
+    async def test_b16_events_today_english(self):
+        """B16: "What events are happening today?" -> event -> calendar (English)"""
+        assert extract_request_type("What events are happening today?") == "event"
+
+        result = await _run_workflow(
+            query="What events are happening today?",
+            session_id="scenario-b16",
+            language="en",
+            mock_decision=_build_decision(
+                next_agent="event",
+                language="en",
+                category="events",
+                request_type="event",
+                confidence=0.93,
+            ),
+            agent_attr="_event_agent",
+            agent_response={
+                "answer": "There is a Python meetup today at 19:00.",
+                "emotion": "happy",
+                "metadata": {"agent": "EventAgent", "status": "success"},
+            },
+        )
+
+        assert result["answer"] is not None
+
+    @pytest.mark.asyncio
+    async def test_b17_restroom_english(self):
+        """B17: "Where is the restroom?" -> facility -> restroom (English)
+
+        From e2e_scenarios.json scn-008.
+        """
+        assert extract_request_type("Where is the restroom?") == "toilet"
+
+        result = await _run_workflow(
+            query="Where is the restroom?",
+            session_id="scenario-b17",
+            language="en",
+            mock_decision=_build_decision(
+                next_agent="facility",
+                language="en",
+                category="facility-info",
+                request_type="toilet",
+                confidence=0.95,
+            ),
+            agent_attr="_facility_agent",
+            agent_response={
+                "answer": "Restrooms are located on each floor.",
+                "emotion": "neutral",
+                "metadata": {"agent": "FacilityAgent", "status": "success"},
+            },
+        )
+
+        assert result["answer"] is not None
+
+
+# =============================================================================
+# C. Reception Flow (受付フロー)
+# =============================================================================
+
+
+class TestReceptionFlow:
+    """Reception workflow scenarios triggered by sensor/button at the kiosk.
+    Tests the full greet -> hear_purpose -> classify -> route flow."""
+
+    @pytest.mark.asyncio
+    async def test_c18_sensor_trigger_facility_use(self):
+        """C18: Sensor trigger -> greeting -> "施設を使いたい" -> facility routing
+
+        Visitor walks up to kiosk, sensor triggers greeting,
+        they say they want to use the facility.
+        """
+        from backend.workflows.reception_workflow import (
+            get_reception_workflow,
+            make_initial_state,
+        )
+        from langchain_core.messages import HumanMessage
+
+        state = make_initial_state(
+            session_id="scenario-c18",
+            language="ja",
+            trigger_type="sensor",
+        )
+        state["messages"] = [HumanMessage(content="施設を使いたいです")]
+
+        svc = MagicMock()
+        svc.identify_by_visitor_id = AsyncMock(return_value=None)
+
+        with patch(
+            "backend.workflows.reception_workflow.VisitorIdentificationService",
+            return_value=svc,
+        ):
+            graph = await get_reception_workflow()
+            result = await graph.ainvoke(state)
+
+        assert result["stage"] == "completed"
+        assert result["purpose"]["category"] == "facility_use"
+        assert result["purpose"]["target_agent"] == "facility"
+
+    @pytest.mark.asyncio
+    async def test_c19_sensor_trigger_tour(self):
+        """C19: Sensor trigger -> greeting -> "I want a tour" -> slide routing
+
+        English tourist at kiosk wants to see the building.
+        """
+        from backend.workflows.reception_workflow import (
+            get_reception_workflow,
+            make_initial_state,
+        )
+        from langchain_core.messages import HumanMessage
+
+        state = make_initial_state(
+            session_id="scenario-c19",
+            language="en",
+            trigger_type="sensor",
+        )
+        state["messages"] = [HumanMessage(content="I want a tour of the building")]
+
+        svc = MagicMock()
+        svc.identify_by_visitor_id = AsyncMock(return_value=None)
+
+        with patch(
+            "backend.workflows.reception_workflow.VisitorIdentificationService",
+            return_value=svc,
+        ):
+            with patch(
+                "backend.utils.purpose_classifier.classify_purpose",
+                new_callable=AsyncMock,
+                return_value=("tour", "Building tour request", 0.90),
+            ):
+                graph = await get_reception_workflow()
+                result = await graph.ainvoke(state)
+
+        assert result["stage"] == "completed"
+        assert result["purpose"]["category"] == "tour"
+        assert result["purpose"]["target_agent"] == "slide"
+
+    @pytest.mark.asyncio
+    async def test_c20_sensor_trigger_event(self):
+        """C20: Sensor trigger -> "イベントに参加しに来ました" -> event routing
+
+        Visitor came for a specific meetup/seminar.
+        """
+        from backend.workflows.reception_workflow import (
+            get_reception_workflow,
+            make_initial_state,
+        )
+        from langchain_core.messages import HumanMessage
+
+        state = make_initial_state(
+            session_id="scenario-c20",
+            language="ja",
+            trigger_type="sensor",
+        )
+        state["messages"] = [HumanMessage(content="イベントに参加しに来ました")]
+
+        svc = MagicMock()
+        svc.identify_by_visitor_id = AsyncMock(return_value=None)
+
+        with patch(
+            "backend.workflows.reception_workflow.VisitorIdentificationService",
+            return_value=svc,
+        ):
+            graph = await get_reception_workflow()
+            result = await graph.ainvoke(state)
+
+        assert result["stage"] == "completed"
+        assert result["purpose"]["category"] == "event_participation"
+        assert result["purpose"]["target_agent"] == "event"
+
+    @pytest.mark.asyncio
+    @pytest.mark.xfail(reason="Wave 7: ambiguous purpose re-ask not yet implemented")
+    async def test_c21_ambiguous_purpose(self):
+        """C21: "ちょっと見に来ただけ" -> should re-ask purpose
+
+        Visitor is just browsing. System should clarify intent before routing.
+        """
+        from backend.workflows.reception_workflow import (
+            get_reception_workflow,
+            make_initial_state,
+        )
+        from langchain_core.messages import HumanMessage
+
+        state = make_initial_state(
+            session_id="scenario-c21",
+            language="ja",
+            trigger_type="sensor",
+        )
+        state["messages"] = [HumanMessage(content="ちょっと見に来ただけです")]
+
+        svc = MagicMock()
+        svc.identify_by_visitor_id = AsyncMock(return_value=None)
+
+        with patch(
+            "backend.workflows.reception_workflow.VisitorIdentificationService",
+            return_value=svc,
+        ):
+            graph = await get_reception_workflow()
+            result = await graph.ainvoke(state)
+
+        assert result["stage"] in ("purpose_hearing", "clarification")
+        assert "purpose" not in result or result["purpose"]["confidence"] < 0.5
+
+    @pytest.mark.asyncio
+    async def test_c22_returning_visitor(self):
+        """C22: Returning visitor -> personalized greeting -> purpose
+
+        Recognized visitor gets a personalized welcome with their name.
+        """
+        from backend.workflows.reception_workflow import (
+            get_reception_workflow,
+            make_initial_state,
+        )
+        from langchain_core.messages import HumanMessage
+
+        state = make_initial_state(
+            session_id="scenario-c22",
+            language="ja",
+            trigger_type="sensor",
+        )
+        state["messages"] = [HumanMessage(content="作業したいです")]
+
+        svc = MagicMock()
+        svc.identify_by_visitor_id = AsyncMock(
+            return_value={
+                "visitor_type": "returning",
+                "name": "山田太郎",
+                "last_purpose": "コーディング",
+                "visit_count": 5,
+            }
+        )
+
+        with patch(
+            "backend.workflows.reception_workflow.VisitorIdentificationService",
+            return_value=svc,
+        ):
+            graph = await get_reception_workflow()
+            result = await graph.ainvoke(state)
+
+        assert result["stage"] == "completed"
+        assert "山田太郎" in result["greeting"]
+        assert result["visitor_identity"]["visitor_type"] == "returning"
+        assert result["purpose"]["category"] == "facility_use"
+
+
+# =============================================================================
+# D. Cross-domain & Edge Cases
+# =============================================================================
+
+
+class TestCrossDomainAndEdgeCases:
+    """Edge cases that test routing robustness and multi-intent handling."""
+
+    @pytest.mark.asyncio
+    @pytest.mark.xfail(reason="Wave 7: multi-intent splitting not yet implemented")
+    async def test_d23_multi_intent_wifi_and_hours(self):
+        """D23: "WiFiパスワードと営業時間を教えて" -> both answers
+
+        From e2e_scenarios.json scn-005. Visitors often ask multiple things.
+        """
+        assert extract_request_type("WiFiパスワードと営業時間を教えて") == "wifi"
+
+        result = await _run_workflow(
+            query="WiFiパスワードと営業時間を教えて",
+            session_id="scenario-d23",
+            language="ja",
+            mock_decision=_build_decision(
+                next_agent="business_info",
+                category="business-hours",
+                request_type="hours",
+                confidence=0.85,
+            ),
+            agent_attr="_business_info_agent",
+            agent_response={
+                "answer": (
+                    "Wi-Fiパスワードは受付でお伝えしています。"
+                    "営業時間は平日・土曜9:00〜22:00、日曜・祝日9:00〜20:00です。"
+                ),
+                "emotion": "neutral",
+                "metadata": {"agent": "BusinessInfoAgent", "status": "success"},
+            },
+        )
+
+        answer = result["answer"]
+        assert "Wi-Fi" in answer or "wifi" in answer.lower()
+        assert "9:00" in answer
+
+    @pytest.mark.asyncio
+    async def test_d24_mixed_language_query(self):
+        """D24: "hello, wifi password?" -> mixed language -> WiFi answer
+
+        Non-native speakers mixing English greetings with keywords.
+        """
+        assert extract_request_type("hello, wifi password?") == "wifi"
+
+        result = await _run_workflow(
+            query="hello, wifi password?",
+            session_id="scenario-d24",
+            language="en",
+            mock_decision=_build_decision(
+                next_agent="facility",
+                language="en",
+                category="facility-info",
+                request_type="wifi",
+                confidence=0.95,
+            ),
+            agent_attr="_facility_agent",
+            agent_response={
+                "answer": "WiFi is free. Please ask at the reception for the password.",
+                "emotion": "happy",
+                "metadata": {"agent": "FacilityAgent", "status": "success"},
+            },
+        )
+
+        assert result["answer"] is not None
+
+    @pytest.mark.asyncio
+    @pytest.mark.xfail(reason="Wave 7: anaphora resolution not yet implemented")
+    async def test_d25_anaphora_needs_context(self):
+        """D25: "それについてもう少し教えて" -> needs memory context
+
+        Follow-up referencing previous context. Should NOT fast-path.
+        """
+        assert extract_request_type("それについてもう少し教えて") is None
+
+        result = await _run_workflow(
+            query="それについてもう少し教えて",
+            session_id="scenario-d25",
+            language="ja",
+            mock_decision=_build_decision(
+                next_agent="general_knowledge",
+                category="memory",
+                request_type="general",
+                confidence=0.6,
+                reasoning="Anaphora detected, requires memory context",
+            ),
+            agent_attr="_general_knowledge_agent",
+            agent_response={
+                "answer": "前の質問の続きですね。もう少し詳しく教えてください。",
+                "emotion": "neutral",
+                "metadata": {"agent": "GeneralKnowledgeAgent", "status": "success"},
+            },
+        )
+
+        assert result["answer"] is not None
+
+    @pytest.mark.asyncio
+    async def test_d26_floor_location_query(self):
+        """D26: "ここは何階ですか？" -> facility with context
+
+        Visitor disoriented in the multi-floor building.
+        """
+        result = await _run_workflow(
+            query="ここは何階ですか？今いる場所は？",
+            session_id="scenario-d26",
+            language="ja",
+            mock_decision=_build_decision(
+                next_agent="facility",
+                category="facility-info",
+                request_type="general",
+                confidence=0.85,
+            ),
+            agent_attr="_facility_agent",
+            agent_response={
+                "answer": "こちらは1階のメインフロアです。受付と作業スペースがあります。",
+                "emotion": "neutral",
+                "metadata": {"agent": "FacilityAgent", "status": "success"},
+            },
+        )
+
+        assert result["answer"] is not None
+
+    @pytest.mark.asyncio
+    async def test_d27_off_topic_weather(self):
+        """D27: "明日の天気は？" -> polite rejection
+
+        Visitor asking something unrelated to Engineer Cafe.
+        """
+        assert extract_request_type("明日の天気は？") is None
+
+        result = await _run_workflow(
+            query="明日の天気は？",
+            session_id="scenario-d27",
+            language="ja",
+            mock_decision=_build_decision(
+                next_agent="general_knowledge",
+                category="general",
+                request_type="general",
+                confidence=0.3,
+                reasoning="Off-topic query",
+            ),
+            agent_attr="_general_knowledge_agent",
+            agent_response={
+                "answer": (
+                    "申し訳ございませんが、天気予報についてはお答えできません。"
+                    "エンジニアカフェに関するご質問はいかがですか？"
+                ),
+                "emotion": "neutral",
+                "metadata": {"agent": "GeneralKnowledgeAgent", "status": "success"},
+            },
+        )
+
+        assert result["answer"] is not None
+
+    @pytest.mark.asyncio
+    async def test_d28_emergency_fire(self):
+        """D28: "火事だ！" -> emergency -> immediate guidance
+
+        Emergency situation at the facility.
+        """
+        assert extract_request_type("火事だ！") == "emergency"
+
+        result = await _run_workflow(
+            query="火事だ！",
+            session_id="scenario-d28",
+            language="ja",
+            mock_decision=_build_decision(
+                next_agent="facility",
+                category="emergency",
+                request_type="emergency",
+                confidence=0.99,
+                reasoning="Emergency keyword: fire",
+            ),
+            agent_attr="_facility_agent",
+            agent_response={
+                "answer": (
+                    "緊急事態です！すぐに119番に通報してください。"
+                    "最寄りの非常口から避難してください。"
+                ),
+                "emotion": "urgent",
+                "metadata": {"agent": "FacilityAgent", "status": "success"},
+            },
+        )
+
+        assert result["answer"] is not None
+
+
+# =============================================================================
+# E. Fast-Path Verification
+# =============================================================================
+
+
+class TestFastPathVerification:
+    """Verify keyword-only queries are correctly classified by
+    extract_request_type for fast-path routing."""
+
+    def test_e29_wifi_fast_path_keyword(self):
+        """E29: "WiFiパスワード" -> wifi (fast-path candidate)"""
+        assert extract_request_type("WiFiパスワード") == "wifi"
+
+    def test_e30_hours_fast_path_keyword(self):
+        """E30: "営業時間" -> hours (fast-path candidate)"""
+        assert extract_request_type("営業時間") == "hours"
+
+    def test_e31_farewell_fast_path(self):
+        """E31: "さようなら" -> farewell fast-path
+
+        Visitor leaving. Triggers farewell with card return reminder.
+        """
+        assert extract_request_type("さようなら") == "farewell"
+
+    def test_e32_wifi_complaint_still_matches_wifi(self):
+        """E32: "WiFiの速度が遅いんですが" -> wifi keyword match
+
+        Mentions WiFi but is a complaint. Keyword matcher returns "wifi"
+        but orchestrator should distinguish simple vs complex queries.
+        """
+        assert extract_request_type("WiFiの速度が遅いんですが") == "wifi"
+
+    def test_e33_emergency_keywords_take_priority(self):
+        """Emergency keywords should take priority over other matches."""
+        assert extract_request_type("地震だ！避難しないと") == "emergency"
+        assert extract_request_type("AEDはどこですか？") == "emergency"
+
+    def test_e34_farewell_variants(self):
+        """Various farewell expressions should all route correctly."""
+        assert extract_request_type("帰ります") == "farewell"
+        assert extract_request_type("お先に失礼します") == "farewell"
+        assert extract_request_type("bye") == "farewell"
+        assert extract_request_type("goodbye") == "farewell"
+
+    def test_e35_lost_and_found(self):
+        """Lost item queries should route correctly."""
+        assert extract_request_type("忘れ物をしました") == "lost_found"
+        assert extract_request_type("I left my bag here") == "lost_found"
+
+    def test_e36_no_match_returns_none(self):
+        """Queries without keywords return None."""
+        assert extract_request_type("それについてもう少し教えて") is None
+        assert extract_request_type("明日の天気は？") is None
+        assert extract_request_type("ありがとう") is None
+
+
+# =============================================================================
+# F. Multilingual (zh/ko)
+# =============================================================================
+
+
+class TestMultilingual:
+    """Chinese and Korean visitor scenarios. Engineer Cafe Fukuoka
+    attracts visitors from neighboring Asian countries."""
+
+    @pytest.mark.asyncio
+    @pytest.mark.xfail(reason="Wave 7: zh/ko language detection not yet fully implemented")
+    async def test_f33_chinese_wifi(self):
+        """F33: "请问WiFi密码是什么？" (Chinese) -> WiFi answer in Chinese
+
+        Chinese tourists visiting Fukuoka often stop by Engineer Cafe.
+        """
+        assert extract_request_type("请问WiFi密码是什么？") == "wifi"
+
+        result = await _run_workflow(
+            query="请问WiFi密码是什么？",
+            session_id="scenario-f33",
+            language="zh",
+            mock_decision=_build_decision(
+                next_agent="facility",
+                language="zh",
+                category="facility-info",
+                request_type="wifi",
+                confidence=0.95,
+            ),
+            agent_attr="_facility_agent",
+            agent_response={
+                "answer": "WiFi是免费的。SSID: EngineerCafe_WiFi",
+                "emotion": "happy",
+                "metadata": {"agent": "FacilityAgent", "status": "success"},
+            },
+        )
+
+        assert "WiFi" in result["answer"] or "wifi" in result["answer"].lower()
+
+    @pytest.mark.asyncio
+    @pytest.mark.xfail(reason="Wave 7: zh/ko language detection not yet fully implemented")
+    async def test_f34_korean_hours(self):
+        """F34: "영업시간이 어떻게 되나요?" (Korean) -> hours in Korean"""
+        result = await _run_workflow(
+            query="영업시간이 어떻게 되나요?",
+            session_id="scenario-f34",
+            language="ko",
+            mock_decision=_build_decision(
+                next_agent="business_info",
+                language="ko",
+                category="business-hours",
+                request_type="hours",
+                confidence=0.90,
+            ),
+            agent_attr="_business_info_agent",
+            agent_response={
+                "answer": "평일과 토요일은 9:00~22:00, 일요일과 공휴일은 9:00~20:00입니다.",
+                "emotion": "neutral",
+                "metadata": {"agent": "BusinessInfoAgent", "status": "success"},
+            },
+        )
+
+        assert "9:00" in result["answer"]
+
+
+# =============================================================================
+# G. Additional Realistic Scenarios (from routing_constants.py keywords)
+# =============================================================================
+
+
+class TestAdditionalRealisticScenarios:
+    """Additional scenarios from routing_constants.py keyword lists
+    representing real questions visitors ask at Engineer Cafe."""
+
+    @pytest.mark.asyncio
+    async def test_g35_parking(self):
+        """G35: "駐車場はありますか？" -> facility -> parking
+
+        From e2e_scenarios.json scn-008. No dedicated parking.
+        """
+        assert extract_request_type("駐車場はありますか？") == "parking"
+
+        result = await _run_workflow(
+            query="駐車場はありますか？",
+            session_id="scenario-g35",
+            language="ja",
+            mock_decision=_build_decision(
+                next_agent="facility",
+                category="parking",
+                request_type="parking",
+                confidence=0.95,
+            ),
+            agent_attr="_facility_agent",
+            agent_response={
+                "answer": "専用駐車場はありません。近隣のコインパーキングをご利用ください。",
+                "emotion": "neutral",
+                "metadata": {"agent": "FacilityAgent", "status": "success"},
+            },
+        )
+
+        assert result["answer"] is not None
+
+    @pytest.mark.asyncio
+    async def test_g36_career_consultation(self):
+        """G36: "転職を考えているのですが、相談できますか？" -> business_info -> consultation
+
+        From e2e_scenarios.json scn-007. Community managers offer career
+        counseling.
+        """
+        assert extract_request_type("転職を考えているのですが、相談できますか？") == "consultation"
+
+        result = await _run_workflow(
+            query="転職を考えているのですが、相談できますか？",
+            session_id="scenario-g36",
+            language="ja",
+            mock_decision=_build_decision(
+                next_agent="business_info",
+                category="consultation",
+                request_type="consultation",
+                confidence=0.92,
+            ),
+            agent_attr="_business_info_agent",
+            agent_response={
+                "answer": (
+                    "コミュニティマネージャーにキャリア相談ができます。受付でお声がけください。"
+                ),
+                "emotion": "happy",
+                "metadata": {"agent": "BusinessInfoAgent", "status": "success"},
+            },
+        )
+
+        assert result["answer"] is not None
+
+    @pytest.mark.asyncio
+    async def test_g37_food_and_drink(self):
+        """G37: "飲食は持ち込めますか？" -> facility -> food_drink
+
+        Saino Cafe is on 1F for drinks.
+        """
+        assert extract_request_type("飲食は持ち込めますか？") == "food_drink"
+
+        result = await _run_workflow(
+            query="飲食は持ち込めますか？",
+            session_id="scenario-g37",
+            language="ja",
+            mock_decision=_build_decision(
+                next_agent="facility",
+                category="food_drink",
+                request_type="food_drink",
+                confidence=0.93,
+            ),
+            agent_attr="_facility_agent",
+            agent_response={
+                "answer": (
+                    "蓋つきの飲み物は持ち込み可能です。"
+                    "1FのSaino Cafeでドリンクもお求めいただけます。"
+                ),
+                "emotion": "neutral",
+                "metadata": {"agent": "FacilityAgent", "status": "success"},
+            },
+        )
+
+        assert result["answer"] is not None
+
+    @pytest.mark.asyncio
+    async def test_g38_smoking(self):
+        """G38: "喫煙所はありますか？" -> facility -> smoking
+
+        Building is non-smoking.
+        """
+        assert extract_request_type("喫煙所はありますか？") == "smoking"
+
+        result = await _run_workflow(
+            query="喫煙所はありますか？",
+            session_id="scenario-g38",
+            language="ja",
+            mock_decision=_build_decision(
+                next_agent="facility",
+                category="smoking",
+                request_type="smoking",
+                confidence=0.95,
+            ),
+            agent_attr="_facility_agent",
+            agent_response={
+                "answer": "館内は全面禁煙です。近隣の喫煙所をご案内いたします。",
+                "emotion": "neutral",
+                "metadata": {"agent": "FacilityAgent", "status": "success"},
+            },
+        )
+
+        assert result["answer"] is not None
+
+    @pytest.mark.asyncio
+    async def test_g39_bicycle_parking(self):
+        """G39: "自転車で来たのですが、駐輪場はありますか？" -> facility -> bicycle
+
+        Cycling is common in Fukuoka.
+        """
+        assert extract_request_type("自転車で来たのですが、駐輪場はありますか？") == "bicycle"
+
+        result = await _run_workflow(
+            query="自転車で来たのですが、駐輪場はありますか？",
+            session_id="scenario-g39",
+            language="ja",
+            mock_decision=_build_decision(
+                next_agent="facility",
+                category="bicycle",
+                request_type="bicycle",
+                confidence=0.93,
+            ),
+            agent_attr="_facility_agent",
+            agent_response={
+                "answer": "建物の近くに駐輪スペースがあります。",
+                "emotion": "neutral",
+                "metadata": {"agent": "FacilityAgent", "status": "success"},
+            },
+        )
+
+        assert result["answer"] is not None
+
+    @pytest.mark.asyncio
+    async def test_g40_building_history(self):
+        """G40: "この建物の歴史を教えてください" -> facility -> building
+
+        The Akarenga Cultural Hall was built in 1909 by Tatsuno Kingo.
+        Registered Important Cultural Property.
+        """
+        assert extract_request_type("この建物の歴史を教えてください") == "building"
+
+        result = await _run_workflow(
+            query="この建物の歴史を教えてください",
+            session_id="scenario-g40",
+            language="ja",
+            mock_decision=_build_decision(
+                next_agent="facility",
+                category="facility-info",
+                request_type="building",
+                confidence=0.90,
+            ),
+            agent_attr="_facility_agent",
+            agent_response={
+                "answer": (
+                    "この建物は1909年（明治42年）に建設された赤煉瓦文化館です。"
+                    "国の重要文化財に指定されています。"
+                ),
+                "emotion": "happy",
+                "metadata": {"agent": "FacilityAgent", "status": "success"},
+            },
+        )
+
+        assert result["answer"] is not None
+
+    @pytest.mark.asyncio
+    async def test_g41_nearby_lunch(self):
+        """G41: "近くにランチできる場所はありますか？" -> facility -> nearby"""
+        assert extract_request_type("近くにランチできる場所はありますか？") == "nearby"
+
+        result = await _run_workflow(
+            query="近くにランチできる場所はありますか？",
+            session_id="scenario-g41",
+            language="ja",
+            mock_decision=_build_decision(
+                next_agent="facility",
+                category="nearby",
+                request_type="nearby",
+                confidence=0.90,
+            ),
+            agent_attr="_facility_agent",
+            agent_response={
+                "answer": "周辺にはレストランやカフェが多数あります。中洲エリアが近いです。",
+                "emotion": "happy",
+                "metadata": {"agent": "FacilityAgent", "status": "success"},
+            },
+        )
+
+        assert result["answer"] is not None
+
+    @pytest.mark.asyncio
+    async def test_g42_accessibility(self):
+        """G42: "車椅子で入れますか？" -> facility -> accessibility"""
+        assert extract_request_type("車椅子で入れますか？") == "accessibility"
+
+        result = await _run_workflow(
+            query="車椅子で入れますか？",
+            session_id="scenario-g42",
+            language="ja",
+            mock_decision=_build_decision(
+                next_agent="facility",
+                category="policy",
+                request_type="accessibility",
+                confidence=0.92,
+            ),
+            agent_attr="_facility_agent",
+            agent_response={
+                "answer": "エレベーターがありますので、車椅子でもご利用いただけます。",
+                "emotion": "neutral",
+                "metadata": {"agent": "FacilityAgent", "status": "success"},
+            },
+        )
+
+        assert result["answer"] is not None
+
+    @pytest.mark.asyncio
+    async def test_g43_lost_item(self):
+        """G43: "忘れ物をしたのですが" -> facility -> lost_found"""
+        assert extract_request_type("忘れ物をしたのですが") == "lost_found"
+
+        result = await _run_workflow(
+            query="忘れ物をしたのですが",
+            session_id="scenario-g43",
+            language="ja",
+            mock_decision=_build_decision(
+                next_agent="facility",
+                category="lost_found",
+                request_type="lost_found",
+                confidence=0.95,
+            ),
+            agent_attr="_facility_agent",
+            agent_response={
+                "answer": "忘れ物については受付スタッフにお問い合わせください。",
+                "emotion": "neutral",
+                "metadata": {"agent": "FacilityAgent", "status": "success"},
+            },
+        )
+
+        assert result["answer"] is not None
+
+    @pytest.mark.asyncio
+    async def test_g44_3d_printer(self):
+        """G44: "3Dプリンターは使えますか？" -> facility -> equipment
+
+        From e2e_scenarios.json scn-002. MAKER's space has 3D printers.
+        """
+        assert extract_request_type("3Dプリンターは使えますか？") == "facility"
+
+        result = await _run_workflow(
+            query="3Dプリンターは使えますか？",
+            session_id="scenario-g44",
+            language="ja",
+            mock_decision=_build_decision(
+                next_agent="facility",
+                category="facilities",
+                request_type="facility",
+                confidence=0.92,
+            ),
+            agent_attr="_facility_agent",
+            agent_response={
+                "answer": (
+                    "地下のMAKER'sスペースで3Dプリンターをご利用いただけます。"
+                    "フィラメント代は実費負担となります。"
+                ),
+                "emotion": "happy",
+                "metadata": {"agent": "FacilityAgent", "status": "success"},
+            },
+        )
+
+        assert result["answer"] is not None

--- a/docs/STT-Implementation-Trace.md
+++ b/docs/STT-Implementation-Trace.md
@@ -1,0 +1,1323 @@
+# STT（Speech-to-Text）実装 完全トレースレポート
+
+**作成日:** 2026-03-28
+**プロジェクト:** Engineer Cafe Navigator
+**対象:** フロントエンド → バックエンド → Docker デプロイメント
+
+---
+
+## 1. 全体アーキテクチャ図
+
+```
+┌─────────────────────────────────────────────────────────────────┐
+│                       ユーザーのブラウザ                              │
+│  ┌───────────────────────────────────────────────────────────┐  │
+│  │ VoiceInterface.tsx + VoiceRecorder                        │  │
+│  │ 1. getUserMedia() → AudioContext + MediaRecorder          │  │
+│  │ 2. 音声キャプチャ → Blob (WebM/audio format)             │  │
+│  │ 3. arrayBufferToBase64() → Base64 文字列                  │  │
+│  └───────────────────────────────────────────────────────────┘  │
+└─────────────────────────────────────┬───────────────────────────┘
+                                      │
+                      POST /api/voice (JSON, Base64)
+                      ┌─────────────────────┐
+                      │ action: "speech_to_text"
+                      │ audioData: <base64>
+                      │ language: "ja"/"en"
+                      └─────────────────────┘
+                                      │
+                                      ▼
+┌─────────────────────────────────────────────────────────────────┐
+│                   フロントエンド Next.js                           │
+│  ┌───────────────────────────────────────────────────────────┐  │
+│  │ frontend/src/app/api/voice/route.ts                      │  │
+│  │ 1. リクエスト受け取り                                       │  │
+│  │ 2. backendFetch('/api/voice') でバックエンドにプロキシ      │  │
+│  │ 3. VoiceResponse を返す                                   │  │
+│  └───────────────────────────────────────────────────────────┘  │
+└─────────────────────────────────────┬───────────────────────────┘
+                                      │
+                      POST /api/voice (JSON)
+                      ┌─────────────────────┐
+                      │ audioData: <base64>
+                      │ language: "ja"
+                      │ action: "speech_to_text"
+                      └─────────────────────┘
+                                      │
+                                      ▼
+┌─────────────────────────────────────────────────────────────────┐
+│              バックエンド FastAPI (Python)                        │
+│  ┌───────────────────────────────────────────────────────────┐  │
+│  │ backend/main.py: @app.post("/api/voice")                │  │
+│  │ 1. VoiceRequest Pydantic モデルで検証                     │  │
+│  │ 2. Base64 デコード → audio_bytes                         │  │
+│  │ 3. _handle_stt() 呼び出し                                 │  │
+│  │    ↓                                                      │  │
+│  │    _get_stt_agent().speech_to_text()                    │  │
+│  └───────────────────────────────────────────────────────────┘  │
+│                                      │                          │
+│  ┌────────────────────────────────────▼──────────────────────┐  │
+│  │ backend/agents/stt_agent.py: STTAgent                     │  │
+│  │                                                            │  │
+│  │ speech_to_text(audio_bytes, language="ja")               │  │
+│  │ ↓                                                          │  │
+│  │ LocalSTTClient._sync_transcribe()                        │  │
+│  │ ├─ WAV ヘッダ検証                                         │  │
+│  │ ├─ WebM → WAV 変換（pydub 使用）                         │  │
+│  │ ├─ Vosk モデル読み込み（models/vosk-model-ja など）       │  │
+│  │ ├─ KaldiRecognizer 初期化                                │  │
+│  │ ├─ AcceptWaveform() で音声フレーム入力                   │  │
+│  │ ├─ FinalResult() で JSON 結果取得                        │  │
+│  │ └─ TranscriptionResult に変換（confidence 計算）          │  │
+│  │    ↓                                                      │  │
+│  │ _try_fallback() → Google STT へフォールバック            │  │
+│  │ （confidence < 0.4 の場合）                               │  │
+│  └────────────────────────────────────────────────────────────┘  │
+│                                      │                          │
+│  ┌────────────────────────────────────▼──────────────────────┐  │
+│  │ VoiceResponse (JSON)                                      │  │
+│  │ {                                                          │  │
+│  │   "success": true,                                        │  │
+│  │   "transcript": "...",                                    │  │
+│  │   "confidence": 0.85,                                     │  │
+│  │   "language": "ja",                                       │  │
+│  │   "provider": "vosk"                                      │  │
+│  │ }                                                          │  │
+│  └────────────────────────────────────────────────────────────┘  │
+└─────────────────────────────────────┬───────────────────────────┘
+                                      │
+            POST /api/voice → VoiceResponse (JSON)
+                                      │
+                                      ▼
+┌─────────────────────────────────────────────────────────────────┐
+│                    フロントエンド（ブラウザ）                      │
+│  VoiceInterface.tsx: sttResult.transcript をテキスト入力に利用     │
+│  （STT補正後、会話ルーティングへ）                                 │
+└─────────────────────────────────────────────────────────────────┘
+```
+
+---
+
+## 2. フロントエンド STT フロー
+
+### 2.1 音声キャプチャ（VoiceRecorder）
+
+**ファイル:** `frontend/src/lib/voice-recorder.ts`
+
+#### 初期化フロー
+
+```typescript
+// 1. getUserMedia で音声ストリーム取得
+const audioConstraints = {
+  channelCount: 1,        // モノラル
+  sampleRate: 16000,      // 16kHz（Vosk 推奨）
+  echoCancellation: true, // エコーキャンセル有効
+  noiseSuppression: true, // ノイズ抑制有効
+  autoGainControl: true   // 自動ゲイン制御有効
+};
+
+this.stream = await navigator.mediaDevices.getUserMedia({
+  audio: audioConstraints
+});
+
+// 2. MediaRecorder 作成
+const mimeType = this.getSupportedMimeType(); // audio/webm など
+this.mediaRecorder = new MediaRecorder(this.stream, { mimeType });
+```
+
+#### サポート MIME タイプ
+
+```typescript
+getSupportedMimeType(): string {
+  // ブラウザが対応している MIME タイプを順に試す
+  const candidates = [
+    'audio/webm',
+    'audio/webm;codecs=opus',
+    'audio/mp4',
+    'audio/ogg',
+    'audio/wav'
+  ];
+
+  for (const mimeType of candidates) {
+    if (MediaRecorder.isTypeSupported(mimeType)) {
+      return mimeType;
+    }
+  }
+  return ''; // フォールバック（OS デフォルト）
+}
+```
+
+#### 音声記録
+
+```typescript
+start(): void {
+  this.mediaRecorder.start();
+  this.isRecording = true;
+}
+
+// MediaRecorder のイベントハンドラ
+this.mediaRecorder.ondataavailable = (event) => {
+  if (event.data.size > 0) {
+    this.audioChunks.push(event.data); // Blob[] に蓄積
+  }
+};
+
+this.mediaRecorder.onstop = () => {
+  // 複数 Blob を結合
+  const audioBlob = new Blob(this.audioChunks, {
+    type: this.mediaRecorder.mimeType || 'audio/webm'
+  });
+  this.onDataAvailable(audioBlob); // コールバック
+  this.audioChunks = [];
+};
+```
+
+### 2.2 Base64 エンコーディング
+
+**ファイル:** `frontend/src/lib/voice-recorder.ts:263-270`
+
+```typescript
+static arrayBufferToBase64(buffer: ArrayBuffer): string {
+  const bytes = new Uint8Array(buffer);
+  let binary = '';
+  for (let i = 0; i < bytes.byteLength; i++) {
+    binary += String.fromCharCode(bytes[i]);
+  }
+  return btoa(binary); // Base64 エンコード
+}
+```
+
+**プロセス:**
+1. `audioBlob.arrayBuffer()` で ArrayBuffer を取得
+2. `Uint8Array` に変換
+3. `btoa()` で Base64 エンコード
+
+### 2.3 API 送信
+
+**ファイル:** `frontend/src/app/components/VoiceInterface.tsx:520-550`
+
+```typescript
+const sttResponse = await fetch('/api/voice', {
+  method: 'POST',
+  headers: {
+    'Content-Type': 'application/json',
+  },
+  body: JSON.stringify({
+    action: 'speech_to_text',
+    audioData: await toBase64(audioBlob),  // Base64 文字列
+    language: currentLanguage,             // "ja" or "en"
+    sessionId: sessionId                   // オプション
+  }),
+  signal: abortController.signal
+});
+
+const sttResult = await sttResponse.json();
+// {
+//   success: true,
+//   transcript: "エンジニアカフェについて教えてください",
+//   confidence: 0.85,
+//   language: "ja",
+//   detectedLanguage?: "ja",
+//   provider?: "vosk"
+// }
+
+setTranscript(sttResult.transcript);
+await sendMessage(sttResult.transcript);
+```
+
+### 2.4 STT 補正
+
+**ファイル:** `frontend/src/lib/stt-correction.ts`
+
+STT 補正は現在、フロントエンド側で実装されていません。バックエンド STT 結果はそのまま使用されます。
+
+---
+
+## 3. フロントエンド プロキシ API
+
+**ファイル:** `frontend/src/app/api/voice/route.ts`
+
+```typescript
+// POST /api/voice
+export async function POST(request: NextRequest) {
+  const body = await request.json();
+  // {
+  //   action: "speech_to_text",
+  //   audioData: <base64>,
+  //   language: "ja",
+  //   sessionId?: "..."
+  // }
+
+  const response = await backendFetch('/api/voice', {
+    body: {
+      action: body.action,
+      audioData: body.audioData,
+      sessionId: body.sessionId,
+      language: body.language || 'ja',
+      text: body.text,           // TTS 用
+      streaming: body.streaming  // TTS 用
+    }
+  });
+
+  if (!response.ok) {
+    return createBackendErrorResponse(response);
+  }
+
+  return NextResponse.json(response.data);
+}
+```
+
+**機能:**
+- フロントエンド `/api/voice` はシンプルなプロキシ
+- バックエンド `/api/voice` へ JSON を転送
+- エラーハンドリング（createBackendErrorResponse）
+
+---
+
+## 4. バックエンド STT フロー
+
+### 4.1 エンドポイント定義
+
+**ファイル:** `backend/main.py:638-705`
+
+```python
+@app.post("/api/voice", response_model=VoiceResponse,
+          dependencies=[Depends(verify_api_key)])
+@_rate_limit("20/minute")
+async def voice_api(request: Request, body: VoiceRequest):
+    try:
+        if body.action == "speech_to_text":
+            return await _handle_stt(body)
+        elif body.action == "process_voice":
+            return await _handle_stt(body)
+        # ... other actions
+    except Exception as e:
+        return VoiceResponse(success=False, error=str(e), ...)
+```
+
+### 4.2 Pydantic モデル
+
+**ファイル:** `backend/main.py:511-535`
+
+```python
+class VoiceRequest(BaseModel):
+    action: str                                          # "speech_to_text", "text_to_speech", etc.
+    audioData: Optional[str] = None                      # Base64 音声データ
+    sessionId: Optional[str] = None                      # セッション ID
+    language: Optional[str] = Field(default="ja",
+                                     max_length=10)      # "ja", "en"
+    text: Optional[str] = Field(default=None,
+                                max_length=5000)         # TTS 用テキスト
+    streaming: Optional[bool] = False                    # ストリーミング TTS
+    conversationStage: Optional[str] = None              # 会話ステージ
+    emotion: Optional[str] = None                        # TTS 感情
+
+class VoiceResponse(BaseModel):
+    success: bool
+    transcript: Optional[str] = None                     # STT 結果
+    response: Optional[str] = None
+    audioResponse: Optional[str] = None                  # TTS 結果（Base64）
+    emotion: Optional[str] = None
+    sessionId: Optional[str] = None
+    error: Optional[str] = None
+    detectedLanguage: Optional[str] = None               # Vosk 検出言語
+    confidence: Optional[float] = None                   # Vosk confidence
+    interruptStatus: Optional[str] = None
+```
+
+### 4.3 STT ハンドラ
+
+**ファイル:** `backend/main.py:576-605`
+
+```python
+async def _handle_stt(body: VoiceRequest) -> VoiceResponse:
+    """Shared STT processing for process_voice and speech_to_text"""
+    if not body.audioData:
+        raise HTTPException(status_code=400,
+                          detail="Missing audioData")
+
+    # 1. Base64 デコード
+    audio_bytes = base64.b64decode(body.audioData)
+
+    # 2. STT エージェント呼び出し
+    stt_result = await _get_stt_agent().speech_to_text(
+        audio_bytes,
+        language=body.language,
+        conversation_stage=body.conversationStage
+    )
+
+    # 3. 結果レスポンス
+    if not stt_result["success"]:
+        return VoiceResponse(
+            success=False,
+            error=stt_result.get("error", "STT failed"),
+            sessionId=body.sessionId
+        )
+
+    return VoiceResponse(
+        success=True,
+        transcript=stt_result["transcript"],
+        emotion="neutral",
+        detectedLanguage=stt_result.get("language"),
+        confidence=stt_result.get("confidence"),
+        sessionId=body.sessionId
+    )
+```
+
+### 4.4 STT エージェント初期化
+
+**ファイル:** `backend/main.py:548-575`
+
+```python
+def _get_stt_agent():
+    """Lazy load STTAgent (singleton)"""
+    global _stt_agent
+    if _stt_agent is None:
+        from backend.agents.stt_agent import STTAgent
+        _stt_agent = STTAgent(
+            stt_provider=os.getenv("STT_PROVIDER", "vosk"),
+            use_grammar=False,
+            confidence_threshold=0.4  # Vosk → Google fallback threshold
+        )
+    return _stt_agent
+```
+
+---
+
+## 5. バックエンド STT エージェント詳細
+
+### 5.1 STTAgent クラス
+
+**ファイル:** `backend/agents/stt_agent.py:513-570`
+
+```python
+class STTAgent:
+    def __init__(
+        self,
+        stt_provider: Optional[str] = None,
+        stt_client: Optional[Any] = None,
+        use_grammar: bool = False,
+        language_processor: Optional[Any] = None,
+        confidence_threshold: float = 0.4,
+        fallback_client: Optional[Any] = None
+    ):
+        self.stt_provider = stt_provider or os.getenv("STT_PROVIDER", "vosk")
+        self.use_grammar = use_grammar
+        self.confidence_threshold = confidence_threshold
+
+        # STT クライアント初期化
+        if self.stt_provider == "vosk":
+            self.stt_client = LocalSTTClient()
+            self.fallback_client = GoogleSTTClient()  # Google STT フォールバック
+        elif self.stt_provider == "google":
+            self.stt_client = GoogleSTTClient()
+            self.fallback_client = None
+```
+
+### 5.2 speech_to_text メソッド
+
+**ファイル:** `backend/agents/stt_agent.py:712-785`
+
+```python
+async def speech_to_text(
+    self,
+    audio_data: bytes,
+    language: Optional[str] = "ja",
+    conversation_stage: Optional[str] = None
+) -> Dict[str, Any]:
+    """
+    音声 → テキスト変換
+
+    Args:
+        audio_data: WAV バイナリ（16kHz, 16bit, mono 推奨）
+        language: "ja", "en", or None（自動検出）
+        conversation_stage: "greeting", "service_selection", "confirmation"
+
+    Returns:
+        {
+            "success": bool,
+            "transcript": str,
+            "confidence": float,  # Vosk のみ
+            "language": str,
+            "provider": str,
+            "error": str  # 失敗時
+        }
+    """
+    provider = self.stt_provider
+    grammar = self._resolve_grammar(conversation_stage)
+
+    try:
+        if language is None and isinstance(self.stt_client, LocalSTTClient):
+            # 自動言語検出（日英並列実行）
+            result = await self.stt_client.transcribe_auto_detect(
+                audio_data, grammar=grammar
+            )
+        else:
+            # 指定言語で STT
+            lang = language or "ja"
+            if isinstance(self.stt_client, LocalSTTClient):
+                grammar_list = (grammar or {}).get(lang) if grammar else None
+                result = await self.stt_client.transcribe(
+                    audio_data, lang, grammar=grammar_list
+                )
+            else:
+                result = await self.stt_client.transcribe(audio_data, lang)
+
+        # TranscriptionResult（Vosk）vs str（Google STT）の処理
+        if isinstance(result, TranscriptionResult):
+            # 言語バリデーション
+            validated = await self._validate_language(result, audio_data)
+            response = {
+                "success": True,
+                "transcript": validated.text,
+                "confidence": validated.confidence,
+                "language": validated.language,
+                "provider": provider
+            }
+            # 低信頼度時に Google STT へフォールバック
+            return await self._try_fallback(audio_data, validated.language, response)
+        else:
+            # Google STT の場合
+            return {
+                "success": True,
+                "transcript": result,
+                "confidence": None,
+                "language": language or "ja",
+                "provider": provider
+            }
+    except Exception as e:
+        logger.error("STT failed (%s): %s", provider, e)
+        return {
+            "success": False,
+            "transcript": "",
+            "confidence": 0.0,
+            "language": language or "unknown",
+            "provider": provider,
+            "error": str(e)
+        }
+```
+
+### 5.3 Vosk モデルパス
+
+**ファイル:** `backend/agents/stt_agent.py:221-226`
+
+```python
+DEFAULT_MODEL_PATHS: Dict[str, str] = {
+    "ja": "models/vosk-model-ja",
+    "en": "models/vosk-model-en-us"
+}
+
+SUPPORTED_LANGUAGES = ("ja", "en")
+```
+
+---
+
+## 6. オーディオフォーマット詳細
+
+### 6.1 フロントエンド送信形式
+
+| 項目 | 値 |
+|------|------|
+| **形式** | WebM（Opus コーデック）、MP4、OGG、WAV など（ブラウザサポートに依存） |
+| **サンプルレート** | リクエスト時は 16kHz を指定（ブラウザが自動処理） |
+| **チャネル数** | モノラル（1 チャネル） |
+| **ビット深度** | 16-bit |
+| **エンコーディング** | Base64（JSON 送信時） |
+
+**実装:**
+```typescript
+// VoiceRecorder.tsx
+const audioConstraints = {
+  channelCount: 1,     // モノラル
+  sampleRate: 16000,   // 16kHz
+  echoCancellation: true,
+  noiseSuppression: true,
+  autoGainControl: true
+};
+
+// MediaRecorder は上記制約に従い、16kHz/mono の WebM を生成
+// → Base64 エンコード → JSON POST
+```
+
+### 6.2 バックエンド処理フロー
+
+```
+Blob (WebM)
+  ↓
+toBase64() (JavaScript)
+  ↓
+JSON POST (Base64 文字列)
+  ↓
+backend/main.py: base64.b64decode()
+  ↓
+audio_bytes (バイナリ)
+  ↓
+LocalSTTClient (Vosk)
+  ├─ WAV ヘッダチェック
+  ├─ WebM → WAV 変換（pydub）
+  ├─ Vosk モデル読み込み
+  └─ 16kHz/16-bit/mono WAV で Kaldi 推論
+```
+
+### 6.3 WebM → WAV 変換（pydub）
+
+**ファイル:** `backend/agents/stt_agent.py:239-268`
+
+```python
+def _convert_audio_to_wav(self, audio_data: bytes) -> bytes:
+    """Convert WebM/Opus audio to WAV PCM for Vosk"""
+
+    from pydub import AudioSegment
+
+    segment = AudioSegment.from_file(
+        io.BytesIO(audio_data),
+        format=None  # 自動フォーマット検出
+    )
+
+    # 正規化：16kHz/16-bit/mono
+    normalized = segment \
+        .set_frame_rate(16000) \
+        .set_sample_width(2) \     # 2 bytes = 16-bit
+        .set_channels(1)
+
+    # WAV export
+    wav_buffer = io.BytesIO()
+    normalized.export(wav_buffer, format="wav")
+
+    return wav_buffer.getvalue()
+```
+
+---
+
+## 7. Vosk 実装詳細
+
+### 7.1 LocalSTTClient（Vosk ラッパー）
+
+**ファイル:** `backend/agents/stt_agent.py:231-455`
+
+#### モデル読み込み
+
+```python
+class LocalSTTClient:
+    def __init__(self, model_paths: Optional[Dict[str, str]] = None):
+        self.model_paths = {**DEFAULT_MODEL_PATHS, **(model_paths or {})}
+        self._models: Dict[str, Any] = {}  # キャッシュ
+
+    def _load_model(self, lang: str):
+        """Lazy load Vosk model"""
+        if lang in self._models:
+            return self._models[lang]
+
+        try:
+            from vosk import Model
+        except ImportError:
+            raise RuntimeError("Vosk not installed. pip install vosk")
+
+        model_path = os.path.expanduser(self.model_paths[lang])
+        if not os.path.exists(model_path):
+            raise RuntimeError(
+                f"Vosk model not found: {model_path}\n"
+                f"Download from https://alphacephei.com/vosk/models"
+            )
+
+        self._models[lang] = Model(model_path)
+        logger.info(f"Loaded Vosk {lang} model from {model_path}")
+        return self._models[lang]
+```
+
+#### 推論ロジック
+
+**ファイル:** `backend/agents/stt_agent.py:301-375`
+
+```python
+def _sync_transcribe(
+    self,
+    audio_data: bytes,
+    language: str = "ja",
+    grammar: Optional[List[str]] = None
+) -> TranscriptionResult:
+    """同期 Vosk 推論（ThreadPoolExecutor で実行）"""
+
+    # 1. WAV ヘッダ検証
+    if audio_data[:4] != b"RIFF":
+        audio_data = self._convert_audio_to_wav(audio_data)
+
+    # 2. WAV フレームを読み込み
+    import wave
+    bio = io.BytesIO(audio_data)
+    with wave.open(bio, "rb") as wf:
+        sample_rate = wf.getframerate()
+        frames = wf.readframes(wf.getnframes())
+
+    # 3. Vosk モデル読み込み
+    model = self._load_model(language)
+
+    # 4. KaldiRecognizer 初期化
+    from vosk import KaldiRecognizer
+    if grammar:
+        rec = KaldiRecognizer(model, sample_rate, json.dumps(grammar))
+    else:
+        rec = KaldiRecognizer(model, sample_rate)
+
+    # 5. SetWords で word-level confidence を取得
+    rec.SetWords(True)
+
+    # 6. 音声フレーム送入
+    rec.AcceptWaveform(frames)
+
+    # 7. 最終結果取得
+    result_json = rec.FinalResult()
+    result = json.loads(result_json)
+
+    # 8. テキスト抽出
+    text = result.get("text", "")
+
+    # 9. Word-level confidence 計算
+    word_results = result.get("result", [])
+    word_confidences = [
+        {"word": w.get("word", ""), "conf": w.get("conf", 0.0)}
+        for w in word_results
+    ]
+
+    avg_confidence = (
+        sum(w["conf"] for w in word_confidences) / len(word_confidences)
+        if word_confidences else None
+    )
+
+    return TranscriptionResult(
+        text=text or " ".join(w.get("word", "") for w in word_results),
+        confidence=avg_confidence,
+        language=language,
+        word_confidences=word_confidences
+    )
+
+async def transcribe(
+    self,
+    audio_data: bytes,
+    language: str = "ja",
+    grammar: Optional[List[str]] = None
+) -> TranscriptionResult:
+    """非同期ラッパー（ThreadPoolExecutor で実行）"""
+    loop = asyncio.get_running_loop()
+    with concurrent.futures.ThreadPoolExecutor() as pool:
+        return await loop.run_in_executor(
+            pool,
+            lambda: self._sync_transcribe(audio_data, language, grammar)
+        )
+```
+
+### 7.2 自動言語検出
+
+**ファイル:** `backend/agents/stt_agent.py:390-447`
+
+```python
+async def transcribe_auto_detect(
+    self,
+    audio_data: bytes,
+    grammar: Optional[Dict[str, List[str]]] = None
+) -> TranscriptionResult:
+    """日英並列実行、confidence が高い方を選択"""
+
+    async def _run_model(lang: str) -> Optional[TranscriptionResult]:
+        lang_grammar = (grammar or {}).get(lang)
+        try:
+            return await self.transcribe(audio_data, lang, grammar=lang_grammar)
+        except (RuntimeError, ValueError):
+            return None
+
+    # 日英並列実行
+    results = await asyncio.gather(
+        _run_model("ja"),
+        _run_model("en")
+    )
+
+    valid_results = [r for r in results if r is not None]
+
+    if not valid_results:
+        raise RuntimeError(
+            "Auto-detect failed: neither Japanese nor English model produced a result"
+        )
+
+    # Confidence が高い方を選択
+    best = max(
+        valid_results,
+        key=lambda r: r.confidence if r.confidence is not None else 0.0
+    )
+
+    logger.info(
+        f"Auto-detect: selected {best.language} "
+        f"(confidence={best.confidence:.3f})"
+    )
+
+    return best
+```
+
+### 7.3 Grammar（ドメイン固有語彙）
+
+**ファイル:** `backend/agents/stt_agent.py:60-215`
+
+#### Engineer Cafe Grammar
+
+```python
+ENGINEER_CAFE_GRAMMAR: Dict[str, List[str]] = {
+    "ja": [
+        "エンジニアカフェ",
+        "エンジニアカフェラボ",
+        "営業時間",
+        "会議室",
+        "ミーティング",
+        "ミートアップ",
+        "集中スペース",
+        "メーカーズスペース",
+        "地下",
+        "赤煉瓦",
+        "天神",
+        "博多",
+        # ... etc
+    ],
+    "en": [
+        "engineer cafe",
+        "meeting room",
+        "coworking space",
+        # ... etc
+    ]
+}
+```
+
+#### Stage-Specific Grammar
+
+```python
+STAGE_GRAMMARS: Dict[str, Dict[str, List[str]]] = {
+    "greeting": {
+        "ja": ["こんにちは", "すみません", "エンジニアカフェ", ...],
+        "en": ["hello", "hi", "engineer cafe", ...]
+    },
+    "service_selection": {
+        "ja": ["会議室", "コワーキング", "Wi-Fi", ...],
+        "en": ["meeting room", "coworking", "wifi", ...]
+    },
+    "confirmation": {
+        "ja": ["はい", "いいえ", "お願いします", ...],
+        "en": ["yes", "no", "please", ...]
+    }
+}
+```
+
+---
+
+## 8. フォールバック（Google STT）
+
+**ファイル:** `backend/agents/stt_agent.py:456-510`
+
+```python
+class GoogleSTTClient:
+    """Google Cloud Speech-to-Text フォールバック"""
+
+    async def transcribe(self, audio_data: bytes, language: str):
+        from google.cloud import speech_v1
+
+        client = speech_v1.SpeechClient()
+
+        audio = speech_v1.RecognitionAudio(content=audio_data)
+        config = speech_v1.RecognitionConfig(
+            encoding=speech_v1.RecognitionConfig.AudioEncoding.LINEAR16,
+            sample_rate_hertz=16000,
+            language_code=f"{language}-{language.upper()}"
+        )
+
+        response = client.recognize(config=config, audio=audio)
+
+        for result in response.results:
+            if result.alternatives:
+                return result.alternatives[0].transcript
+
+        raise ValueError("Google STT returned no results")
+```
+
+#### フォールバック条件
+
+```python
+async def _try_fallback(
+    self,
+    audio_data: bytes,
+    language: str,
+    vosk_response: Dict[str, Any]
+) -> Dict[str, Any]:
+    """Vosk confidence < threshold → Google STT へフォールバック"""
+
+    confidence = vosk_response.get("confidence")
+
+    if (confidence is not None and
+        confidence < self.confidence_threshold and
+        self.fallback_client):
+
+        try:
+            google_result = await self.fallback_client.transcribe(
+                audio_data, language
+            )
+
+            vosk_response["transcript"] = google_result
+            vosk_response["confidence"] = None  # Google STT は confidence なし
+            vosk_response["provider"] = "google (fallback)"
+            vosk_response["fallback_used"] = True
+
+            logger.info(
+                f"Vosk fallback to Google STT "
+                f"(vosk_confidence={confidence:.3f})"
+            )
+        except Exception as e:
+            logger.warning(f"Google fallback failed: {e}")
+            # Vosk 結果を使用
+
+    return vosk_response
+```
+
+---
+
+## 9. 環境変数・設定
+
+### 9.1 STT 関連環境変数
+
+| 環境変数 | デフォルト | 説明 |
+|---------|----------|------|
+| `STT_PROVIDER` | `vosk` | `vosk` または `google` |
+| `GOOGLE_APPLICATION_CREDENTIALS` | （未設定） | Google Cloud サービスアカウント JSON パス |
+
+**ファイル:** `backend/main.py:548-575`
+
+```python
+stt_provider = os.getenv("STT_PROVIDER", "vosk")
+```
+
+### 9.2 STTAgent 初期化パラメータ
+
+```python
+STTAgent(
+    stt_provider="vosk",           # Provider
+    use_grammar=False,             # ドメイン語彙使用
+    confidence_threshold=0.4,      # フォールバック閾値
+    # language_processor: 言語バリデーション
+    # fallback_client: Google STT クライアント
+)
+```
+
+### 9.3 LocalSTTClient モデルパス
+
+```python
+DEFAULT_MODEL_PATHS = {
+    "ja": "models/vosk-model-ja",      # 48MB
+    "en": "models/vosk-model-en-us"    # 40MB
+}
+```
+
+---
+
+## 10. Docker 統合
+
+### 10.1 Dockerfile（バックエンド）
+
+**ファイル:** `backend/Dockerfile`
+
+```dockerfile
+FROM python:3.11-slim AS base
+
+# システム依存
+RUN apt-get update && apt-get install -y \
+    gcc \
+    g++ \
+    curl \
+    unzip \
+    ffmpeg          # pydub（WebM → WAV 変換）用
+    && rm -rf /var/lib/apt/lists/*
+
+# Python 依存
+COPY requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
+
+# Development ターゲット
+FROM base AS development
+
+COPY . .
+
+# Vosk モデルダウンロード（ビルド時）
+RUN bash scripts/download_vosk_models.sh models
+
+# Production ターゲット
+FROM base AS production
+
+COPY . .
+
+# 注：Production では モデルをボリュームマウント
+# volumes:
+#   - ./models:/app/models
+```
+
+### 10.2 Vosk モデルダウンロード
+
+**ファイル:** `backend/scripts/download_vosk_models.sh`
+
+```bash
+#!/bin/bash
+
+MODEL_DIR="${1:-models}"
+
+JA_MODEL_URL="https://alphacephei.com/vosk/models/vosk-model-small-ja-0.22.zip"
+EN_MODEL_URL="https://alphacephei.com/vosk/models/vosk-model-small-en-us-0.15.zip"
+
+# 各モデル（~88MB 合計）をダウンロード
+curl -L -o /tmp/ja.zip "$JA_MODEL_URL"
+unzip -q /tmp/ja.zip -d "$MODEL_DIR"
+
+curl -L -o /tmp/en.zip "$EN_MODEL_URL"
+unzip -q /tmp/en.zip -d "$MODEL_DIR"
+```
+
+**モデルサイズ:**
+- 日本語：48MB
+- 英語：40MB
+- **合計：~88MB**
+
+### 10.3 Docker Compose
+
+**ファイル:** `docker-compose.yml:35-62`
+
+```yaml
+backend:
+  build:
+    context: ./backend
+    target: development
+  container_name: engineer-cafe-backend
+  ports:
+    - "0.0.0.0:8000:8000"
+  volumes:
+    - ./backend:/app
+    - /app/__pycache__
+    - backend-vosk-models:/app/models  # モデルボリューム永続化
+  environment:
+    - PYTHONUNBUFFERED=1
+  env_file:
+    - ./backend/.env
+  depends_on:
+    voicevox:
+      condition: service_healthy
+    kokoro-tts:
+      condition: service_healthy
+  healthcheck:
+    test: ["CMD", "python", "scripts/healthcheck.py"]
+    interval: 30s
+    timeout: 10s
+    retries: 3
+
+volumes:
+  backend-vosk-models:
+```
+
+### 10.4 イメージサイズへの影響
+
+```
+Python 3.11-slim：~150MB
++ 依存パッケージ（numpy, pydub, etc）：~200MB
++ Vosk モデル（ja + en）：~88MB
+──────────────────────────
+合計：~440MB（Development image）
+
+Production では モデルをボリュームマウント
+→ イメージサイズ：~350MB
+```
+
+---
+
+## 11. エラーハンドリング
+
+### 11.1 空白音声（無音）処理
+
+**ファイル:** `backend/agents/stt_agent.py:362-375`
+
+```python
+def _sync_transcribe(...) -> TranscriptionResult:
+    # ... Vosk 推論 ...
+
+    text = result.get("text", "")
+
+    # フォールバック：word results から組み立て
+    if not text and word_results:
+        text = " ".join(w.get("word", "") for w in word_results).strip()
+
+    text = (text or "").strip()
+
+    # 空白チェック
+    if not text:
+        logger.warning("Vosk returned empty transcript")
+        raise RuntimeError("Vosk returned empty recognition result")
+
+    return TranscriptionResult(...)
+```
+
+### 11.2 バリデーションエラー
+
+**ファイル:** `backend/main.py:576-605`
+
+```python
+async def _handle_stt(body: VoiceRequest) -> VoiceResponse:
+    # audioData チェック
+    if not body.audioData:
+        raise HTTPException(status_code=400,
+                          detail="Missing audioData")
+
+    # Base64 デコード失敗
+    try:
+        audio_bytes = base64.b64decode(body.audioData)
+    except Exception as e:
+        raise HTTPException(status_code=400,
+                          detail=f"Invalid base64 audio data: {e}")
+```
+
+### 11.3 WAV ヘッダ検証
+
+**ファイル:** `backend/agents/stt_agent.py:39-41, 304-313`
+
+```python
+WAV_RIFF_HEADER = b"RIFF"
+MIN_WAV_HEADER_BYTES = 44
+
+def _sync_transcribe(...):
+    if audio_data[:4] == WAV_RIFF_HEADER:
+        if len(audio_data) < MIN_WAV_HEADER_BYTES:
+            raise ValueError(
+                "Audio data must be in WAV format (RIFF) "
+                "and include a complete WAV header (minimum 44 bytes). "
+                "Received truncated data."
+            )
+    else:
+        # WebM → WAV 変換
+        audio_data = self._convert_audio_to_wav(audio_data)
+```
+
+### 11.4 モデルロード失敗
+
+**ファイル:** `backend/agents/stt_agent.py:278-297`
+
+```python
+def _load_model(self, lang: str):
+    try:
+        from vosk import Model
+    except ImportError:
+        logger.error("Vosk not installed. Install with: pip install vosk")
+        raise RuntimeError("Vosk not installed. pip install vosk")
+
+    model_path = os.path.expanduser(self.model_paths[lang])
+
+    if not os.path.exists(model_path):
+        logger.warning(f"Vosk model not found at {model_path}")
+        raise RuntimeError(
+            f"Vosk model not found: {model_path}. "
+            f"Download from https://alphacephei.com/vosk/models"
+        )
+```
+
+### 11.5 最大オーディオサイズ制限
+
+**ファイル:** `backend/agents/stt_agent.py:34`
+
+```python
+MAX_AUDIO_UPLOAD_BYTES = 10 * 1024 * 1024  # 10MB
+
+def _convert_audio_to_wav(self, audio_data: bytes):
+    if len(audio_data) > MAX_AUDIO_UPLOAD_BYTES:
+        raise ValueError(
+            f"Audio payload too large ({len(audio_data)} bytes). "
+            f"Maximum: {MAX_AUDIO_UPLOAD_BYTES} bytes."
+        )
+```
+
+---
+
+## 12. テストケース
+
+### 12.1 STT エージェント テスト
+
+**ファイル:** `backend/tests/agents/test_stt_agent.py`
+
+```python
+class TestLocalSTTClient:
+    def test_init_default_paths(self):
+        client = LocalSTTClient()
+        assert client.model_paths["ja"] == "models/vosk-model-ja"
+
+    def test_load_model_not_found(self):
+        client = LocalSTTClient(model_paths={"ja": "/nonexistent"})
+        with pytest.raises(RuntimeError) as exc_info:
+            client._load_model("ja")
+        assert "not found" in str(exc_info.value).lower()
+```
+
+### 12.2 Voice API テスト
+
+**ファイル:** `backend/tests/api/test_voice_api.py`
+
+```python
+@pytest.mark.asyncio
+async def test_voice_api_speech_to_text():
+    test_wav = generate_test_wav(16000, 0.5)
+    audio_base64 = base64.b64encode(test_wav).decode()
+
+    response = await client.post("/api/voice", json={
+        "action": "speech_to_text",
+        "audioData": audio_base64,
+        "language": "ja"
+    })
+
+    assert response.status_code == 200
+    result = response.json()
+    assert result["success"]
+    assert "transcript" in result
+```
+
+---
+
+## 13. 現在の制限事項・既知の問題
+
+### 13.1 Vosk の制限
+
+- **精度：** 約 85-90%（Google Cloud STT の 95% に比べて）
+- **リアルタイム処理：** オフライン STT はネットワーク遅延なし（利点）
+- **モデルサイズ：** 日本語 48MB、英語 40MB（スマートフォンには大きい）
+- **マルチスレッド：** Vosk は GIL の影響を受ける（ThreadPoolExecutor で回避）
+
+### 13.2 オーディオフォーマット
+
+- **入力形式の多様性：** WebM、MP4、OGG など複数形式をサポートしているが、pydub に依存
+- **リサンプリング時間：** WebM → WAV 変換に 0.2～0.5 秒（ネットワークより遅い可能性）
+
+### 13.3 Google STT フォールバック
+
+- **API キー必須：** `GOOGLE_APPLICATION_CREDENTIALS` 環境変数が必要
+- **API 料金：** 毎月 60 分まで無料、超過後は料金発生
+
+### 13.4 言語検出
+
+- **自動検出の信頼性：** 日英の confidence が近い場合、誤判定の可能性
+- **その他言語未サポート：** 現在は日本語（ja）、英語（en）のみ
+
+---
+
+## 14. パフォーマンス特性
+
+### 14.1 レイテンシ
+
+| ステップ | 時間 |
+|---------|------|
+| ブラウザ → Base64 エンコード | 10～50ms |
+| HTTP POST | 50～200ms（ネットワーク依存） |
+| Base64 デコード | 5～10ms |
+| WebM → WAV 変換（pydub） | 200～500ms |
+| Vosk 推論（0.5秒音声） | 100～300ms |
+| **合計** | **365～1,060ms** |
+
+### 14.2 メモリ使用量
+
+- **Vosk モデル（日本語）:** ~100MB（メモリ上ロード）
+- **オーディオバッファ（10秒）:** ~320KB（16kHz/16-bit/mono）
+- **推論時最大：** ~150MB
+
+### 14.3 CPU 使用率
+
+- **WebM → WAV 変換：** 1コア 20～40%（pydub/ffmpeg）
+- **Vosk 推論：** 1コア 50～100%（Kaldi）
+
+---
+
+## 15. 改善提案
+
+### 15.1 音声品質向上
+
+1. **Vosk モデル更新**
+   - 最新モデル：vosk-model-small-ja-0.22（現在） → vosk-model-ja-0.28（仮定）
+   - 精度向上見込み：～2～3%
+
+2. **piper-plus（軽量 STT）**
+   - メモリフットプリント削減（Vosk 100MB → 20MB）
+   - オフライン推論でレイテンシ削減
+   - 参考：https://github.com/k2-fsa/sherpa-onnx
+
+### 15.2 レイテンシ削減
+
+1. **WebM → WAV 変換の事前化**
+   - ブラウザ側で WAV キャプチャ（MediaRecorder 設定調整）
+   - バックエンド変換スキップで ~200～500ms 短縮
+
+2. **キャッシング戦略**
+   - ユーザーの頻出フレーズをメモリキャッシュ
+   - 同一フレーズ再認識時にキャッシュ結果返却
+
+### 15.3 エラーハンドリング強化
+
+1. **タイムアウト設定**
+   ```python
+   STT_TIMEOUT = 10  # 10秒以上の音声は失敗
+   ```
+
+2. **自動リトライ**
+   - Vosk 失敗時、自動的に Google STT へフォールバック（現在実装済み）
+
+---
+
+## 16. デプロイメント チェックリスト
+
+### 16.1 バックエンド デプロイ
+
+- [ ] `STT_PROVIDER` 環境変数を `vosk` に設定
+- [ ] `GOOGLE_APPLICATION_CREDENTIALS` を設定（Google STT フォールバック用）
+- [ ] Vosk モデルをコンテナに含める、またはボリュームマウント
+- [ ] Docker イメージサイズが 500MB 以下であることを確認
+- [ ] Cloud Run メモリを 2GB 以上に設定
+
+### 16.2 フロントエンド デプロイ
+
+- [ ] VoiceRecorder が HTTPS で動作（iOS対応）
+- [ ] マイク許可プロンプムが正しく表示される
+- [ ] Base64 エンコーディングが正確
+
+### 16.3 本番検証
+
+- [ ] STT レイテンシが 1 秒以内
+- [ ] エラーレート < 1%
+- [ ] モデルロード時間を監視
+
+---
+
+## 付録 A：ファイル参照一覧
+
+| ファイル | 行番号 | 説明 |
+|---------|--------|------|
+| `frontend/src/lib/voice-recorder.ts` | 1-270 | ブラウザ音声キャプチャ |
+| `frontend/src/app/api/voice/route.ts` | 1-55 | フロントエンド STT プロキシ |
+| `frontend/src/app/components/VoiceInterface.tsx` | 520-550 | STT API 送信ロジック |
+| `backend/main.py` | 511-705 | バックエンド Voice API エンドポイント |
+| `backend/agents/stt_agent.py` | 1-785 | STT エージェント実装 |
+| `backend/agents/voice_agent.py` | 1-600+ | Voice エージェント（TTS含む） |
+| `backend/scripts/download_vosk_models.sh` | 1-50 | Vosk モデルダウンロード |
+| `backend/Dockerfile` | 1-75 | バックエンド Docker イメージ |
+| `docker-compose.yml` | 35-62 | Docker Compose 設定 |
+| `backend/tests/agents/test_stt_agent.py` | 1-300+ | STT テストケース |
+
+---
+
+## 付録 B：キー用語解説
+
+| 用語 | 説明 |
+|------|------|
+| **Vosk** | オフライン音声認識ライブラリ（Kaldi ベース） |
+| **Kaldi** | 音声認識ツールキット |
+| **WebM** | ブラウザネイティブの音声形式（Opus コーデック） |
+| **WAV** | PCM 波形形式（Vosk の標準入力） |
+| **pydub** | Python 音声処理ライブラリ |
+| **ffmpeg** | マルチメディア変換ツール |
+| **Base64** | バイナリ → ASCII エンコーディング |
+| **Confidence** | 認識信頼度（0.0～1.0） |
+| **Grammar** | ドメイン固有の認識辞書 |
+| **Fallback** | フォールバック（Vosk 失敗時に Google STT へ） |
+
+---
+
+**レポート終了**

--- a/docs/STT-Migration-Guide-qwen3-asr.md
+++ b/docs/STT-Migration-Guide-qwen3-asr.md
@@ -1,0 +1,914 @@
+# STT マイグレーションガイド: qwen3-asr-1.7b
+
+**Issue:** #370
+**担当:** takegawa333
+**作成日:** 2026-03-28
+**プロジェクト:** Engineer Cafe Navigator
+
+---
+
+## 1. 現行実装サマリー
+
+現在の STT は **Vosk** をプライマリ、**Google Cloud STT** をフォールバックとして使用しています。
+
+### データフロー
+
+```
+ブラウザ (WebM/Opus)
+  → Base64 エンコード
+  → POST /api/voice (Frontend proxy)
+  → POST /api/voice (Backend)
+  → STTAgent.speech_to_text()
+    → LocalSTTClient._sync_transcribe()
+      ├─ WebM → WAV 変換 (pydub/ffmpeg)
+      ├─ Vosk モデル読み込み (lazy, cached)
+      ├─ KaldiRecognizer 推論
+      └─ TranscriptionResult (text, confidence, language)
+    → confidence < 0.4 → GoogleSTTClient (fallback)
+  → VoiceResponse (transcript, confidence, language, provider)
+```
+
+### 主要ファイル
+
+| ファイル | 役割 |
+|---------|------|
+| `backend/agents/stt_agent.py` | STTAgent, LocalSTTClient, GoogleSTTClient (785行) |
+| `backend/main.py:548-605` | `_get_stt_agent()` 初期化, `_handle_stt()` ハンドラ |
+| `frontend/src/app/api/voice/route.ts` | Frontend proxy (変更不要) |
+
+### 現行パフォーマンス
+
+| ステップ | 時間 |
+|---------|------|
+| WebM → WAV 変換 | 200-500ms |
+| Vosk 推論 (0.5秒音声) | 100-300ms |
+| 合計 (E2E) | 365-1,060ms |
+
+---
+
+## 2. 目標
+
+**既存の Vosk 実装を維持したまま**、qwen3-asr-1.7b を代替 STT provider として追加する。
+
+- `STT_PROVIDER=vosk` (デフォルト、変更なし)
+- `STT_PROVIDER=qwen3` (新規追加)
+- 環境変数で切り替え可能な Strategy Pattern を導入
+- Vosk のコード・テスト・動作に一切影響を与えない
+
+---
+
+## 3. アーキテクチャ変更
+
+### 3.1 Provider Pattern 導入
+
+```
+backend/agents/
+├── stt_agent.py              ← Factory + STTAgent (既存ファイルを修正)
+├── stt_providers/             ← 新規ディレクトリ
+│   ├── __init__.py
+│   ├── base.py                ← 抽象基底クラス
+│   ├── vosk_provider.py       ← 既存 LocalSTTClient を移動
+│   ├── google_provider.py     ← 既存 GoogleSTTClient を移動
+│   └── qwen3_provider.py     ← 新規
+```
+
+### 3.2 Provider Interface
+
+```python
+# backend/agents/stt_providers/base.py
+
+from abc import ABC, abstractmethod
+from dataclasses import dataclass
+from typing import Any, Dict, List, Optional
+
+
+@dataclass
+class STTResult:
+    """STT provider の統一出力形式"""
+    transcript: str
+    confidence: Optional[float]  # 0.0-1.0, None = 不明
+    detected_language: str       # "ja", "en"
+    word_confidences: Optional[List[Dict[str, Any]]] = None
+    provider: str = ""
+
+
+class BaseSTTProvider(ABC):
+    """STT provider の抽象基底クラス"""
+
+    @abstractmethod
+    async def transcribe(
+        self,
+        audio_data: bytes,
+        language: Optional[str] = "ja",
+        grammar: Optional[List[str]] = None,
+    ) -> STTResult:
+        """
+        音声データをテキストに変換する。
+
+        Args:
+            audio_data: 音声バイナリ (WAV or WebM)
+            language: 言語コード ("ja", "en") or None (自動検出)
+            grammar: ドメイン固有語彙リスト (provider がサポートする場合)
+
+        Returns:
+            STTResult
+
+        Raises:
+            RuntimeError: 推論失敗時
+        """
+        ...
+
+    @abstractmethod
+    async def transcribe_auto_detect(
+        self,
+        audio_data: bytes,
+        grammar: Optional[Dict[str, List[str]]] = None,
+    ) -> STTResult:
+        """
+        言語を自動検出して音声をテキストに変換する。
+
+        Args:
+            audio_data: 音声バイナリ
+            grammar: 言語別ドメイン固有語彙
+
+        Returns:
+            STTResult (detected_language が設定される)
+        """
+        ...
+
+    def convert_audio_to_wav(self, audio_data: bytes) -> bytes:
+        """WebM/Opus → WAV 変換 (共通ユーティリティ)"""
+        if audio_data[:4] == b"RIFF":
+            return audio_data
+
+        from pydub import AudioSegment
+        import io
+
+        MAX_AUDIO_UPLOAD_BYTES = 10 * 1024 * 1024
+        if len(audio_data) > MAX_AUDIO_UPLOAD_BYTES:
+            raise ValueError(
+                f"Audio payload too large ({len(audio_data)} bytes). "
+                f"Maximum: {MAX_AUDIO_UPLOAD_BYTES} bytes."
+            )
+
+        segment = AudioSegment.from_file(io.BytesIO(audio_data), format=None)
+        normalized = segment.set_frame_rate(16000).set_sample_width(2).set_channels(1)
+
+        wav_buffer = io.BytesIO()
+        normalized.export(wav_buffer, format="wav")
+        return wav_buffer.getvalue()
+```
+
+### 3.3 Factory Pattern
+
+```python
+# backend/agents/stt_providers/__init__.py
+
+from backend.agents.stt_providers.base import BaseSTTProvider, STTResult
+
+
+def create_stt_provider(provider_name: str, **kwargs) -> BaseSTTProvider:
+    """STT provider を作成する Factory"""
+
+    if provider_name == "vosk":
+        from backend.agents.stt_providers.vosk_provider import VoskSTTProvider
+        return VoskSTTProvider(**kwargs)
+
+    elif provider_name == "qwen3":
+        from backend.agents.stt_providers.qwen3_provider import Qwen3STTProvider
+        return Qwen3STTProvider(**kwargs)
+
+    elif provider_name == "google":
+        from backend.agents.stt_providers.google_provider import GoogleSTTProvider
+        return GoogleSTTProvider(**kwargs)
+
+    else:
+        raise ValueError(f"Unknown STT provider: {provider_name}")
+
+
+__all__ = ["BaseSTTProvider", "STTResult", "create_stt_provider"]
+```
+
+### 3.4 STTAgent の修正
+
+`stt_agent.py` の `STTAgent.__init__` を修正して factory を使用する:
+
+```python
+# backend/agents/stt_agent.py (修正箇所)
+
+from backend.agents.stt_providers import create_stt_provider, STTResult
+
+class STTAgent:
+    def __init__(
+        self,
+        stt_provider: Optional[str] = None,
+        stt_client: Optional[Any] = None,  # テスト用 DI
+        use_grammar: bool = False,
+        language_processor: Optional[Any] = None,
+        confidence_threshold: float = 0.4,
+        fallback_client: Optional[Any] = None,
+    ):
+        self.stt_provider = stt_provider or os.getenv("STT_PROVIDER", "vosk")
+        self.use_grammar = use_grammar
+        self.confidence_threshold = confidence_threshold
+
+        # Provider 初期化 (factory 経由)
+        if stt_client:
+            self.stt_client = stt_client  # テスト用
+        else:
+            self.stt_client = create_stt_provider(self.stt_provider)
+
+        # Fallback (Vosk の場合のみ Google へ fallback)
+        if self.stt_provider == "vosk" and not fallback_client:
+            self.fallback_client = create_stt_provider("google")
+        else:
+            self.fallback_client = fallback_client
+```
+
+### 3.5 `STT_PROVIDER` 環境変数による切り替え
+
+```
+# .env
+STT_PROVIDER=vosk    # デフォルト（既存動作）
+# STT_PROVIDER=qwen3  # qwen3-asr に切り替え
+```
+
+`main.py:548-575` の `_get_stt_agent()` は変更不要（既に `os.getenv("STT_PROVIDER", "vosk")` を使用）。
+
+---
+
+## 4. 実装手順
+
+### Step 1: `backend/agents/stt_providers/base.py` を作成
+
+上記 3.2 の `BaseSTTProvider` と `STTResult` を作成する。
+
+**注意:** 既存の `TranscriptionResult` (stt_agent.py:25-30 付近) との互換性を保つ。`STTResult` は `TranscriptionResult` を置き換えるのではなく、provider 層の出力として使用し、`STTAgent.speech_to_text()` 内部で `TranscriptionResult` → `STTResult` のマッピングを行う。
+
+### Step 2: `backend/agents/stt_providers/vosk_provider.py` を作成
+
+既存の `LocalSTTClient` (stt_agent.py:231-455) のロジックを `VoskSTTProvider` クラスに移動する。
+
+```python
+# backend/agents/stt_providers/vosk_provider.py
+
+import asyncio
+import concurrent.futures
+import io
+import json
+import logging
+import os
+from typing import Any, Dict, List, Optional
+
+from backend.agents.stt_providers.base import BaseSTTProvider, STTResult
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_MODEL_PATHS: Dict[str, str] = {
+    "ja": "models/vosk-model-ja",
+    "en": "models/vosk-model-en-us",
+}
+
+WAV_RIFF_HEADER = b"RIFF"
+MIN_WAV_HEADER_BYTES = 44
+
+
+class VoskSTTProvider(BaseSTTProvider):
+    """Vosk ベースの STT provider"""
+
+    def __init__(self, model_paths: Optional[Dict[str, str]] = None):
+        self.model_paths = {**DEFAULT_MODEL_PATHS, **(model_paths or {})}
+        self._models: Dict[str, Any] = {}
+
+    def _load_model(self, lang: str):
+        if lang in self._models:
+            return self._models[lang]
+
+        try:
+            from vosk import Model
+        except ImportError:
+            raise RuntimeError("Vosk not installed. pip install vosk")
+
+        model_path = os.path.expanduser(self.model_paths[lang])
+        if not os.path.exists(model_path):
+            raise RuntimeError(
+                f"Vosk model not found: {model_path}. "
+                f"Download from https://alphacephei.com/vosk/models"
+            )
+
+        self._models[lang] = Model(model_path)
+        logger.info("Loaded Vosk %s model from %s", lang, model_path)
+        return self._models[lang]
+
+    # ... 既存の _sync_transcribe, transcribe, transcribe_auto_detect を移動
+    # TranscriptionResult → STTResult に変換して返す
+```
+
+**重要:** `stt_agent.py` 内の `LocalSTTClient` は削除せず、`VoskSTTProvider` からの import alias として残す。既存テストが壊れないようにする。
+
+```python
+# stt_agent.py 末尾 (後方互換)
+from backend.agents.stt_providers.vosk_provider import VoskSTTProvider as LocalSTTClient
+```
+
+### Step 3: `backend/agents/stt_providers/google_provider.py` を作成
+
+既存の `GoogleSTTClient` (stt_agent.py:456-510) を移動。
+
+```python
+# backend/agents/stt_providers/google_provider.py
+
+from backend.agents.stt_providers.base import BaseSTTProvider, STTResult
+
+
+class GoogleSTTProvider(BaseSTTProvider):
+    """Google Cloud Speech-to-Text provider"""
+
+    async def transcribe(
+        self, audio_data: bytes, language: str = "ja", grammar=None
+    ) -> STTResult:
+        from google.cloud import speech_v1
+
+        wav_data = self.convert_audio_to_wav(audio_data)
+
+        client = speech_v1.SpeechClient()
+        audio = speech_v1.RecognitionAudio(content=wav_data)
+        config = speech_v1.RecognitionConfig(
+            encoding=speech_v1.RecognitionConfig.AudioEncoding.LINEAR16,
+            sample_rate_hertz=16000,
+            language_code=f"{language}-{language.upper()}",
+        )
+
+        response = client.recognize(config=config, audio=audio)
+
+        for result in response.results:
+            if result.alternatives:
+                return STTResult(
+                    transcript=result.alternatives[0].transcript,
+                    confidence=result.alternatives[0].confidence,
+                    detected_language=language,
+                    provider="google",
+                )
+
+        raise ValueError("Google STT returned no results")
+
+    async def transcribe_auto_detect(self, audio_data, grammar=None) -> STTResult:
+        return await self.transcribe(audio_data, language="ja", grammar=grammar)
+```
+
+### Step 4: `backend/agents/stt_providers/qwen3_provider.py` を作成 (新規)
+
+```python
+# backend/agents/stt_providers/qwen3_provider.py
+
+import asyncio
+import concurrent.futures
+import io
+import logging
+import os
+from typing import Dict, List, Optional
+
+from backend.agents.stt_providers.base import BaseSTTProvider, STTResult
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_MODEL_ID = "Qwen/Qwen3-ASR-1.7B"
+DEFAULT_DEVICE = "cpu"
+
+
+class Qwen3STTProvider(BaseSTTProvider):
+    """Qwen3-ASR-1.7B ベースの STT provider"""
+
+    def __init__(
+        self,
+        model_path: Optional[str] = None,
+        device: Optional[str] = None,
+    ):
+        self.model_id = model_path or os.getenv(
+            "QWEN3_ASR_MODEL_PATH", DEFAULT_MODEL_ID
+        )
+        self.device = device or os.getenv("QWEN3_ASR_DEVICE", DEFAULT_DEVICE)
+        self._model = None
+        self._processor = None
+
+    def _load_model(self):
+        """Lazy load qwen3-asr model"""
+        if self._model is not None:
+            return
+
+        try:
+            from transformers import AutoModelForSpeechSeq2Seq, AutoProcessor
+        except ImportError:
+            raise RuntimeError(
+                "transformers not installed. "
+                "pip install transformers torch torchaudio"
+            )
+
+        logger.info(
+            "Loading qwen3-asr model: %s (device=%s)",
+            self.model_id, self.device,
+        )
+
+        self._processor = AutoProcessor.from_pretrained(
+            self.model_id, trust_remote_code=True,
+        )
+        self._model = AutoModelForSpeechSeq2Seq.from_pretrained(
+            self.model_id, trust_remote_code=True,
+        )
+
+        if self.device == "cuda":
+            import torch
+            if torch.cuda.is_available():
+                self._model = self._model.to("cuda")
+            else:
+                logger.warning("CUDA requested but not available. Falling back to CPU.")
+                self.device = "cpu"
+
+        logger.info("qwen3-asr model loaded successfully")
+
+    def _sync_transcribe(
+        self, audio_data: bytes, language: Optional[str] = "ja",
+    ) -> STTResult:
+        """同期推論 (ThreadPoolExecutor で実行)"""
+        import numpy as np
+        import wave
+
+        self._load_model()
+
+        wav_data = self.convert_audio_to_wav(audio_data)
+
+        bio = io.BytesIO(wav_data)
+        with wave.open(bio, "rb") as wf:
+            sample_rate = wf.getframerate()
+            frames = wf.readframes(wf.getnframes())
+            audio_array = np.frombuffer(frames, dtype=np.int16).astype(np.float32)
+            audio_array /= 32768.0  # Normalize to [-1.0, 1.0]
+
+        # ⚠️ qwen3-asr の正確な API は PoC で検証が必要
+        inputs = self._processor(
+            audio_array, sampling_rate=sample_rate, return_tensors="pt",
+        )
+
+        if self.device == "cuda":
+            inputs = {k: v.to("cuda") for k, v in inputs.items()}
+
+        import torch
+        with torch.no_grad():
+            generated_ids = self._model.generate(
+                **inputs, max_new_tokens=256,
+                language=language,  # ⚠️ qwen3-asr 固有パラメータ要検証
+            )
+
+        transcription = self._processor.batch_decode(
+            generated_ids, skip_special_tokens=True
+        )[0]
+
+        return STTResult(
+            transcript=transcription.strip(),
+            confidence=None,
+            detected_language=language or "ja",
+            provider="qwen3",
+        )
+
+    async def transcribe(
+        self, audio_data: bytes, language: Optional[str] = "ja",
+        grammar: Optional[List[str]] = None,
+    ) -> STTResult:
+        """非同期ラッパー"""
+        loop = asyncio.get_running_loop()
+        with concurrent.futures.ThreadPoolExecutor() as pool:
+            return await loop.run_in_executor(
+                pool, lambda: self._sync_transcribe(audio_data, language),
+            )
+
+    async def transcribe_auto_detect(
+        self, audio_data: bytes,
+        grammar: Optional[Dict[str, List[str]]] = None,
+    ) -> STTResult:
+        """
+        qwen3-asr は多言語対応のため、language=None で自動検出可能。
+        ⚠️ 自動検出の精度は PoC で要検証
+        """
+        return await self.transcribe(audio_data, language=None, grammar=None)
+```
+
+### Step 5: Docker / モデルダウンロード
+
+#### 5.1 requirements.txt への追加
+
+```
+# backend/requirements.txt (追加分 — qwen3 使用時のみ必要)
+transformers>=4.40.0
+torch>=2.0.0
+torchaudio>=2.0.0
+sentencepiece>=0.2.0
+```
+
+#### 5.2 Dockerfile 修正
+
+```dockerfile
+# backend/Dockerfile (追加箇所)
+
+# qwen3-asr のモデルダウンロード (オプション)
+ARG STT_PROVIDER=vosk
+RUN if [ "$STT_PROVIDER" = "qwen3" ]; then \
+    python -c "from transformers import AutoProcessor, AutoModelForSpeechSeq2Seq; \
+    AutoProcessor.from_pretrained('Qwen/Qwen3-ASR-1.7B', trust_remote_code=True); \
+    AutoModelForSpeechSeq2Seq.from_pretrained('Qwen/Qwen3-ASR-1.7B', trust_remote_code=True)"; \
+    fi
+```
+
+#### 5.3 モデルダウンロードスクリプト
+
+```bash
+# backend/scripts/download_qwen3_model.sh
+#!/bin/bash
+set -e
+
+MODEL_ID="${QWEN3_ASR_MODEL_PATH:-Qwen/Qwen3-ASR-1.7B}"
+
+echo "Downloading qwen3-asr model: $MODEL_ID"
+
+python -c "
+from transformers import AutoProcessor, AutoModelForSpeechSeq2Seq
+print('Downloading processor...')
+AutoProcessor.from_pretrained('$MODEL_ID', trust_remote_code=True)
+print('Downloading model...')
+AutoModelForSpeechSeq2Seq.from_pretrained('$MODEL_ID', trust_remote_code=True)
+print('Done.')
+"
+
+echo "Estimated disk usage: ~3.4GB"
+```
+
+### Step 6: テスト追加
+
+```python
+# backend/tests/agents/test_stt_providers.py
+
+import pytest
+from unittest.mock import MagicMock, AsyncMock, patch
+from backend.agents.stt_providers import create_stt_provider, STTResult
+from backend.agents.stt_providers.base import BaseSTTProvider
+
+
+class TestSTTProviderFactory:
+    def test_create_vosk_provider(self):
+        provider = create_stt_provider("vosk")
+        assert isinstance(provider, BaseSTTProvider)
+
+    def test_create_qwen3_provider(self):
+        provider = create_stt_provider("qwen3")
+        assert isinstance(provider, BaseSTTProvider)
+
+    def test_create_google_provider(self):
+        provider = create_stt_provider("google")
+        assert isinstance(provider, BaseSTTProvider)
+
+    def test_unknown_provider_raises(self):
+        with pytest.raises(ValueError, match="Unknown STT provider"):
+            create_stt_provider("unknown")
+
+
+class TestQwen3Provider:
+    def test_init_default(self):
+        from backend.agents.stt_providers.qwen3_provider import Qwen3STTProvider
+        provider = Qwen3STTProvider()
+        assert provider.model_id == "Qwen/Qwen3-ASR-1.7B"
+        assert provider.device == "cpu"
+
+    def test_init_custom_model(self):
+        from backend.agents.stt_providers.qwen3_provider import Qwen3STTProvider
+        provider = Qwen3STTProvider(
+            model_path="Qwen/Qwen3-ASR-0.6B", device="cuda",
+        )
+        assert provider.model_id == "Qwen/Qwen3-ASR-0.6B"
+
+    @pytest.mark.slow
+    @pytest.mark.asyncio
+    async def test_transcribe_with_real_model(self):
+        """実モデル推論テスト (CI ではスキップ)"""
+        from backend.agents.stt_providers.qwen3_provider import Qwen3STTProvider
+        provider = Qwen3STTProvider()
+        test_wav = _generate_silent_wav(16000, 1.0)
+        result = await provider.transcribe(test_wav, language="ja")
+        assert isinstance(result, STTResult)
+        assert result.provider == "qwen3"
+
+
+class TestSTTResultDataclass:
+    def test_create_result(self):
+        result = STTResult(
+            transcript="テスト", confidence=0.95,
+            detected_language="ja", provider="vosk",
+        )
+        assert result.transcript == "テスト"
+
+    def test_optional_fields(self):
+        result = STTResult(
+            transcript="test", confidence=None,
+            detected_language="en", provider="qwen3",
+        )
+        assert result.confidence is None
+
+
+def _generate_silent_wav(sample_rate: int, duration: float) -> bytes:
+    import struct, io, wave
+    n_frames = int(sample_rate * duration)
+    frames = struct.pack(f"<{n_frames}h", *([0] * n_frames))
+    buf = io.BytesIO()
+    with wave.open(buf, "wb") as wf:
+        wf.setnchannels(1)
+        wf.setsampwidth(2)
+        wf.setframerate(sample_rate)
+        wf.writeframes(frames)
+    return buf.getvalue()
+```
+
+### Step 7: docker-compose.yml 更新
+
+qwen3 はバックエンドコンテナ内で動作するため、新サービス追加は不要。環境変数のみ追加:
+
+```yaml
+# docker-compose.yml (backend サービスの environment に追加)
+backend:
+  environment:
+    - STT_PROVIDER=${STT_PROVIDER:-vosk}
+    - QWEN3_ASR_MODEL_PATH=${QWEN3_ASR_MODEL_PATH:-Qwen/Qwen3-ASR-1.7B}
+    - QWEN3_ASR_DEVICE=${QWEN3_ASR_DEVICE:-cpu}
+```
+
+---
+
+## 5. Provider インターフェース仕様
+
+### Input
+
+| パラメータ | 型 | 必須 | 説明 |
+|-----------|-----|------|------|
+| `audio_data` | `bytes` | Yes | WAV or WebM バイナリ (最大 10MB) |
+| `language` | `Optional[str]` | No | `"ja"`, `"en"`, or `None` (自動検出) |
+| `grammar` | `Optional[List[str]]` | No | ドメイン固有語彙 (Vosk のみ使用) |
+
+### Output: `STTResult`
+
+| フィールド | 型 | 説明 |
+|-----------|-----|------|
+| `transcript` | `str` | 認識テキスト |
+| `confidence` | `Optional[float]` | 認識信頼度 (0.0-1.0)。qwen3 は `None` |
+| `detected_language` | `str` | 検出言語 (`"ja"`, `"en"`) |
+| `word_confidences` | `Optional[List[Dict]]` | 単語レベル信頼度 (Vosk のみ) |
+| `provider` | `str` | `"vosk"`, `"qwen3"`, `"google"` |
+
+### 必須処理
+
+- WebM → WAV 変換: `BaseSTTProvider.convert_audio_to_wav()` を再利用
+- 空音声: 空文字列の transcript を返す場合は `RuntimeError` を raise
+- タイムアウト: 30秒以内に推論完了しない場合は `RuntimeError` を raise
+
+---
+
+## 6. qwen3-asr 固有の注意点
+
+### 6.1 モデルサイズ
+
+| モデル | パラメータ | ディスク容量 | メモリ使用量 |
+|--------|-----------|-------------|-------------|
+| Qwen3-ASR-1.7B | 1.7B | ~3.4GB | ~4.7GB (推論時) |
+| Qwen3-ASR-0.6B | 0.6B | ~1.2GB | ~2.0GB (推論時) |
+
+**推奨:** 開発・テストには 0.6B、本番には 1.7B を使用。
+
+### 6.2 GPU vs CPU
+
+| 環境 | 推論時間 (5秒音声) | メモリ |
+|------|-------------------|--------|
+| GPU (CUDA) | ~1-2秒 | 4.7GB VRAM |
+| CPU | ~5-15秒 | 4.7GB RAM |
+
+**注意:** CPU モードでは Vosk より大幅に遅い。CPU 環境では 0.6B 推奨。
+
+### 6.3 依存パッケージ
+
+```
+transformers>=4.40.0
+torch>=2.0.0
+torchaudio>=2.0.0
+sentencepiece>=0.2.0
+```
+
+**Docker イメージサイズ増加:** +2-3GB (PyTorch + モデル)
+
+### 6.4 ストリーミング非対応
+
+qwen3-asr は Vosk と異なりストリーミング推論をサポートしていない。音声全体をバッファしてからバッチ推論を行う。現行アーキテクチャ (フロントエンドで録音完了後に送信) と一致するため問題なし。
+
+### 6.5 Grammar 非対応
+
+qwen3-asr はドメイン固有語彙 (Grammar) をサポートしていない。`grammar` パラメータは無視される。
+
+### ⚠️ PoC 検証が必要な項目
+
+1. **qwen3-asr の正確な transformers API** — `AutoModelForSpeechSeq2Seq` で正しいか、`AutoModelForCausalLM` の可能性あり
+2. **`language` パラメータの渡し方** — `generate()` の引数として渡せるか
+3. **自動言語検出の精度** — 明示指定なしで日英判定できるか
+4. **CPU 推論速度** — 0.6B モデルが実用的なレイテンシ (2秒以内) を達成できるか
+5. **出力フォーマット** — transcript のみか、タイムスタンプ付きか
+
+---
+
+## 7. 環境変数
+
+| 環境変数 | デフォルト | 説明 |
+|---------|----------|------|
+| `STT_PROVIDER` | `vosk` | `vosk` \| `qwen3` \| `google` |
+| `QWEN3_ASR_MODEL_PATH` | `Qwen/Qwen3-ASR-1.7B` | HuggingFace モデル ID or ローカルパス |
+| `QWEN3_ASR_DEVICE` | `cpu` | `cpu` \| `cuda` |
+| `GOOGLE_APPLICATION_CREDENTIALS` | (未設定) | Google STT fallback 用 |
+
+### .env 設定例
+
+```bash
+# Vosk (デフォルト — 変更不要)
+STT_PROVIDER=vosk
+
+# qwen3-asr (切り替え時)
+STT_PROVIDER=qwen3
+QWEN3_ASR_MODEL_PATH=Qwen/Qwen3-ASR-1.7B
+QWEN3_ASR_DEVICE=cpu
+
+# 低リソース環境
+STT_PROVIDER=qwen3
+QWEN3_ASR_MODEL_PATH=Qwen/Qwen3-ASR-0.6B
+QWEN3_ASR_DEVICE=cpu
+```
+
+---
+
+## 8. テスト計画
+
+### 8.1 Unit テスト
+
+| テスト | 内容 |
+|--------|------|
+| Factory テスト | `create_stt_provider("vosk")`, `("qwen3")`, `("google")`, `("unknown")` |
+| STTResult テスト | dataclass の作成、optional フィールド |
+| Qwen3Provider init | デフォルトパラメータ、カスタムパラメータ |
+| Audio 変換 | `convert_audio_to_wav()` (WebM → WAV) |
+| 空音声処理 | 空の transcript で RuntimeError |
+
+### 8.2 Integration テスト (`@pytest.mark.slow`)
+
+| テスト | 内容 |
+|--------|------|
+| Vosk 推論 | 既存テストがそのまま通ること |
+| qwen3 推論 | テスト WAV → transcript |
+| Provider 切り替え | `STT_PROVIDER` 環境変数による切り替え |
+| Fallback | qwen3 失敗時の動作 |
+
+### 8.3 Benchmark
+
+| メトリクス | 計測方法 |
+|-----------|---------|
+| WER (Word Error Rate) | Common Voice ja/en テストセットで比較 |
+| レイテンシ | 5秒音声の推論時間 (p50, p95, p99) |
+| メモリ使用量 | `tracemalloc` で計測 |
+
+---
+
+## 9. Cloud Run デプロイ考慮
+
+### 9.1 メモリ要件
+
+| Provider | 最小メモリ | 推奨メモリ |
+|----------|-----------|-----------|
+| Vosk | 512MB | 2GB |
+| qwen3-asr 1.7B | 6GB | 8GB |
+| qwen3-asr 0.6B | 3GB | 4GB |
+
+### 9.2 Cold Start
+
+| Provider | Cold Start 時間 |
+|----------|----------------|
+| Vosk | ~2秒 |
+| qwen3-asr 1.7B | ~30-60秒 |
+| qwen3-asr 0.6B | ~15-30秒 |
+
+### 9.3 別サービス化の検討
+
+qwen3-asr の要件 (大メモリ、長い Cold Start) を考慮すると、**別の Cloud Run サービスとして分離**することを推奨:
+
+```
+engineer-cafe-backend (既存)
+  ├─ STT_PROVIDER=vosk (デフォルト)
+  └─ QWEN3_ASR_URL=https://qwen3-asr-xxx.run.app  (別サービスへ委譲)
+
+qwen3-asr-service (新規)
+  ├─ POST /transcribe
+  ├─ Memory: 8GB
+  ├─ Min instances: 0 (コスト削減)
+  └─ Max instances: 2 (スケーリング)
+```
+
+この場合、`Qwen3STTProvider` は内蔵推論ではなく HTTP クライアントとして実装する。
+
+---
+
+## 10. 受入基準
+
+### 必須 (P0)
+
+- [ ] `STT_PROVIDER=vosk` (デフォルト) で既存動作が一切変わらないこと
+- [ ] `STT_PROVIDER=qwen3` で qwen3-asr による音声認識が動作すること
+- [ ] Provider factory (`create_stt_provider`) が正しく provider を選択すること
+- [ ] `BaseSTTProvider` 抽象クラスと `STTResult` dataclass が定義されていること
+- [ ] 既存テストが全て通ること (`pytest -m "not slow"`)
+- [ ] 新規テスト (factory, qwen3 provider) が追加されていること
+- [ ] ruff / black が通ること
+
+### 推奨 (P1)
+
+- [ ] qwen3-asr の推論ベンチマーク結果 (WER, レイテンシ)
+- [ ] 0.6B モデルでの動作確認
+- [ ] Docker イメージビルド確認
+- [ ] Cloud Run デプロイ計画 (別サービス vs 統合)
+
+### 将来対応 (P2)
+
+- [ ] qwen3-asr 専用の Fallback 機構 (qwen3 → vosk)
+- [ ] ストリーミング推論対応
+- [ ] 0.6B / 1.7B の自動切り替え (リソースベース)
+
+---
+
+## 変更しないもの
+
+| 対象 | 理由 |
+|------|------|
+| `frontend/` 全体 | STT provider の切り替えはバックエンド内部の問題 |
+| `backend/main.py` の `_handle_stt()` | STTAgent のインターフェースは変わらない |
+| `backend/main.py` の `_get_stt_agent()` | 既に `STT_PROVIDER` env var に対応済み |
+| `VoiceResponse` Pydantic モデル | レスポンス形式は変わらない |
+| Vosk モデルファイル | 既存モデルはそのまま |
+| `docker-compose.yml` の voicevox/kokoro 設定 | TTS は別の Issue (#371) |
+| Grammar 定義 (`ENGINEER_CAFE_GRAMMAR` 等) | Vosk 専用、qwen3 では不使用 |
+
+---
+
+## 付録 A: ファイル作成・変更一覧
+
+### 新規作成
+
+| ファイル | 説明 |
+|---------|------|
+| `backend/agents/stt_providers/__init__.py` | Factory + exports |
+| `backend/agents/stt_providers/base.py` | BaseSTTProvider, STTResult |
+| `backend/agents/stt_providers/vosk_provider.py` | Vosk 実装 (既存ロジック移動) |
+| `backend/agents/stt_providers/google_provider.py` | Google STT 実装 (既存ロジック移動) |
+| `backend/agents/stt_providers/qwen3_provider.py` | qwen3-asr 実装 (新規) |
+| `backend/tests/agents/test_stt_providers.py` | Provider テスト |
+| `backend/scripts/download_qwen3_model.sh` | モデルダウンロードスクリプト |
+
+### 修正
+
+| ファイル | 変更内容 |
+|---------|---------|
+| `backend/agents/stt_agent.py` | Provider factory を使用するように `__init__` を修正 |
+| `backend/requirements.txt` | `transformers`, `torch`, `torchaudio` を追加 (optional) |
+
+### 変更なし
+
+| ファイル |
+|---------|
+| `frontend/` (全て) |
+| `backend/main.py` |
+| `backend/agents/voice_agent.py` |
+
+---
+
+## 付録 B: 開発環境セットアップ
+
+```bash
+# 1. ブランチ作成
+git checkout develop
+git pull origin develop
+git checkout -b feat/370-stt-qwen3-asr
+
+# 2. 依存パッケージ追加 (qwen3 テスト用)
+cd backend
+pip install transformers torch torchaudio sentencepiece
+
+# 3. モデルダウンロード (テスト用、0.6B 推奨)
+QWEN3_ASR_MODEL_PATH=Qwen/Qwen3-ASR-0.6B bash scripts/download_qwen3_model.sh
+
+# 4. テスト実行
+pytest tests/agents/test_stt_providers.py -v
+pytest -m "not slow and not ragas" --tb=short -q
+
+# 5. Lint
+ruff check .
+black --check .
+
+# 6. qwen3 モードで動作確認
+STT_PROVIDER=qwen3 python -m uvicorn main:app --reload --host 0.0.0.0 --port 8000
+```

--- a/docs/TTS-Migration-Guide-piper-plus.md
+++ b/docs/TTS-Migration-Guide-piper-plus.md
@@ -1,0 +1,1084 @@
+# TTS マイグレーションガイド: piper-plus
+
+**Issue:** #371
+**担当:** junfabregas4
+**作成日:** 2026-03-28
+**プロジェクト:** Engineer Cafe Navigator
+
+---
+
+## 1. 現行実装サマリー
+
+現在の TTS は言語別に2つの provider を使い分けています:
+
+- **日本語:** VOICEVOX (ローカル REST API, speaker #3 ずんだもん)
+- **英語:** Kokoro TTS (ローカル REST API, voice af_bella)
+- **フォールバック:** Google Cloud TTS (MP3 形式)
+
+### データフロー
+
+```
+Frontend (VoiceInterface.tsx)
+  → POST /api/voice { action: "text_to_speech", text, language }
+  → Frontend proxy (route.ts)
+  → Backend POST /api/voice
+  → VoiceAgent.text_to_speech()
+    ├─ 言語検出 (LanguageProcessor)
+    ├─ Emotion タグ解析 + テキスト前処理
+    ├─ 言語ルーティング:
+    │   ├─ "en" → KokoroTTSClient → WAV
+    │   ├─ "ja" + voicevox → VoiceVoxClient → WAV
+    │   └─ google → GoogleTTSClient → MP3
+    ├─ Base64 エンコード
+    └─ VoiceResponse { audioResponse, emotion, format }
+  → Frontend playAudio() + Lip-sync
+```
+
+### 主要ファイル
+
+| ファイル | 役割 |
+|---------|------|
+| `backend/agents/voice_agent.py` | VoiceAgent, VoiceVoxClient, KokoroTTSClient (807行) |
+| `backend/main.py:638-688` | `/api/voice` エンドポイント |
+| `docker-compose.yml` | voicevox (port 50021), kokoro-tts (port 8880) |
+
+### 現行パフォーマンス
+
+| Provider | Cold Start | Warm レイテンシ | メモリ |
+|----------|-----------|----------------|--------|
+| VOICEVOX | 2-5秒 | 200-500ms | 4GB |
+| Kokoro | 1-2秒 | 300-800ms | 2GB |
+| Google TTS | - | 500ms-2秒 | - |
+
+### 言語ルーティングロジック (voice_agent.py:751-768)
+
+```python
+if language == "en":
+    audio_b64 = await self.kokoro_client.synthesize_wav_base64(processed, language)
+    audio_format = "audio/wav"
+elif self.tts_provider == "voicevox":
+    audio_b64 = await self.tts_client.synthesize_wav_base64(processed, language)
+    audio_format = "audio/wav"
+else:  # google
+    tts_emotion = map_vrm_to_tts_emotion(vrm_emotion)
+    audio_b64 = await self.tts_client.synthesize_mp3_base64(processed, language, tts_emotion)
+    audio_format = "audio/mpeg"
+```
+
+---
+
+## 2. 目標
+
+**既存の VOICEVOX/Kokoro 実装を維持したまま**、piper-plus を代替 TTS provider として追加する。
+
+- `TTS_PROVIDER_JA=voicevox` (デフォルト、変更なし)
+- `TTS_PROVIDER_EN=kokoro` (デフォルト、変更なし)
+- `TTS_PROVIDER_JA=piper` / `TTS_PROVIDER_EN=piper` (新規追加)
+- 言語別に独立して provider を切り替え可能
+- VOICEVOX/Kokoro のコード・テスト・動作に一切影響を与えない
+
+---
+
+## 3. アーキテクチャ変更
+
+### 3.1 Provider Pattern 導入
+
+```
+backend/agents/
+├── voice_agent.py             ← Factory + VoiceAgent (既存ファイルを修正)
+├── tts_providers/              ← 新規ディレクトリ
+│   ├── __init__.py
+│   ├── base.py                 ← 抽象基底クラス
+│   ├── voicevox_provider.py    ← 既存 VoiceVoxClient を移動
+│   ├── kokoro_provider.py      ← 既存 KokoroTTSClient を移動
+│   ├── google_provider.py      ← 既存 GoogleTTSClient を移動
+│   └── piper_provider.py      ← 新規
+```
+
+### 3.2 Provider Interface
+
+```python
+# backend/agents/tts_providers/base.py
+
+from abc import ABC, abstractmethod
+from dataclasses import dataclass
+from typing import Optional
+
+
+@dataclass
+class TTSResult:
+    """TTS provider の統一出力形式"""
+    audio_data: bytes       # WAV or MP3 バイナリ
+    format: str             # "audio/wav" or "audio/mpeg"
+    sample_rate: int        # 例: 24000, 44100
+    provider: str           # "voicevox", "kokoro", "piper", "google"
+
+
+class BaseTTSProvider(ABC):
+    """TTS provider の抽象基底クラス"""
+
+    @abstractmethod
+    async def synthesize(
+        self,
+        text: str,
+        language: str = "ja",
+        speaker_id: Optional[int] = None,
+        voice: Optional[str] = None,
+        speed: float = 1.0,
+    ) -> TTSResult:
+        """
+        テキストを音声に変換する。
+
+        Args:
+            text: 合成テキスト (前処理済み, 最大 5000 bytes)
+            language: 言語コード ("ja", "en")
+            speaker_id: 話者 ID (VOICEVOX 用, 例: 3)
+            voice: 音声モデル名 (Kokoro/piper 用, 例: "af_bella")
+            speed: 再生速度 (1.0 = 通常)
+
+        Returns:
+            TTSResult
+
+        Raises:
+            RuntimeError: 合成失敗時
+        """
+        ...
+
+    async def synthesize_wav_base64(
+        self,
+        text: str,
+        language: str = "ja",
+        **kwargs,
+    ) -> str:
+        """Base64 エンコード済み WAV を返す (既存 API との互換性)"""
+        import base64
+
+        result = await self.synthesize(text, language, **kwargs)
+        return base64.b64encode(result.audio_data).decode("utf-8")
+
+    async def health_check(self) -> bool:
+        """Provider の健全性チェック (オプション)"""
+        return True
+```
+
+### 3.3 Factory Pattern
+
+```python
+# backend/agents/tts_providers/__init__.py
+
+from backend.agents.tts_providers.base import BaseTTSProvider, TTSResult
+
+
+def create_tts_provider(provider_name: str, **kwargs) -> BaseTTSProvider:
+    """TTS provider を作成する Factory"""
+
+    if provider_name == "voicevox":
+        from backend.agents.tts_providers.voicevox_provider import VoicevoxTTSProvider
+        return VoicevoxTTSProvider(**kwargs)
+
+    elif provider_name == "kokoro":
+        from backend.agents.tts_providers.kokoro_provider import KokoroTTSProvider
+        return KokoroTTSProvider(**kwargs)
+
+    elif provider_name == "piper":
+        from backend.agents.tts_providers.piper_provider import PiperTTSProvider
+        return PiperTTSProvider(**kwargs)
+
+    elif provider_name == "google":
+        from backend.agents.tts_providers.google_provider import GoogleTTSProvider
+        return GoogleTTSProvider(**kwargs)
+
+    else:
+        raise ValueError(f"Unknown TTS provider: {provider_name}")
+
+
+__all__ = ["BaseTTSProvider", "TTSResult", "create_tts_provider"]
+```
+
+### 3.4 VoiceAgent の修正
+
+`voice_agent.py` の `VoiceAgent.__init__` と言語ルーティングを修正:
+
+```python
+# backend/agents/voice_agent.py (修正箇所)
+
+from backend.agents.tts_providers import create_tts_provider
+
+class VoiceAgent:
+    def __init__(
+        self,
+        tts_provider: str = "voicevox",     # 後方互換
+        tts_client: Optional[Any] = None,   # テスト用 DI
+        language_processor: Optional[LanguageProcessor] = None,
+        clarification_agent: Optional[Any] = None,
+    ):
+        # 言語別 provider (環境変数で切り替え)
+        self.tts_provider_ja = os.getenv("TTS_PROVIDER_JA", tts_provider)
+        self.tts_provider_en = os.getenv("TTS_PROVIDER_EN", "kokoro")
+
+        # Provider 初期化 (factory 経由)
+        if tts_client:
+            self.tts_client = tts_client  # テスト用 (日本語)
+        else:
+            self.tts_client = create_tts_provider(self.tts_provider_ja)
+
+        self.tts_client_en = create_tts_provider(self.tts_provider_en)
+
+        # ... 既存の language_processor, clarification_agent 初期化
+```
+
+### 3.5 言語ルーティングの修正
+
+```python
+# voice_agent.py text_to_speech() 内 (Lines 751-768 を修正)
+
+if language == "en":
+    # 英語 → TTS_PROVIDER_EN で指定された provider
+    audio_b64 = await self.tts_client_en.synthesize_wav_base64(processed, language)
+    audio_format = "audio/wav"
+else:
+    # 日本語 → TTS_PROVIDER_JA で指定された provider
+    result = await self.tts_client.synthesize(processed, language)
+    audio_b64 = base64.b64encode(result.audio_data).decode("utf-8")
+    audio_format = result.format
+```
+
+### 3.6 環境変数による切り替え
+
+```
+# .env
+TTS_PROVIDER_JA=voicevox   # デフォルト（既存動作）
+TTS_PROVIDER_EN=kokoro     # デフォルト（既存動作）
+
+# piper-plus に切り替え
+# TTS_PROVIDER_JA=piper
+# TTS_PROVIDER_EN=piper
+```
+
+---
+
+## 4. 実装手順
+
+### Step 1: `backend/agents/tts_providers/base.py` を作成
+
+上記 3.2 の `BaseTTSProvider` と `TTSResult` を作成する。
+
+`synthesize_wav_base64()` メソッドを基底クラスに実装し、既存の `VoiceVoxClient.synthesize_wav_base64()` / `KokoroTTSClient.synthesize_wav_base64()` との互換性を保つ。
+
+### Step 2: `backend/agents/tts_providers/voicevox_provider.py` を作成
+
+既存の `VoiceVoxClient` (voice_agent.py:440-520) のロジックを移動。
+
+```python
+# backend/agents/tts_providers/voicevox_provider.py
+
+import base64
+import logging
+import os
+from typing import Optional
+
+import httpx
+
+from backend.agents.tts_providers.base import BaseTTSProvider, TTSResult
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_SPEAKER_JA = 3  # ずんだもん - Normal
+DEFAULT_SPEAKER_EN = 3
+
+
+class VoicevoxTTSProvider(BaseTTSProvider):
+    """VOICEVOX REST API ベースの TTS provider"""
+
+    def __init__(self, api_url: Optional[str] = None):
+        self.api_url = (
+            api_url or os.getenv("VOICEVOX_API_URL", "http://localhost:50021")
+        ).rstrip("/")
+        self._initialized_speakers: set[int] = set()
+
+    async def _initialize_speaker(self, speaker_id: int) -> None:
+        if speaker_id in self._initialized_speakers:
+            return
+        try:
+            async with httpx.AsyncClient(timeout=10) as client:
+                await client.post(
+                    f"{self.api_url}/initialize_speaker",
+                    params={"speaker": speaker_id},
+                )
+            self._initialized_speakers.add(speaker_id)
+        except Exception as e:
+            logger.warning("Speaker init failed (non-fatal): %s", e)
+
+    async def synthesize(
+        self,
+        text: str,
+        language: str = "ja",
+        speaker_id: Optional[int] = None,
+        voice: Optional[str] = None,
+        speed: float = 1.0,
+    ) -> TTSResult:
+        sid = speaker_id or DEFAULT_SPEAKER_JA
+        await self._initialize_speaker(sid)
+
+        async with httpx.AsyncClient(timeout=30) as client:
+            # Step 1: Audio Query
+            query_resp = await client.post(
+                f"{self.api_url}/audio_query",
+                params={"text": text, "speaker": sid},
+            )
+            if query_resp.status_code >= 400:
+                raise RuntimeError(
+                    f"VOICEVOX audio_query failed: {query_resp.status_code}"
+                )
+            audio_query = query_resp.json()
+
+            # Speed 調整
+            if speed != 1.0:
+                audio_query["speedScale"] = speed
+
+            # Step 2: Synthesis
+            synth_resp = await client.post(
+                f"{self.api_url}/synthesis",
+                params={"speaker": sid},
+                json=audio_query,
+                headers={"Content-Type": "application/json"},
+            )
+            if synth_resp.status_code >= 400:
+                raise RuntimeError(
+                    f"VOICEVOX synthesis failed: {synth_resp.status_code}"
+                )
+
+        return TTSResult(
+            audio_data=synth_resp.content,
+            format="audio/wav",
+            sample_rate=24000,  # VOICEVOX default
+            provider="voicevox",
+        )
+
+    async def health_check(self) -> bool:
+        try:
+            async with httpx.AsyncClient(timeout=5) as client:
+                resp = await client.get(f"{self.api_url}/version")
+                return resp.status_code == 200
+        except Exception:
+            return False
+```
+
+**重要:** `voice_agent.py` 内の `VoiceVoxClient` は後方互換として alias を残す:
+
+```python
+# voice_agent.py 末尾
+from backend.agents.tts_providers.voicevox_provider import VoicevoxTTSProvider as VoiceVoxClient
+```
+
+### Step 3: `backend/agents/tts_providers/kokoro_provider.py` を作成
+
+既存の `KokoroTTSClient` (voice_agent.py:527-593) を移動。
+
+```python
+# backend/agents/tts_providers/kokoro_provider.py
+
+import base64
+import logging
+import os
+from typing import Optional
+
+import httpx
+
+from backend.agents.tts_providers.base import BaseTTSProvider, TTSResult
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_VOICE_EN = "af_bella"
+
+
+class KokoroTTSProvider(BaseTTSProvider):
+    """Kokoro FastAPI ベースの TTS provider"""
+
+    def __init__(self, api_url: Optional[str] = None):
+        self.api_url = (
+            api_url or os.getenv("KOKORO_API_URL", "http://localhost:8880")
+        ).rstrip("/")
+
+    async def synthesize(
+        self,
+        text: str,
+        language: str = "en",
+        speaker_id: Optional[int] = None,
+        voice: Optional[str] = None,
+        speed: float = 1.0,
+    ) -> TTSResult:
+        voice_name = voice or DEFAULT_VOICE_EN
+
+        async with httpx.AsyncClient(timeout=30) as client:
+            resp = await client.post(
+                f"{self.api_url}/v1/audio/speech",
+                json={
+                    "model": "kokoro",
+                    "input": text,
+                    "voice": voice_name,
+                    "response_format": "wav",
+                    "speed": speed,
+                },
+            )
+            if resp.status_code >= 400:
+                raise RuntimeError(
+                    f"Kokoro synthesis failed: {resp.status_code} {resp.text}"
+                )
+
+        return TTSResult(
+            audio_data=resp.content,
+            format="audio/wav",
+            sample_rate=24000,
+            provider="kokoro",
+        )
+
+    async def health_check(self) -> bool:
+        try:
+            async with httpx.AsyncClient(timeout=5) as client:
+                resp = await client.get(f"{self.api_url}/v1/audio/voices")
+                return resp.status_code == 200
+        except Exception:
+            return False
+```
+
+### Step 4: `backend/agents/tts_providers/piper_provider.py` を作成 (新規)
+
+```python
+# backend/agents/tts_providers/piper_provider.py
+
+import logging
+import os
+from typing import Optional
+
+import httpx
+
+from backend.agents.tts_providers.base import BaseTTSProvider, TTSResult
+
+logger = logging.getLogger(__name__)
+
+# piper-plus デフォルト設定
+DEFAULT_PIPER_URL = "http://localhost:10200"
+DEFAULT_VOICE_JA = "ja_JP-takumi-medium"   # ⚠️ 利用可能モデル要確認
+DEFAULT_VOICE_EN = "en_US-amy-medium"      # ⚠️ 利用可能モデル要確認
+
+
+class PiperTTSProvider(BaseTTSProvider):
+    """piper-plus ベースの TTS provider
+
+    piper-plus repository: https://github.com/ayutaz/piper-plus/
+
+    ⚠️ piper-plus の REST API 仕様は PoC で検証が必要。
+    以下は piper (rhasspy/piper) の一般的な HTTP API を想定。
+    """
+
+    def __init__(
+        self,
+        api_url: Optional[str] = None,
+        voice_ja: Optional[str] = None,
+        voice_en: Optional[str] = None,
+    ):
+        self.api_url = (
+            api_url or os.getenv("PIPER_PLUS_URL", DEFAULT_PIPER_URL)
+        ).rstrip("/")
+        self.voice_ja = voice_ja or os.getenv("PIPER_VOICE_JA", DEFAULT_VOICE_JA)
+        self.voice_en = voice_en or os.getenv("PIPER_VOICE_EN", DEFAULT_VOICE_EN)
+
+    def _get_voice(self, language: str, voice: Optional[str] = None) -> str:
+        """言語に応じた音声モデルを返す"""
+        if voice:
+            return voice
+        if language == "en":
+            return self.voice_en
+        return self.voice_ja
+
+    async def synthesize(
+        self,
+        text: str,
+        language: str = "ja",
+        speaker_id: Optional[int] = None,
+        voice: Optional[str] = None,
+        speed: float = 1.0,
+    ) -> TTSResult:
+        if not text or not text.strip():
+            raise RuntimeError("Empty text for TTS synthesis")
+
+        voice_model = self._get_voice(language, voice)
+
+        # ⚠️ piper-plus の正確な API エンドポイントは PoC で検証が必要
+        # 以下は piper HTTP server の一般的なパターン
+        async with httpx.AsyncClient(timeout=30) as client:
+            resp = await client.post(
+                f"{self.api_url}/api/tts",
+                json={
+                    "text": text,
+                    "voice": voice_model,
+                    "output_format": "wav",
+                    "speed": speed,
+                    "speaker_id": speaker_id,
+                },
+            )
+
+            if resp.status_code >= 400:
+                # フォールバック: GET パラメータ形式を試行
+                # ⚠️ piper-plus が GET/POST どちらをサポートするか要確認
+                resp = await client.get(
+                    f"{self.api_url}/api/tts",
+                    params={
+                        "text": text,
+                        "voice": voice_model,
+                    },
+                )
+                if resp.status_code >= 400:
+                    raise RuntimeError(
+                        f"piper-plus synthesis failed: {resp.status_code} {resp.text}"
+                    )
+
+        # piper の出力は WAV (16-bit PCM)
+        audio_data = resp.content
+
+        # WAV ヘッダ検証
+        if audio_data[:4] != b"RIFF":
+            raise RuntimeError(
+                f"piper-plus returned unexpected format "
+                f"(expected WAV, got {audio_data[:4]!r})"
+            )
+
+        return TTSResult(
+            audio_data=audio_data,
+            format="audio/wav",
+            sample_rate=22050,  # piper default (⚠️ モデルにより異なる)
+            provider="piper",
+        )
+
+    async def health_check(self) -> bool:
+        """piper-plus の健全性チェック"""
+        try:
+            async with httpx.AsyncClient(timeout=5) as client:
+                # ⚠️ health check エンドポイントは piper-plus の実装による
+                resp = await client.get(f"{self.api_url}/api/voices")
+                return resp.status_code == 200
+        except Exception:
+            return False
+```
+
+### Step 5: VoiceAgent の言語ルーティング修正
+
+`voice_agent.py` の `text_to_speech()` メソッド内の言語ルーティング (Lines 751-768) を修正:
+
+```python
+# voice_agent.py text_to_speech() 内 (修正後)
+
+import base64
+
+if language == "en":
+    # 英語 provider で合成
+    result = await self.tts_client_en.synthesize(
+        processed, language=language, speed=1.0,
+    )
+    audio_b64 = base64.b64encode(result.audio_data).decode("utf-8")
+    audio_format = result.format
+else:
+    # 日本語 provider で合成
+    result = await self.tts_client.synthesize(
+        processed, language=language, speed=1.0,
+    )
+    audio_b64 = base64.b64encode(result.audio_data).decode("utf-8")
+    audio_format = result.format
+```
+
+### Step 6: piper-plus Docker サービス追加
+
+```yaml
+# docker-compose.yml (追加)
+
+services:
+  # ... 既存の voicevox, kokoro-tts, backend ...
+
+  piper-tts:
+    image: ghcr.io/ayutaz/piper-plus:latest  # ⚠️ 正確なイメージ名要確認
+    container_name: engineer-cafe-piper-tts
+    ports:
+      - "10200:10200"
+    volumes:
+      - piper-models:/app/models
+    environment:
+      - PIPER_PORT=10200
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:10200/api/voices"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 30s
+    restart: unless-stopped
+    networks:
+      - engineer-cafe-network
+
+volumes:
+  # ... 既存 volumes ...
+  piper-models:
+```
+
+**production 用 (docker-compose.production.yml):**
+
+```yaml
+  piper-tts:
+    image: ghcr.io/ayutaz/piper-plus:latest  # ⚠️ 要確認
+    expose:
+      - "10200"
+    volumes:
+      - piper-models:/app/models
+    deploy:
+      resources:
+        limits:
+          cpus: "0.5"
+          memory: 512M
+    logging:
+      driver: json-file
+      options:
+        max-size: "50m"
+        max-file: "3"
+    restart: unless-stopped
+    networks:
+      - engineer-cafe-network
+```
+
+### Step 7: テスト追加
+
+```python
+# backend/tests/agents/test_tts_providers.py
+
+import pytest
+from unittest.mock import AsyncMock, patch, MagicMock
+from backend.agents.tts_providers import create_tts_provider, TTSResult
+from backend.agents.tts_providers.base import BaseTTSProvider
+
+
+class TestTTSProviderFactory:
+    def test_create_voicevox_provider(self):
+        provider = create_tts_provider("voicevox")
+        assert isinstance(provider, BaseTTSProvider)
+
+    def test_create_kokoro_provider(self):
+        provider = create_tts_provider("kokoro")
+        assert isinstance(provider, BaseTTSProvider)
+
+    def test_create_piper_provider(self):
+        provider = create_tts_provider("piper")
+        assert isinstance(provider, BaseTTSProvider)
+
+    def test_create_google_provider(self):
+        provider = create_tts_provider("google")
+        assert isinstance(provider, BaseTTSProvider)
+
+    def test_unknown_provider_raises(self):
+        with pytest.raises(ValueError, match="Unknown TTS provider"):
+            create_tts_provider("unknown")
+
+
+class TestPiperProvider:
+    def test_init_default(self):
+        from backend.agents.tts_providers.piper_provider import PiperTTSProvider
+        provider = PiperTTSProvider()
+        assert "10200" in provider.api_url
+
+    def test_init_custom_url(self):
+        from backend.agents.tts_providers.piper_provider import PiperTTSProvider
+        provider = PiperTTSProvider(api_url="http://custom:9999")
+        assert provider.api_url == "http://custom:9999"
+
+    def test_get_voice_ja(self):
+        from backend.agents.tts_providers.piper_provider import PiperTTSProvider
+        provider = PiperTTSProvider()
+        voice = provider._get_voice("ja")
+        assert "ja" in voice.lower()
+
+    def test_get_voice_en(self):
+        from backend.agents.tts_providers.piper_provider import PiperTTSProvider
+        provider = PiperTTSProvider()
+        voice = provider._get_voice("en")
+        assert "en" in voice.lower()
+
+    def test_get_voice_custom(self):
+        from backend.agents.tts_providers.piper_provider import PiperTTSProvider
+        provider = PiperTTSProvider()
+        voice = provider._get_voice("ja", voice="custom_voice")
+        assert voice == "custom_voice"
+
+    @pytest.mark.asyncio
+    async def test_synthesize_empty_text_raises(self):
+        from backend.agents.tts_providers.piper_provider import PiperTTSProvider
+        provider = PiperTTSProvider()
+        with pytest.raises(RuntimeError, match="Empty text"):
+            await provider.synthesize("", language="ja")
+
+
+class TestTTSResultDataclass:
+    def test_create_result(self):
+        result = TTSResult(
+            audio_data=b"RIFF...",
+            format="audio/wav",
+            sample_rate=22050,
+            provider="piper",
+        )
+        assert result.format == "audio/wav"
+        assert result.provider == "piper"
+
+
+class TestVoicevoxProvider:
+    """既存 VOICEVOX の provider 化が後方互換であることを確認"""
+
+    def test_init(self):
+        from backend.agents.tts_providers.voicevox_provider import VoicevoxTTSProvider
+        provider = VoicevoxTTSProvider()
+        assert "50021" in provider.api_url
+
+
+class TestKokoroProvider:
+    """既存 Kokoro の provider 化が後方互換であることを確認"""
+
+    def test_init(self):
+        from backend.agents.tts_providers.kokoro_provider import KokoroTTSProvider
+        provider = KokoroTTSProvider()
+        assert "8880" in provider.api_url
+```
+
+---
+
+## 5. Provider インターフェース仕様
+
+### Input
+
+| パラメータ | 型 | 必須 | 説明 |
+|-----------|-----|------|------|
+| `text` | `str` | Yes | 合成テキスト (前処理済み, 最大 5000 bytes) |
+| `language` | `str` | Yes | `"ja"` or `"en"` |
+| `speaker_id` | `Optional[int]` | No | VOICEVOX 話者 ID (例: 3) |
+| `voice` | `Optional[str]` | No | 音声モデル名 (例: "af_bella", "ja_JP-takumi-medium") |
+| `speed` | `float` | No | 再生速度 (デフォルト 1.0) |
+
+### Output: `TTSResult`
+
+| フィールド | 型 | 説明 |
+|-----------|-----|------|
+| `audio_data` | `bytes` | WAV or MP3 バイナリ |
+| `format` | `str` | `"audio/wav"` or `"audio/mpeg"` |
+| `sample_rate` | `int` | サンプルレート (例: 22050, 24000) |
+| `provider` | `str` | `"voicevox"`, `"kokoro"`, `"piper"`, `"google"` |
+
+### 必須処理
+
+- 空テキスト: `RuntimeError` を raise
+- 長テキスト (>5000 chars): `VoiceAgent.text_to_speech()` で事前に truncation 済み (provider では処理不要)
+- Emotion タグ: `VoiceAgent` で事前にパースされている。provider は clean text を受け取る
+- タイムアウト: 30秒
+
+---
+
+## 6. piper-plus 固有の注意点
+
+### 6.1 ONNX Runtime ベース
+
+piper-plus は ONNX Runtime を使用しており、GPU なしで高速推論が可能。これは VOICEVOX (CPU_NUM_THREADS 依存) や Kokoro (CPU 版イメージ使用) と同等の環境で動作する。
+
+### 6.2 日本語モデルの可用性
+
+⚠️ **PoC 検証が必要:**
+
+- piper-plus が日本語モデルを提供しているか確認
+- 利用可能な日本語音声の品質を VOICEVOX と比較
+- 日本語モデルが存在しない場合、piper-plus は英語専用として使い、日本語は引き続き VOICEVOX を使用
+
+### 6.3 音声モデル選択
+
+| 言語 | デフォルトモデル | 備考 |
+|------|---------------|------|
+| 日本語 | `ja_JP-takumi-medium` | ⚠️ 存在確認要 |
+| 英語 | `en_US-amy-medium` | piper standard voice |
+
+**モデル一覧取得:**
+```bash
+# piper-plus のモデル一覧を確認
+curl http://localhost:10200/api/voices
+```
+
+### 6.4 レスポンス形式
+
+piper は WAV (16-bit PCM) を出力する。これはフロントエンドの `AudioDataProcessor.detectAudioFormat()` と互換性がある。
+
+### 6.5 piper-plus リポジトリ
+
+- Repository: https://github.com/ayutaz/piper-plus/
+- オリジナル piper: https://github.com/rhasspy/piper
+
+### ⚠️ PoC 検証が必要な項目
+
+1. **piper-plus の REST API 仕様** — エンドポイント URL、リクエスト/レスポンス形式
+2. **Docker イメージ** — `ghcr.io/ayutaz/piper-plus:latest` で正しいか
+3. **日本語モデルの有無と品質** — VOICEVOX との比較
+4. **出力サンプルレート** — 22050Hz or 24000Hz (モデル依存)
+5. **Health check エンドポイント** — `/api/voices` で良いか
+6. **同時リクエスト処理** — 複数ユーザー同時使用時の性能
+
+---
+
+## 7. 環境変数
+
+| 環境変数 | デフォルト | 説明 |
+|---------|----------|------|
+| `TTS_PROVIDER_JA` | `voicevox` | 日本語 TTS: `voicevox` \| `piper` \| `google` |
+| `TTS_PROVIDER_EN` | `kokoro` | 英語 TTS: `kokoro` \| `piper` \| `google` |
+| `PIPER_PLUS_URL` | `http://localhost:10200` | piper-plus サービス URL |
+| `PIPER_VOICE_JA` | `ja_JP-takumi-medium` | 日本語音声モデル名 |
+| `PIPER_VOICE_EN` | `en_US-amy-medium` | 英語音声モデル名 |
+| `VOICEVOX_API_URL` | `http://localhost:50021` | (既存、変更なし) |
+| `KOKORO_API_URL` | `http://localhost:8880` | (既存、変更なし) |
+
+### .env 設定例
+
+```bash
+# デフォルト（既存動作、変更不要）
+TTS_PROVIDER_JA=voicevox
+TTS_PROVIDER_EN=kokoro
+
+# piper-plus に全面切り替え
+TTS_PROVIDER_JA=piper
+TTS_PROVIDER_EN=piper
+PIPER_PLUS_URL=http://piper-tts:10200
+
+# 日本語は VOICEVOX、英語のみ piper
+TTS_PROVIDER_JA=voicevox
+TTS_PROVIDER_EN=piper
+PIPER_PLUS_URL=http://piper-tts:10200
+```
+
+---
+
+## 8. Docker / デプロイ
+
+### 8.1 piper-plus Docker サービス
+
+```yaml
+# docker-compose.yml (piper-tts サービス追加)
+piper-tts:
+  image: ghcr.io/ayutaz/piper-plus:latest  # ⚠️ 正確なイメージ名要確認
+  container_name: engineer-cafe-piper-tts
+  ports:
+    - "10200:10200"
+  volumes:
+    - piper-models:/app/models
+  healthcheck:
+    test: ["CMD", "curl", "-f", "http://localhost:10200/api/voices"]
+    interval: 30s
+    timeout: 10s
+    retries: 3
+    start_period: 30s
+  networks:
+    - engineer-cafe-network
+```
+
+### 8.2 イメージサイズ
+
+| サービス | イメージサイズ |
+|---------|-------------|
+| VOICEVOX | ~2.5GB |
+| Kokoro | ~1.5GB |
+| piper-plus | ~50-100MB (⚠️ 要確認) + モデル (~50MB/voice) |
+
+### 8.3 backend の依存関係
+
+piper-plus を使用する場合、`backend` サービスの `depends_on` を更新:
+
+```yaml
+backend:
+  depends_on:
+    voicevox:
+      condition: service_healthy
+    kokoro-tts:
+      condition: service_healthy
+    piper-tts:
+      condition: service_healthy  # piper 使用時のみ必要
+  environment:
+    - TTS_PROVIDER_JA=${TTS_PROVIDER_JA:-voicevox}
+    - TTS_PROVIDER_EN=${TTS_PROVIDER_EN:-kokoro}
+    - PIPER_PLUS_URL=http://piper-tts:10200
+```
+
+**注意:** `depends_on` に piper-tts を追加すると、piper を使わない場合もコンテナが起動する。これを避けるには Docker Compose profiles を使用:
+
+```yaml
+piper-tts:
+  profiles:
+    - piper  # docker compose --profile piper up で起動
+```
+
+### 8.4 Health check
+
+```bash
+# piper-plus の Health check
+curl -f http://localhost:10200/api/voices
+
+# VOICEVOX の Health check (既存)
+curl -f http://localhost:50021/version
+
+# Kokoro の Health check (既存)
+curl -f http://localhost:8880/v1/audio/voices
+```
+
+---
+
+## 9. テスト計画
+
+### 9.1 Unit テスト
+
+| テスト | 内容 |
+|--------|------|
+| Factory テスト | `create_tts_provider("voicevox")`, `("kokoro")`, `("piper")`, `("google")`, `("unknown")` |
+| TTSResult テスト | dataclass の作成 |
+| PiperProvider init | デフォルト URL、カスタム URL |
+| Voice 選択 | `_get_voice("ja")`, `_get_voice("en")`, custom voice |
+| 空テキスト | `synthesize("")` で RuntimeError |
+| VoicevoxProvider init | 後方互換確認 |
+| KokoroProvider init | 後方互換確認 |
+
+### 9.2 Integration テスト
+
+| テスト | 内容 |
+|--------|------|
+| VOICEVOX 合成 | 既存テストがそのまま通ること |
+| Kokoro 合成 | 既存テストがそのまま通ること |
+| piper 合成 | テストテキスト → WAV audio |
+| Provider 切り替え | `TTS_PROVIDER_JA` / `TTS_PROVIDER_EN` 環境変数 |
+| 言語ルーティング | 日本語 → JA provider, 英語 → EN provider |
+
+### 9.3 主観評価 (Subjective)
+
+| テスト | 内容 |
+|--------|------|
+| 日本語品質 | VOICEVOX vs piper の聴き比べ (5段階評価) |
+| 英語品質 | Kokoro vs piper の聴き比べ |
+| 自然さ | イントネーション、ポーズ、発音の自然さ |
+
+### 9.4 Performance ベンチマーク
+
+| メトリクス | 目標 | 計測方法 |
+|-----------|------|---------|
+| レイテンシ (日本語 100文字) | VOICEVOX の 50% 以下 | p50, p95 計測 |
+| レイテンシ (英語 100 words) | Kokoro と同等 | p50, p95 計測 |
+| メモリ使用量 | 512MB 以下 | Docker stats |
+| Cold Start | 10秒以下 | コンテナ起動→Health check |
+
+---
+
+## 10. 受入基準
+
+### 必須 (P0)
+
+- [ ] `TTS_PROVIDER_JA=voicevox` + `TTS_PROVIDER_EN=kokoro` (デフォルト) で既存動作が一切変わらないこと
+- [ ] `TTS_PROVIDER_JA=piper` で piper-plus による日本語音声合成が動作すること
+- [ ] `TTS_PROVIDER_EN=piper` で piper-plus による英語音声合成が動作すること
+- [ ] Provider factory (`create_tts_provider`) が正しく provider を選択すること
+- [ ] `BaseTTSProvider` 抽象クラスと `TTSResult` dataclass が定義されていること
+- [ ] 出力形式が WAV であること (フロントエンドの Lip-sync と互換)
+- [ ] 既存テストが全て通ること
+- [ ] 新規テスト (factory, piper provider) が追加されていること
+- [ ] ruff / black が通ること
+- [ ] docker-compose.yml に piper-tts サービスが追加されていること
+
+### 推奨 (P1)
+
+- [ ] VOICEVOX vs piper の品質比較レポート (日本語)
+- [ ] Kokoro vs piper の品質比較レポート (英語)
+- [ ] レイテンシベンチマーク (目標: VOICEVOX の 50% 以下)
+- [ ] Docker Compose profiles による条件起動
+
+### 将来対応 (P2)
+
+- [ ] Emotion サポート (piper が SSML をサポートする場合)
+- [ ] 複数話者切り替え
+- [ ] Cloud Run 用の piper-plus サービス設定
+
+---
+
+## 変更しないもの
+
+| 対象 | 理由 |
+|------|------|
+| `frontend/` 全体 | TTS provider の切り替えはバックエンド内部の問題。フロントエンドは WAV/MP3 の Base64 を受け取るだけ |
+| `backend/main.py` の `voice_api()` | VoiceAgent のインターフェースは変わらない |
+| `VoiceResponse` Pydantic モデル | レスポンス形式は変わらない |
+| Emotion タグ解析 (`parse_emotion_tags`, `map_to_vrm_emotion`) | provider の前段で処理済み |
+| テキスト前処理 (`clean_text_for_tts`, `preprocess_tts`) | provider の前段で処理済み |
+| Lip-sync 処理 (フロントエンド) | WAV 形式であれば互換 |
+| `backend/agents/stt_agent.py` | STT は別の Issue (#370) |
+| VOICEVOX Docker サービス設定 | 既存サービスはそのまま |
+| Kokoro Docker サービス設定 | 既存サービスはそのまま |
+
+---
+
+## 付録 A: ファイル作成・変更一覧
+
+### 新規作成
+
+| ファイル | 説明 |
+|---------|------|
+| `backend/agents/tts_providers/__init__.py` | Factory + exports |
+| `backend/agents/tts_providers/base.py` | BaseTTSProvider, TTSResult |
+| `backend/agents/tts_providers/voicevox_provider.py` | VOICEVOX 実装 (既存ロジック移動) |
+| `backend/agents/tts_providers/kokoro_provider.py` | Kokoro 実装 (既存ロジック移動) |
+| `backend/agents/tts_providers/google_provider.py` | Google TTS 実装 (既存ロジック移動) |
+| `backend/agents/tts_providers/piper_provider.py` | piper-plus 実装 (新規) |
+| `backend/tests/agents/test_tts_providers.py` | Provider テスト |
+
+### 修正
+
+| ファイル | 変更内容 |
+|---------|---------|
+| `backend/agents/voice_agent.py` | Provider factory を使用するように `__init__` と言語ルーティングを修正。VoiceVoxClient/KokoroTTSClient の alias を残す |
+| `docker-compose.yml` | piper-tts サービス追加、backend の環境変数追加 |
+| `docker-compose.production.yml` | piper-tts サービス追加 |
+
+### 変更なし
+
+| ファイル |
+|---------|
+| `frontend/` (全て) |
+| `backend/main.py` |
+| `backend/agents/stt_agent.py` |
+
+---
+
+## 付録 B: 開発環境セットアップ
+
+```bash
+# 1. ブランチ作成
+git checkout develop
+git pull origin develop
+git checkout -b feat/371-tts-piper-plus
+
+# 2. piper-plus コンテナ起動
+docker compose --profile piper up -d piper-tts
+# or
+docker run -d -p 10200:10200 ghcr.io/ayutaz/piper-plus:latest  # ⚠️ 要確認
+
+# 3. piper-plus の動作確認
+curl http://localhost:10200/api/voices          # モデル一覧
+curl -X POST http://localhost:10200/api/tts \
+  -H "Content-Type: application/json" \
+  -d '{"text":"Hello world","voice":"en_US-amy-medium"}' \
+  --output test.wav                             # 音声合成テスト
+
+# 4. テスト実行
+cd backend
+pytest tests/agents/test_tts_providers.py -v
+pytest -m "not slow and not ragas" --tb=short -q
+
+# 5. Lint
+ruff check .
+black --check .
+
+# 6. piper モードで動作確認
+TTS_PROVIDER_JA=piper TTS_PROVIDER_EN=piper \
+  PIPER_PLUS_URL=http://localhost:10200 \
+  python -m uvicorn main:app --reload --host 0.0.0.0 --port 8000
+```

--- a/docs/adr/006-langgraph-workflow-redesign.md
+++ b/docs/adr/006-langgraph-workflow-redesign.md
@@ -1,0 +1,140 @@
+# ADR-006: LangGraph ワークフロー再設計 — 多言語対応・受付統一・ルーティング最適化
+
+## Status
+
+Proposed (2026-03-28)
+
+## Context
+
+Engineer Cafe Navigator のバックエンドは LangGraph Supervisor Pattern を採用している。kiosk デプロイ（2026-04-11目標）に向けて、3つのソース（Codex CLI アーキテクチャレビュー、内部ワークフロー分析、Web技術調査）から以下の構造的問題が特定された：
+
+### 特定された問題
+
+1. **ルーティング効率**: memory_loader が全クエリに対して実行され、キーワード fast-path の効果を相殺（Codex HIGH）
+2. **多言語RAG不整合**: 英語クエリ翻訳後も `language` パラメータが元のまま → テキストフォールバックが空振り（Codex HIGH）
+3. **Reception二重実装**: reception_workflow.py と main_workflow.py 内 inline が並立し、ルーティングマッピングが不一致（Codex MEDIUM-HIGH）
+4. **日本語ナレッジのみ**: 英語ユーザーの検索精度が構造的に劣化
+
+## Decision
+
+LangGraph ワークフローを再設計し、キーワード fast-path 導入・Reception 統一・多言語 RAG 修正により、kiosk デプロイ（2026-04-11）に必要な応答速度と多言語品質を確保する。
+
+以下の変更を Phase 1（4/11前）で実施する。D-RAG は Phase 2 に移行。
+
+### D1: キーワード Fast-Path のグラフ分岐（Reception gate 付き）
+
+- グラフ構造を以下に変更:
+  ```
+  START → reception_check → {
+    active_reception: memory_loader → orchestrator,
+    no_reception: keyword_router → {
+      fast: agent直行,
+      normal: memory_loader → orchestrator
+    }
+  }
+  ```
+- **Reception gate**: キーワードルーティングの前に reception 状態を必ず確認する
+  - アクティブな reception セッション中 → 常に memory_loader → orchestrator 経由（fast-path スキップ）
+  - Mixed-intent greeting（例: "hello, wifi password?"） → normal path
+  - 代名詞・照応クエリ（例: "それについて教えて"） → normal path（コンテキスト必要）
+  - メモリ関連クエリ → normal path
+  - Topic guard 必要なクエリ → normal path
+- キーワードマッチで確定できるクエリ（WiFi、営業時間、料金等）は memory_loader/RAG をスキップ
+- 根拠: LangGraph の conditional_edges パターン
+
+### D2: Reception ワークフロー一本化
+
+現在 Reception は以下の3箇所に分散実装されている:
+
+1. **main_workflow.py inline**: `_handle_reception_gate`, `_handle_reception_inline` による inline 処理
+2. **reception_workflow.py**: 独立した StateGraph による standalone 実装
+3. **backend/api/reception.py**: API フロー（PurposeFlowService, ReceptionHandoffService を使用）
+
+統一方針:
+- LangGraph subgraphs を使用し、Reception を first-class graph component として統合
+- main_workflow.py 内の inline reception handler を削除
+- reception_workflow.py を subgraph として MainWorkflow に組み込み
+- `consultation` のルーティング先を `general_knowledge` に統一（reception_workflow.py 側を正とする）
+- PurposeFlowService と ReceptionHandoffService は統一アーキテクチャ内で保持
+- 状態遷移を明確にドキュメント化: `initiated → greeting → purpose_hearing → routing → completed`（ambiguous-purpose ループを含む）
+- 根拠: DDD Bounded Context原則 — Reception は独立したドメイン、LangGraph Subgraphs パターン
+
+### D3: 多言語RAG修正（tRAG パターン — ja/en/zh/ko）
+
+システムは既に ja/en/zh/ko サポートを宣言している（reception.py L256, purpose_flow_service.py L21）。D3 はこの4言語すべてに対応する。
+
+#### D3a: 即時バグ修正（Phase 1）
+
+- 翻訳済みクエリの RAG 呼び出し時に `language="ja"` を明示的に設定（全非日本語言語共通）
+- テキストフォールバック検索の言語フィルタを修正
+- 根拠: tRAG (Translation RAG) パターン
+
+#### D3b: 多言語戦略拡充（Phase 1）
+
+- Top-20 FAQ を en/zh/ko でナレッジベースに追加（既存マークダウンから抽出）
+- en/zh/ko クエリハンドリングの統一（翻訳 → ja RAG → 元言語で回答）
+- 多言語 RAGAS 評価を実施（en/zh/ko 各言語での answer_correctness 計測）
+
+### D4: CRAG retrieval grading 強化 + bilingual FAQ 拡張（Phase 1）
+
+- 既存の CRAG スタイル grading（enhanced_rag.py L250）を活用し、retrieval quality の判定を強化
+- bilingual FAQ エントリを knowledge_base に追加
+- 多言語 RAGAS 評価を実施（D3b と連携）
+- 根拠: 既存 CRAG パターンの段階的強化
+
+### D5: D-RAG（弁証法RAG）導入 — Phase 2（post 4/11）
+
+- 日本語RAG結果と英語クエリの整合性をクロスバリデーション
+- LangGraph ノードとして実装: `rag_validator` ノードが日英の検索結果を比較・統合
+- Self-RAG の自己反省メカニズムとの組み合わせを検討
+- 根拠: Dialectic RAG（+12.9% accuracy improvement — 仮説、本プロジェクトでの検証未実施）
+
+## Consequences
+
+### Positive
+
+- kiosk レスポンス速度向上（FAQ 50-70% が fast-path 対象 — 仮説、計測で検証予定）
+- 多言語ユーザー（en/zh/ko）の回答品質改善
+- Reception フローの一貫性確保（3実装 → subgraph 1本化）
+- テスト可能性の向上（Reception が独立ドメインとして分離）
+
+### Negative
+
+- グラフ構造変更に伴うリグレッションリスク
+- 既存テストの修正が必要
+- D-RAG は Phase 2 に延期 → 多言語クロスバリデーションの恩恵は 4/11 には間に合わない
+
+### Risks
+
+- memory_loader スキップ時に会話コンテキストが欠落するケースの考慮が必要
+- Reception gate 判定の精度（mixed-intent の分類ミス）
+- 多言語 FAQ の品質（翻訳精度の担保）
+
+### Acceptance Criteria (Phase 1 — 2026-04-11)
+
+- Fast-path リグレッションテストが全パス
+- Reception 状態遷移テストが全パス（initiated → greeting → purpose_hearing → routing → completed）
+- 多言語 retrieval テストが全パス（en/zh/ko クエリで正しい結果を返す）
+- レイテンシ: FAQ クエリ < 500ms、通常クエリ < 3s
+- RAGAS answer_correctness >= 0.85（日本語）、>= 0.75（英語）
+
+## References
+
+- LangGraph 1.0 GA: https://changelog.langchain.com/announcements/langgraph-1-0-is-now-generally-available
+- LangGraph Conditional Edges: https://langchain-ai.github.io/langgraph/concepts/low_level/#conditional-edges
+- LangGraph Subgraphs: https://docs.langchain.com/oss/python/langgraph/use-subgraphs
+- tRAG Pattern: https://arxiv.org/html/2407.01463v1
+- D-RAG (Dialectic RAG): https://arxiv.org/html/2504.04771v1
+- Self-RAG: https://arxiv.org/html/2310.11511v1
+- Language Drift in Multilingual LLMs: https://arxiv.org/html/2511.09984v1
+- RAGAS Evaluation: https://docs.ragas.io/
+- DDD for Multi-Agent AI: https://www.jamescroft.co.uk/applying-domain-driven-design-principles-to-multi-agent-ai-systems/
+
+## Related Issues
+
+- Epic: #376
+- Sub Issues: #377, #378, #379, #380, #381, #382
+- #117 (受付フロー統合)
+- #138 (多言語品質改善)
+- #139 (E2Eテスト)
+- #367 (Wave 6計画)


### PR DESCRIPTION
## Summary
- ADR-006: LangGraph ワークフロー再設計（Codex CLIレビュー2回反映済み）
- STT/TTS移行ガイド（takegawa333/junfabregas4向け）
- STT実装トレース（現行Voskアーキテクチャ）
- 48件のTDDシナリオテスト（Engineer Cafe受付の実践的シナリオ）

## Test plan
- [ ] `cd backend && ruff check . && black --check .`
- [ ] `pytest backend/tests/scenarios/ -m scenario --co` (テスト収集確認)
- [ ] ドキュメントの内容確認

Closes #376
Related: Sub Issues #377-#382

🤖 Generated with [Claude Code](https://claude.com/claude-code)