### PR TITLE
test: add knowledge and onboarding UI e2e coverage

### DIFF
--- a/frontend/e2e/helpers/home.ts
+++ b/frontend/e2e/helpers/home.ts
@@ -1,0 +1,14 @@
+import { expect, type Page } from '@playwright/test';
+
+export async function dismissInitialSettingsModal(page: Page, timeout = 10_000) {
+  const dialog = page.getByRole('dialog');
+  await expect(dialog).toBeVisible({ timeout });
+  await page.getByTestId('initial-settings-close').click();
+  await expect
+    .poll(async () => {
+      const isHidden = await dialog.isHidden().catch(() => true);
+      const bubbleVisible = await page.getByTestId('response-bubble').isVisible().catch(() => false);
+      return isHidden || bubbleVisible;
+    }, { timeout })
+    .toBe(true);
+}

--- a/frontend/e2e/helpers/knowledge.ts
+++ b/frontend/e2e/helpers/knowledge.ts
@@ -53,9 +53,8 @@ export async function fillKnowledgeForm(
 
   if (data.content) {
     const mdEditorTextarea = page.locator('.w-md-editor-text-input');
-    if (await mdEditorTextarea.isVisible({ timeout: 2_000 }).catch(() => false)) {
-      await mdEditorTextarea.fill(data.content);
-    }
+    await expect(mdEditorTextarea).toBeVisible({ timeout: 5_000 });
+    await mdEditorTextarea.fill(data.content);
   }
 
   if (data.language) {

--- a/frontend/e2e/helpers/knowledge.ts
+++ b/frontend/e2e/helpers/knowledge.ts
@@ -1,0 +1,82 @@
+import { type Page, expect } from '@playwright/test';
+
+export async function gotoKnowledgeList(page: Page) {
+  await page.goto('/admin/knowledge');
+  await expect(page.getByRole('table')).toBeVisible({ timeout: 10_000 });
+}
+
+export async function gotoKnowledgeNew(page: Page) {
+  await page.goto('/admin/knowledge/new');
+  await expect(page.locator('#title')).toBeVisible({ timeout: 10_000 });
+}
+
+export async function gotoKnowledgeDetail(page: Page, id: string) {
+  await page.goto(`/admin/knowledge/${id}`, { waitUntil: 'domcontentloaded' });
+  await expect(page.getByRole('heading', { level: 1 }).first()).toBeVisible({ timeout: 10_000 });
+}
+
+export async function fillKnowledgeForm(
+  page: Page,
+  data: {
+    title?: string;
+    category?: string;
+    subcategory?: string;
+    content?: string;
+    language?: string;
+  },
+) {
+  if (data.title) {
+    await page.locator('#title').fill(data.title);
+  }
+
+  if (data.category) {
+    const categorySelect = page.locator('#category');
+    const options = await categorySelect.locator('option').count();
+    let categoryExists = false;
+
+    for (let i = 0; i < options; i++) {
+      const text = await categorySelect.locator('option').nth(i).textContent();
+      if (text === data.category) {
+        categoryExists = true;
+        break;
+      }
+    }
+
+    if (categoryExists) {
+      await categorySelect.selectOption(data.category);
+    }
+  }
+
+  if (data.subcategory && data.category) {
+    await page.locator('#subcategory').selectOption(data.subcategory);
+  }
+
+  if (data.content) {
+    const mdEditorTextarea = page.locator('.w-md-editor-text-input');
+    if (await mdEditorTextarea.isVisible({ timeout: 2_000 }).catch(() => false)) {
+      await mdEditorTextarea.fill(data.content);
+    }
+  }
+
+  if (data.language) {
+    await page.locator('#language').selectOption(data.language);
+  }
+}
+
+export function acceptDialog(page: Page) {
+  page.on('dialog', (dialog) => {
+    void dialog.accept();
+  });
+}
+
+export function dismissDialog(page: Page) {
+  page.on('dialog', (dialog) => {
+    void dialog.dismiss();
+  });
+}
+
+export async function waitForToast(page: Page, text: string, timeout = 5_000) {
+  await expect(page.locator('[role="status"]').filter({ hasText: text }).first()).toBeVisible({
+    timeout,
+  });
+}

--- a/frontend/e2e/helpers/marp.ts
+++ b/frontend/e2e/helpers/marp.ts
@@ -1,0 +1,54 @@
+import { type Page, expect } from '@playwright/test';
+
+export async function gotoGuide(
+  page: Page,
+  lang: 'ja' | 'en' = 'ja',
+  options?: { autoplay?: boolean },
+) {
+  const params = new URLSearchParams({ lang });
+  if (options?.autoplay) {
+    params.set('autoplay', '1');
+  }
+
+  await page.goto(`/guide?${params.toString()}`, { waitUntil: 'domcontentloaded' });
+  await expect(page.getByTestId('customer-guide-shell')).toBeVisible({ timeout: 10_000 });
+  await expect(page.getByTestId('marp-viewer')).toBeVisible({ timeout: 15_000 });
+}
+
+export async function waitForSlide(
+  page: Page,
+  slideNumber: number,
+  totalSlides: number,
+  timeout = 15_000,
+) {
+  const expectedText = `${slideNumber} / ${totalSlides}`;
+  await expect(page.getByTestId('marp-slide-counter')).toBeVisible({ timeout });
+  await expect(page.getByTestId('marp-slide-counter')).toHaveText(expectedText, { timeout });
+}
+
+export async function clickPrevSlide(page: Page) {
+  await page.getByTestId('marp-prev-button').click();
+}
+
+export async function clickPlayPause(page: Page) {
+  await page.getByTestId('marp-play-pause-button').click();
+}
+
+export async function clickReset(page: Page) {
+  await page.getByTestId('marp-reset-button').click();
+}
+
+export async function clickSwitchToEnglish(page: Page) {
+  await page.getByTestId('guide-language-toggle').click();
+}
+
+export async function waitForVoiceRequest(page: Page, expectedCount = 1, timeout = 5_000) {
+  const voiceRequests: string[] = [];
+
+  await page.route('/api/voice', (route) => {
+    voiceRequests.push(route.request().url());
+    return route.continue();
+  });
+
+  await expect.poll(() => voiceRequests.length, { timeout }).toBe(expectedCount);
+}

--- a/frontend/e2e/helpers/marp.ts
+++ b/frontend/e2e/helpers/marp.ts
@@ -41,14 +41,3 @@ export async function clickReset(page: Page) {
 export async function clickSwitchToEnglish(page: Page) {
   await page.getByTestId('guide-language-toggle').click();
 }
-
-export async function waitForVoiceRequest(page: Page, expectedCount = 1, timeout = 5_000) {
-  const voiceRequests: string[] = [];
-
-  await page.route('/api/voice', (route) => {
-    voiceRequests.push(route.request().url());
-    return route.continue();
-  });
-
-  await expect.poll(() => voiceRequests.length, { timeout }).toBe(expectedCount);
-}

--- a/frontend/e2e/helpers/mocks.ts
+++ b/frontend/e2e/helpers/mocks.ts
@@ -1,0 +1,235 @@
+import { type Page } from '@playwright/test';
+
+/**
+ * Knowledge エントリのモックデータ
+ */
+export const MOCK_KNOWLEDGE_ENTRY = {
+  id: 'entry-001',
+  title: 'WiFiパスワード',
+  content: 'WiFiのパスワードは1234です',
+  category: '設備',
+  subcategory: 'WiFi',
+  language: 'ja',
+  source: '内部Wiki',
+  metadata: {},
+  created_at: '2025-01-01T00:00:00Z',
+  updated_at: '2025-06-01T12:00:00Z',
+};
+
+/**
+ * Knowledge 一覧レスポンスのモックデータ
+ */
+export const MOCK_KNOWLEDGE_LIST = {
+  data: [MOCK_KNOWLEDGE_ENTRY],
+  total: 1,
+  page: 1,
+  limit: 20,
+};
+
+/**
+ * Knowledge エディタ設定のモックデータ
+ */
+export const MOCK_EDITOR_CONFIG = {
+  categories: ['設備', '基本情報', 'イベント'],
+  subcategories: {
+    '設備': ['会議室', 'WiFi'],
+    '基本情報': ['営業時間', '所在地'],
+    'イベント': ['今後のイベント'],
+  },
+  sources: ['内部Wiki', '構造化データ'],
+  languages: ['ja', 'en'],
+  templates: {
+    default: { title: '', importance: 'medium', tags: '' },
+    '設備': { title: '', importance: 'high', tags: '' },
+  },
+};
+
+/**
+ * Marp レスポンスのモックデータ
+ */
+export const MOCK_MARP_RESPONSE = {
+  success: true,
+  html: `<!DOCTYPE html><html><head><title>Slides</title></head><body>
+    <div class="marpit">
+      <svg id="slide1"><text>Slide 1 Content</text></svg>
+      <svg id="slide2"><text>Slide 2 Content</text></svg>
+      <svg id="slide3"><text>Slide 3 Content</text></svg>
+    </div>
+  </body></html>`,
+  slideData: {
+    slides: [
+      { slideNumber: 1, title: 'スライド1', content: '内容1', notes: 'ノート1' },
+      { slideNumber: 2, title: 'スライド2', content: '内容2', notes: '' },
+      { slideNumber: 3, title: 'スライド3', content: '内容3', notes: '' },
+    ],
+  },
+  narrationData: {
+    metadata: { title: 'テスト', language: 'ja', speaker: 'sakura', version: '1' },
+    slides: [
+      {
+        slideNumber: 1,
+        narration: { auto: 'ナレーション1', onEnter: '', onDemand: {} },
+        transitions: { next: 'next', previous: null },
+      },
+      {
+        slideNumber: 2,
+        narration: { auto: 'ナレーション2', onEnter: '', onDemand: {} },
+        transitions: { next: 'next', previous: 'prev' },
+      },
+      {
+        slideNumber: 3,
+        narration: { auto: '', onEnter: '', onDemand: {} },
+        transitions: { next: null, previous: 'prev' },
+      },
+    ],
+  },
+  slideCount: 3,
+  metadata: { title: 'テストスライド', language: 'ja' },
+};
+
+/**
+ * 音声レスポンスのモックデータ
+ * 最小の有効な MP3: ID3 ヘッダ + 1フレーム（無音）
+ */
+export const MOCK_VOICE_RESPONSE = {
+  success: true,
+  audioResponse:
+    'SUQzBAAAAAAAI1RTU0UAAAAPAAADTGF2ZjU4LjI5LjEwMAAAAAAAAAAAAAAA//OEAAAAAAAAAAAASW5mbwAAAA8AAAAEAAABIADAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAAAAJMYXZjNTguNTQAAAAAAAAAAAAAAAAkAAAAAAAAAAABIIJ4AAAAAAAAAAAAAAAAAAAAAP/zhAAAAAAAAAAAAAAAAAAAAAAAAEluZm8AAAAPAAAABAAAASAAw',
+};
+
+/**
+ * Knowledge API ルートをモック
+ */
+export async function setupKnowledgeMocks(page: Page) {
+  // editor-config エンドポイント
+  await page.route('/api/admin/knowledge/editor-config', (route) =>
+    route.fulfill({ json: MOCK_EDITOR_CONFIG }),
+  );
+
+  // 個別エントリ取得・更新・削除
+  await page.route('/api/admin/knowledge/entry-001', (route) => {
+    const method = route.request().method();
+    if (method === 'GET') {
+      return route.fulfill({ json: MOCK_KNOWLEDGE_ENTRY });
+    } else if (method === 'DELETE') {
+      return route.fulfill({ json: { success: true } });
+    }
+    return route.continue();
+  });
+
+  // 一覧取得・作成
+  await page.route('/api/admin/knowledge', (route) => {
+    const method = route.request().method();
+    if (method === 'GET') {
+      return route.fulfill({ json: MOCK_KNOWLEDGE_LIST });
+    } else if (method === 'POST') {
+      return route.fulfill({ status: 201, json: { ...MOCK_KNOWLEDGE_ENTRY, id: 'new-001' } });
+    }
+    return route.continue();
+  });
+}
+
+/**
+ * Marp API ルートをモック
+ */
+export async function setupMarpMocks(page: Page) {
+  await page.route('/api/marp', (route) => route.fulfill({ json: MOCK_MARP_RESPONSE }));
+
+  await page.route('/api/voice', (route) => route.fulfill({ json: MOCK_VOICE_RESPONSE }));
+
+  await page.route('/api/slides', (route) =>
+    route.fulfill({ json: { success: true } }),
+  );
+}
+
+/**
+ * Web Audio API をスタブ化
+ * AudioContext と関連する Web Audio API をモック化してブラウザに注入
+ */
+export async function setupWebAudioMock(page: Page) {
+  await page.addInitScript(() => {
+    // Mock AudioBuffer
+    class MockAudioBuffer {
+      duration = 0.01;
+      length = 441;
+      numberOfChannels = 1;
+      sampleRate = 44100;
+
+      getChannelData() {
+        return new Float32Array(441);
+      }
+
+      copyFromChannel() {}
+      copyToChannel() {}
+    }
+
+    // Mock BufferSource
+    class MockBufferSource {
+      buffer: unknown = null;
+      onended: (() => void) | null = null;
+
+      connect() {
+        return this;
+      }
+
+      start() {
+        // 10ms後にonendedを呼び出して再生完了をシミュレート
+        setTimeout(() => {
+          this.onended?.();
+        }, 10);
+      }
+
+      stop() {}
+      disconnect() {}
+
+      addEventListener(event: string, cb: () => void) {
+        if (event === 'ended') this.onended = cb;
+      }
+
+      removeEventListener() {}
+    }
+
+    // Mock GainNode
+    class MockGainNode {
+      gain = { value: 1, setValueAtTime() {}, linearRampToValueAtTime() {} };
+
+      connect() {
+        return this;
+      }
+
+      disconnect() {}
+    }
+
+    // Mock AudioContext
+    class MockAudioContext {
+      state = 'running';
+      sampleRate = 44100;
+      currentTime = 0;
+      destination = { connect() {} };
+
+      createBufferSource() {
+        return new MockBufferSource();
+      }
+
+      createGain() {
+        return new MockGainNode();
+      }
+
+      decodeAudioData(_ab: ArrayBuffer, success?: (b: MockAudioBuffer) => void) {
+        const buf = new MockAudioBuffer();
+        if (success) {
+          setTimeout(() => success(buf), 5);
+        }
+        return Promise.resolve(buf);
+      }
+
+      async resume() {}
+      async close() {}
+    }
+
+    // @ts-ignore
+    window.AudioContext = MockAudioContext;
+    // @ts-ignore
+    window.webkitAudioContext = MockAudioContext;
+  });
+}

--- a/frontend/e2e/knowledge.spec.ts
+++ b/frontend/e2e/knowledge.spec.ts
@@ -52,13 +52,11 @@ test.describe('Knowledge 一覧ページ', () => {
   test('言語フィルタで絞り込める', async ({ page }) => {
     await gotoKnowledgeList(page);
 
-    const languageSelect = page.locator('select').filter({ hasText: /言語/ }).first();
-    const selectExists = await languageSelect.isVisible({ timeout: 2_000 }).catch(() => false);
-    if (selectExists) {
-      await languageSelect.selectOption('ja');
-      await page.getByRole('button', { name: /検索|適用|更新/ }).click();
-      await expect(page.getByRole('table')).toBeVisible();
-    }
+    const languageSelect = page.getByLabel('言語');
+    await expect(languageSelect).toBeVisible();
+    await languageSelect.selectOption('ja');
+    await page.getByRole('button', { name: /検索|適用|更新/ }).click();
+    await expect(page.getByRole('table')).toBeVisible();
   });
 
   test('削除ダイアログを承認すると削除される', async ({ page }) => {
@@ -127,9 +125,8 @@ test.describe('Knowledge 新規作成ページ', () => {
     });
 
     const mdEditorTextarea = page.locator('.w-md-editor-text-input');
-    if (await mdEditorTextarea.isVisible({ timeout: 2_000 }).catch(() => false)) {
-      await mdEditorTextarea.fill('テストコンテンツ');
-    }
+    await expect(mdEditorTextarea).toBeVisible({ timeout: 5_000 });
+    await mdEditorTextarea.fill('テストコンテンツ');
 
     await page.getByRole('button', { name: /作成|保存/ }).click();
     await expect(page).toHaveURL(/\/admin\/knowledge\/new$/);

--- a/frontend/e2e/knowledge.spec.ts
+++ b/frontend/e2e/knowledge.spec.ts
@@ -1,0 +1,272 @@
+import { expect, test } from '@playwright/test';
+import {
+  MOCK_EDITOR_CONFIG,
+  MOCK_KNOWLEDGE_ENTRY,
+  MOCK_KNOWLEDGE_LIST,
+} from './helpers/mocks';
+import {
+  acceptDialog,
+  dismissDialog,
+  fillKnowledgeForm,
+  gotoKnowledgeDetail,
+  gotoKnowledgeList,
+  gotoKnowledgeNew,
+  waitForToast,
+} from './helpers/knowledge';
+
+test.describe('Knowledge 一覧ページ', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.route(/\/api\/admin\/knowledge(\?|$)/, async (route) => {
+      return route.fulfill({ json: MOCK_KNOWLEDGE_LIST });
+    });
+    await page.route('/api/admin/knowledge/editor-config', async (route) => {
+      return route.fulfill({ json: MOCK_EDITOR_CONFIG });
+    });
+    await page.route(/\/api\/admin\/knowledge\/entry-[^/]+($|\?)/, async (route) => {
+      const method = route.request().method();
+      if (method === 'GET') {
+        return route.fulfill({ json: MOCK_KNOWLEDGE_ENTRY });
+      }
+      if (method === 'DELETE') {
+        return route.fulfill({ json: { success: true } });
+      }
+      return route.continue();
+    });
+  });
+
+  test('エントリ一覧が表示される', async ({ page }) => {
+    await gotoKnowledgeList(page);
+
+    await expect(page.getByText(MOCK_KNOWLEDGE_ENTRY.title)).toBeVisible();
+    await expect(page.getByRole('link', { name: '詳細' })).toBeVisible();
+    await expect(page.getByRole('button', { name: '削除' })).toBeVisible();
+  });
+
+  test('新規作成リンクが /admin/knowledge/new に遷移する', async ({ page }) => {
+    await gotoKnowledgeList(page);
+
+    await page.getByRole('link', { name: /新規作成|新規登録/ }).click();
+    await expect(page).toHaveURL(/\/admin\/knowledge\/new$/);
+  });
+
+  test('言語フィルタで絞り込める', async ({ page }) => {
+    await gotoKnowledgeList(page);
+
+    const languageSelect = page.locator('select').filter({ hasText: /言語/ }).first();
+    const selectExists = await languageSelect.isVisible({ timeout: 2_000 }).catch(() => false);
+    if (selectExists) {
+      await languageSelect.selectOption('ja');
+      await page.getByRole('button', { name: /検索|適用|更新/ }).click();
+      await expect(page.getByRole('table')).toBeVisible();
+    }
+  });
+
+  test('削除ダイアログを承認すると削除される', async ({ page }) => {
+    acceptDialog(page);
+
+    await gotoKnowledgeList(page);
+    await page.getByRole('button', { name: '削除' }).first().click();
+
+    await waitForToast(page, '削除');
+  });
+
+  test('削除ダイアログをキャンセルすると削除されない', async ({ page }) => {
+    dismissDialog(page);
+
+    let deleteRequestMade = false;
+    await page.route(/\/api\/admin\/knowledge\/entry-[^/]+($|\?)/, async (route) => {
+      if (route.request().method() === 'DELETE') {
+        deleteRequestMade = true;
+        return route.fulfill({ json: { success: true } });
+      }
+      return route.continue();
+    });
+
+    await gotoKnowledgeList(page);
+    await page.getByRole('button', { name: '削除' }).first().click();
+
+    await expect(page.getByText(MOCK_KNOWLEDGE_ENTRY.title)).toBeVisible();
+    expect(deleteRequestMade).toBe(false);
+  });
+});
+
+test.describe('Knowledge 新規作成ページ', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.route(/\/api\/admin\/knowledge(\?|$)/, async (route) => {
+      const method = route.request().method();
+      if (method === 'GET') {
+        return route.fulfill({ json: MOCK_KNOWLEDGE_LIST });
+      }
+      if (method === 'POST') {
+        return route.fulfill({ status: 201, json: { ...MOCK_KNOWLEDGE_ENTRY, id: 'new-001' } });
+      }
+      return route.continue();
+    });
+    await page.route('/api/admin/knowledge/editor-config', async (route) => {
+      return route.fulfill({ json: MOCK_EDITOR_CONFIG });
+    });
+  });
+
+  test('フォームが表示されてカテゴリ選択肢が読み込まれる', async ({ page }) => {
+    await gotoKnowledgeNew(page);
+
+    await expect(page.locator('#title')).toBeVisible();
+    await expect(page.locator('#category')).toBeVisible();
+    await expect(
+      page.locator('#category option', { hasText: MOCK_EDITOR_CONFIG.categories[0] }),
+    ).toBeAttached();
+  });
+
+  test('タイトルが空だと保存できない', async ({ page }) => {
+    await gotoKnowledgeNew(page);
+    let postCount = 0;
+    page.on('request', (request) => {
+      if (request.method() === 'POST' && request.url().includes('/api/admin/knowledge')) {
+        postCount += 1;
+      }
+    });
+
+    const mdEditorTextarea = page.locator('.w-md-editor-text-input');
+    if (await mdEditorTextarea.isVisible({ timeout: 2_000 }).catch(() => false)) {
+      await mdEditorTextarea.fill('テストコンテンツ');
+    }
+
+    await page.getByRole('button', { name: /作成|保存/ }).click();
+    await expect(page).toHaveURL(/\/admin\/knowledge\/new$/);
+    expect(postCount).toBe(0);
+  });
+
+  test('コンテンツが空だと保存できない', async ({ page }) => {
+    await gotoKnowledgeNew(page);
+
+    await page.locator('#title').fill('テストタイトル');
+    await page.getByRole('button', { name: /作成|保存/ }).click();
+
+    await expect(
+      page.locator('[role="status"]').filter({ hasText: /コンテンツ.*必須/ }).first(),
+    ).toBeVisible({ timeout: 3_000 });
+  });
+
+  test('カテゴリを選択するとサブカテゴリが有効になる', async ({ page }) => {
+    await gotoKnowledgeNew(page);
+
+    const subcategorySelect = page.locator('#subcategory');
+    await expect(subcategorySelect).toBeDisabled();
+
+    await page.locator('#category').selectOption(MOCK_EDITOR_CONFIG.categories[0]);
+    await expect(subcategorySelect).toBeEnabled({ timeout: 3_000 });
+  });
+
+  test('正常に作成して一覧に遷移する', async ({ page }) => {
+    await gotoKnowledgeNew(page);
+
+    await fillKnowledgeForm(page, {
+      title: '新しいエントリ',
+      category: MOCK_EDITOR_CONFIG.categories[0],
+      content: '新しいコンテンツ',
+      language: 'ja',
+    });
+
+    await page.getByRole('button', { name: /作成|保存/ }).click();
+    await expect(page).toHaveURL(/\/admin\/knowledge$/, { timeout: 5_000 });
+  });
+
+  test('キャンセルで一覧に戻る', async ({ page }) => {
+    await gotoKnowledgeNew(page);
+
+    await page.getByRole('button', { name: /キャンセル|戻る/ }).click();
+    await expect(page).toHaveURL(/\/admin\/knowledge$/);
+  });
+});
+
+test.describe('Knowledge 詳細ページ', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.route(/\/api\/admin\/knowledge\/entry-[^/]+($|\?)/, async (route) => {
+      const method = route.request().method();
+      if (method === 'GET') {
+        return route.fulfill({ json: MOCK_KNOWLEDGE_ENTRY });
+      }
+      if (method === 'DELETE') {
+        return route.fulfill({ json: { success: true } });
+      }
+      return route.continue();
+    });
+    await page.route('/api/admin/knowledge/editor-config', async (route) => {
+      return route.fulfill({ json: MOCK_EDITOR_CONFIG });
+    });
+  });
+
+  test('エントリ詳細が表示される', async ({ page }) => {
+    await gotoKnowledgeDetail(page, MOCK_KNOWLEDGE_ENTRY.id);
+
+    await expect(page.getByText(MOCK_KNOWLEDGE_ENTRY.title)).toBeVisible();
+    await expect(page.getByText(MOCK_KNOWLEDGE_ENTRY.category!)).toBeVisible();
+    await expect(page.getByRole('button', { name: '編集' })).toBeVisible();
+    await expect(page.getByRole('button', { name: '削除' })).toBeVisible();
+  });
+
+  test('編集ボタンで編集モードに切り替わる', async ({ page }) => {
+    await gotoKnowledgeDetail(page, MOCK_KNOWLEDGE_ENTRY.id);
+
+    await page.getByRole('button', { name: '編集' }).click();
+    await expect(page.locator('#title')).toBeVisible({ timeout: 10_000 });
+    await expect(page.getByRole('heading', { name: /編集|修正|更新/ })).toBeVisible();
+  });
+
+  test('削除確認で一覧にリダイレクトされる', async ({ page }) => {
+    acceptDialog(page);
+
+    await gotoKnowledgeDetail(page, MOCK_KNOWLEDGE_ENTRY.id);
+    await page.getByRole('button', { name: '削除' }).click();
+
+    await expect(page).toHaveURL(/\/admin\/knowledge$/, { timeout: 5_000 });
+  });
+
+  test('「一覧に戻る」リンクで一覧に遷移する', async ({ page }) => {
+    await gotoKnowledgeDetail(page, MOCK_KNOWLEDGE_ENTRY.id);
+
+    await page.getByRole('link', { name: /一覧に戻る|一覧/ }).first().click();
+    await expect(page).toHaveURL(/\/admin\/knowledge$/);
+  });
+});
+
+test.describe('Knowledge アップロードページ', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.route(/\/api\/admin\/knowledge(\?|$)/, async (route) => {
+      return route.fulfill({ json: MOCK_KNOWLEDGE_LIST });
+    });
+    await page.route('/api/admin/knowledge/editor-config', async (route) => {
+      return route.fulfill({ json: MOCK_EDITOR_CONFIG });
+    });
+  });
+
+  test('ページが表示されてファイル選択エリアがある', async ({ page }) => {
+    await page.goto('/admin/knowledge/upload');
+
+    await expect(page.getByRole('heading', { name: /アップロード|ファイル/ })).toBeVisible();
+    await expect(page.getByText('☁ ファイルをドラッグ&ドロップ')).toBeVisible();
+  });
+
+  test('Markdownファイルを選択するとプレビューが表示される', async ({ page }) => {
+    await page.goto('/admin/knowledge/upload');
+
+    const fileContent = '# テスト\nこれはテストコンテンツです';
+    const fileInput = page.locator('input[type="file"]').first();
+
+    await fileInput.setInputFiles({
+      name: 'test.md',
+      mimeType: 'text/markdown',
+      buffer: Buffer.from(fileContent),
+    });
+
+    await expect(page.getByText('test.md', { exact: true })).toBeVisible({ timeout: 3_000 });
+    await expect(page.getByText('# テスト')).toBeVisible({ timeout: 3_000 });
+  });
+
+  test('キャンセルで一覧に戻る', async ({ page }) => {
+    await page.goto('/admin/knowledge/upload');
+
+    await page.getByRole('button', { name: /キャンセル|戻る/ }).click();
+    await expect(page).toHaveURL(/\/admin\/knowledge$/);
+  });
+});

