### PR TITLE
fix(backend): Fast-Path分岐 — reception_check + keyword_router追加 #377

### DIFF
--- a/backend/tests/workflows/test_main_workflow.py
+++ b/backend/tests/workflows/test_main_workflow.py
@@ -9,6 +9,7 @@ import os
 from types import SimpleNamespace
 
 import pytest
+from backend.agents.orchestrator_agent import OrchestratorAgent
 from unittest.mock import MagicMock, Mock, AsyncMock, patch
 
 
@@ -19,6 +20,27 @@ def _mock_runtime():
     rt.context.user_id = "anonymous"
     rt.store = None
     return rt
+
+
+class _StubLanguageProcessor:
+    def detect_language(self, query: str) -> dict[str, object]:
+        detected = "ja" if any(ord(ch) > 127 for ch in query) else "en"
+        return {"detected": detected, "confidence": 1.0}
+
+    def determine_response_language(self, language_result: dict[str, object]) -> str:
+        return str(language_result["detected"])
+
+
+class _StubOrchestrator:
+    def __init__(self) -> None:
+        self.language_processor = _StubLanguageProcessor()
+        self.decide_next_agent = AsyncMock()
+
+    def _try_fast_routing(self, query: str):
+        return OrchestratorAgent._try_fast_routing(self, query)
+
+    def _is_memory_related_question(self, query: str) -> bool:
+        return OrchestratorAgent._is_memory_related_question(self, query)
 
 
 class TestMainWorkflowMemoryIntegration:
@@ -734,6 +756,95 @@ class TestOrchestratorIntegration:
             assert result["metadata"]["vrm_control"] is None
             assert result["metadata"]["lipsync_data"] == []
             assert result["messages"][-1].content == "9時から22時です。"
+
+    @pytest.mark.asyncio
+    @patch("backend.workflows.main_workflow.OrchestratorAgent")
+    async def test_reception_check_node_marks_active_session(self, mock_orchestrator_class):
+        from backend.workflows.main_workflow import MainWorkflow
+
+        mock_orchestrator_class.return_value = _StubOrchestrator()
+        workflow = MainWorkflow()
+
+        with patch(
+            "backend.utils.reception_status.check_reception_status",
+            new=AsyncMock(return_value={"completed": False, "stage": "greeting"}),
+        ):
+            result = await workflow._reception_check_node({"session_id": "reception-session"})
+
+        assert result["reception_status"]["stage"] == "greeting"
+        assert workflow._reception_check_decision(result) == "active_reception"
+
+    @pytest.mark.asyncio
+    @patch("backend.workflows.main_workflow.OrchestratorAgent")
+    async def test_keyword_router_fast_routes_wifi_query(self, mock_orchestrator_class):
+        from backend.workflows.main_workflow import MainWorkflow
+
+        mock_orchestrator_class.return_value = _StubOrchestrator()
+
+        with patch("backend.utils.memory_helper.get_memory_helper") as mock_get_helper:
+            mock_helper = AsyncMock()
+            mock_helper.store_message = AsyncMock()
+            mock_get_helper.return_value = mock_helper
+
+            workflow = MainWorkflow()
+            result = await workflow._keyword_router_node(
+                {
+                    "query": "WiFiのパスワードは？",
+                    "session_id": "fast-router-session",
+                    "language": "ja",
+                    "routing": {},
+                }
+            )
+
+        assert result["routing"]["pre_memory_fast_path_agent"] == "facility"
+        assert result["routing"]["request_type"] == "wifi"
+        mock_helper.store_message.assert_awaited_once_with(
+            session_id="fast-router-session",
+            role="user",
+            content="WiFiのパスワードは？",
+        )
+
+    @pytest.mark.asyncio
+    @patch("backend.workflows.main_workflow.OrchestratorAgent")
+    async def test_keyword_router_keeps_anaphora_on_normal_path(self, mock_orchestrator_class):
+        from backend.workflows.main_workflow import MainWorkflow
+
+        mock_orchestrator_class.return_value = _StubOrchestrator()
+        workflow = MainWorkflow()
+
+        result = await workflow._keyword_router_node(
+            {
+                "query": "それについてもう少し教えて",
+                "session_id": "anaphora-session",
+                "language": "ja",
+                "routing": {},
+            }
+        )
+
+        assert result["routing"]["pre_memory_fast_path_agent"] is None
+        assert workflow._keyword_router_decision({"routing": result["routing"]}) == "normal"
+
+    @pytest.mark.asyncio
+    @patch("backend.workflows.main_workflow.OrchestratorAgent")
+    async def test_keyword_router_keeps_mixed_intent_greeting_on_normal_path(
+        self, mock_orchestrator_class
+    ):
+        from backend.workflows.main_workflow import MainWorkflow
+
+        mock_orchestrator_class.return_value = _StubOrchestrator()
+        workflow = MainWorkflow()
+
+        result = await workflow._keyword_router_node(
+            {
+                "query": "hello wifi?",
+                "session_id": "mixed-intent-session",
+                "language": "en",
+                "routing": {},
+            }
+        )
+
+        assert result["routing"]["pre_memory_fast_path_agent"] is None
+        assert workflow._keyword_router_decision({"routing": result["routing"]}) == "normal"
 
 
 class TestAsyncWorkflowMethods:

