### PR TITLE
docs: Wave 7 アーキテクチャドキュメント更新

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -82,12 +82,17 @@ The backend uses **LangGraph** with a Supervisor Pattern:
 - RAG: EnhancedRAGSearch with Supabase RPC `search_knowledge_base()` + Tavily web search fallback
 - Embeddings: OpenRouter API (`openai/text-embedding-3-small`, 1536 dimensions)
 
+**Reception subgraph (Wave 7, PR #390)**: Reception handling is a first-class LangGraph subgraph. The three previously separate implementations (main_workflow.py inline handlers, reception_workflow.py standalone, api/reception.py) are unified. `reception_workflow.py` is invoked via `invoke_reception_subgraph()` with explicit state conversion functions. `api/reception.py` uses a singleton workflow instance (protected by `asyncio.Lock`). `consultation` routes to `general_knowledge` (not `business_info`).
+
+**Multilingual RAG — tRAG pattern (Wave 7, PR #389)**: The knowledge base is Japanese-only. For English queries, tRAG translates to Japanese before embedding lookup and sets `language="ja"` on the RAG call. Chinese and Korean queries skip translation and use cross-lingual embeddings directly. `text_fallback_search` always filters by `"ja"`. Entity labels and advice templates support en/zh/ko. RAGAS targets: ja >= 0.85, en >= 0.75, zh/ko >= 0.65 (answer_correctness).
+
 The frontend is a **pure UI layer** — all AI processing is proxied to the backend via `backendFetch()`.
 
 ### Key Data Flow
 
 - Voice: Browser → `/api/voice` (FE proxy) → Backend STT/TTS → Browser
 - Q&A: Browser → `/api/qa` (FE proxy) → Backend `/api/chat` → LangGraph → RAG/Web search → Response
+- Reception: Browser → `/api/reception/*` (FE proxy) → Backend → `invoke_reception_subgraph()` → LangGraph reception subgraph → Response
 - Calendar: Browser → `/api/calendar` (FE proxy) → Backend `/api/calendar` → Google Calendar ICS
 - Slides: Marp markdown in `frontend/src/slides/` → `/api/marp` renders HTML → MarpViewer component
 

--- a/backend/README.md
+++ b/backend/README.md
@@ -34,11 +34,14 @@ Notable implementation details:
 
 - API-key protection exists, but becomes optional only in local/dev environments without `API_SECRET_KEY`; `staging`, `preview`, and `production` fail closed.
 - Rate limiting depends on `slowapi`; without it, the decorators become no-ops.
-- Reception session state is currently stored in process memory, not durable storage.
+- Reception session state is currently stored in process memory, not durable storage. The singleton workflow instance is protected by `asyncio.Lock` for thread safety.
 - Agent prompts include oral/conversational style instructions for natural TTS output.
 - `clean_text_for_tts` in `utils/text_utils.py` strips Markdown artifacts (headers, bold, lists, links, code blocks) before speech synthesis.
 - Recent STT fixes added WebM-to-WAV conversion, which means ffmpeg/runtime availability matters for some environments.
 - OrchestratorAgent gates on reception status before LLM routing — sessions with an active reception are handled by the reception workflow first.
+- Reception is implemented as a single LangGraph subgraph (`invoke_reception_subgraph()`). The previously separate inline handlers in `main_workflow.py` were removed in PR #390. `api/reception.py` uses a singleton workflow instance.
+- Multilingual RAG uses the tRAG pattern: English queries are translated to Japanese before the embedding lookup (`language="ja"`); Chinese and Korean queries use cross-lingual embeddings without translation. The knowledge base is Japanese-only.
+- `consultation` intent routes to `general_knowledge` (not `business_info`).
 - `POST /api/reception/complete` invokes `ainvoke_from_reception()` in the main workflow to generate an agent response using the full visitor context.
 - `POST /api/reception/start` accepts an optional `visitor_identity` field for OCR-pre-identified visitors.
 - `backend/utils/reception_status.py` provides the reception status checker used by the orchestrator gate.

--- a/docs/adr/006-langgraph-workflow-redesign.md
+++ b/docs/adr/006-langgraph-workflow-redesign.md
@@ -2,7 +2,7 @@
 
 ## Status
 
-Proposed (2026-03-28)
+Accepted (2026-03-29)
 
 ## Context
 
@@ -117,6 +117,40 @@ LangGraph ワークフローを再設計し、キーワード fast-path 導入�
 - 多言語 retrieval テストが全パス（en/zh/ko クエリで正しい結果を返す）
 - レイテンシ: FAQ クエリ < 500ms、通常クエリ < 3s
 - RAGAS answer_correctness >= 0.85（日本語）、>= 0.75（英語）
+
+## Implementation Notes
+
+What was actually implemented versus the original plan, as of 2026-03-29:
+
+### D1: キーワード Fast-Path — In Progress (#377)
+
+実装未着手。グラフ構造変更（reception_check → keyword_router 分岐）は Wave 7 後半で対応予定。
+
+### D2: Reception ワークフロー一本化 — DONE (PR #390)
+
+- `main_workflow.py` 内の `_handle_reception_gate()` と `_handle_reception_inline()` を削除（約200行削減）
+- `reception_workflow.py` を callable subgraph として昇格
+- 新関数 `workflow_state_to_reception_state()`、`reception_state_to_workflow_result()`、`invoke_reception_subgraph()` を追加
+- `api/reception.py` はシングルトンワークフローを使用（`asyncio.Lock` で保護）
+- `consultation` のルーティング先を `general_knowledge` に統一（plan 通り）
+
+### D3: 多言語RAG修正（tRAG） — DONE (PR #389)
+
+- 翻訳ガード変更: 英語クエリのみ日本語に翻訳してRAGを呼び出す（zh/ko はクロスリンガル埋め込みを直接使用し翻訳をスキップ）
+- `text_fallback_search` は常に `"ja"` でフィルタ（KB は日本語のみのため）
+- エンティティラベルとアドバイステンプレートを en/zh/ko に対応
+- 中国語・韓国語のグリーティングキーワードを追加
+- 新規テスト30件追加
+
+### D4: CRAG 強化 + bilingual FAQ — Partial (PR #391)
+
+- 多言語 RAGAS ベンチマークを追加: `ground_truth.json` に30件（en×10、zh×10、ko×10）
+- 新評価ランナー `run_multilingual_eval.py`（言語別スコア分解）
+- bilingual FAQ エントリの knowledge_base への追加は未実施
+
+### D5: D-RAG — Deferred (Phase 2, post 4/11)
+
+計画通り延期。日英クロスバリデーションは Phase 2 で対応。
 
 ## References
 


### PR DESCRIPTION
## Summary

- CLAUDE.md: Reception subgraph + tRAG multilingual sections追加
- ADR-006: Proposed → Accepted、Implementation Notes追加
- backend/README.md: singleton + routing更新

Relates to #378, #379, #382

Closes #376

🤖 Generated with [Claude Code](https://claude.com/claude-code)