--- a/frontend/e2e/marp-viewer.spec.ts
+++ b/frontend/e2e/marp-viewer.spec.ts
@@ -1,0 +1,134 @@
+import { expect, test } from '@playwright/test';
+import {
+  MOCK_VOICE_RESPONSE,
+  setupMarpMocks,
+  setupWebAudioMock,
+} from './helpers/mocks';
+import {
+  clickPlayPause,
+  clickPrevSlide,
+  clickReset,
+  clickSwitchToEnglish,
+  gotoGuide,
+  waitForSlide,
+} from './helpers/marp';
+
+test.describe('MarpViewer — 基本表示', () => {
+  test.beforeEach(async ({ page }) => {
+    await setupWebAudioMock(page);
+    await setupMarpMocks(page);
+  });
+
+  test('/guide?lang=ja でシェルとスライドが読み込まれる', async ({ page }) => {
+    await gotoGuide(page, 'ja');
+
+    await expect(page.getByTestId('customer-guide-shell')).toBeVisible();
+    await expect(page.getByTestId('marp-viewer')).toBeVisible();
+    await expect(page.locator('main h1')).toBeVisible();
+  });
+
+  test('スライドカウンターが「1 / 3」と表示される', async ({ page }) => {
+    await gotoGuide(page, 'ja');
+    await waitForSlide(page, 1, 3);
+  });
+
+  test('最初のスライドでは前へボタンが無効', async ({ page }) => {
+    await gotoGuide(page, 'ja');
+    await waitForSlide(page, 1, 3);
+    await expect(page.getByTestId('marp-prev-button')).toBeDisabled();
+  });
+});
+
+test.describe('MarpViewer — スライドナビゲーション', () => {
+  test.beforeEach(async ({ page }) => {
+    await setupWebAudioMock(page);
+    await setupMarpMocks(page);
+  });
+
+  test('スライド2にいるとき前へボタンでスライド1に戻る', async ({ page }) => {
+    await gotoGuide(page, 'ja');
+    await waitForSlide(page, 1, 3);
+    await clickPlayPause(page);
+    await waitForSlide(page, 2, 3);
+
+    await expect(page.getByTestId('marp-prev-button')).toBeEnabled();
+    await clickPrevSlide(page);
+
+    await waitForSlide(page, 1, 3);
+  });
+
+  test('リセットボタンでスライド1に戻る', async ({ page }) => {
+    await gotoGuide(page, 'ja', { autoplay: true });
+    await waitForSlide(page, 2, 3);
+
+    await clickPlayPause(page);
+    await clickReset(page);
+
+    await waitForSlide(page, 1, 3);
+  });
+});
+
+test.describe('MarpViewer — 再生制御', () => {
+  test.beforeEach(async ({ page }) => {
+    await setupWebAudioMock(page);
+    await setupMarpMocks(page);
+  });
+
+  test('再生ボタンをクリックするとナレーションAPIが呼ばれる', async ({ page }) => {
+    const voiceRequests: string[] = [];
+    await page.route('/api/voice', (route) => {
+      voiceRequests.push(route.request().url());
+      return route.fulfill({ json: MOCK_VOICE_RESPONSE });
+    });
+
+    await gotoGuide(page, 'ja');
+    await waitForSlide(page, 1, 3);
+
+    await clickPlayPause(page);
+
+    await expect
+      .poll(() => voiceRequests.length, { timeout: 5_000 })
+      .toBeGreaterThan(0);
+  });
+
+  test('一時停止ボタンで再生が止まる', async ({ page }) => {
+    await gotoGuide(page, 'ja', { autoplay: true });
+    await waitForSlide(page, 1, 3);
+
+    const counterBefore = await page.getByTestId('marp-slide-counter').textContent();
+
+    await clickPlayPause(page);
+
+    await page.waitForTimeout(500);
+    const counterAfter = await page.getByTestId('marp-slide-counter').textContent();
+
+    expect(counterBefore).toBe(counterAfter);
+  });
+});
+
+test.describe('MarpViewer — CustomerGuideShell 言語切り替え', () => {
+  test.beforeEach(async ({ page }) => {
+    await setupWebAudioMock(page);
+    await setupMarpMocks(page);
+  });
+
+  test('/guide?lang=ja で日本語タイトルが表示される', async ({ page }) => {
+    await gotoGuide(page, 'ja');
+
+    await expect(page.locator('main h1')).toBeVisible();
+    await expect(page.getByRole('heading', { name: 'First Visit Registration Guide' })).toHaveCount(0);
+    await expect(page.getByTestId('guide-language-toggle')).toBeVisible();
+  });
+
+  test('英語切り替えボタンで /onboarding?lang=en に遷移する', async ({ page }) => {
+    await gotoGuide(page, 'ja');
+    await page.request.get('/onboarding?lang=en');
+
+    await clickSwitchToEnglish(page);
+
+    await expect(page).toHaveURL(/\/onboarding\?lang=en$/, { timeout: 30_000 });
+    await expect(page.getByRole('heading', { name: 'First Visit Registration Guide' })).toBeVisible({
+      timeout: 30_000,
+    });
+  });
+});