--- a/backend/tests/workflows/test_multi_agent_scenarios.py
+++ b/backend/tests/workflows/test_multi_agent_scenarios.py
@@ -15,7 +15,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 from langgraph.checkpoint.memory import MemorySaver
 
-from backend.agents.orchestrator_agent import OrchestratorDecision
+from backend.agents.orchestrator_agent import OrchestratorAgent, OrchestratorDecision
 
 # ---------------------------------------------------------------------------
 # Shared fixtures
@@ -83,6 +83,27 @@ def _make_context_priority_mock():
     return mock_engine
 
 
+class _StubLanguageProcessor:
+    def detect_language(self, query: str) -> dict[str, object]:
+        detected = "ja" if any(ord(ch) > 127 for ch in query) else "en"
+        return {"detected": detected, "confidence": 1.0}
+
+    def determine_response_language(self, language_result: dict[str, object]) -> str:
+        return str(language_result["detected"])
+
+
+class _StubOrchestrator:
+    def __init__(self) -> None:
+        self.language_processor = _StubLanguageProcessor()
+        self.decide_next_agent = AsyncMock()
+
+    def _try_fast_routing(self, query: str):
+        return OrchestratorAgent._try_fast_routing(self, query)
+
+    def _is_memory_related_question(self, query: str) -> bool:
+        return OrchestratorAgent._is_memory_related_question(self, query)
+
+
 @contextmanager
 def _patch_memory_loader_deps():
     """memory_loader_node 内でインポートされる依存のパッチ一式
@@ -125,6 +146,116 @@ def _patch_memory_loader_deps_with_category(category):
         ),
     ):
         yield
+
+
+# ===========================================================================
+# Scenario 0: Pre-memory graph split
+# ===========================================================================
+
+
+class TestPreMemoryRoutingScenario:
+    @patch("backend.utils.memory_helper.get_memory_helper")
+    @patch("backend.workflows.main_workflow.OrchestratorAgent")
+    async def test_fast_path_wifi_skips_memory_loader(
+        self,
+        mock_orchestrator_class,
+        mock_get_helper,
+    ):
+        from backend.workflows.main_workflow import MainWorkflow
+
+        stub_orchestrator = _StubOrchestrator()
+        stub_orchestrator.decide_next_agent.side_effect = AssertionError(
+            "orchestrator should not run on pre-memory fast path"
+        )
+        mock_orchestrator_class.return_value = stub_orchestrator
+
+        mock_helper = _make_memory_helper_mock()
+        mock_get_helper.return_value = mock_helper
+
+        checkpointer = MemorySaver()
+
+        with patch(
+            "backend.utils.reception_status.check_reception_status",
+            new=AsyncMock(return_value={"completed": True, "stage": "none"}),
+        ):
+            workflow = MainWorkflow(checkpointer=checkpointer)
+            workflow._facility_agent.answer_facility_query = AsyncMock(
+                return_value={
+                    "answer": "WiFi is available. Please ask reception for the password.",
+                    "emotion": "happy",
+                    "metadata": {"agent": "FacilityAgent", "status": "success"},
+                }
+            )
+
+            result = await workflow.ainvoke(
+                {
+                    "query": "WiFiのパスワードは？",
+                    "session_id": "fast-path-1",
+                    "language": "ja",
+                }
+            )
+
+        assert result["answer"] == "WiFi is available. Please ask reception for the password."
+        workflow._facility_agent.answer_facility_query.assert_awaited_once()
+        mock_helper.get_context.assert_not_awaited()
+
+        store_calls = mock_helper.store_message.await_args_list
+        assert len(store_calls) == 2
+        assert store_calls[0].kwargs["role"] == "user"
+        assert store_calls[0].kwargs["content"] == "WiFiのパスワードは？"
+        assert store_calls[1].kwargs["role"] == "assistant"
+        stub_orchestrator.decide_next_agent.assert_not_awaited()
+
+    @patch("backend.utils.memory_helper.get_memory_helper")
+    @patch("backend.workflows.main_workflow.OrchestratorAgent")
+    async def test_active_reception_always_uses_normal_path(
+        self,
+        mock_orchestrator_class,
+        mock_get_helper,
+    ):
+        from backend.workflows.main_workflow import MainWorkflow
+
+        stub_orchestrator = _StubOrchestrator()
+        stub_orchestrator.decide_next_agent.side_effect = AssertionError(
+            "active reception should short-circuit before LLM routing"
+        )
+        mock_orchestrator_class.return_value = stub_orchestrator
+
+        mock_helper = _make_memory_helper_mock()
+        mock_get_helper.return_value = mock_helper
+
+        checkpointer = MemorySaver()
+
+        with (
+            _patch_memory_loader_deps(),
+            patch(
+                "backend.utils.reception_status.check_reception_status",
+                new=AsyncMock(return_value={"completed": False, "stage": "purpose_hearing"}),
+            ),
+            patch(
+                "backend.workflows.reception_workflow.invoke_reception_subgraph",
+                new=AsyncMock(
+                    return_value={
+                        "answer": "受付フローを続けます。ご用件を教えてください。",
+                        "emotion": "neutral",
+                        "metadata": {"reception_stage": "purpose_hearing"},
+                    }
+                ),
+            ),
+        ):
+            workflow = MainWorkflow(checkpointer=checkpointer)
+
+            result = await workflow.ainvoke(
+                {
+                    "query": "WiFiのパスワードは？",
+                    "session_id": "active-reception-1",
+                    "language": "ja",
+                }
+            )
+
+        assert result["answer"] == "受付フローを続けます。ご用件を教えてください。"
+        mock_helper.get_context.assert_awaited_once()
+        stub_orchestrator.decide_next_agent.assert_not_awaited()
 
 
 # ===========================================================================

--- a/backend/workflows/main_workflow.py
+++ b/backend/workflows/main_workflow.py
@@ -33,6 +33,8 @@ from backend.agents.orchestrator_agent import (
     OrchestratorDecision,
     RoutingTarget,
 )
+from backend.agents.orchestrator_agent import OrchestratorAgent as RoutingLogicAgent
+from backend.config.routing_constants import GREETING_KEYWORDS, match_keywords
 
 logger = logging.getLogger(__name__)
 
@@ -52,6 +54,7 @@ class WorkflowStateDict(TypedDict):
     emotion: Optional[str]
     metadata: dict
     context: dict
+    reception_status: dict
     image_data: Optional[Any]  # np.ndarray (optional vision input)
     ocr_result: Optional[dict]  # OCR result from VisionAgent
 
@@ -175,6 +178,22 @@ class MainWorkflow:
         "space-clarification-needed",
         "general-clarification-needed",
     )
+    _PRE_MEMORY_DIRECT_AGENTS = {"facility"}
+    _PRE_MEMORY_INLINE_CATEGORIES = {"emergency", "greeting", *_CLARIFICATION_CATEGORIES}
+    _ANAPHORA_MARKERS = (
+        "それについて",
+        "それって",
+        "それのこと",
+        "あれについて",
+        "これについて",
+        "that one",
+        "about that",
+        "about it",
+        "more about that",
+        "more about it",
+        "tell me more about that",
+        "tell me more about it",
+    )
 
     def _build_graph(self) -> StateGraph:
         """Supervisor Patternに基づくグラフ構造を構築"""
@@ -185,6 +204,8 @@ class MainWorkflow:
 
         # ノードの追加
         # memory_loader, format_response: LLM非依存のためリトライ不要
+        workflow.add_node("reception_check", self._reception_check_node)
+        workflow.add_node("keyword_router", self._keyword_router_node)
         workflow.add_node("memory_loader", self._memory_loader_node)
         workflow.add_node("vision", self._vision_node, retry_policy=llm_retry)
         workflow.add_node("format_response", self._format_response_node)
@@ -199,13 +220,29 @@ class MainWorkflow:
         workflow.add_node("farewell", self._farewell_node, retry_policy=llm_retry)
 
         # エッジの定義（Supervisor Pattern）
-        # START → (text: memory_loader, image: vision) → memory_loader → orchestrator
+        # START → (text: reception_check, image: vision)
         workflow.add_conditional_edges(
             START,
             self._input_type_decision,
             {
-                "text": "memory_loader",
+                "text": "reception_check",
                 "image": "vision",
+            },
+        )
+        workflow.add_conditional_edges(
+            "reception_check",
+            self._reception_check_decision,
+            {
+                "active_reception": "memory_loader",
+                "no_reception": "keyword_router",
+            },
+        )
+        workflow.add_conditional_edges(
+            "keyword_router",
+            self._keyword_router_decision,
+            {
+                "normal": "memory_loader",
+                "facility": "facility",
             },
         )
         workflow.add_edge("vision", "memory_loader")
@@ -238,6 +275,145 @@ class MainWorkflow:
         if state.get("image_data") is not None:
             return "image"
         return "text"
+
+    @staticmethod
+    def _reception_is_active(reception_status: Optional[dict[str, Any]]) -> bool:
+        if not reception_status:
+            return False
+        return not reception_status.get("completed") and reception_status.get("stage") not in (
+            "none",
+            "error",
+        )
+
+    def _has_mixed_intent_greeting(self, query: str) -> bool:
+        lower_query = query.lower().strip()
+        if not match_keywords(lower_query, GREETING_KEYWORDS):
+            return False
+
+        remaining = lower_query
+        for keyword in sorted(GREETING_KEYWORDS, key=len, reverse=True):
+            remaining = remaining.replace(keyword.lower(), " ").strip()
+
+        remaining = remaining.strip("!！?？。、.,  ")
+        return len(remaining) > 3
+
+    def _requires_memory_loader_before_fast_path(self, query: str) -> bool:
+        stripped_query = query.strip()
+        lower_query = stripped_query.lower()
+
+        if len(stripped_query) < 5:
+            return True
+
+        if any(marker in lower_query for marker in self._ANAPHORA_MARKERS):
+            return True
+
+        if self._has_mixed_intent_greeting(stripped_query):
+            return True
+
+        return RoutingLogicAgent._is_memory_related_question(self, stripped_query)
+
+    def _get_response_language(self, query: str, fallback_language: str) -> str:
+        from backend.utils.language_processor import LanguageProcessor
+
+        language_processor = LanguageProcessor()
+        language_result = language_processor.detect_language(query)
+        response_language = language_processor.determine_response_language(language_result)
+        return response_language or fallback_language
+
+    async def _store_fast_path_user_message(self, session_id: str, query: str) -> None:
+        if not session_id or not query:
+            return
+
+        try:
+            from backend.utils.memory_helper import get_memory_helper
+
+            memory_helper = get_memory_helper()
+            await memory_helper.store_message(
+                session_id=session_id,
+                role="user",
+                content=query,
+            )
+        except Exception as exc:
+            logger.warning("Failed to store fast-path user message: %s", exc)
+
+    async def _reception_check_node(self, state: WorkflowStateDict) -> dict[str, Any]:
+        from backend.utils.reception_status import check_reception_status
+
+        session_id = state.get("session_id", "")
+        reception_status = await check_reception_status(session_id)
+        return {"reception_status": reception_status}
+
+    def _reception_check_decision(self, state: WorkflowStateDict) -> str:
+        if self._reception_is_active(state.get("reception_status")):
+            return "active_reception"
+        return "no_reception"
+
+    async def _keyword_router_node(self, state: WorkflowStateDict) -> dict[str, Any]:
+        query = state.get("query", "")
+        fallback_language = state.get("language", "ja")
+
+        if self._requires_memory_loader_before_fast_path(query):
+            return {"routing": {**state.get("routing", {}), "pre_memory_fast_path_agent": None}}
+
+        response_language = self._get_response_language(query, fallback_language)
+        fast_route = RoutingLogicAgent._try_fast_routing(self, query)
+        if fast_route is None:
+            return {
+                "language": response_language,
+                "routing": {**state.get("routing", {}), "pre_memory_fast_path_agent": None},
+            }
+
+        if fast_route["category"] in self._PRE_MEMORY_INLINE_CATEGORIES:
+            return {
+                "language": response_language,
+                "routing": {**state.get("routing", {}), "pre_memory_fast_path_agent": None},
+            }
+
+        try:
+            from backend.utils.topic_guard import check_topic_adherence
+
+            on_topic, _ = check_topic_adherence(
+                query=query,
+                routing_category=fast_route["category"],
+                language=response_language,
+            )
+            if not on_topic:
+                return {
+                    "language": response_language,
+                    "routing": {**state.get("routing", {}), "pre_memory_fast_path_agent": None},
+                }
+        except Exception as guard_err:
+            logger.debug("Pre-memory topic guard skipped: %s", guard_err)
+
+        fast_path_agent = fast_route["agent"]
+        if fast_path_agent not in self._PRE_MEMORY_DIRECT_AGENTS:
+            return {
+                "language": response_language,
+                "routing": {**state.get("routing", {}), "pre_memory_fast_path_agent": None},
+            }
+
+        await self._store_fast_path_user_message(state.get("session_id", ""), query)
+
+        return {
+            "language": response_language,
+            "routing": {
+                **state.get("routing", {}),
+                **fast_route,
+                "pre_memory_fast_path_agent": fast_path_agent,
+                "confidence": 0.9,
+                "debug_info": {
+                    "fast_path": True,
+                    "path": "keyword_router",
+                },
+            },
+        }
+
+    def _keyword_router_decision(self, state: WorkflowStateDict) -> str:
+        routing = state.get("routing", {})
+        fast_path_agent = routing.get("pre_memory_fast_path_agent")
+        if fast_path_agent in self._PRE_MEMORY_DIRECT_AGENTS:
+            return cast(str, fast_path_agent)
+        return "normal"
 
     async def _vision_node(self, state: WorkflowStateDict) -> dict:
         """ビジョンノード: 画像からOCR/表情認識を実行し、queryに変換"""
@@ -657,11 +833,11 @@ class MainWorkflow:
         session_id = state.get("session_id", "")
 
         # --- Reception status gate (before LLM call) ---
-        reception_status = await check_reception_status(session_id)
-        if not reception_status.get("completed") and reception_status.get("stage") not in (
-            "none",
-            "error",
-        ):
+        reception_status = state.get("reception_status")
+        if reception_status is None or not reception_status:
+            reception_status = await check_reception_status(session_id)
+
+        if self._reception_is_active(reception_status):
             reception_result = await invoke_reception_subgraph(
                 state,
                 reception_status,
@@ -1155,6 +1331,7 @@ class MainWorkflow:
             "emotion": None,
             "metadata": {},
             "context": input_data.get("context", {}),
+            "reception_status": {},
             "image_data": self._decode_image_data(raw_image) if raw_image is not None else None,
             "ocr_result": None,
         }


### PR DESCRIPTION
## Summary
- Added `reception_check` and `keyword_router` graph nodes before `memory_loader` in the LangGraph main workflow
- FAQ queries (e.g., WiFi password) that match keyword routing now skip `memory_loader` for faster response
- Guards ensure anaphora ("それについて"), mixed-intent greetings, short queries (<5 chars), and memory-related questions fall back to the normal path through `memory_loader`
- Reception sessions always take the normal path (reception_check gates first)
- 55 workflow tests pass, ruff + black clean

## Implementation Details
- `reception_check` node: checks reception status via `check_reception_status()`, routes active sessions to `memory_loader`
- `keyword_router` node: uses `OrchestratorAgent._try_fast_routing()` for keyword matching, then applies guards before allowing fast-path
- Only `facility` agent is currently in `_PRE_MEMORY_DIRECT_AGENTS` (conservative rollout)
- Fast-path stores user message via `_store_fast_path_user_message()` to maintain conversation history
- `topic_guard` check is applied before fast-path to prevent off-topic routing

## Graph Flow
```
START → reception_check → (active_reception → memory_loader, no_reception → keyword_router)
keyword_router → (normal → memory_loader, facility → facility_node)
```

## Test Plan
- [x] `test_reception_check_node_marks_active_session` — active reception routes correctly
- [x] `test_keyword_router_fast_routes_wifi_query` — WiFi query hits fast-path
- [x] `test_keyword_router_keeps_anaphora_on_normal_path` — anaphora guarded
- [x] `test_keyword_router_keeps_mixed_intent_greeting_on_normal_path` — mixed intent guarded
- [x] `test_fast_path_wifi_skips_memory_loader` — end-to-end fast-path verification
- [x] `test_active_reception_always_uses_normal_path` — reception priority verified
- [x] All 55 workflow tests pass
- [x] ruff + black clean

Closes #377

Generated with [Claude Code](https://claude.com/claude-code)