### PR TITLE
fix(frontend): キオスクのマイク取得・解放とトグル/PTT挙動を整理

### DIFF
--- a/frontend/src/app/components/InitialSettingsModal.tsx
+++ b/frontend/src/app/components/InitialSettingsModal.tsx
@@ -15,7 +15,7 @@ import {
 } from '@/lib/kiosk-constants';
 import { cn } from '@/lib/cn';
 import { X } from 'lucide-react';
-import { useCallback, useEffect, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 
 export interface InitialSettingsPreferences {
   language: 'ja' | 'en';
@@ -41,6 +41,7 @@ export default function InitialSettingsModal({
   const [uiLanguage, setUiLanguage] = useState<'ja' | 'en'>(language);
   const [triggerMode, setTriggerMode] = useState<KioskTriggerMode>('screen');
   const [micMode, setMicMode] = useState<KioskMicMode>('toggle');
+  const micPermissionProbeDoneRef = useRef(false);
 
   useEffect(() => {
     if (open) {
@@ -49,6 +50,46 @@ export default function InitialSettingsModal({
       setMicMode(readKioskMicMode());
     }
   }, [open, language]);
+
+  /** One-time mic permission probe while this modal is first shown (tracks stopped immediately after grant). */
+  useEffect(() => {
+    if (!open || micPermissionProbeDoneRef.current) {
+      return;
+    }
+    micPermissionProbeDoneRef.current = true;
+
+    if (typeof window === 'undefined' || !navigator.mediaDevices?.getUserMedia) {
+      return;
+    }
+    if (window.location.protocol !== 'https:' && window.location.hostname !== 'localhost') {
+      return;
+    }
+
+    let cancelled = false;
+
+    void (async () => {
+      try {
+        const stream = await navigator.mediaDevices.getUserMedia({
+          audio: {
+            echoCancellation: true,
+            noiseSuppression: true,
+            autoGainControl: true,
+          },
+        });
+        if (cancelled) {
+          stream.getTracks().forEach((track) => track.stop());
+          return;
+        }
+        stream.getTracks().forEach((track) => track.stop());
+      } catch {
+        // Denied or unavailable; VoiceInterface will surface errors when the user speaks.
+      }
+    })();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [open]);
 
   const labels = {
     ...kioskSettingsLabels[uiLanguage],

--- a/frontend/src/app/components/VoiceInterface.tsx
+++ b/frontend/src/app/components/VoiceInterface.tsx
@@ -76,6 +76,13 @@ interface VoiceInterfaceProps {
   onLanguageChange?: (language: 'ja' | 'en') => void;
   layout?: 'vertical' | 'horizontal';
   language?: 'ja' | 'en';
+  /** When false, idle wake-word listening is off (no mic via Web Speech API). Default true. */
+  wakeWordEnabled?: boolean;
+  /**
+   * When false, after assistant TTS the session does not auto-return to listening (mic stays off until the user starts again).
+   * Use for kiosk push-to-talk. Default true (continuous toggle conversations).
+   */
+  autoResumeListeningAfterAssistant?: boolean;
   autoGreeting?: boolean;
   onVisemeControl?: ((viseme: string, intensity: number) => void) | null;
   children?: (props: VoiceInterfaceRenderProps) => ReactNode;
@@ -179,6 +186,8 @@ export default function VoiceInterface({
   onLanguageChange,
   layout = 'vertical',
   language = 'ja',
+  wakeWordEnabled = true,
+  autoResumeListeningAfterAssistant = true,
   autoGreeting = false,
   onVisemeControl,
   children,
@@ -188,6 +197,7 @@ export default function VoiceInterface({
   onAssistantPlaybackStart,
   onAssistantPlaybackEnd,
 }: VoiceInterfaceProps) {
+  const skipAssistantTurnAutoResume = !autoResumeListeningAfterAssistant;
   const [currentLanguage, setCurrentLanguage] = useState<'ja' | 'en'>(language);
   const [volume, setVolumeState] = useState(0.8);
   const [isMuted, setIsMuted] = useState(false);
@@ -259,6 +269,7 @@ export default function VoiceInterface({
 
   const voiceController = useVoiceSessionController({
     enabled: true,
+    wakeWordEnabled,
     stream: mediaStream,
     wakeWords: DEFAULT_WAKE_WORDS,
     language: toLocale(currentLanguage),
@@ -316,10 +327,10 @@ export default function VoiceInterface({
       cleanupAudioPlayback();
 
       if (completeTurn) {
-        voiceController.notifySpeakingComplete();
+        voiceController.notifySpeakingComplete(skipAssistantTurnAutoResume);
       }
     },
-    [cleanupAudioPlayback, onVisemeControl, voiceController],
+    [cleanupAudioPlayback, onVisemeControl, skipAssistantTurnAutoResume, voiceController],
   );
 
   const playAssistantAudio = useCallback(
@@ -328,7 +339,7 @@ export default function VoiceInterface({
         voiceController.notifySpeaking();
         onAssistantPlaybackStart?.({ metadata: metadataForPlayback ?? null });
         window.setTimeout(() => {
-          voiceController.notifySpeakingComplete();
+          voiceController.notifySpeakingComplete(skipAssistantTurnAutoResume);
         }, 240);
         return;
       }
@@ -375,7 +386,7 @@ export default function VoiceInterface({
         },
         onEnded: () => {
           cleanupAudioPlayback();
-          voiceController.notifySpeakingComplete();
+          voiceController.notifySpeakingComplete(skipAssistantTurnAutoResume);
         },
         onError: (playbackError) => {
           cleanupAudioPlayback();
@@ -401,6 +412,7 @@ export default function VoiceInterface({
       onVisemeControl,
       revokeAudioUrl,
       scheduleLipSyncFrames,
+      skipAssistantTurnAutoResume,
       voiceController,
     ],
   );
@@ -477,7 +489,7 @@ export default function VoiceInterface({
         } else {
           voiceController.notifySpeaking();
           window.setTimeout(() => {
-            voiceController.notifySpeakingComplete();
+            voiceController.notifySpeakingComplete(skipAssistantTurnAutoResume);
           }, 240);
         }
       } catch (sendError) {
@@ -495,7 +507,14 @@ export default function VoiceInterface({
         setLoadingMessage('');
       }
     },
-    [cancelPendingRequest, currentLanguage, playAssistantAudio, stopPlayback, voiceController],
+    [
+      cancelPendingRequest,
+      currentLanguage,
+      playAssistantAudio,
+      skipAssistantTurnAutoResume,
+      stopPlayback,
+      voiceController,
+    ],
   );
 
   const handleRecordedAudio = useCallback(
@@ -570,6 +589,14 @@ export default function VoiceInterface({
         setLoadingMessage('');
         isRecordingRef.current = false;
       },
+      () => {
+        if (recorderRef.current !== recorder) {
+          return;
+        }
+        recorderRef.current = null;
+        setMediaStream(null);
+        isRecordingRef.current = false;
+      },
     );
 
     setIsLoading(true);
@@ -597,6 +624,9 @@ export default function VoiceInterface({
 
     try {
       const recorder = await ensureRecorder();
+      await new Promise<void>((resolve) => {
+        queueMicrotask(() => resolve());
+      });
       if (recorder.getState() === 'recording') {
         return;
       }
@@ -627,11 +657,9 @@ export default function VoiceInterface({
       return;
     }
 
-    if (!isRecordingRef.current) {
-      return;
+    if (isRecordingRef.current) {
+      stopRecorderCapture(sessionState === 'idle');
     }
-
-    stopRecorderCapture(sessionState === 'idle');
   }, [sessionState, startRecorderCapture, stopRecorderCapture, voiceController.shouldListen]);
 
   const startListening = useCallback(() => {

--- a/frontend/src/app/hooks/useVoiceSessionController.ts
+++ b/frontend/src/app/hooks/useVoiceSessionController.ts
@@ -15,6 +15,8 @@ export type VoiceCharacterState = 'idle' | 'listening' | 'thinking' | 'speaking'
 
 export interface UseVoiceSessionControllerOptions {
   enabled?: boolean;
+  /** When false, wake-word listening is disabled (no Web Speech mic while idle). */
+  wakeWordEnabled?: boolean;
   stream?: MediaStream | null;
   wakeWords?: string[];
   language?: string;
@@ -56,6 +58,7 @@ const DEFAULT_WAKE_WORDS = ['すみません', 'hello'];
 
 export function useVoiceSessionController({
   enabled = true,
+  wakeWordEnabled = true,
   stream = null,
   wakeWords = DEFAULT_WAKE_WORDS,
   language = 'ja-JP',
@@ -121,7 +124,7 @@ export function useVoiceSessionController({
     detectedWakeWord: lastWakeWordMatch,
   } = useWakeWord({
     wakeWords,
-    enabled: enabled && shouldArmWakeWord,
+    enabled: enabled && shouldArmWakeWord && wakeWordEnabled,
     language,
     continuous: wakeWordContinuous,
     interimResults: wakeWordInterimResults,
@@ -130,9 +133,13 @@ export function useVoiceSessionController({
     onWakeWord: handleWakeWord,
   });
 
+  // Only wire the mic stream into Web Audio while actively listening; keeping a stale
+  // MediaStream here can leave Chrome's mic indicator on after tracks should have stopped.
+  const waveformStream = enabled && shouldListen && stream ? stream : null;
+
   const { levels: waveformBars, averageLevel } = useVoiceWaveform({
-    stream,
-    enabled: enabled && shouldListen,
+    stream: waveformStream,
+    enabled: Boolean(waveformStream),
     barCount: waveformBarCount,
     fftSize: waveformFftSize,
     smoothingTimeConstant: waveformSmoothingTimeConstant,

--- a/frontend/src/app/hooks/useVoiceWaveform.ts
+++ b/frontend/src/app/hooks/useVoiceWaveform.ts
@@ -131,7 +131,9 @@ export function useVoiceWaveform({
 
       source.disconnect();
       analyser.disconnect();
-      void audioContext.close();
+      void audioContext.close().catch(() => {
+        // close() rejects if already closed; ignore
+      });
     };
   }, [barCount, enabled, fftSize, smoothingTimeConstant, stream]);
 

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -438,6 +438,10 @@ export default function Home() {
       <VoiceInterface
       language={currentLanguage}
       onLanguageChange={setCurrentLanguage}
+      wakeWordEnabled={false}
+      autoResumeListeningAfterAssistant={
+        micInputMode === 'push_to_talk' ? false : kioskVoiceLocked
+      }
       onVisemeControl={setVisemeFunction}
       showDefaultUI={false}
       onMetadataChange={setLatestMetadata}
@@ -758,7 +762,16 @@ export default function Home() {
                       };
                       const handleKioskVoiceStop = () => {
                         setKioskVoiceLocked(false);
-                        voice.stopListening();
+                        if (isPushToTalk) {
+                          voice.stopListening();
+                          return;
+                        }
+                        // Toggle: end utterance and run STT/QA if still listening; otherwise drop session.
+                        if (voice.sessionState === 'listening') {
+                          voice.stopListening();
+                          return;
+                        }
+                        voice.cancelSession();
                       };
 
                       return (

--- a/frontend/src/lib/voice-recorder.ts
+++ b/frontend/src/lib/voice-recorder.ts
@@ -6,7 +6,8 @@ export class VoiceRecorder {
 
   constructor(
     private onDataAvailable: (audioBlob: Blob) => void,
-    private onError: (error: Error) => void
+    private onError: (error: Error) => void,
+    private onHardwareReleased?: () => void,
   ) {}
 
   async initialize(): Promise<void> {
@@ -48,19 +49,19 @@ export class VoiceRecorder {
       // iOS-specific audio constraints
       const isIOS = /iPad|iPhone|iPod/.test(navigator.userAgent) && !(window as any).MSStream;
       
-      const audioConstraints = isIOS ? {
-        // Simplified constraints for iOS
-        echoCancellation: true,
-        noiseSuppression: true,
-        autoGainControl: true,
-      } : {
-        // Full constraints for other platforms
-        channelCount: 1,
-        sampleRate: 16000,
-        echoCancellation: true,
-        noiseSuppression: true,
-        autoGainControl: true,
-      };
+      const audioConstraints = isIOS
+        ? {
+            echoCancellation: true,
+            noiseSuppression: true,
+            autoGainControl: true,
+          }
+        : {
+            // Avoid exact sampleRate/channelCount: some Chrome builds keep the capture
+            // pipeline (and tab mic indicator) active longer than necessary.
+            echoCancellation: true,
+            noiseSuppression: true,
+            autoGainControl: true,
+          };
 
       try {
         this.stream = await getUserMediaFunc({ audio: audioConstraints });
@@ -106,11 +107,17 @@ export class VoiceRecorder {
       };
 
       this.mediaRecorder.onstop = () => {
+        const mimeType = this.mediaRecorder?.mimeType || 'audio/webm';
         const audioBlob = new Blob(this.audioChunks, {
-          type: this.mediaRecorder?.mimeType || 'audio/webm',
+          type: mimeType,
         });
         this.onDataAvailable(audioBlob);
         this.audioChunks = [];
+
+        // Always stop tracks after each segment so the browser mic indicator turns off.
+        // (A boolean "release after stop" flag races with shouldListen flipping true before onstop.)
+        this.teardownMicrophonePipeline();
+        this.onHardwareReleased?.();
       };
 
       this.mediaRecorder.onerror = (event) => {
@@ -161,6 +168,15 @@ export class VoiceRecorder {
     }
   }
 
+  private teardownMicrophonePipeline(): void {
+    if (this.stream) {
+      this.stream.getTracks().forEach((track) => track.stop());
+      this.stream = null;
+    }
+    this.mediaRecorder = null;
+    this.isRecording = false;
+  }
+
   pause(): void {
     if (!this.mediaRecorder || !this.isRecording) {
       return;
@@ -194,7 +210,7 @@ export class VoiceRecorder {
     }
 
     if (this.stream) {
-      this.stream.getTracks().forEach(track => track.stop());
+      this.stream.getTracks().forEach((track) => track.stop());
       this.stream = null;
     }
 


### PR DESCRIPTION
Closes #384

## 概要

キオスク画面で Chrome のマイク表示が不要な時間帯も点灯し続ける問題と、トグル / Push-to-Talk で意図と異なる挙動（トグル OFF 後に QA が進まない、PTT 後に応答完了までマイクが再開する等）を修正する。

## 変更内容

- **初期設定モーダル**: 初回表示時に一度だけ `getUserMedia` で権限を確認し、取得後すぐトラックを停止する。
- **キオスク `VoiceInterface`**: `wakeWordEnabled={false}` とし、アイドル時の Web Speech（ウェイクワード）によるマイク使用をやめる。
- **`VoiceRecorder`**: 各録音セグメントの `MediaRecorder` `onstop` で常にマイクトラックを停止し、パイプラインを破棄する（解放フラグと `shouldListen` のレースを避ける）。デスクトップ向け `getUserMedia` から `sampleRate` / `channelCount` の固定指定を外す。
- **`VoiceInterface`**: ハードウェア解放コールバックで `recorderRef` を誤って消さないようガード。`start` 直前に `queueMicrotask` で順序を安定化。アシスタント再生後の自動 `listening` 再開を `autoResumeListeningAfterAssistant` で制御。
- **`useVoiceSessionController`**: 波形用に渡す `MediaStream` を「聞き取り中」のときだけに限定する（`waveformStream`）。`wakeWordEnabled` を `useWakeWord` に連携。
- **`useVoiceWaveform`**: `audioContext.close()` の失敗を握りつぶし、二重 close で落ちないようにする。
- **`page.tsx`**: PTT は離したとき `stopListening` のみ。トグル OFF は `listening` 中は `stopListening`（発話確定→STT/QA）、それ以外は `cancelSession`。`autoResumeListeningAfterAssistant` は PTT では常にオフ、トグルでは `kioskVoiceLocked` が true のときだけオン。

## 確認したこと

- [ ] Chrome でマイクインジケーターが、聞き取り不要時に消えること（環境依存のため完全保証は難しい）
- [ ] PTT: 押下中のみ録音、離したあと STT→QA→TTS が進み、応答後に勝手に聞き取りに戻らないこと
- [ ] トグル ON: ターン間で聞き取りに戻ること
- [ ] トグル OFF: 発話が STT/QA に送られ、OFF 後は応答まで自動でマイク ON に戻らないこと

## 関連

- Issue: #384