--- a/frontend/e2e/marp-viewer.spec.ts
+++ b/frontend/e2e/marp-viewer.spec.ts
@@ -95,14 +95,14 @@ test.describe('MarpViewer — 再生制御', () => {
     await gotoGuide(page, 'ja', { autoplay: true });
     await waitForSlide(page, 1, 3);
 
-    const counterBefore = await page.getByTestId('marp-slide-counter').textContent();
+    const playPauseButton = page.getByTestId('marp-play-pause-button');
+    await expect(playPauseButton).toHaveAttribute('data-state', 'playing');
 
     await clickPlayPause(page);
 
-    await page.waitForTimeout(500);
-    const counterAfter = await page.getByTestId('marp-slide-counter').textContent();
-
-    expect(counterBefore).toBe(counterAfter);
+    await expect(playPauseButton).toHaveAttribute('data-state', 'paused');
+    await expect(playPauseButton).toHaveAttribute('aria-label', /自動再生を開始|Start autoplay/);
+    await expect(page.getByTestId('marp-slide-counter')).toHaveText('1 / 3');
   });
 });
 
@@ -122,9 +122,11 @@ test.describe('MarpViewer — CustomerGuideShell 言語切り替え', () => {
 
   test('英語切り替えボタンで /onboarding?lang=en に遷移する', async ({ page }) => {
     await gotoGuide(page, 'ja');
-    await page.request.get('/onboarding?lang=en');
 
-    await clickSwitchToEnglish(page);
+    await Promise.all([
+      page.waitForURL(/\/onboarding\?lang=en$/, { timeout: 30_000 }),
+      clickSwitchToEnglish(page),
+    ]);
 
     await expect(page).toHaveURL(/\/onboarding\?lang=en$/, { timeout: 30_000 });
     await expect(page.getByRole('heading', { name: 'First Visit Registration Guide' })).toBeVisible({

--- a/frontend/e2e/navigation.spec.ts
+++ b/frontend/e2e/navigation.spec.ts
@@ -1,27 +1,27 @@
 import { expect, test } from '@playwright/test';
+import { dismissInitialSettingsModal } from './helpers/home';
+import { gotoGuide } from './helpers/marp';
 
 test.describe('Navigation', () => {
   test('opens the onboarding guide and returns to the reception screen', async ({ page }) => {
-    await page.goto('/guide?lang=ja');
+    await gotoGuide(page, 'ja');
+    await Promise.all([
+      page.waitForURL(/\/$/, { timeout: 60_000, waitUntil: 'domcontentloaded' }),
+      page.getByTestId('guide-back-button').click(),
+    ]);
 
-    await expect(page.getByTestId('customer-guide-shell')).toBeVisible();
-    await expect(page.getByRole('heading', { name: '初回登録ガイド' })).toBeVisible();
-
-    await page.getByRole('button', { name: '受付画面に戻る' }).click();
-
-    await expect(page).toHaveURL(/\/$/);
+    await dismissInitialSettingsModal(page);
     await expect(page.getByTestId('response-bubble')).toBeVisible();
   });
 
   test('switches onboarding language without leaving the page', async ({ page }) => {
     await page.goto('/onboarding?lang=en');
-
     await expect(page.getByRole('heading', { name: 'First Visit Registration Guide' })).toBeVisible();
 
-    await page.getByRole('button', { name: 'Switch to Japanese' }).click();
+    await page.getByTestId('guide-language-toggle').click();
 
     await expect(page).toHaveURL(/\/onboarding\?lang=ja$/);
-    await expect(page.getByRole('heading', { name: '初回登録ガイド' })).toBeVisible();
+    await expect(page.getByTestId('customer-guide-shell')).toBeVisible();
   });
 
   test('shows a 404 response for an unknown route', async ({ page }) => {

--- a/frontend/e2e/navigation.spec.ts
+++ b/frontend/e2e/navigation.spec.ts
@@ -18,7 +18,10 @@ test.describe('Navigation', () => {
     await page.goto('/onboarding?lang=en');
     await expect(page.getByRole('heading', { name: 'First Visit Registration Guide' })).toBeVisible();
 
-    await page.getByTestId('guide-language-toggle').click();
+    await Promise.all([
+      page.waitForURL(/\/onboarding\?lang=ja$/, { timeout: 30_000 }),
+      page.getByTestId('guide-language-toggle').click(),
+    ]);
 
     await expect(page).toHaveURL(/\/onboarding\?lang=ja$/);
     await expect(page.getByTestId('customer-guide-shell')).toBeVisible();

--- a/frontend/e2e/smoke.spec.ts
+++ b/frontend/e2e/smoke.spec.ts
@@ -1,4 +1,5 @@
 import { expect, test } from '@playwright/test';
+import { dismissInitialSettingsModal } from './helpers/home';
 
 test.describe('Smoke tests', () => {
   test('loads the home page and renders the main UI shell', async ({ page }) => {
@@ -10,12 +11,13 @@ test.describe('Smoke tests', () => {
     await expect(page).toHaveTitle(/Engineer Cafe Navigator/);
     await expect(page.locator('html')).toHaveAttribute('lang', 'ja');
     await expect(page.locator('main')).toBeVisible();
+    await dismissInitialSettingsModal(page);
     await expect(page.getByTestId('response-bubble')).toBeVisible();
     await expect(page.getByTestId('response-text')).toContainText(
       'マイクを押して、エンジニアカフェについて聞いてください。',
     );
-    await expect(page.getByRole('button', { name: '話しかける' })).toBeVisible();
-    await expect(page.getByRole('button', { name: '設定' })).toBeVisible();
-    await expect(page.getByTestId('text-input-toggle')).toBeVisible();
+    await expect(page.getByTestId('kiosk-voice-button')).toBeVisible();
+    await expect(page.getByTestId('kiosk-settings-button')).toBeVisible();
+    await expect(page.getByTestId('kiosk-slides-button')).toBeVisible();
   });
 });

--- a/frontend/src/app/(admin)/admin/knowledge/components/KnowledgeEditor.tsx
+++ b/frontend/src/app/(admin)/admin/knowledge/components/KnowledgeEditor.tsx
@@ -292,8 +292,9 @@ export function KnowledgeEditor({ entry, onSave, onCancel }: KnowledgeEditorProp
   return (
     <form onSubmit={handleSubmit} className="space-y-6">
       <div>
-        <label className="block text-sm font-medium text-gray-700 mb-2">タイトル *</label>
+        <label htmlFor="title" className="block text-sm font-medium text-gray-700 mb-2">タイトル *</label>
         <input
+          id="title"
           type="text"
           value={formData.title}
           onChange={(e) =>
@@ -308,9 +309,10 @@ export function KnowledgeEditor({ entry, onSave, onCancel }: KnowledgeEditorProp
 
       <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
         <div>
-          <label className="block text-sm font-medium text-gray-700 mb-2">カテゴリ</label>
+          <label htmlFor="category" className="block text-sm font-medium text-gray-700 mb-2">カテゴリ</label>
           <div className="space-y-2">
             <select
+              id="category"
               value={showCustomCategory ? '__custom__' : formData.category}
               onChange={(e) => {
                 if (e.target.value === '__custom__') {
@@ -353,9 +355,10 @@ export function KnowledgeEditor({ entry, onSave, onCancel }: KnowledgeEditorProp
         </div>
 
         <div>
-          <label className="block text-sm font-medium text-gray-700 mb-2">サブカテゴリ</label>
+          <label htmlFor="subcategory" className="block text-sm font-medium text-gray-700 mb-2">サブカテゴリ</label>
           <div className="space-y-2">
             <select
+              id="subcategory"
               value={showCustomSubcategory ? '__custom__' : formData.subcategory}
               onChange={(e) => {
                 if (e.target.value === '__custom__') {
@@ -400,8 +403,9 @@ export function KnowledgeEditor({ entry, onSave, onCancel }: KnowledgeEditorProp
         </div>
 
         <div>
-          <label className="block text-sm font-medium text-gray-700 mb-2">言語</label>
+          <label htmlFor="language" className="block text-sm font-medium text-gray-700 mb-2">言語</label>
           <select
+            id="language"
             value={formData.language}
             onChange={(e) =>
               setFormData((prev) => ({

--- a/frontend/src/app/(admin)/admin/knowledge/components/KnowledgeTable.tsx
+++ b/frontend/src/app/(admin)/admin/knowledge/components/KnowledgeTable.tsx
@@ -66,7 +66,7 @@ export function KnowledgeTable({ data, onDelete, page, onPageChange }: Knowledge
       </div>
 
       <div className="overflow-x-auto">
-        <table className="min-w-full divide-y divide-gray-200">
+        <table data-testid="knowledge-table" className="min-w-full divide-y divide-gray-200">
           <thead className="bg-gray-50">
             <tr>
               <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">

--- a/frontend/src/app/(admin)/admin/knowledge/page.tsx
+++ b/frontend/src/app/(admin)/admin/knowledge/page.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import Link from 'next/link';
-import { type MouseEvent, useCallback, useState } from 'react';
+import { useCallback, useState } from 'react';
 import useSWR from 'swr';
 import { Toaster, toast } from 'react-hot-toast';
 import { deleteKnowledge, getKnowledgeList } from '@/lib/api/knowledge';
@@ -34,22 +34,6 @@ export default function KnowledgeAdminPage() {
     }
   }, [mutate]);
 
-  const handleHardNavigation = useCallback((event: MouseEvent<HTMLAnchorElement>, href: string) => {
-    if (
-      event.defaultPrevented ||
-      event.button !== 0 ||
-      event.metaKey ||
-      event.ctrlKey ||
-      event.shiftKey ||
-      event.altKey
-    ) {
-      return;
-    }
-
-    event.preventDefault();
-    window.location.assign(href);
-  }, []);
-
   if (error) {
     return (
       <div className="min-h-screen bg-gray-50 p-8">
@@ -74,16 +58,12 @@ export default function KnowledgeAdminPage() {
               <div className="flex gap-3">
                 <Link
                   href="/admin/knowledge/upload"
-                  prefetch={false}
-                  onClick={(event) => handleHardNavigation(event, '/admin/knowledge/upload')}
                   className="bg-green-600 text-white px-4 py-2 rounded-lg hover:bg-green-700 transition-colors"
                 >
                   ファイルアップロード
                 </Link>
                 <Link
                   href="/admin/knowledge/new"
-                  prefetch={false}
-                  onClick={(event) => handleHardNavigation(event, '/admin/knowledge/new')}
                   className="bg-blue-600 text-white px-4 py-2 rounded-lg hover:bg-blue-700 transition-colors"
                 >
                   新規作成
@@ -96,8 +76,11 @@ export default function KnowledgeAdminPage() {
             <form onSubmit={handleSearch} className="mb-6">
               <div className="grid grid-cols-1 md:grid-cols-4 gap-4">
                 <div>
-                  <label className="block text-sm font-medium text-gray-700 mb-2">検索</label>
+                  <label htmlFor="knowledge-search-filter" className="block text-sm font-medium text-gray-700 mb-2">
+                    検索
+                  </label>
                   <input
+                    id="knowledge-search-filter"
                     type="text"
                     value={search}
                     onChange={(e) => setSearch(e.target.value)}
@@ -107,8 +90,11 @@ export default function KnowledgeAdminPage() {
                 </div>
 
                 <div>
-                  <label className="block text-sm font-medium text-gray-700 mb-2">言語</label>
+                  <label htmlFor="knowledge-language-filter" className="block text-sm font-medium text-gray-700 mb-2">
+                    言語
+                  </label>
                   <select
+                    id="knowledge-language-filter"
                     value={language}
                     onChange={(e) => setLanguage(e.target.value)}
                     className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
@@ -120,8 +106,11 @@ export default function KnowledgeAdminPage() {
                 </div>
 
                 <div>
-                  <label className="block text-sm font-medium text-gray-700 mb-2">カテゴリ</label>
+                  <label htmlFor="knowledge-category-filter" className="block text-sm font-medium text-gray-700 mb-2">
+                    カテゴリ
+                  </label>
                   <input
+                    id="knowledge-category-filter"
                     type="text"
                     value={category}
                     onChange={(e) => setCategory(e.target.value)}

--- a/frontend/src/app/(admin)/admin/knowledge/page.tsx
+++ b/frontend/src/app/(admin)/admin/knowledge/page.tsx
@@ -1,7 +1,7 @@
 'use client';
 
-import { useCallback, useState } from 'react';
 import Link from 'next/link';
+import { type MouseEvent, useCallback, useState } from 'react';
 import useSWR from 'swr';
 import { Toaster, toast } from 'react-hot-toast';
 import { deleteKnowledge, getKnowledgeList } from '@/lib/api/knowledge';
@@ -34,6 +34,22 @@ export default function KnowledgeAdminPage() {
     }
   }, [mutate]);
 
+  const handleHardNavigation = useCallback((event: MouseEvent<HTMLAnchorElement>, href: string) => {
+    if (
+      event.defaultPrevented ||
+      event.button !== 0 ||
+      event.metaKey ||
+      event.ctrlKey ||
+      event.shiftKey ||
+      event.altKey
+    ) {
+      return;
+    }
+
+    event.preventDefault();
+    window.location.assign(href);
+  }, []);
+
   if (error) {
     return (
       <div className="min-h-screen bg-gray-50 p-8">
@@ -58,12 +74,16 @@ export default function KnowledgeAdminPage() {
               <div className="flex gap-3">
                 <Link
                   href="/admin/knowledge/upload"
+                  prefetch={false}
+                  onClick={(event) => handleHardNavigation(event, '/admin/knowledge/upload')}
                   className="bg-green-600 text-white px-4 py-2 rounded-lg hover:bg-green-700 transition-colors"
                 >
                   ファイルアップロード
                 </Link>
                 <Link
                   href="/admin/knowledge/new"
+                  prefetch={false}
+                  onClick={(event) => handleHardNavigation(event, '/admin/knowledge/new')}
                   className="bg-blue-600 text-white px-4 py-2 rounded-lg hover:bg-blue-700 transition-colors"
                 >
                   新規作成

--- a/frontend/src/app/components/InitialSettingsModal.tsx
+++ b/frontend/src/app/components/InitialSettingsModal.tsx
@@ -231,6 +231,7 @@ export default function InitialSettingsModal({
             <button
               type="button"
               onClick={() => void handleClose()}
+              data-testid="initial-settings-close"
               className="inline-flex min-h-11 min-w-[140px] items-center justify-center rounded-full bg-white px-6 py-3 text-sm font-semibold text-slate-900 shadow-lg transition-transform hover:scale-[1.02]"
             >
               {labels.close}

--- a/frontend/src/app/components/MarpViewer.tsx
+++ b/frontend/src/app/components/MarpViewer.tsx
@@ -140,6 +140,20 @@ export default function MarpViewer({
   const [slideViewTimes, setSlideViewTimes] = useState<Map<number, number>>(new Map());
   const [lipSyncCacheStats, setLipSyncCacheStats] = useState<any>(null);
 
+  useEffect(() => {
+    setCurrentLanguage(language);
+  }, [language]);
+
+  useEffect(() => {
+    if (!autoPlay) {
+      return;
+    }
+
+    setSlideState(1, false);
+    startPlaybackSession();
+    setIsPlaying(true);
+  }, [autoPlay]);
+
   const iframeRef = useRef<HTMLIFrameElement>(null);
   const autoPlayTimerRef = useRef<NodeJS.Timeout | null>(null);
   const narrationScheduleTimerRef = useRef<NodeJS.Timeout | null>(null);
@@ -147,9 +161,10 @@ export default function MarpViewer({
   const narrationAbortControllerRef = useRef<AbortController | null>(null);
   const currentRequestIdRef = useRef<string>('');
   const currentAudioServiceRef = useRef<any>(null);
-  const loadSlideDataRef = useRef<(requestedLang?: string) => Promise<void>>(async () => {});
+  const loadSlideDataRef = useRef<(requestedLang?: string) => Promise<boolean>>(async () => false);
   const narrateWithRetryRef = useRef<(retries?: number) => Promise<void>>(async () => {});
   const stopAutoPlayRef = useRef<() => void>(() => {});
+  const clearPlaybackWorkRef = useRef<() => void>(() => {});
   const previousSlideRef = useRef<() => Promise<void>>(async () => {});
   const updateIframeSlideRef = useRef<(slideNumber: number, retryCount?: number) => void>(() => {});
   const lastRenderedSlideRef = useRef<number>(0);
@@ -158,12 +173,19 @@ export default function MarpViewer({
   const isPlayingRef = useRef(isPlaying);
   const presentationStartTimeRef = useRef<number | null>(presentationStartTime);
   const currentLanguageRef = useRef(currentLanguage);
+  const currentSlideRef = useRef(currentSlide);
+  const totalSlidesRef = useRef(totalSlides);
+  const playbackSessionRef = useRef(0);
+  const loadSessionRef = useRef(0);
+  const loadInitializationTimerRef = useRef<NodeJS.Timeout | null>(null);
 
   isNarratingRef.current = isNarrating;
   isNarrationInProgressRef.current = isNarrationInProgress;
   isPlayingRef.current = isPlaying;
   presentationStartTimeRef.current = presentationStartTime;
   currentLanguageRef.current = currentLanguage;
+  currentSlideRef.current = currentSlide;
+  totalSlidesRef.current = totalSlides;
 
   // Analytics tracking
   const trackPresentationEvent = (event: string, data: any) => {
@@ -177,32 +199,97 @@ export default function MarpViewer({
     setIsNarrationInProgress(false);
   };
 
+  const setSlideState = (slideNumber: number, notify = true) => {
+    currentSlideRef.current = slideNumber;
+    setCurrentSlide(slideNumber);
+    if (notify) {
+      onSlideChange?.(slideNumber);
+    }
+  };
+
+  const startPlaybackSession = () => {
+    playbackSessionRef.current += 1;
+    isPlayingRef.current = true;
+    return playbackSessionRef.current;
+  };
+
+  const invalidatePlaybackSession = () => {
+    playbackSessionRef.current += 1;
+    isPlayingRef.current = false;
+    return playbackSessionRef.current;
+  };
+
+  const isActivePlaybackSession = (sessionId: number) =>
+    playbackSessionRef.current === sessionId && isPlayingRef.current;
+
+  const clearLoadInitializationTimer = () => {
+    if (loadInitializationTimerRef.current) {
+      clearTimeout(loadInitializationTimerRef.current);
+      loadInitializationTimerRef.current = null;
+    }
+  };
+
+  const clearPlaybackWork = useCallback(() => {
+    if (narrationAbortControllerRef.current) {
+      narrationAbortControllerRef.current.abort();
+      narrationAbortControllerRef.current = null;
+    }
+
+    if (autoPlayTimerRef.current) {
+      clearTimeout(autoPlayTimerRef.current);
+      autoPlayTimerRef.current = null;
+    }
+
+    if (narrationScheduleTimerRef.current) {
+      clearTimeout(narrationScheduleTimerRef.current);
+      narrationScheduleTimerRef.current = null;
+    }
+
+    resetNarrationFlags();
+    audioStateManager.stopAll();
+
+    if (onVisemeControl) {
+      onVisemeControl('Closed', 0);
+    }
+
+    if (onExpressionControl) {
+      onExpressionControl('neutral', 1.0);
+    }
+
+    audioCache.forEach((audioUrl) => {
+      URL.revokeObjectURL(audioUrl);
+    });
+    setAudioCache(new Map());
+  }, [audioCache, onExpressionControl, onVisemeControl]);
+
   const advancePresentation = (delayMs = SLIDE_TRANSITION_DELAY_MS) => {
+    const playbackSession = playbackSessionRef.current;
+
     const advance = () => {
       autoPlayTimerRef.current = null;
       resetNarrationFlags();
 
-      if (!isPlayingRef.current) {
+      if (!isActivePlaybackSession(playbackSession)) {
         return;
       }
 
-      if (currentSlide < totalSlides) {
-        setCurrentSlide(prev => {
-          const nextSlide = prev + 1;
-          onSlideChange?.(nextSlide);
-          return nextSlide;
-        });
+      const currentSlideNumber = currentSlideRef.current;
+      const totalSlideCount = totalSlidesRef.current;
+
+      if (currentSlideNumber < totalSlideCount) {
+        setSlideState(currentSlideNumber + 1);
         // Explicitly schedule next narration after slide transition
         // Instead of relying on useEffect re-trigger via currentSlide dependency
         narrationScheduleTimerRef.current = setTimeout(() => {
           narrationScheduleTimerRef.current = null;
-          if (isPlayingRef.current) {
+          if (isActivePlaybackSession(playbackSession)) {
             void narrateWithRetryRef.current();
           }
         }, NARRATION_SCHEDULE_DELAY_MS);
         return;
       }
 
+      invalidatePlaybackSession();
       setIsPlaying(false);
       trackPresentationEvent('presentation_completed', {
         totalDuration: presentationStartTimeRef.current ? Date.now() - presentationStartTimeRef.current : 0
@@ -219,17 +306,37 @@ export default function MarpViewer({
       clearTimeout(autoPlayTimerRef.current);
     }
 
-    autoPlayTimerRef.current = setTimeout(advance, delayMs);
+    autoPlayTimerRef.current = setTimeout(() => {
+      if (!isActivePlaybackSession(playbackSession)) {
+        autoPlayTimerRef.current = null;
+        return;
+      }
+
+      advance();
+    }, delayMs);
   };
 
   // Error recovery with retry logic
   const narrateWithRetry = async (retries = 3) => {
+    const playbackSession = playbackSessionRef.current;
+
     for (let i = 0; i < retries; i++) {
+      if (!isActivePlaybackSession(playbackSession)) {
+        return;
+      }
+
       try {
         await narrateCurrentSlide();
+        if (!isActivePlaybackSession(playbackSession)) {
+          return;
+        }
         setRetryCount(0);
         break;
       } catch (error) {
+        if (!isActivePlaybackSession(playbackSession)) {
+          return;
+        }
+
         // Narration attempt failed, retrying
         setRetryCount(i + 1);
         
@@ -246,17 +353,21 @@ export default function MarpViewer({
               : 'Narration unavailable. Continue without audio?'
           );
           
-          if (shouldContinue && isPlayingRef.current && currentSlide < totalSlides) {
+          if (
+            shouldContinue &&
+            isActivePlaybackSession(playbackSession) &&
+            currentSlideRef.current < totalSlidesRef.current
+          ) {
             setTimeout(() => {
+              if (!isActivePlaybackSession(playbackSession)) {
+                return;
+              }
+
               resetNarrationFlags();
-              setCurrentSlide(prev => {
-                const nextSlide = prev + 1;
-                onSlideChange?.(nextSlide);
-                return nextSlide;
-              });
+              setSlideState(currentSlideRef.current + 1);
               // Schedule follow-up narration for the next slide
               setTimeout(() => {
-                if (isPlayingRef.current) {
+                if (isActivePlaybackSession(playbackSession)) {
                   void narrateWithRetryRef.current();
                 }
               }, NARRATION_SCHEDULE_DELAY_MS);
@@ -319,7 +430,7 @@ export default function MarpViewer({
       // Auto-play skipped - already playing
     }
 
-    return () => stopAutoPlayRef.current();
+    return () => clearPlaybackWorkRef.current();
   }, [isPlaying, totalSlides]);
 
   // Save settings to localStorage whenever they change
@@ -345,9 +456,10 @@ export default function MarpViewer({
         }
         
         // Always reset to slide 1 before starting a new presentation
-        setCurrentSlide(1);
+        setSlideState(1, false);
         // Stop any currently playing presentation first
-        if (isPlaying) {
+        if (isPlayingRef.current) {
+          stopAutoPlayRef.current();
           setIsPlaying(false);
           setRenderedHtml('');
         }
@@ -359,8 +471,13 @@ export default function MarpViewer({
         // Force update the current language state immediately
         setCurrentLanguage(eventLanguage as 'ja' | 'en');
         
-        loadSlideDataRef.current(eventLanguage).then(() => {
+        loadSlideDataRef.current(eventLanguage).then((didLoadCurrent) => {
+          if (!didLoadCurrent) {
+            return;
+          }
+
           // Slide data loaded, starting auto-play
+          startPlaybackSession();
           setIsPlaying(true);
         }).catch((error) => {
           // Failed to load slide data
@@ -433,11 +550,17 @@ export default function MarpViewer({
     if (abortControllerRef.current) {
       abortControllerRef.current.abort();
     }
+
+    clearLoadInitializationTimer();
     
     // Create new abort controller for this request
     abortControllerRef.current = new AbortController();
+    const loadSession = loadSessionRef.current + 1;
+    loadSessionRef.current = loadSession;
     const currentRequestId = `${requestedLang}-${Date.now()}-${Math.random()}`;
     currentRequestIdRef.current = currentRequestId;
+    const isCurrentLoad = () =>
+      loadSessionRef.current === loadSession && currentRequestIdRef.current === currentRequestId;
     
     try {
       
@@ -494,11 +617,11 @@ export default function MarpViewer({
       }
 
       // Check if this is still the current request
-      if (currentRequestIdRef.current !== currentRequestId) {
+      if (!isCurrentLoad()) {
         if (process.env.NODE_ENV !== 'production') {
           // Ignoring outdated response
         }
-        return;
+        return false;
       }
 
       // Ignore response if a newer loadSlideData was triggered in the meantime
@@ -506,9 +629,11 @@ export default function MarpViewer({
         if (result.slideData && result.slideData.slides) {
           setSlides(result.slideData.slides);
           setTotalSlides(result.slideData.slides.length);
+          totalSlidesRef.current = result.slideData.slides.length;
         } else if (result.slideCount) {
           // Fallback to slideCount if slideData is not available
           setTotalSlides(result.slideCount);
+          totalSlidesRef.current = result.slideCount;
         }
 
         if (result.narrationData) {
@@ -667,10 +792,17 @@ export default function MarpViewer({
         }
 
         // Give iframe time to render, then show first slide
-        setTimeout(() => {
-          setCurrentSlide(1);
+        loadInitializationTimerRef.current = setTimeout(() => {
+          loadInitializationTimerRef.current = null;
+          if (!isCurrentLoad()) {
+            return;
+          }
+
+          setSlideState(1, false);
           updateIframeSlideRef.current(1);
         }, 1000);
+
+        return true;
       } else {
         setError(result.error || 'Failed to load slides');
       }
@@ -680,25 +812,27 @@ export default function MarpViewer({
         if (process.env.NODE_ENV !== 'production') {
           // Request was aborted
         }
-        return;
+        return false;
       }
       
       // Check if this is still the current request before showing error
-      if (currentRequestIdRef.current !== currentRequestId) {
+      if (!isCurrentLoad()) {
         if (process.env.NODE_ENV !== 'production') {
           // Ignoring error from outdated request
         }
-        return;
+        return false;
       }
       
       // Error loading slides
       setError('Error loading slides');
     } finally {
       // Only clear loading if this is still the current request
-      if (currentRequestIdRef.current === currentRequestId) {
+      if (isCurrentLoad()) {
         setIsLoading(false);
       }
     }
+
+    return false;
   }, [slideFile]);
 
 
@@ -714,15 +848,20 @@ export default function MarpViewer({
     setIsNarrating(true);
     
     try {
+      const playbackSession = playbackSessionRef.current;
+      const slideNumberAtStart = currentSlideRef.current;
+
       // Create new AbortController for this narration
       narrationAbortControllerRef.current = new AbortController();
 
       const slideNarration =
-        narrationData?.slides[currentSlide - 1]?.narration?.auto?.trim() ?? '';
+        narrationData?.slides[slideNumberAtStart - 1]?.narration?.auto?.trim() ?? '';
 
       // If the current slide has no auto narration, proceed without audio.
       if (!slideNarration) {
-        advancePresentation(500);
+        if (isActivePlaybackSession(playbackSession)) {
+          advancePresentation(500);
+        }
         return;
       }
 
@@ -751,9 +890,27 @@ export default function MarpViewer({
         throw new Error(result.error || 'TTS response missing audioResponse');
       }
 
+      // Manual navigation may have already moved the viewer to a different slide.
+      if (
+        !isActivePlaybackSession(playbackSession) ||
+        currentSlideRef.current !== slideNumberAtStart
+      ) {
+        resetNarrationFlags();
+        return;
+      }
+
       try {
         // Wait for audio playback completion before advancing.
         await playAudioWithLipSync(result.audioResponse);
+
+        if (
+          !isActivePlaybackSession(playbackSession) ||
+          currentSlideRef.current !== slideNumberAtStart
+        ) {
+          resetNarrationFlags();
+          return;
+        }
+
         advancePresentation(500);
       } catch (error: any) {
         resetNarrationFlags();
@@ -771,7 +928,7 @@ export default function MarpViewer({
           return;
         }
 
-        if (isPlayingRef.current) {
+        if (isActivePlaybackSession(playbackSession)) {
           advancePresentation(1000);
         }
       }
@@ -851,38 +1008,8 @@ export default function MarpViewer({
 
 
   const stopAutoPlay = () => {
-    
-    // Abort any pending narration API calls
-    if (narrationAbortControllerRef.current) {
-      narrationAbortControllerRef.current.abort();
-      narrationAbortControllerRef.current = null;
-    }
-    
-    if (autoPlayTimerRef.current) {
-      clearTimeout(autoPlayTimerRef.current);
-      autoPlayTimerRef.current = null;
-    }
-    if (narrationScheduleTimerRef.current) {
-      clearTimeout(narrationScheduleTimerRef.current);
-      narrationScheduleTimerRef.current = null;
-    }
-    resetNarrationFlags();
-    audioStateManager.stopAll();
-    
-    // Reset viseme to closed mouth when stopping
-    if (onVisemeControl) {
-      onVisemeControl('Closed', 0);
-    }
-    
-    // Reset to neutral expression when stopping presentation
-    if (onExpressionControl) {
-      onExpressionControl('neutral', 1.0);
-    }
-    
-    audioCache.forEach((audioUrl) => {
-      URL.revokeObjectURL(audioUrl);
-    });
-    setAudioCache(new Map());
+    invalidatePlaybackSession();
+    clearPlaybackWork();
   };
 
   const handleSlideNavigation = async (action: string, targetSlide?: number) => {
@@ -918,9 +1045,8 @@ export default function MarpViewer({
 
       if (result.success && result.slideNumber) {
         // Only update if we got a valid slide number
-        if (result.slideNumber !== currentSlide) {
-          setCurrentSlide(result.slideNumber);
-          onSlideChange?.(result.slideNumber);
+        if (result.slideNumber !== currentSlideRef.current) {
+          setSlideState(result.slideNumber);
         }
 
         // Play narration audio if available
@@ -940,16 +1066,19 @@ export default function MarpViewer({
 
   const previousSlide = async () => {
     if (currentSlide > 1) {
+      const newSlide = currentSlide - 1;
+      const wasPlaying = isPlayingRef.current;
+
+      // Manual navigation should always cancel any pending auto-advance first.
+      stopAutoPlay();
+
       // Stop current narration when manually navigating
-      if (isPlaying) {
+      if (wasPlaying) {
         setIsPlaying(false); // Set this first to prevent new narrations
-        stopAutoPlay();
         onPresentationComplete?.('stopped');
       }
-      
-      const newSlide = currentSlide - 1;
-      setCurrentSlide(newSlide);
-      onSlideChange?.(newSlide);
+
+      setSlideState(newSlide);
       // Don't await to avoid blocking UI
       handleSlideNavigation('previous', newSlide);
     }
@@ -957,15 +1086,16 @@ export default function MarpViewer({
 
   const gotoSlide = async (slideNumber: number) => {
     if (slideNumber >= 1 && slideNumber <= totalSlides) {
+      const wasPlaying = isPlayingRef.current;
+
       // Stop current narration when manually jumping to a slide
-      if (isPlaying) {
+      if (wasPlaying) {
         stopAutoPlay();
         setIsPlaying(false);
         onPresentationComplete?.('stopped');
       }
-      
-      setCurrentSlide(slideNumber);
-      onSlideChange?.(slideNumber);
+
+      setSlideState(slideNumber);
       // Don't await to avoid blocking UI
       handleSlideNavigation('goto', slideNumber);
     }
@@ -1004,6 +1134,7 @@ export default function MarpViewer({
       // Force initialize to mark this as a user interaction (button click)
       await manager.forceInitialize();
       
+      startPlaybackSession();
       setIsPlaying(true);
     } catch (error: any) {
       console.error('Audio initialization failed:', error);
@@ -1025,11 +1156,13 @@ export default function MarpViewer({
       }
       
       setShowAudioPermissionPrompt(false);
+      startPlaybackSession();
       setIsPlaying(true);
     } catch (error) {
       console.error('[MarpViewer] Failed to initialize audio context:', error);
       // Continue anyway - some audio might still work
       setShowAudioPermissionPrompt(false);
+      startPlaybackSession();
       setIsPlaying(true);
     }
   };
@@ -1174,6 +1307,7 @@ export default function MarpViewer({
   loadSlideDataRef.current = loadSlideData;
   narrateWithRetryRef.current = narrateWithRetry;
   stopAutoPlayRef.current = stopAutoPlay;
+  clearPlaybackWorkRef.current = clearPlaybackWork;
   previousSlideRef.current = previousSlide;
   updateIframeSlideRef.current = updateIframeSlide;
 
@@ -1235,8 +1369,8 @@ export default function MarpViewer({
 
   if (isLoading) {
     return (
-      <div className="flex items-center justify-center h-full">
-        <div className="text-center">
+      <div data-testid="marp-viewer" className="flex h-full items-center justify-center">
+        <div data-testid="marp-viewer-loading" className="text-center">
           <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-blue-500 mx-auto mb-4"></div>
           <p className="text-gray-600">
             {currentLanguage === 'ja' ? 'スライドを読み込んでいます...' : 'Loading slides...'}
@@ -1248,8 +1382,8 @@ export default function MarpViewer({
 
   if (error) {
     return (
-      <div className="flex items-center justify-center h-full">
-        <div className="text-center">
+      <div data-testid="marp-viewer" className="flex h-full items-center justify-center">
+        <div data-testid="marp-viewer-error" className="text-center">
           <p className="text-red-600 mb-4">{error}</p>
           <button
             onClick={() => loadSlideData(currentLanguage)}
@@ -1318,6 +1452,7 @@ export default function MarpViewer({
 
           {/* Reset */}
           <button
+            data-testid="marp-reset-button"
             onClick={() => gotoSlide(1)}
             className="p-2 rounded bg-gray-500 text-white hover:bg-gray-600 transition-colors"
             title={currentLanguage === 'ja' ? '最初から' : 'Start Over'}
@@ -1433,7 +1568,8 @@ export default function MarpViewer({
                     
                     
                     // Only update if count is reasonable (between 1 and 100)
-                    if (slideCount > 0 && slideCount <= 100 && slideCount !== totalSlides) {
+                    if (slideCount > 0 && slideCount <= 100 && slideCount !== totalSlidesRef.current) {
+                      totalSlidesRef.current = slideCount;
                       setTotalSlides(slideCount);
                     }
                     

--- a/frontend/src/app/components/MarpViewer.tsx
+++ b/frontend/src/app/components/MarpViewer.tsx
@@ -1367,6 +1367,14 @@ export default function MarpViewer({
     }
   };
 
+  const playPauseLabel = isPlaying
+    ? currentLanguage === 'ja'
+      ? '自動再生を一時停止'
+      : 'Pause autoplay'
+    : currentLanguage === 'ja'
+      ? '自動再生を開始'
+      : 'Start autoplay';
+
   if (isLoading) {
     return (
       <div data-testid="marp-viewer" className="flex h-full items-center justify-center">
@@ -1421,6 +1429,10 @@ export default function MarpViewer({
           <button
             data-testid="marp-play-pause-button"
             onClick={toggleAutoPlay}
+            aria-label={playPauseLabel}
+            aria-pressed={isPlaying}
+            data-state={isPlaying ? 'playing' : 'paused'}
+            title={playPauseLabel}
             className={`p-2 rounded transition-colors ${
               isPlaying ? 'bg-red-500 hover:bg-red-600' : 'bg-green-500 hover:bg-green-600'
             } text-white`}

--- a/frontend/src/app/components/MarpViewer.tsx
+++ b/frontend/src/app/components/MarpViewer.tsx
@@ -1263,11 +1263,12 @@ export default function MarpViewer({
   }
 
   return (
-    <div className="h-full flex flex-col">
+    <div data-testid="marp-viewer" className="h-full flex flex-col">
       {/* Controls */}
       <div className="flex items-center justify-between p-4 border-b bg-gray-50">
         <div className="flex items-center space-x-2">
           <button
+            data-testid="marp-prev-button"
             onClick={previousSlide}
             disabled={currentSlide === 1}
             className="p-2 rounded bg-blue-500 text-white disabled:bg-gray-300 hover:bg-blue-600 transition-colors"
@@ -1275,7 +1276,7 @@ export default function MarpViewer({
             <ChevronLeft className="w-4 h-4" />
           </button>
           
-          <span className="text-sm font-medium text-gray-700">
+          <span data-testid="marp-slide-counter" className="text-sm font-medium text-gray-700">
             {currentSlide} / {totalSlides}
           </span>
           
@@ -1284,6 +1285,7 @@ export default function MarpViewer({
         <div className="flex items-center space-x-2">
           {/* Auto-play controls */}
           <button
+            data-testid="marp-play-pause-button"
             onClick={toggleAutoPlay}
             className={`p-2 rounded transition-colors ${
               isPlaying ? 'bg-red-500 hover:bg-red-600' : 'bg-green-500 hover:bg-green-600'
@@ -1400,6 +1402,7 @@ export default function MarpViewer({
           {renderedHtml ? (
             /* allow-scripts + allow-same-origin: required for Marp rendering + postMessage. Content is DOMPurify-sanitized. */
             <iframe
+              data-testid="marp-slide-iframe"
               ref={iframeRef}
               srcDoc={renderedHtml}
               className="w-full h-full border-0"

--- a/frontend/src/app/components/presentation/CustomerGuideShell.tsx
+++ b/frontend/src/app/components/presentation/CustomerGuideShell.tsx
@@ -2,7 +2,7 @@
 
 import Link from 'next/link';
 import { ArrowLeft, Languages } from 'lucide-react';
-import { type MouseEvent, useCallback, useState } from 'react';
+import { useState } from 'react';
 
 import CharacterAvatar from '@/app/components/CharacterAvatar';
 import MarpViewer from '@/app/components/MarpViewer';
@@ -50,21 +50,6 @@ export default function CustomerGuideShell({
     nextParams.set('autoplay', '1');
   }
   const languageHref = `/onboarding?${nextParams.toString()}`;
-  const handleHardNavigation = useCallback((event: MouseEvent<HTMLAnchorElement>, href: string) => {
-    if (
-      event.defaultPrevented ||
-      event.button !== 0 ||
-      event.metaKey ||
-      event.ctrlKey ||
-      event.shiftKey ||
-      event.altKey
-    ) {
-      return;
-    }
-
-    event.preventDefault();
-    window.location.assign(href);
-  }, []);
 
   return (
     <main
@@ -81,8 +66,6 @@ export default function CustomerGuideShell({
           <div className="flex flex-wrap gap-2">
             <Link
               href="/"
-              prefetch={false}
-              onClick={(event) => handleHardNavigation(event, '/')}
               data-testid="guide-back-button"
               className="inline-flex min-h-11 items-center gap-2 rounded-full border border-slate-300 bg-white px-4 py-2 text-sm font-medium text-slate-900 transition-colors hover:bg-slate-50"
             >
@@ -91,8 +74,6 @@ export default function CustomerGuideShell({
             </Link>
             <Link
               href={languageHref}
-              prefetch={false}
-              onClick={(event) => handleHardNavigation(event, languageHref)}
               data-testid="guide-language-toggle"
               className="inline-flex min-h-11 items-center gap-2 rounded-full bg-slate-900 px-4 py-2 text-sm font-medium text-white transition-colors hover:bg-slate-800"
             >

--- a/frontend/src/app/components/presentation/CustomerGuideShell.tsx
+++ b/frontend/src/app/components/presentation/CustomerGuideShell.tsx
@@ -1,8 +1,8 @@
 'use client';
 
+import Link from 'next/link';
 import { ArrowLeft, Languages } from 'lucide-react';
-import { useEffect, useState } from 'react';
-import { useRouter } from 'next/navigation';
+import { type MouseEvent, useCallback, useState } from 'react';
 
 import CharacterAvatar from '@/app/components/CharacterAvatar';
 import MarpViewer from '@/app/components/MarpViewer';
@@ -30,28 +30,41 @@ const guideCopy = {
   },
 } as const;
 
-export default function CustomerGuideShell() {
-  const router = useRouter();
-  const [language, setLanguage] = useState<'ja' | 'en'>('ja');
-  const [autoPlay, setAutoPlay] = useState(false);
+interface CustomerGuideShellProps {
+  autoPlay?: boolean;
+  language?: 'ja' | 'en';
+}
+
+export default function CustomerGuideShell({
+  autoPlay = false,
+  language = 'ja',
+}: CustomerGuideShellProps) {
   const [setViseme, setSetViseme] = useState<((viseme: string, intensity: number) => void) | null>(null);
   const [setExpression, setSetExpression] = useState<((expression: string, weight: number) => void) | null>(null);
 
-  useEffect(() => {
-    const params = new URLSearchParams(window.location.search);
-    const nextLanguage = params.get('lang') === 'en' ? 'en' : 'ja';
-    setLanguage(nextLanguage);
-    setAutoPlay(params.get('autoplay') === '1');
-  }, []);
-
   const copy = guideCopy[language];
+  const nextLanguage = language === 'ja' ? 'en' : 'ja';
+  const nextParams = new URLSearchParams();
+  nextParams.set('lang', nextLanguage);
+  if (autoPlay) {
+    nextParams.set('autoplay', '1');
+  }
+  const languageHref = `/onboarding?${nextParams.toString()}`;
+  const handleHardNavigation = useCallback((event: MouseEvent<HTMLAnchorElement>, href: string) => {
+    if (
+      event.defaultPrevented ||
+      event.button !== 0 ||
+      event.metaKey ||
+      event.ctrlKey ||
+      event.shiftKey ||
+      event.altKey
+    ) {
+      return;
+    }
 
-  const handleLanguageChange = (nextLanguage: 'ja' | 'en') => {
-    setLanguage(nextLanguage);
-    const params = new URLSearchParams(window.location.search);
-    params.set('lang', nextLanguage);
-    router.replace(`/onboarding?${params.toString()}`);
-  };
+    event.preventDefault();
+    window.location.assign(href);
+  }, []);
 
   return (
     <main
@@ -66,22 +79,26 @@ export default function CustomerGuideShell() {
             <p className="mt-3 text-pretty text-sm leading-6 text-slate-600">{copy.subtitle}</p>
           </div>
           <div className="flex flex-wrap gap-2">
-            <button
-              type="button"
-              onClick={() => router.push('/')}
+            <Link
+              href="/"
+              prefetch={false}
+              onClick={(event) => handleHardNavigation(event, '/')}
+              data-testid="guide-back-button"
               className="inline-flex min-h-11 items-center gap-2 rounded-full border border-slate-300 bg-white px-4 py-2 text-sm font-medium text-slate-900 transition-colors hover:bg-slate-50"
             >
               <ArrowLeft className="size-4" aria-hidden="true" />
               {copy.back}
-            </button>
-            <button
-              type="button"
-              onClick={() => handleLanguageChange(language === 'ja' ? 'en' : 'ja')}
+            </Link>
+            <Link
+              href={languageHref}
+              prefetch={false}
+              onClick={(event) => handleHardNavigation(event, languageHref)}
+              data-testid="guide-language-toggle"
               className="inline-flex min-h-11 items-center gap-2 rounded-full bg-slate-900 px-4 py-2 text-sm font-medium text-white transition-colors hover:bg-slate-800"
             >
               <Languages className="size-4" aria-hidden="true" />
               {copy.toggle}
-            </button>
+            </Link>
           </div>
         </header>
 

--- a/frontend/src/app/guide/page.tsx
+++ b/frontend/src/app/guide/page.tsx
@@ -1,5 +1,16 @@
 import CustomerGuideShell from '@/app/components/presentation/CustomerGuideShell';
 
-export default function GuidePage() {
-  return <CustomerGuideShell />;
+interface GuidePageProps {
+  searchParams: Promise<{
+    autoplay?: string;
+    lang?: string;
+  }>;
+}
+
+export default async function GuidePage({ searchParams }: GuidePageProps) {
+  const params = await searchParams;
+  const language = params.lang === 'en' ? 'en' : 'ja';
+  const autoPlay = params.autoplay === '1';
+
+  return <CustomerGuideShell language={language} autoPlay={autoPlay} />;
 }

--- a/frontend/src/app/onboarding/page.tsx
+++ b/frontend/src/app/onboarding/page.tsx
@@ -1,5 +1,16 @@
 import CustomerGuideShell from '@/app/components/presentation/CustomerGuideShell';
 
-export default function OnboardingPage() {
-  return <CustomerGuideShell />;
+interface OnboardingPageProps {
+  searchParams: Promise<{
+    autoplay?: string;
+    lang?: string;
+  }>;
+}
+
+export default async function OnboardingPage({ searchParams }: OnboardingPageProps) {
+  const params = await searchParams;
+  const language = params.lang === 'en' ? 'en' : 'ja';
+  const autoPlay = params.autoplay === '1';
+
+  return <CustomerGuideShell language={language} autoPlay={autoPlay} />;
 }

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -177,9 +177,10 @@ function KioskVoiceStatusStack({
     isLoading && response.length > 0 && sessionState !== 'speaking';
   const isErrorVisible = Boolean(error) && errorVisibleUntil > now;
   const isOcrStatusVisible = Boolean(ocrStatus && ocrStatus.visibleUntil > now);
+  const displayResponse = response || (sessionState === 'idle' && !response ? labels.defaultPrompt : '');
   const isResponseVisible =
-    response.length > 0 &&
-    (sessionState === 'speaking' || responseVisibleUntil > now);
+    displayResponse.length > 0 &&
+    (sessionState === 'speaking' || responseVisibleUntil > now || !response);
   const isTranscriptVisible =
     transcript.length > 0 && !isSttLoading && transcriptVisibleUntil > now;
 
@@ -228,10 +229,15 @@ function KioskVoiceStatusStack({
         </div>
       ) : null}
       {isResponseVisible ? (
-        <div className="flex w-full items-center gap-2 rounded-xl border border-white/30 bg-black/35 px-4 py-2 text-sm font-medium text-white/95 shadow-sm backdrop-blur-sm">
+        <div
+          className="flex w-full items-center gap-2 rounded-xl border border-white/30 bg-black/35 px-4 py-2 text-sm font-medium text-white/95 shadow-sm backdrop-blur-sm"
+          data-testid="response-bubble"
+        >
           <Volume2 className="size-4 shrink-0" />
-          <span>
-            {labels.responseLabel}: {response}
+          <span data-testid="response-text">
+            {response
+              ? `${labels.responseLabel}: ${response}`
+              : displayResponse}
           </span>
         </div>
       ) : null}

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -785,6 +785,7 @@ export default function Home() {
                   }}
                 >
                   <button
+                    data-testid="kiosk-settings-button"
                     type="button"
                     onClick={() => setShowSettingsPanel(true)}
                     aria-label={voice.currentLanguage === 'ja' ? '設定' : 'Settings'}
@@ -901,7 +902,7 @@ export default function Home() {
                 </div>
               ) : null}
 
-              {(kioskPhase === 'idle' || kioskPhase === 'voice') && (
+              {(kioskPhase === 'idle' || kioskPhase === 'voice' || kioskPhase === 'notice') && (
                 <div
                   className="pointer-events-auto absolute inset-x-0 bottom-0 z-[25] flex justify-center pb-[max(0.75rem,env(safe-area-inset-bottom))] pl-[max(1rem,env(safe-area-inset-left))] pr-[max(1rem,env(safe-area-inset-right))] pt-2"
                 >
@@ -934,7 +935,7 @@ export default function Home() {
                       return (
                         <>
                     <KioskVoiceStatusStack
-                      enabled={kioskPhase === 'voice' || kioskPhase === 'idle'}
+                      enabled={kioskPhase === 'voice' || kioskPhase === 'idle' || kioskPhase === 'notice'}
                       labels={labels}
                       transcript={voice.transcript}
                       response={voice.response}
@@ -967,6 +968,7 @@ export default function Home() {
                       </span>
                     </button>
                     <button
+                      data-testid="kiosk-voice-button"
                       type="button"
                       onPointerDown={(event) => {
                         if (!isPushToTalk) {
@@ -1066,6 +1068,7 @@ export default function Home() {
                       </span>
                     </button>
                     <button
+                      data-testid="kiosk-slides-button"
                       type="button"
                       onClick={() => {
                         markAudioUserInteraction();

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -75,6 +75,7 @@ type ConversationHistoryItem = {
 
 function KioskVoiceStatusStack({
   enabled,
+  phase,
   labels,
   transcript,
   response,
@@ -85,6 +86,7 @@ function KioskVoiceStatusStack({
   sessionState,
 }: {
   enabled: boolean;
+  phase: KioskPhase;
   labels: (typeof overlayLabels)['ja'] | (typeof overlayLabels)['en'];
   transcript: string;
   response: string;
@@ -100,21 +102,38 @@ function KioskVoiceStatusStack({
 }) {
   const [transcriptVisibleUntil, setTranscriptVisibleUntil] = useState<number>(0);
   const [responseVisibleUntil, setResponseVisibleUntil] = useState<number>(0);
+  const [defaultPromptVisibleUntil, setDefaultPromptVisibleUntil] = useState<number>(0);
   const [errorVisibleUntil, setErrorVisibleUntil] = useState<number>(0);
   const [now, setNow] = useState<number>(Date.now());
   const previousSessionStateRef = useRef<VoiceSessionState>(sessionState);
+  const previousPhaseRef = useRef<KioskPhase>(phase);
 
   useEffect(() => {
     if (!enabled) {
       setTranscriptVisibleUntil(0);
       setResponseVisibleUntil(0);
+      setDefaultPromptVisibleUntil(0);
       setErrorVisibleUntil(0);
+      previousPhaseRef.current = phase;
       return;
     }
     if (transcript.length > 0) {
       setTranscriptVisibleUntil(Date.now() + 5000);
     }
   }, [enabled, transcript]);
+
+  useEffect(() => {
+    if (!enabled) {
+      previousPhaseRef.current = phase;
+      return;
+    }
+
+    const previousPhase = previousPhaseRef.current;
+    if (phase === 'notice' || (previousPhase !== phase && phase === 'idle')) {
+      setDefaultPromptVisibleUntil(Date.now() + 5000);
+    }
+    previousPhaseRef.current = phase;
+  }, [enabled, phase]);
 
   useEffect(() => {
     if (!enabled) {
@@ -154,6 +173,9 @@ function KioskVoiceStatusStack({
     if (responseVisibleUntil > now) {
       timers.push(window.setTimeout(() => setNow(Date.now()), responseVisibleUntil - now));
     }
+    if (defaultPromptVisibleUntil > now) {
+      timers.push(window.setTimeout(() => setNow(Date.now()), defaultPromptVisibleUntil - now));
+    }
     if (errorVisibleUntil > now) {
       timers.push(window.setTimeout(() => setNow(Date.now()), errorVisibleUntil - now));
     }
@@ -163,7 +185,15 @@ function KioskVoiceStatusStack({
     return () => {
       timers.forEach((timerId) => window.clearTimeout(timerId));
     };
-  }, [enabled, errorVisibleUntil, now, ocrStatus, responseVisibleUntil, transcriptVisibleUntil]);
+  }, [
+    defaultPromptVisibleUntil,
+    enabled,
+    errorVisibleUntil,
+    now,
+    ocrStatus,
+    responseVisibleUntil,
+    transcriptVisibleUntil,
+  ]);
 
   if (!enabled) {
     return null;
@@ -177,10 +207,14 @@ function KioskVoiceStatusStack({
     isLoading && response.length > 0 && sessionState !== 'speaking';
   const isErrorVisible = Boolean(error) && errorVisibleUntil > now;
   const isOcrStatusVisible = Boolean(ocrStatus && ocrStatus.visibleUntil > now);
-  const displayResponse = response || (sessionState === 'idle' && !response ? labels.defaultPrompt : '');
+  const isDefaultPromptVisible =
+    response.length === 0 &&
+    sessionState === 'idle' &&
+    defaultPromptVisibleUntil > now;
+  const displayResponse = response || (isDefaultPromptVisible ? labels.defaultPrompt : '');
   const isResponseVisible =
     displayResponse.length > 0 &&
-    (sessionState === 'speaking' || responseVisibleUntil > now || !response);
+    (sessionState === 'speaking' || responseVisibleUntil > now || isDefaultPromptVisible);
   const isTranscriptVisible =
     transcript.length > 0 && !isSttLoading && transcriptVisibleUntil > now;
 
@@ -936,6 +970,7 @@ export default function Home() {
                         <>
                     <KioskVoiceStatusStack
                       enabled={kioskPhase === 'voice' || kioskPhase === 'idle' || kioskPhase === 'notice'}
+                      phase={kioskPhase}
                       labels={labels}
                       transcript={voice.transcript}
                       response={voice.response}


### PR DESCRIPTION
## 概要
- ナレッジ管理画面向けの Playwright E2E テストを追加しました
- オンボーディング / ガイド / MarpViewer 向けの Playwright E2E テストを追加しました
- E2E で安定して操作できるように、UI 側へ `data-testid` 追加やフォーム関連付けの修正を入れました
- `CustomerGuideShell` のクエリパラメータ処理を page 側に移し、build 時に落ちないよう修正しました
- `MarpViewer` の自動再生 / ナレーションまわりで古い非同期処理が state を壊さないように調整しました

## 追加したテスト項目

### Knowledge 一覧ページ
- エントリ一覧が表示される
- 新規作成リンクが `/admin/knowledge/new` に遷移する
- 言語フィルタで絞り込める
- 削除ダイアログを承認すると削除される
- 削除ダイアログをキャンセルすると削除されない

### Knowledge 新規作成ページ
- フォームが表示されてカテゴリ選択肢が読み込まれる
- タイトルが空だと保存できない
- コンテンツが空だと保存できない
- カテゴリを選択するとサブカテゴリが有効になる
- 正常に作成して一覧に遷移する
- キャンセルで一覧に戻る

### Knowledge 詳細ページ
- エントリ詳細が表示される
- 編集ボタンで編集モードに切り替わる
- 削除確認で一覧にリダイレクトされる
- 一覧に戻るリンクで一覧に遷移する

### Knowledge アップロードページ
- ページが表示されてファイル選択エリアがある
- Markdown ファイルを選択するとプレビューが表示される
- キャンセルで一覧に戻る

### MarpViewer / ガイド画面
- `/guide?lang=ja` でシェルとスライドが読み込まれる
- スライドカウンターが `1 / 3` と表示される
- 最初のスライドでは前へボタンが無効
- スライド2にいるとき前へボタンでスライド1に戻る
- リセットボタンでスライド1に戻る
- 再生ボタンをクリックするとナレーション API が呼ばれる
- 一時停止ボタンで再生が止まる
- `/guide?lang=ja` で日本語タイトルが表示される
- 英語切り替えボタンで `/onboarding?lang=en` に遷移する

### 既存導線の回帰確認
- ガイドから受付画面に戻れる
- オンボーディング画面で言語切り替えできる
- ホーム画面の主要 UI が表示される

## 実装修正
- ナレッジ編集フォームに `htmlFor` / `id` を付与し、ラベルとフォーム要素を正しく関連付けました
- 初期設定モーダルの閉じるボタン、kiosk の主要操作ボタン、ガイド画面の導線に `data-testid` を追加しました
- ガイド画面の戻る / 言語切り替え導線は、E2E で安定して扱えるように調整しました
- `CustomerGuideShell` は `useSearchParams()` 依存をやめ、`page.tsx` 側から `language` / `autoPlay` を受け取る構成に変更しました
- `MarpViewer` は autoplay / narration / slide 初期化の古い非同期処理が新しい state を上書きしないよう、session ベースのガードを追加しました

## 確認
- `pnpm build`

## 補足
- issue #192 のうち、現時点で着手可能なナレッジ UI とガイド / スライド UI のテスト整備を対象にしています
- issue コメントの最新ステータスに合わせて、未解消の前提条件がある統合フロー全体のテストは今回の対象外です
