### PR TITLE
feat: M5Stack sensor trigger → Frontend welcome polling bridge (#404)

### DIFF
--- a/backend/api/reception.py
+++ b/backend/api/reception.py
@@ -90,6 +90,7 @@ def _reset_session_storage() -> None:
     _session_repository = None
     _active_sessions.clear()
     _sensor_trigger_cooldowns.clear()
+    _latest_sensor_events.clear()
 
 
 def _serialize_session(session: ReceptionSession, *, status: str = "active") -> dict[str, Any]:
@@ -317,12 +318,22 @@ class SensorTriggerResponse(BaseModel):
     message: Optional[str] = None
 
 
+class SensorStatusResponse(BaseModel):
+    triggered: bool
+    device_id: Optional[str] = None
+    sensor_type: Optional[str] = None
+    distance_mm: Optional[int] = None
+    timestamp: Optional[float] = None
+
+
 # ---------------------------------------------------------------------------
 # Per-device rate limiting for sensor triggers
 # ---------------------------------------------------------------------------
 
 _sensor_trigger_cooldowns: dict[str, float] = {}
+_latest_sensor_events: dict[str, dict[str, Any]] = {}
 SENSOR_TRIGGER_RATE_LIMIT_SECONDS = 5
+SENSOR_TRIGGER_EVENT_TTL_SECONDS = 30
 
 
 @reception_router.post("/sensor-trigger", response_model=SensorTriggerResponse)
@@ -337,6 +348,12 @@ async def sensor_trigger(request: SensorTriggerRequest) -> SensorTriggerResponse
             message=f"Device {request.device_id} is rate limited",
         )
     _sensor_trigger_cooldowns[request.device_id] = now
+    _latest_sensor_events[request.device_id] = {
+        "device_id": request.device_id,
+        "sensor_type": request.sensor_type,
+        "distance_mm": request.distance_mm,
+        "timestamp": now,
+    }
 
     logger.info(
         "Sensor trigger received: device=%s sensor=%s distance=%dmm",
@@ -349,6 +366,34 @@ async def sensor_trigger(request: SensorTriggerRequest) -> SensorTriggerResponse
         action="trigger_received",
         message=f"Sensor trigger from {request.device_id} acknowledged",
     )
+
+
+@reception_router.get(
+    "/sensor-status",
+    response_model=SensorStatusResponse,
+    response_model_exclude_none=True,
+)
+async def get_sensor_status(
+    device_id: str = Query(default="m5stack-001", max_length=100),
+    since: float = Query(default=0),
+) -> SensorStatusResponse:
+    """Return whether a new sensor trigger exists for polling clients.
+
+    Note: this uses in-memory storage and only reflects events seen by the
+    current Cloud Run instance.
+    """
+    event = _latest_sensor_events.get(device_id)
+    if event is None:
+        return SensorStatusResponse(triggered=False)
+
+    if time.time() - float(event["timestamp"]) > SENSOR_TRIGGER_EVENT_TTL_SECONDS:
+        _latest_sensor_events.pop(device_id, None)
+        return SensorStatusResponse(triggered=False)
+
+    if float(event["timestamp"]) <= since:
+        return SensorStatusResponse(triggered=False)
+
+    return SensorStatusResponse(triggered=True, **event)
 
 
 @reception_router.post("/start", response_model=ReceptionStartResponse)

--- a/backend/api/reception.py
+++ b/backend/api/reception.py
@@ -354,6 +354,12 @@ async def sensor_trigger(request: SensorTriggerRequest) -> SensorTriggerResponse
         "distance_mm": request.distance_mm,
         "timestamp": now,
     }
+    try:
+        await _get_session_repository().store_sensor_event(
+            request.device_id, request.sensor_type, request.distance_mm
+        )
+    except Exception as exc:
+        logger.warning("Sensor event persistence failed; in-memory only: %s", exc)
 
     logger.info(
         "Sensor trigger received: device=%s sensor=%s distance=%dmm",
@@ -379,9 +385,34 @@ async def get_sensor_status(
 ) -> SensorStatusResponse:
     """Return whether a new sensor trigger exists for polling clients.
 
-    Note: this uses in-memory storage and only reflects events seen by the
-    current Cloud Run instance.
+    Reads from Supabase first (shared across Cloud Run instances),
+    falling back to in-memory storage when the database is unavailable.
     """
+    # Try Supabase first (shared across Cloud Run instances)
+    try:
+        record = await _get_session_repository().get_latest_sensor_event(
+            device_id, since_epoch=since
+        )
+        if record is not None:
+            triggered_at = record["triggered_at"]
+            if isinstance(triggered_at, str):
+                from datetime import datetime as _dt, timezone as _tz
+
+                triggered_at = _dt.fromisoformat(triggered_at).replace(tzinfo=_tz.utc)
+            event_epoch = triggered_at.timestamp()
+            if event_epoch <= since:
+                return SensorStatusResponse(triggered=False)
+            return SensorStatusResponse(
+                triggered=True,
+                device_id=device_id,
+                sensor_type=record["sensor_type"],
+                distance_mm=record["distance_mm"],
+                timestamp=event_epoch,
+            )
+    except Exception as exc:
+        logger.warning("Sensor status DB read failed; falling back to in-memory: %s", exc)
+
+    # Fallback: in-memory
     event = _latest_sensor_events.get(device_id)
     if event is None:
         return SensorStatusResponse(triggered=False)

--- a/backend/tests/api/test_reception_api.py
+++ b/backend/tests/api/test_reception_api.py
@@ -586,3 +586,46 @@ class TestSensorTriggerEndpoint:
         resp_b = client.post("/api/reception/sensor-trigger", json=payload_b)
         assert resp_b.status_code == 200
         assert resp_b.json()["success"] is True
+
+    def test_sensor_status_returns_new_event(self):
+        payload = {
+            "sensor_type": "tof",
+            "distance_mm": 500,
+            "device_id": "m5stack-status-test",
+        }
+
+        trigger_response = client.post("/api/reception/sensor-trigger", json=payload)
+        assert trigger_response.status_code == 200
+
+        status_response = client.get(
+            "/api/reception/sensor-status",
+            params={"device_id": payload["device_id"]},
+        )
+        assert status_response.status_code == 200
+        data = status_response.json()
+        assert data["triggered"] is True
+        assert data["device_id"] == payload["device_id"]
+        assert data["sensor_type"] == payload["sensor_type"]
+        assert data["distance_mm"] == payload["distance_mm"]
+        assert isinstance(data["timestamp"], float)
+
+    def test_sensor_status_ignores_already_seen_event(self):
+        payload = {
+            "sensor_type": "tof",
+            "distance_mm": 500,
+            "device_id": "m5stack-seen-test",
+        }
+
+        client.post("/api/reception/sensor-trigger", json=payload)
+        status_response = client.get(
+            "/api/reception/sensor-status",
+            params={"device_id": payload["device_id"]},
+        )
+        timestamp = status_response.json()["timestamp"]
+
+        seen_response = client.get(
+            "/api/reception/sensor-status",
+            params={"device_id": payload["device_id"], "since": timestamp},
+        )
+        assert seen_response.status_code == 200
+        assert seen_response.json() == {"triggered": False}

--- a/backend/tests/api/test_reception_api.py
+++ b/backend/tests/api/test_reception_api.py
@@ -95,6 +95,37 @@ def mock_canonical_classifier():
         yield
 
 
+@pytest.fixture(autouse=True)
+def mock_sensor_event_db():
+    """Stub Supabase sensor-event calls so tests run without a real DB."""
+    from backend.utils.reception_repository import ReceptionRepository
+
+    fake_repo = ReceptionRepository.__new__(ReceptionRepository)
+    fake_repo._supabase = None
+
+    async def _store_sensor_event(device_id, sensor_type, distance_mm):
+        pass  # no-op; in-memory path is what tests assert against
+
+    async def _get_latest_sensor_event(device_id, since_epoch=0):
+        return None  # forces in-memory fallback
+
+    fake_repo.store_sensor_event = _store_sensor_event
+    fake_repo.get_latest_sensor_event = _get_latest_sensor_event
+
+    # Delegate other calls to a real repository (mocked at method level elsewhere)
+    real_repo = ReceptionRepository()
+    fake_repo.store_session = real_repo.store_session
+    fake_repo.get_session_record = real_repo.get_session_record
+    fake_repo.get_session_by_conversation_id = real_repo.get_session_by_conversation_id
+    fake_repo.complete_session = real_repo.complete_session
+    fake_repo.list_active_sessions = real_repo.list_active_sessions
+    fake_repo.cleanup_expired = real_repo.cleanup_expired
+
+    reception_module._session_repository = fake_repo
+    yield
+    reception_module._session_repository = None
+
+
 def _start_session(session_id: str = "sess-001", language: str = "ja") -> dict:
     response = client.post(
         "/api/reception/start",

--- a/backend/tests/api/test_reception_persistence.py
+++ b/backend/tests/api/test_reception_persistence.py
@@ -57,6 +57,10 @@ class _FakeTableQuery:
         self._filters.append(("lt", column, value))
         return self
 
+    def gt(self, column: str, value: Any) -> _FakeTableQuery:
+        self._filters.append(("gt", column, value))
+        return self
+
     def order(self, column: str, desc: bool = False) -> _FakeTableQuery:
         self._order_by = (column, desc)
         return self
@@ -113,6 +117,9 @@ class _FakeTableQuery:
                 return False
             if operation == "lt":
                 if _parse_timestamp(actual) >= _parse_timestamp(expected):
+                    return False
+            if operation == "gt":
+                if _parse_timestamp(actual) <= _parse_timestamp(expected):
                     return False
         return True
 
@@ -237,6 +244,72 @@ async def test_repository_cleanup_expired_sessions() -> None:
     assert expired_count == 1
     assert fake_client.storage["reception_sessions"]["expired-session"]["status"] == "expired"
     assert [row["id"] for row in active_sessions] == ["active-session"]
+
+
+@pytest.mark.asyncio
+async def test_repository_get_latest_sensor_event_returns_fresh_event_only() -> None:
+    fake_client = _FakeSupabaseClient()
+    repo = ReceptionRepository(fake_client)  # type: ignore[arg-type]
+
+    fake_client.storage["sensor_events"] = {
+        "1": {
+            "id": 1,
+            "device_id": "m5stack-001",
+            "sensor_type": "pir_sr04",
+            "distance_mm": 65,
+            "triggered_at": datetime.now(timezone.utc).isoformat(),
+        }
+    }
+
+    event = await repo.get_latest_sensor_event("m5stack-001")
+
+    assert event is not None
+    assert event["device_id"] == "m5stack-001"
+    assert event["distance_mm"] == 65
+
+
+@pytest.mark.asyncio
+async def test_repository_get_latest_sensor_event_ignores_stale_event() -> None:
+    fake_client = _FakeSupabaseClient()
+    repo = ReceptionRepository(fake_client)  # type: ignore[arg-type]
+
+    fake_client.storage["sensor_events"] = {
+        "1": {
+            "id": 1,
+            "device_id": "m5stack-001",
+            "sensor_type": "pir_sr04",
+            "distance_mm": 65,
+            "triggered_at": (datetime.now(timezone.utc) - timedelta(minutes=5)).isoformat(),
+        }
+    }
+
+    event = await repo.get_latest_sensor_event("m5stack-001")
+
+    assert event is None
+
+
+@pytest.mark.asyncio
+async def test_repository_get_latest_sensor_event_respects_since_epoch() -> None:
+    fake_client = _FakeSupabaseClient()
+    repo = ReceptionRepository(fake_client)  # type: ignore[arg-type]
+    triggered_at = datetime.now(timezone.utc) - timedelta(seconds=5)
+
+    fake_client.storage["sensor_events"] = {
+        "1": {
+            "id": 1,
+            "device_id": "m5stack-001",
+            "sensor_type": "pir_sr04",
+            "distance_mm": 65,
+            "triggered_at": triggered_at.isoformat(),
+        }
+    }
+
+    event = await repo.get_latest_sensor_event(
+        "m5stack-001",
+        since_epoch=(triggered_at + timedelta(seconds=1)).timestamp(),
+    )
+
+    assert event is None
 
 
 def test_reception_api_session_survives_restart() -> None:

--- a/backend/utils/reception_repository.py
+++ b/backend/utils/reception_repository.py
@@ -143,3 +143,51 @@ class ReceptionRepository:
             .execute()
         )
         return len(result.data) if result.data else 0
+
+    # ------------------------------------------------------------------
+    # Sensor events
+    # ------------------------------------------------------------------
+
+    async def store_sensor_event(self, device_id: str, sensor_type: str, distance_mm: int) -> None:
+        """Insert a new sensor trigger event into ``sensor_events``."""
+        client = await self._get_client()
+        client.table("sensor_events").insert(
+            {
+                "device_id": device_id,
+                "sensor_type": sensor_type,
+                "distance_mm": distance_mm,
+            }
+        ).execute()
+
+    async def get_latest_sensor_event(
+        self, device_id: str, since_epoch: float = 0
+    ) -> Optional[dict[str, Any]]:
+        """Return the most recent sensor event for *device_id*.
+
+        If *since_epoch* is provided (UNIX seconds), only events after that
+        timestamp are considered.  Returns ``None`` when no matching row
+        exists or the event is older than 30 seconds.
+        """
+        client = await self._get_client()
+        query = (
+            client.table("sensor_events")
+            .select("device_id, sensor_type, distance_mm, triggered_at")
+            .eq("device_id", device_id)
+            .order("triggered_at", desc=True)
+            .limit(1)
+        )
+
+        if since_epoch > 0:
+            since_dt = datetime.fromtimestamp(since_epoch, tz=timezone.utc).isoformat()
+            query = query.gt("triggered_at", since_dt)
+
+        result = query.execute()
+        if not result.data:
+            return None
+
+        row = result.data[0]
+        triggered_at = row["triggered_at"]
+        if isinstance(triggered_at, str):
+            triggered_at = datetime.fromisoformat(triggered_at).replace(tzinfo=timezone.utc)
+        row["triggered_at"] = triggered_at
+        return row

--- a/backend/utils/reception_repository.py
+++ b/backend/utils/reception_repository.py
@@ -188,6 +188,10 @@ class ReceptionRepository:
         row = result.data[0]
         triggered_at = row["triggered_at"]
         if isinstance(triggered_at, str):
-            triggered_at = datetime.fromisoformat(triggered_at).replace(tzinfo=timezone.utc)
+            triggered_at = datetime.fromisoformat(triggered_at.replace("Z", "+00:00"))
+
+        if triggered_at < datetime.now(timezone.utc) - timedelta(seconds=30):
+            return None
+
         row["triggered_at"] = triggered_at
         return row

--- a/frontend/src/__tests__/api-proxy-contract.test.ts
+++ b/frontend/src/__tests__/api-proxy-contract.test.ts
@@ -97,6 +97,29 @@ test(
 );
 
 test(
+  'reception sensor-status GET forwards query params and backend payloads',
+  { concurrency: false },
+  async () => {
+    process.env.BACKEND_API_URL = 'https://backend.example.com';
+    (process.env as Record<string, string | undefined>).NODE_ENV = 'test';
+    mockBackendJsonResponse({ triggered: true, device_id: 'm5stack-001' }, 200);
+
+    const { GET } = await import('../app/api/reception/sensor-status/route');
+    const response = await GET(
+      new NextRequest(
+        'https://example.com/api/reception/sensor-status?device_id=m5stack-001&since=123'
+      )
+    );
+
+    assert.equal(response.status, 200);
+    assert.deepEqual(await response.json(), {
+      triggered: true,
+      device_id: 'm5stack-001',
+    });
+  }
+);
+
+test(
   'slides route no longer exports a GET handler',
   { concurrency: false },
   async () => {

--- a/frontend/src/__tests__/device-webhook.test.ts
+++ b/frontend/src/__tests__/device-webhook.test.ts
@@ -83,3 +83,120 @@ test('startSensorPolling dispatches device-detection when backend reports a new 
     distance_mm: 65,
   });
 });
+
+test('stopSensorPolling suppresses a stale in-flight sensor response', async () => {
+  const windowMock = createWindow();
+  (global as unknown as { window: Window & typeof globalThis }).window =
+    windowMock as unknown as Window & typeof globalThis;
+
+  const events: Array<Record<string, unknown>> = [];
+  windowMock.addEventListener('device-detection', (event) => {
+    events.push((event as CustomEvent<Record<string, unknown>>).detail);
+  });
+
+  let resolveFetch: ((value: Response) => void) | null = null;
+  global.fetch =
+    ((async () =>
+      await new Promise<Response>((resolve) => {
+        resolveFetch = resolve;
+      })) as unknown as typeof fetch);
+
+  const { startSensorPolling, stopSensorPolling } = await import('../lib/api/device-webhook');
+  startSensorPolling('m5stack-stop-test', 60_000);
+  stopSensorPolling();
+
+  const stopTestResolver = resolveFetch as ((value: Response) => void) | null;
+  if (stopTestResolver) {
+    stopTestResolver(
+      new Response(
+        JSON.stringify({
+          triggered: true,
+          device_id: 'm5stack-stop-test',
+          sensor_type: 'pir_sr04',
+          distance_mm: 70,
+          timestamp: 1712221539.085,
+        }),
+        {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' },
+        }
+      )
+    );
+  }
+
+  await new Promise((resolve) => setTimeout(resolve, 0));
+  await new Promise((resolve) => setTimeout(resolve, 0));
+
+  assert.equal(events.length, 0);
+});
+
+test('restartSensorPolling immediately polls new session even if old request is in flight', async () => {
+  const windowMock = createWindow();
+  (global as unknown as { window: Window & typeof globalThis }).window =
+    windowMock as unknown as Window & typeof globalThis;
+
+  const events: Array<Record<string, unknown>> = [];
+  windowMock.addEventListener('device-detection', (event) => {
+    events.push((event as CustomEvent<Record<string, unknown>>).detail);
+  });
+
+  let resolveFirstFetch: ((value: Response) => void) | null = null;
+  let fetchCount = 0;
+  global.fetch = (async () => {
+    fetchCount += 1;
+    if (fetchCount === 1) {
+      return await new Promise<Response>((resolve) => {
+        resolveFirstFetch = resolve;
+      });
+    }
+
+    return new Response(
+      JSON.stringify({
+        triggered: true,
+        device_id: 'm5stack-restart-test',
+        sensor_type: 'pir_sr04',
+        distance_mm: 80,
+        timestamp: 1712221540.085,
+      }),
+      {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      }
+    );
+  }) as typeof fetch;
+
+  const { startSensorPolling, stopSensorPolling } = await import('../lib/api/device-webhook');
+  startSensorPolling('m5stack-restart-test', 60_000);
+  stopSensorPolling();
+  startSensorPolling('m5stack-restart-test', 60_000);
+
+  await new Promise((resolve) => setTimeout(resolve, 0));
+  await new Promise((resolve) => setTimeout(resolve, 0));
+
+  assert.equal(fetchCount, 2);
+  assert.equal(events.length, 1);
+
+  const restartTestResolver = resolveFirstFetch as ((value: Response) => void) | null;
+  if (restartTestResolver) {
+    restartTestResolver(
+      new Response(
+        JSON.stringify({
+          triggered: true,
+          device_id: 'm5stack-restart-test',
+          sensor_type: 'pir_sr04',
+          distance_mm: 90,
+          timestamp: 1712221541.085,
+        }),
+        {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' },
+        }
+      )
+    );
+  }
+
+  await new Promise((resolve) => setTimeout(resolve, 0));
+  await new Promise((resolve) => setTimeout(resolve, 0));
+
+  assert.equal(events.length, 1);
+});

--- a/frontend/src/__tests__/device-webhook.test.ts
+++ b/frontend/src/__tests__/device-webhook.test.ts
@@ -1,0 +1,85 @@
+import assert from 'node:assert/strict';
+import { afterEach, test } from 'node:test';
+
+type DeviceWindow = EventTarget & {
+  __engineerCafe?: Record<string, unknown>;
+  setInterval: typeof global.setInterval;
+};
+
+const originalWindow = global.window;
+const originalFetch = global.fetch;
+
+function createWindow(): DeviceWindow {
+  return Object.assign(new EventTarget(), {
+    setInterval: global.setInterval,
+  }) as DeviceWindow;
+}
+
+afterEach(async () => {
+  global.fetch = originalFetch;
+  (global as typeof globalThis & { window?: Window & typeof globalThis }).window = originalWindow;
+
+  const deviceWebhook = await import('../lib/api/device-webhook');
+  deviceWebhook.stopSensorPolling();
+});
+
+test('handleDeviceDetection dispatches the browser device-detection event', async () => {
+  const windowMock = createWindow();
+  (global as unknown as { window: Window & typeof globalThis }).window =
+    windowMock as unknown as Window & typeof globalThis;
+
+  const events: Array<Record<string, unknown>> = [];
+  windowMock.addEventListener('device-detection', (event) => {
+    events.push((event as CustomEvent<Record<string, unknown>>).detail);
+  });
+
+  const { handleDeviceDetection } = await import('../lib/api/device-webhook');
+  handleDeviceDetection({
+    type: 'sensor_triggered',
+    device_id: 'm5stack-001',
+    timestamp: '2026-04-04T10:00:00.000Z',
+  });
+
+  assert.equal(events.length, 1);
+  assert.equal(events[0].device_id, 'm5stack-001');
+});
+
+test('startSensorPolling dispatches device-detection when backend reports a new trigger', async () => {
+  const windowMock = createWindow();
+  (global as unknown as { window: Window & typeof globalThis }).window =
+    windowMock as unknown as Window & typeof globalThis;
+
+  const events: Array<Record<string, unknown>> = [];
+  windowMock.addEventListener('device-detection', (event) => {
+    events.push((event as CustomEvent<Record<string, unknown>>).detail);
+  });
+
+  global.fetch = (async () =>
+    new Response(
+      JSON.stringify({
+        triggered: true,
+        device_id: 'm5stack-poll-test',
+        sensor_type: 'pir_sr04',
+        distance_mm: 65,
+        timestamp: 1712221538.085,
+      }),
+      {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      }
+    )) as typeof fetch;
+
+  const { startSensorPolling } = await import('../lib/api/device-webhook');
+  startSensorPolling('m5stack-poll-test', 60_000);
+
+  await new Promise((resolve) => setTimeout(resolve, 0));
+  await new Promise((resolve) => setTimeout(resolve, 0));
+
+  assert.equal(events.length, 1);
+  assert.equal(events[0].device_id, 'm5stack-poll-test');
+  assert.equal(events[0].type, 'sensor_triggered');
+  assert.deepEqual(events[0].data, {
+    sensor_type: 'pir_sr04',
+    distance_mm: 65,
+  });
+});

--- a/frontend/src/app/api/reception/sensor-status/route.ts
+++ b/frontend/src/app/api/reception/sensor-status/route.ts
@@ -1,0 +1,17 @@
+import { NextRequest } from 'next/server';
+
+import { proxyReceptionRequest } from '../_shared';
+
+export async function GET(request: NextRequest) {
+  const deviceId = request.nextUrl.searchParams.get('device_id') ?? 'm5stack-001';
+  const since = request.nextUrl.searchParams.get('since') ?? '0';
+  const search = new URLSearchParams({
+    device_id: deviceId,
+    since,
+  }).toString();
+
+  return proxyReceptionRequest(`/api/reception/sensor-status?${search}`, {
+    method: 'GET',
+    headers: { 'Content-Type': 'application/json' },
+  });
+}

--- a/frontend/src/app/components/ConversationHistoryEffects.tsx
+++ b/frontend/src/app/components/ConversationHistoryEffects.tsx
@@ -1,0 +1,58 @@
+'use client';
+
+import {
+  useEffect,
+  type Dispatch,
+  type MutableRefObject,
+  type SetStateAction,
+} from 'react';
+
+export type ConversationHistoryItem = {
+  id: string;
+  role: 'user' | 'assistant';
+  text: string;
+};
+
+export function ConversationHistoryEffects({
+  transcript,
+  response,
+  lastTranscriptRef,
+  lastResponseRef,
+  setConversationHistory,
+}: {
+  transcript: string;
+  response: string;
+  lastTranscriptRef: MutableRefObject<string>;
+  lastResponseRef: MutableRefObject<string>;
+  setConversationHistory: Dispatch<SetStateAction<ConversationHistoryItem[]>>;
+}) {
+  useEffect(() => {
+    if (transcript && transcript !== lastTranscriptRef.current) {
+      lastTranscriptRef.current = transcript;
+      setConversationHistory((prev) => [
+        ...prev,
+        {
+          id: `u-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`,
+          role: 'user',
+          text: transcript,
+        },
+      ]);
+    }
+  }, [lastTranscriptRef, setConversationHistory, transcript]);
+
+  useEffect(() => {
+    if (response && response !== lastResponseRef.current) {
+      lastResponseRef.current = response;
+      setConversationHistory((prev) => [
+        ...prev,
+        {
+          id: `a-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`,
+          role: 'assistant',
+          text: response,
+        },
+      ]);
+    }
+  }, [lastResponseRef, response, setConversationHistory]);
+
+  return null;
+}

--- a/frontend/src/app/components/KioskBottomBar.tsx
+++ b/frontend/src/app/components/KioskBottomBar.tsx
@@ -1,0 +1,237 @@
+'use client';
+
+import { markAudioUserInteraction } from '@/lib/audio/audio-user-interaction-gate';
+import { cn } from '@/lib/cn';
+import { overlayLabels } from '@/lib/kiosk-labels';
+import type { KioskMicMode, KioskPhase } from '@/lib/kiosk-constants';
+import { Camera, Mic, PenLine, Presentation, Sparkles } from 'lucide-react';
+import { KioskVoiceStatusStack } from './KioskVoiceStatusStack';
+import type { VoiceInterfaceRenderProps } from './VoiceInterface';
+
+export function KioskBottomBar({
+  kioskPhase,
+  setKioskPhase,
+  kioskVoiceLocked,
+  setKioskVoiceLocked,
+  micInputMode,
+  showKioskScreenChrome,
+  welcomeCooldown,
+  labels,
+  ocrStatus,
+  voice,
+  onPlayWelcome,
+  onStartPresentation,
+  clearReturnToIdleTimer,
+  setWelcomeMemberOcrOpen,
+  setOcrMode,
+}: {
+  kioskPhase: KioskPhase;
+  setKioskPhase: (phase: KioskPhase | ((prev: KioskPhase) => KioskPhase)) => void;
+  kioskVoiceLocked: boolean;
+  setKioskVoiceLocked: (locked: boolean) => void;
+  micInputMode: KioskMicMode;
+  showKioskScreenChrome: boolean;
+  welcomeCooldown: boolean;
+  labels: (typeof overlayLabels)['ja'] | (typeof overlayLabels)['en'];
+  ocrStatus: {
+    kind: 'member_card' | 'handwriting' | 'error';
+    text: string;
+    visibleUntil: number;
+  } | null;
+  voice: VoiceInterfaceRenderProps;
+  onPlayWelcome: () => void | Promise<void>;
+  onStartPresentation: () => void;
+  clearReturnToIdleTimer: () => void;
+  setWelcomeMemberOcrOpen: (open: boolean) => void;
+  setOcrMode: (mode: 'member_card' | 'handwriting') => void;
+}) {
+  const isVoiceCaptureActive = kioskPhase === 'voice' && kioskVoiceLocked;
+  const isPushToTalk = micInputMode === 'push_to_talk';
+
+  const handleKioskVoiceStart = () => {
+    markAudioUserInteraction();
+    clearReturnToIdleTimer();
+    setWelcomeMemberOcrOpen(false);
+    setKioskPhase('voice');
+    setKioskVoiceLocked(true);
+    void voice.startListening();
+  };
+
+  const handleKioskVoiceStop = () => {
+    setKioskVoiceLocked(false);
+    if (isPushToTalk) {
+      voice.stopListening();
+      return;
+    }
+    if (voice.sessionState === 'listening') {
+      voice.stopListening();
+      return;
+    }
+    voice.cancelSession();
+  };
+
+  const statusEnabled =
+    kioskPhase === 'voice' || kioskPhase === 'idle' || kioskPhase === 'notice';
+
+  return (
+    <div className="pointer-events-auto absolute inset-x-0 bottom-0 z-[25] flex justify-center pb-[max(0.75rem,env(safe-area-inset-bottom))] pl-[max(1rem,env(safe-area-inset-left))] pr-[max(1rem,env(safe-area-inset-right))] pt-2">
+      <div className="flex w-full max-w-5xl flex-col items-stretch justify-center gap-2 sm:gap-3">
+        <KioskVoiceStatusStack
+          enabled={statusEnabled}
+          phase={kioskPhase}
+          labels={labels}
+          transcript={voice.transcript}
+          response={voice.response}
+          error={voice.error}
+          ocrStatus={ocrStatus}
+          isLoading={voice.isLoading}
+          loadingPhase={voice.loadingPhase}
+          sessionState={voice.sessionState}
+        />
+        {showKioskScreenChrome ? (
+          <div className="flex w-full flex-row flex-wrap items-stretch justify-center gap-2 sm:gap-3">
+            <button
+              type="button"
+              onClick={() => {
+                void onPlayWelcome();
+              }}
+              disabled={isVoiceCaptureActive || voice.isLoading || welcomeCooldown}
+              className={cn(
+                'flex min-h-[72px] min-w-[min(100%,7rem)] flex-1 flex-col items-center justify-center gap-1 rounded-2xl px-3 py-3 shadow-md backdrop-blur-sm transition-transform sm:min-h-[80px] sm:flex-initial sm:px-5',
+                isVoiceCaptureActive || voice.isLoading || welcomeCooldown
+                  ? 'cursor-not-allowed border border-slate-500/40 bg-slate-600/40 text-slate-300'
+                  : 'border border-white/35 bg-white/15 text-white hover:scale-[1.02]',
+              )}
+            >
+              <Sparkles className="size-6 shrink-0 sm:size-7" aria-hidden />
+              <span className="text-center text-xs font-semibold leading-tight sm:text-sm">
+                {labels.kioskWelcome}
+              </span>
+            </button>
+            <button
+              data-testid="kiosk-voice-button"
+              type="button"
+              onPointerDown={(event) => {
+                if (!isPushToTalk) {
+                  return;
+                }
+                event.preventDefault();
+                event.currentTarget.setPointerCapture(event.pointerId);
+                if (!isVoiceCaptureActive) {
+                  handleKioskVoiceStart();
+                }
+              }}
+              onPointerUp={(event) => {
+                if (!isPushToTalk) {
+                  return;
+                }
+                if (event.currentTarget.hasPointerCapture(event.pointerId)) {
+                  event.currentTarget.releasePointerCapture(event.pointerId);
+                }
+                if (isVoiceCaptureActive) {
+                  handleKioskVoiceStop();
+                }
+              }}
+              onPointerCancel={(event) => {
+                if (!isPushToTalk) {
+                  return;
+                }
+                if (event.currentTarget.hasPointerCapture(event.pointerId)) {
+                  event.currentTarget.releasePointerCapture(event.pointerId);
+                }
+                if (isVoiceCaptureActive) {
+                  handleKioskVoiceStop();
+                }
+              }}
+              onClick={(event) => {
+                if (isPushToTalk) {
+                  event.preventDefault();
+                  return;
+                }
+                if (isVoiceCaptureActive) {
+                  handleKioskVoiceStop();
+                  return;
+                }
+                handleKioskVoiceStart();
+              }}
+              className={cn(
+                'flex min-h-[72px] min-w-[min(100%,7rem)] flex-1 flex-col items-center justify-center gap-1 rounded-2xl px-3 py-3 shadow-md backdrop-blur-sm transition-transform sm:min-h-[80px] sm:flex-initial sm:px-5',
+                isVoiceCaptureActive
+                  ? 'border border-emerald-300/70 bg-emerald-500/55 text-white shadow-lg'
+                  : 'border border-white/35 bg-white/15 text-white hover:scale-[1.02]',
+              )}
+            >
+              <Mic className="size-6 shrink-0 sm:size-7" aria-hidden />
+              <span className="text-center text-xs font-semibold leading-tight sm:text-sm">
+                {labels.kioskVoice}
+              </span>
+            </button>
+            <button
+              type="button"
+              onClick={() => {
+                markAudioUserInteraction();
+                setWelcomeMemberOcrOpen(false);
+                setOcrMode('member_card');
+                setKioskPhase('ocr');
+              }}
+              disabled={isVoiceCaptureActive}
+              className={cn(
+                'flex min-h-[72px] min-w-[min(100%,7rem)] flex-1 flex-col items-center justify-center gap-1 rounded-2xl px-3 py-3 shadow-md backdrop-blur-sm transition-transform sm:min-h-[80px] sm:flex-initial sm:px-5',
+                isVoiceCaptureActive
+                  ? 'cursor-not-allowed border border-slate-500/40 bg-slate-600/40 text-slate-300'
+                  : 'border border-white/35 bg-white/15 text-white hover:scale-[1.02]',
+              )}
+            >
+              <Camera className="size-6 shrink-0 sm:size-7" aria-hidden />
+              <span className="text-center text-xs font-semibold leading-tight sm:text-sm">
+                {labels.kioskOcrMember}
+              </span>
+            </button>
+            <button
+              type="button"
+              onClick={() => {
+                markAudioUserInteraction();
+                setWelcomeMemberOcrOpen(false);
+                setOcrMode('handwriting');
+                setKioskPhase('ocr');
+              }}
+              disabled={isVoiceCaptureActive}
+              className={cn(
+                'flex min-h-[72px] min-w-[min(100%,7rem)] flex-1 flex-col items-center justify-center gap-1 rounded-2xl px-3 py-3 shadow-md backdrop-blur-sm transition-transform sm:min-h-[80px] sm:flex-initial sm:px-5',
+                isVoiceCaptureActive
+                  ? 'cursor-not-allowed border border-slate-500/40 bg-slate-600/40 text-slate-300'
+                  : 'border border-white/35 bg-white/15 text-white hover:scale-[1.02]',
+              )}
+            >
+              <PenLine className="size-6 shrink-0 sm:size-7" aria-hidden />
+              <span className="text-center text-xs font-semibold leading-tight sm:text-sm">
+                {labels.kioskOcrHandwriting}
+              </span>
+            </button>
+            <button
+              data-testid="kiosk-slides-button"
+              type="button"
+              onClick={() => {
+                markAudioUserInteraction();
+                setWelcomeMemberOcrOpen(false);
+                onStartPresentation();
+              }}
+              disabled={isVoiceCaptureActive}
+              className={cn(
+                'flex min-h-[72px] min-w-[min(100%,7rem)] flex-1 flex-col items-center justify-center gap-1 rounded-2xl px-3 py-3 shadow-md backdrop-blur-sm transition-transform sm:min-h-[80px] sm:flex-initial sm:px-5',
+                isVoiceCaptureActive
+                  ? 'cursor-not-allowed border border-slate-500/40 bg-slate-600/40 text-slate-300'
+                  : 'border border-white/35 bg-white/15 text-white hover:scale-[1.02]',
+              )}
+            >
+              <Presentation className="size-6 shrink-0 sm:size-7" aria-hidden />
+              <span className="text-center text-xs font-semibold leading-tight sm:text-sm">
+                {labels.kioskSlides}
+              </span>
+            </button>
+          </div>
+        ) : null}
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/app/components/KioskOcrOverlay.tsx
+++ b/frontend/src/app/components/KioskOcrOverlay.tsx
@@ -1,0 +1,62 @@
+'use client';
+
+import { overlayLabels } from '@/lib/kiosk-labels';
+import { OcrCameraView } from '@/components/reception/OcrCameraView';
+import type { OcrResponse } from '@/lib/api/ocr-api';
+
+export function KioskOcrOverlay({
+  visible,
+  ocrMode,
+  labels,
+  sessionId,
+  bumpUserActivity,
+  onSuccess,
+  onFallback,
+  onSkip,
+  onBackToIdle,
+}: {
+  visible: boolean;
+  ocrMode: 'member_card' | 'handwriting';
+  labels: (typeof overlayLabels)['ja'] | (typeof overlayLabels)['en'];
+  sessionId: string;
+  bumpUserActivity: () => void;
+  onSuccess: (result: OcrResponse) => void;
+  onFallback: () => void;
+  onSkip: () => void;
+  onBackToIdle: () => void;
+}) {
+  if (!visible) {
+    return null;
+  }
+
+  return (
+    <div
+      className="absolute inset-0 z-40 overflow-y-auto bg-black/60 p-4"
+      onPointerDownCapture={bumpUserActivity}
+    >
+      <div className="mx-auto max-w-lg rounded-[28px] border border-white/15 bg-white/95 p-5 shadow-xl md:p-8">
+        <h3 className="mb-4 text-center text-lg font-semibold text-slate-900">
+          {ocrMode === 'member_card' ? labels.kioskOcrMember : labels.kioskOcrHandwriting}
+        </h3>
+        <OcrCameraView
+          key={ocrMode}
+          mode={ocrMode}
+          autoStart
+          sessionId={sessionId}
+          onSuccess={onSuccess}
+          onFallback={onFallback}
+          onSkip={onSkip}
+        />
+        <div className="mt-6 flex justify-center">
+          <button
+            type="button"
+            onClick={onBackToIdle}
+            className="inline-flex min-h-11 items-center justify-center rounded-full bg-slate-900 px-6 py-3 text-sm font-medium text-white transition-colors hover:bg-slate-800"
+          >
+            {labels.kioskBackIdle}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/app/components/KioskVoiceStatusStack.tsx
+++ b/frontend/src/app/components/KioskVoiceStatusStack.tsx
@@ -1,0 +1,215 @@
+'use client';
+
+import { overlayLabels } from '@/lib/kiosk-labels';
+import type { KioskPhase } from '@/lib/kiosk-constants';
+import {
+  Camera,
+  Loader2,
+  MessageSquare,
+  TextQuote,
+  Volume2,
+  XCircle,
+} from 'lucide-react';
+import { useEffect, useRef, useState } from 'react';
+import type { VoiceLoadingPhase, VoiceSessionState } from './VoiceInterface';
+
+export function KioskVoiceStatusStack({
+  enabled,
+  phase,
+  labels,
+  transcript,
+  response,
+  error,
+  ocrStatus,
+  isLoading,
+  loadingPhase,
+  sessionState,
+}: {
+  enabled: boolean;
+  phase: KioskPhase;
+  labels: (typeof overlayLabels)['ja'] | (typeof overlayLabels)['en'];
+  transcript: string;
+  response: string;
+  error: string | null;
+  ocrStatus: {
+    kind: 'member_card' | 'handwriting' | 'error';
+    text: string;
+    visibleUntil: number;
+  } | null;
+  isLoading: boolean;
+  loadingPhase: VoiceLoadingPhase;
+  sessionState: VoiceSessionState;
+}) {
+  const [transcriptVisibleUntil, setTranscriptVisibleUntil] = useState<number>(0);
+  const [responseVisibleUntil, setResponseVisibleUntil] = useState<number>(0);
+  const [defaultPromptVisibleUntil, setDefaultPromptVisibleUntil] = useState<number>(0);
+  const [errorVisibleUntil, setErrorVisibleUntil] = useState<number>(0);
+  const [now, setNow] = useState<number>(Date.now());
+  const previousSessionStateRef = useRef<VoiceSessionState>(sessionState);
+  const previousPhaseRef = useRef<KioskPhase>(phase);
+
+  useEffect(() => {
+    if (!enabled) {
+      setTranscriptVisibleUntil(0);
+      setResponseVisibleUntil(0);
+      setDefaultPromptVisibleUntil(0);
+      setErrorVisibleUntil(0);
+      previousPhaseRef.current = phase;
+      return;
+    }
+    if (transcript.length > 0) {
+      setTranscriptVisibleUntil(Date.now() + 5000);
+    }
+  }, [enabled, phase, transcript]);
+
+  useEffect(() => {
+    if (!enabled) {
+      previousPhaseRef.current = phase;
+      return;
+    }
+
+    const previousPhase = previousPhaseRef.current;
+    if (phase === 'notice' || (previousPhase !== phase && phase === 'idle')) {
+      setDefaultPromptVisibleUntil(Date.now() + 5000);
+    }
+    previousPhaseRef.current = phase;
+  }, [enabled, phase]);
+
+  useEffect(() => {
+    if (!enabled) {
+      previousSessionStateRef.current = sessionState;
+      return;
+    }
+
+    if (previousSessionStateRef.current === 'speaking' && sessionState === 'idle' && response.length > 0) {
+      setResponseVisibleUntil(Date.now() + 5000);
+    }
+    previousSessionStateRef.current = sessionState;
+  }, [enabled, response.length, sessionState]);
+
+  useEffect(() => {
+    if (!enabled) {
+      return;
+    }
+    if (error) {
+      setErrorVisibleUntil(Date.now() + 5000);
+    }
+    if (error && transcript.length > 0) {
+      setTranscriptVisibleUntil(Date.now() + 5000);
+    }
+    if (error && response.length > 0) {
+      setResponseVisibleUntil(Date.now() + 5000);
+    }
+  }, [enabled, error, response.length, transcript.length]);
+
+  useEffect(() => {
+    if (!enabled) {
+      return;
+    }
+    const timers: number[] = [];
+    if (transcriptVisibleUntil > now) {
+      timers.push(window.setTimeout(() => setNow(Date.now()), transcriptVisibleUntil - now));
+    }
+    if (responseVisibleUntil > now) {
+      timers.push(window.setTimeout(() => setNow(Date.now()), responseVisibleUntil - now));
+    }
+    if (defaultPromptVisibleUntil > now) {
+      timers.push(window.setTimeout(() => setNow(Date.now()), defaultPromptVisibleUntil - now));
+    }
+    if (errorVisibleUntil > now) {
+      timers.push(window.setTimeout(() => setNow(Date.now()), errorVisibleUntil - now));
+    }
+    if (ocrStatus && ocrStatus.visibleUntil > now) {
+      timers.push(window.setTimeout(() => setNow(Date.now()), ocrStatus.visibleUntil - now));
+    }
+    return () => {
+      timers.forEach((timerId) => window.clearTimeout(timerId));
+    };
+  }, [
+    defaultPromptVisibleUntil,
+    enabled,
+    errorVisibleUntil,
+    now,
+    ocrStatus,
+    responseVisibleUntil,
+    transcriptVisibleUntil,
+  ]);
+
+  if (!enabled) {
+    return null;
+  }
+
+  const isSttLoading = isLoading && loadingPhase === 'stt';
+  const isTtsSynthesizing =
+    isLoading && response.length > 0 && sessionState !== 'speaking';
+  const isErrorVisible = Boolean(error) && errorVisibleUntil > now;
+  const isOcrStatusVisible = Boolean(ocrStatus && ocrStatus.visibleUntil > now);
+  const isDefaultPromptVisible =
+    response.length === 0 &&
+    sessionState === 'idle' &&
+    defaultPromptVisibleUntil > now;
+  const displayResponse = response || (isDefaultPromptVisible ? labels.defaultPrompt : '');
+  const isResponseVisible =
+    displayResponse.length > 0 &&
+    (sessionState === 'speaking' || responseVisibleUntil > now || isDefaultPromptVisible);
+  const isTranscriptVisible =
+    transcript.length > 0 && !isSttLoading && transcriptVisibleUntil > now;
+
+  if (!isSttLoading && !isTtsSynthesizing && !isTranscriptVisible && !isResponseVisible && !isErrorVisible && !isOcrStatusVisible) {
+    return null;
+  }
+
+  return (
+    <div className="w-full space-y-2">
+      {isOcrStatusVisible && ocrStatus ? (
+        <div className="flex w-full items-center gap-2 rounded-xl border border-white/30 bg-black/35 px-4 py-2 text-sm font-medium text-white/95 shadow-sm backdrop-blur-sm">
+          {ocrStatus.kind === 'error' ? (
+            <XCircle className="size-4 shrink-0 text-rose-300" />
+          ) : ocrStatus.kind === 'handwriting' ? (
+            <MessageSquare className="size-4 shrink-0" />
+          ) : (
+            <Camera className="size-4 shrink-0" />
+          )}
+          <span>{ocrStatus.text}</span>
+        </div>
+      ) : null}
+      {isSttLoading ? (
+        <div className="flex w-full items-center gap-2 rounded-xl border border-white/30 bg-black/35 px-4 py-2 text-sm font-medium text-white/95 shadow-sm backdrop-blur-sm">
+          <Loader2 className="size-4 shrink-0 animate-spin" />
+          <span>{labels.sttReading}</span>
+        </div>
+      ) : null}
+      {isTranscriptVisible ? (
+        <div className="flex w-full items-center gap-2 rounded-xl border border-white/30 bg-black/35 px-4 py-2 text-sm font-medium text-white/95 shadow-sm backdrop-blur-sm">
+          <TextQuote className="size-4 shrink-0" />
+          <span>
+            {labels.transcriptLabel}: {transcript}
+          </span>
+        </div>
+      ) : null}
+      {isErrorVisible ? (
+        <div className="flex w-full items-center gap-2 rounded-xl border border-rose-300/45 bg-rose-700/35 px-4 py-2 text-sm font-medium text-rose-50 shadow-sm backdrop-blur-sm">
+          <XCircle className="size-4 shrink-0" />
+          <span>{error}</span>
+        </div>
+      ) : null}
+      {isTtsSynthesizing ? (
+        <div className="flex w-full items-center gap-2 rounded-xl border border-white/30 bg-black/35 px-4 py-2 text-sm font-medium text-white/95 shadow-sm backdrop-blur-sm">
+          <Loader2 className="size-4 shrink-0 animate-spin" />
+          <span>{labels.ttsSynthesizing}</span>
+        </div>
+      ) : null}
+      {isResponseVisible ? (
+        <div
+          className="flex w-full items-center gap-2 rounded-xl border border-white/30 bg-black/35 px-4 py-2 text-sm font-medium text-white/95 shadow-sm backdrop-blur-sm"
+          data-testid="response-bubble"
+        >
+          <Volume2 className="size-4 shrink-0" />
+          <span data-testid="response-text">
+            {response ? `${labels.responseLabel}: ${response}` : displayResponse}
+          </span>
+        </div>
+      ) : null}
+    </div>
+  );
+}

--- a/frontend/src/app/components/KioskWelcomeOverlay.tsx
+++ b/frontend/src/app/components/KioskWelcomeOverlay.tsx
@@ -1,0 +1,57 @@
+'use client';
+
+import { overlayLabels } from '@/lib/kiosk-labels';
+import type { KioskPhase } from '@/lib/kiosk-constants';
+import { OcrCameraView } from '@/components/reception/OcrCameraView';
+import type { OcrResponse } from '@/lib/api/ocr-api';
+
+export function KioskWelcomeOverlay({
+  open,
+  welcomeMemberOcrSessionKey,
+  kioskPhase,
+  showSlideMode,
+  labels,
+  sessionId,
+  bumpUserActivity,
+  onMemberOcrSuccess,
+  onMemberOcrEnd,
+}: {
+  open: boolean;
+  welcomeMemberOcrSessionKey: number;
+  kioskPhase: KioskPhase;
+  showSlideMode: boolean;
+  labels: (typeof overlayLabels)['ja'] | (typeof overlayLabels)['en'];
+  sessionId: string;
+  bumpUserActivity: () => void;
+  onMemberOcrSuccess: (result: OcrResponse) => void;
+  onMemberOcrEnd: () => void;
+}) {
+  if (!open || kioskPhase === 'ocr' || showSlideMode) {
+    return null;
+  }
+
+  return (
+    <div
+      className="pointer-events-auto absolute z-[38] w-[min(92vw,13.5rem)] rounded-xl border border-white/25 bg-white/95 p-3 shadow-2xl backdrop-blur-md"
+      style={{
+        top: 'calc(max(1.5rem, env(safe-area-inset-top)) + 3.25rem)',
+        right: 'max(1rem, env(safe-area-inset-right))',
+      }}
+      onPointerDownCapture={bumpUserActivity}
+    >
+      <p className="mb-2 text-center text-xs font-semibold text-slate-800">{labels.kioskOcrMember}</p>
+      <OcrCameraView
+        key={welcomeMemberOcrSessionKey}
+        mode="member_card"
+        autoStart
+        compact
+        hideSkip
+        sessionId={sessionId}
+        onSuccess={onMemberOcrSuccess}
+        onFallback={onMemberOcrEnd}
+        onSkip={onMemberOcrEnd}
+        onCameraInitFailed={onMemberOcrEnd}
+      />
+    </div>
+  );
+}

--- a/frontend/src/app/components/SettingsPanel.tsx
+++ b/frontend/src/app/components/SettingsPanel.tsx
@@ -8,7 +8,7 @@ import {
   User,
   X,
 } from 'lucide-react';
-import { useState, type ReactNode } from 'react';
+import { useEffect, useState, type ReactNode } from 'react';
 import type { KioskMicMode, KioskTriggerMode } from '@/lib/kiosk-constants';
 import type { CharacterAnimationData } from '../utils/character-animation-utils';
 import SpeakerSettings from './SpeakerSettings';
@@ -138,13 +138,21 @@ export default function SettingsPanel({
     on_kiosk_language_change != null &&
     on_kiosk_trigger_mode_change != null &&
     on_kiosk_mic_mode_change != null;
+  /** Public kiosk: hide admin links; same flag as avatar dev controls (see page / .env.example). */
+  const show_admin_tab = process.env.NEXT_PUBLIC_SHOW_AVATAR_SETTINGS === 'true';
   const tab_list: SettingsPanelTab[] = [
     ...(extra_tab ? (['conversation'] as const) : []),
     ...(has_kiosk_tab ? (['kiosk'] as const) : []),
     'multimedia',
-    'admin',
+    ...(show_admin_tab ? (['admin'] as const) : []),
     'controls',
   ];
+
+  useEffect(() => {
+    if (!show_admin_tab && active_tab === 'admin') {
+      set_active_tab('controls');
+    }
+  }, [active_tab, show_admin_tab]);
 
   return (
     <div className="flex w-80 max-h-[85vh] flex-col overflow-y-auto rounded-lg bg-white bg-opacity-95 p-4 shadow-lg">
@@ -222,7 +230,7 @@ export default function SettingsPanel({
         </div>
       )}
 
-      {active_tab === 'admin' ? (
+      {show_admin_tab && active_tab === 'admin' ? (
         <div className="mb-4 flex flex-col gap-3">
           <a
             href="./admin/knowledge"

--- a/frontend/src/app/components/VoiceInterface.tsx
+++ b/frontend/src/app/components/VoiceInterface.tsx
@@ -30,6 +30,9 @@ import type { CharacterAnimationData } from '../utils/character-animation-utils'
 
 export type VoiceSessionState = 'idle' | 'listening' | 'processing' | 'speaking';
 
+/** Semantic loading stage for kiosk UI; avoids coupling to localized loadingMessage strings. */
+export type VoiceLoadingPhase = 'mic' | 'stt' | 'llm' | 'tts' | null;
+
 export interface VoiceInterfaceMetadata {
   clarification?: {
     clarification_type?: string;
@@ -52,6 +55,7 @@ export interface VoiceInterfaceRenderProps {
   error: string | null;
   isLoading: boolean;
   loadingMessage: string;
+  loadingPhase: VoiceLoadingPhase;
   currentLanguage: 'ja' | 'en';
   volume: number;
   isMuted: boolean;
@@ -212,6 +216,7 @@ export default function VoiceInterface({
   const [error, setError] = useState<string | null>(null);
   const [isLoading, setIsLoading] = useState(false);
   const [loadingMessage, setLoadingMessage] = useState('');
+  const [loadingPhase, setLoadingPhase] = useState<VoiceLoadingPhase>(null);
   const [mediaStream, setMediaStream] = useState<MediaStream | null>(null);
 
   const sessionIdRef = useRef(createSessionId());
@@ -307,6 +312,7 @@ export default function VoiceInterface({
     setError(null);
     setIsLoading(false);
     setLoadingMessage('');
+    setLoadingPhase(null);
     sessionIdRef.current = createSessionId();
   }, []);
 
@@ -380,6 +386,7 @@ export default function VoiceInterface({
       }
 
       setLoadingMessage(LOADING_LABELS[currentLanguage].speaking);
+      setLoadingPhase('tts');
       voiceController.notifySpeaking();
 
       audioService.updateEventHandlers({
@@ -435,6 +442,7 @@ export default function VoiceInterface({
       setTranscript(trimmed);
       setIsLoading(true);
       setLoadingMessage(LOADING_LABELS[currentLanguage].answer);
+      setLoadingPhase('llm');
       voiceController.notifyProcessing();
 
       const abortController = new AbortController();
@@ -518,6 +526,7 @@ export default function VoiceInterface({
         }
         setIsLoading(false);
         setLoadingMessage('');
+        setLoadingPhase(null);
       }
     },
     [
@@ -550,6 +559,7 @@ export default function VoiceInterface({
 
       setIsLoading(true);
       setLoadingMessage(LOADING_LABELS[currentLanguage].speaking);
+      setLoadingPhase('tts');
       voiceController.notifyProcessing();
 
       const abortController = new AbortController();
@@ -596,6 +606,7 @@ export default function VoiceInterface({
         }
         setIsLoading(false);
         setLoadingMessage('');
+        setLoadingPhase(null);
       }
     },
     [
@@ -618,6 +629,7 @@ export default function VoiceInterface({
       setError(null);
       setIsLoading(true);
       setLoadingMessage(LOADING_LABELS[currentLanguage].recognize);
+      setLoadingPhase('stt');
 
       const abortController = new AbortController();
       requestAbortRef.current = abortController;
@@ -648,6 +660,7 @@ export default function VoiceInterface({
         setTranscript(sttResult.transcript);
         setIsLoading(false);
         setLoadingMessage('');
+        setLoadingPhase(null);
         await sendMessage(sttResult.transcript);
       } catch (recordingError) {
         if (recordingError instanceof DOMException && recordingError.name === 'AbortError') {
@@ -662,6 +675,7 @@ export default function VoiceInterface({
         }
         setIsLoading(false);
         setLoadingMessage('');
+        setLoadingPhase(null);
       }
     },
     [cancelPendingRequest, currentLanguage, sendMessage, voiceController],
@@ -681,6 +695,7 @@ export default function VoiceInterface({
         setError(formatError(recorderError, currentLanguage));
         setIsLoading(false);
         setLoadingMessage('');
+        setLoadingPhase(null);
         isRecordingRef.current = false;
       },
       () => {
@@ -695,11 +710,13 @@ export default function VoiceInterface({
 
     setIsLoading(true);
     setLoadingMessage(LOADING_LABELS[currentLanguage].microphone);
+    setLoadingPhase('mic');
     await recorder.initialize();
 
     if (!recorder.isInitialized()) {
       setIsLoading(false);
       setLoadingMessage('');
+      setLoadingPhase(null);
       throw new Error(currentLanguage === 'ja' ? 'マイクを初期化できませんでした' : 'Unable to initialize the microphone');
     }
 
@@ -707,6 +724,7 @@ export default function VoiceInterface({
     setMediaStream(recorder.getStream());
     setIsLoading(false);
     setLoadingMessage('');
+    setLoadingPhase(null);
 
     return recorder;
   }, [currentLanguage, handleRecordedAudio]);
@@ -779,6 +797,7 @@ export default function VoiceInterface({
     stopRecorderCapture(true);
     setIsLoading(false);
     setLoadingMessage('');
+    setLoadingPhase(null);
     voiceController.endManualSession();
   }, [cancelPendingRequest, stopPlayback, stopRecorderCapture, voiceController]);
 
@@ -835,6 +854,7 @@ export default function VoiceInterface({
       error,
       isLoading,
       loadingMessage,
+      loadingPhase,
       currentLanguage,
       volume,
       isMuted,
@@ -863,6 +883,7 @@ export default function VoiceInterface({
       isLoading,
       isMuted,
       loadingMessage,
+      loadingPhase,
       metadata,
       response,
       sendMessage,

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -2,6 +2,7 @@
 
 import { markAudioUserInteraction } from '@/lib/audio/audio-user-interaction-gate';
 import { startSensorPolling, stopSensorPolling } from '@/lib/api/device-webhook';
+import { getStageBackgroundStyle } from '@/lib/get-stage-background-style';
 import { overlayLabels } from '@/lib/kiosk-labels';
 import {
   KIOSK_IDLE_MS,
@@ -14,332 +15,29 @@ import {
   writeKioskMicMode,
   writeKioskTriggerMode,
 } from '@/lib/kiosk-constants';
-import ReactMarkdown from 'react-markdown';
-
 import { cn } from '@/lib/cn';
-import {
-  Camera,
-  Loader2,
-  MessageSquare,
-  Mic,
-  PenLine,
-  Presentation,
-  Settings,
-  Sparkles,
-  TextQuote,
-  Volume2,
-  X,
-  XCircle,
-} from 'lucide-react';
-import {
-  useCallback,
-  useEffect,
-  useRef,
-  useState,
-  type CSSProperties,
-  type Dispatch,
-  type MutableRefObject,
-  type PointerEvent as ReactPointerEvent,
-  type SetStateAction,
-} from 'react';
+import { Settings, X } from 'lucide-react';
+import { useCallback, useEffect, useRef, useState, type CSSProperties } from 'react';
 import type { CharacterAnimationData } from './utils/character-animation-utils';
 import type { BackgroundOption } from './components/BackgroundSelector';
 import CharacterAvatar from './components/CharacterAvatar';
+import {
+  ConversationHistoryEffects,
+  type ConversationHistoryItem,
+} from './components/ConversationHistoryEffects';
+import { KioskBottomBar } from './components/KioskBottomBar';
+import { KioskOcrOverlay } from './components/KioskOcrOverlay';
+import { KioskWelcomeOverlay } from './components/KioskWelcomeOverlay';
+import InitialSettingsModal from './components/InitialSettingsModal';
+import MarpViewer from './components/MarpViewer';
 import SettingsPanel, {
   type SettingsPanelPropsFromSource,
 } from './components/SettingsPanel';
-import MarpViewer from './components/MarpViewer';
-import InitialSettingsModal from './components/InitialSettingsModal';
 import VoiceInterface, {
   type VoiceInterfaceMetadata,
-  type VoiceSessionState,
 } from './components/VoiceInterface';
-import { OcrCameraView } from '@/components/reception/OcrCameraView';
 import type { OcrResponse } from '@/lib/api/ocr-api';
 import { startReception } from '@/lib/reception-api';
-
-const buttonCopy: Record<
-  VoiceSessionState,
-  'idleAction' | 'listeningAction' | 'processingAction' | 'speakingAction'
-> = {
-  idle: 'idleAction',
-  listening: 'listeningAction',
-  processing: 'processingAction',
-  speaking: 'speakingAction',
-};
-
-type ConversationHistoryItem = {
-  id: string;
-  role: 'user' | 'assistant';
-  text: string;
-};
-
-function KioskVoiceStatusStack({
-  enabled,
-  phase,
-  labels,
-  transcript,
-  response,
-  error,
-  ocrStatus,
-  isLoading,
-  loadingMessage,
-  sessionState,
-}: {
-  enabled: boolean;
-  phase: KioskPhase;
-  labels: (typeof overlayLabels)['ja'] | (typeof overlayLabels)['en'];
-  transcript: string;
-  response: string;
-  error: string | null;
-  ocrStatus: {
-    kind: 'member_card' | 'handwriting' | 'error';
-    text: string;
-    visibleUntil: number;
-  } | null;
-  isLoading: boolean;
-  loadingMessage: string;
-  sessionState: VoiceSessionState;
-}) {
-  const [transcriptVisibleUntil, setTranscriptVisibleUntil] = useState<number>(0);
-  const [responseVisibleUntil, setResponseVisibleUntil] = useState<number>(0);
-  const [defaultPromptVisibleUntil, setDefaultPromptVisibleUntil] = useState<number>(0);
-  const [errorVisibleUntil, setErrorVisibleUntil] = useState<number>(0);
-  const [now, setNow] = useState<number>(Date.now());
-  const previousSessionStateRef = useRef<VoiceSessionState>(sessionState);
-  const previousPhaseRef = useRef<KioskPhase>(phase);
-
-  useEffect(() => {
-    if (!enabled) {
-      setTranscriptVisibleUntil(0);
-      setResponseVisibleUntil(0);
-      setDefaultPromptVisibleUntil(0);
-      setErrorVisibleUntil(0);
-      previousPhaseRef.current = phase;
-      return;
-    }
-    if (transcript.length > 0) {
-      setTranscriptVisibleUntil(Date.now() + 5000);
-    }
-  }, [enabled, transcript]);
-
-  useEffect(() => {
-    if (!enabled) {
-      previousPhaseRef.current = phase;
-      return;
-    }
-
-    const previousPhase = previousPhaseRef.current;
-    if (phase === 'notice' || (previousPhase !== phase && phase === 'idle')) {
-      setDefaultPromptVisibleUntil(Date.now() + 5000);
-    }
-    previousPhaseRef.current = phase;
-  }, [enabled, phase]);
-
-  useEffect(() => {
-    if (!enabled) {
-      previousSessionStateRef.current = sessionState;
-      return;
-    }
-
-    if (previousSessionStateRef.current === 'speaking' && sessionState === 'idle' && response.length > 0) {
-      setResponseVisibleUntil(Date.now() + 5000);
-    }
-    previousSessionStateRef.current = sessionState;
-  }, [enabled, response.length, sessionState]);
-
-  useEffect(() => {
-    if (!enabled) {
-      return;
-    }
-    if (error) {
-      setErrorVisibleUntil(Date.now() + 5000);
-    }
-    if (error && transcript.length > 0) {
-      setTranscriptVisibleUntil(Date.now() + 5000);
-    }
-    if (error && response.length > 0) {
-      setResponseVisibleUntil(Date.now() + 5000);
-    }
-  }, [enabled, error, response.length, transcript.length]);
-
-  useEffect(() => {
-    if (!enabled) {
-      return;
-    }
-    const timers: number[] = [];
-    if (transcriptVisibleUntil > now) {
-      timers.push(window.setTimeout(() => setNow(Date.now()), transcriptVisibleUntil - now));
-    }
-    if (responseVisibleUntil > now) {
-      timers.push(window.setTimeout(() => setNow(Date.now()), responseVisibleUntil - now));
-    }
-    if (defaultPromptVisibleUntil > now) {
-      timers.push(window.setTimeout(() => setNow(Date.now()), defaultPromptVisibleUntil - now));
-    }
-    if (errorVisibleUntil > now) {
-      timers.push(window.setTimeout(() => setNow(Date.now()), errorVisibleUntil - now));
-    }
-    if (ocrStatus && ocrStatus.visibleUntil > now) {
-      timers.push(window.setTimeout(() => setNow(Date.now()), ocrStatus.visibleUntil - now));
-    }
-    return () => {
-      timers.forEach((timerId) => window.clearTimeout(timerId));
-    };
-  }, [
-    defaultPromptVisibleUntil,
-    enabled,
-    errorVisibleUntil,
-    now,
-    ocrStatus,
-    responseVisibleUntil,
-    transcriptVisibleUntil,
-  ]);
-
-  if (!enabled) {
-    return null;
-  }
-
-  const isSttLoading =
-    isLoading &&
-    (loadingMessage === '音声を文字にしています...' ||
-      loadingMessage === 'Transcribing your speech...');
-  const isTtsSynthesizing =
-    isLoading && response.length > 0 && sessionState !== 'speaking';
-  const isErrorVisible = Boolean(error) && errorVisibleUntil > now;
-  const isOcrStatusVisible = Boolean(ocrStatus && ocrStatus.visibleUntil > now);
-  const isDefaultPromptVisible =
-    response.length === 0 &&
-    sessionState === 'idle' &&
-    defaultPromptVisibleUntil > now;
-  const displayResponse = response || (isDefaultPromptVisible ? labels.defaultPrompt : '');
-  const isResponseVisible =
-    displayResponse.length > 0 &&
-    (sessionState === 'speaking' || responseVisibleUntil > now || isDefaultPromptVisible);
-  const isTranscriptVisible =
-    transcript.length > 0 && !isSttLoading && transcriptVisibleUntil > now;
-
-  if (!isSttLoading && !isTtsSynthesizing && !isTranscriptVisible && !isResponseVisible && !isErrorVisible && !isOcrStatusVisible) {
-    return null;
-  }
-
-  return (
-    <div className="w-full space-y-2">
-      {isOcrStatusVisible && ocrStatus ? (
-        <div className="flex w-full items-center gap-2 rounded-xl border border-white/30 bg-black/35 px-4 py-2 text-sm font-medium text-white/95 shadow-sm backdrop-blur-sm">
-          {ocrStatus.kind === 'error' ? (
-            <XCircle className="size-4 shrink-0 text-rose-300" />
-          ) : ocrStatus.kind === 'handwriting' ? (
-            <MessageSquare className="size-4 shrink-0" />
-          ) : (
-            <Camera className="size-4 shrink-0" />
-          )}
-          <span>{ocrStatus.text}</span>
-        </div>
-      ) : null}
-      {isSttLoading ? (
-        <div className="flex w-full items-center gap-2 rounded-xl border border-white/30 bg-black/35 px-4 py-2 text-sm font-medium text-white/95 shadow-sm backdrop-blur-sm">
-          <Loader2 className="size-4 shrink-0 animate-spin" />
-          <span>{labels.sttReading}</span>
-        </div>
-      ) : null}
-      {isTranscriptVisible ? (
-        <div className="flex w-full items-center gap-2 rounded-xl border border-white/30 bg-black/35 px-4 py-2 text-sm font-medium text-white/95 shadow-sm backdrop-blur-sm">
-          <TextQuote className="size-4 shrink-0" />
-          <span>
-            {labels.transcriptLabel}: {transcript}
-          </span>
-        </div>
-      ) : null}
-      {isErrorVisible ? (
-        <div className="flex w-full items-center gap-2 rounded-xl border border-rose-300/45 bg-rose-700/35 px-4 py-2 text-sm font-medium text-rose-50 shadow-sm backdrop-blur-sm">
-          <XCircle className="size-4 shrink-0" />
-          <span>{error}</span>
-        </div>
-      ) : null}
-      {isTtsSynthesizing ? (
-        <div className="flex w-full items-center gap-2 rounded-xl border border-white/30 bg-black/35 px-4 py-2 text-sm font-medium text-white/95 shadow-sm backdrop-blur-sm">
-          <Loader2 className="size-4 shrink-0 animate-spin" />
-          <span>{labels.ttsSynthesizing}</span>
-        </div>
-      ) : null}
-      {isResponseVisible ? (
-        <div
-          className="flex w-full items-center gap-2 rounded-xl border border-white/30 bg-black/35 px-4 py-2 text-sm font-medium text-white/95 shadow-sm backdrop-blur-sm"
-          data-testid="response-bubble"
-        >
-          <Volume2 className="size-4 shrink-0" />
-          <span data-testid="response-text">
-            {response
-              ? `${labels.responseLabel}: ${response}`
-              : displayResponse}
-          </span>
-        </div>
-      ) : null}
-    </div>
-  );
-}
-
-function ConversationHistoryEffects({
-  transcript,
-  response,
-  lastTranscriptRef,
-  lastResponseRef,
-  setConversationHistory,
-}: {
-  transcript: string;
-  response: string;
-  lastTranscriptRef: MutableRefObject<string>;
-  lastResponseRef: MutableRefObject<string>;
-  setConversationHistory: Dispatch<SetStateAction<ConversationHistoryItem[]>>;
-}) {
-  useEffect(() => {
-    if (transcript && transcript !== lastTranscriptRef.current) {
-      lastTranscriptRef.current = transcript;
-      setConversationHistory((prev) => [
-        ...prev,
-        {
-          id: `u-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`,
-          role: 'user',
-          text: transcript,
-        },
-      ]);
-    }
-  }, [lastTranscriptRef, setConversationHistory, transcript]);
-
-  useEffect(() => {
-    if (response && response !== lastResponseRef.current) {
-      lastResponseRef.current = response;
-      setConversationHistory((prev) => [
-        ...prev,
-        {
-          id: `a-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`,
-          role: 'assistant',
-          text: response,
-        },
-      ]);
-    }
-  }, [lastResponseRef, response, setConversationHistory]);
-
-  return null;
-}
-
-const getStageBackgroundStyle = (background: BackgroundOption): CSSProperties => {
-  if (background.type === 'image') {
-    return {
-      backgroundImage: `url(${background.value})`,
-      backgroundPosition: 'center',
-      backgroundRepeat: 'no-repeat',
-      backgroundSize: 'cover',
-    };
-  }
-
-  if (background.type === 'gradient') {
-    return { background: background.value };
-  }
-
-  return background.value ? { backgroundColor: background.value } : {};
-};
 
 export default function Home() {
   const [kioskPhase, setKioskPhase] = useState<KioskPhase>('notice');
@@ -363,10 +61,12 @@ export default function Home() {
     value: '/backgrounds/IMG_5573.JPG',
   });
   const [lightingIntensity, setLightingIntensity] = useState(1);
-  const [setVisemeFunction, setSetVisemeFunction] = useState<((viseme: string, intensity: number) => void) | null>(null);
-  const [setExpressionFunction, setSetExpressionFunction] = useState<((expression: string, weight: number) => void) | null>(null);
-  const [textDraft, setTextDraft] = useState('');
-  const [showTextInput, setShowTextInput] = useState(false);
+  const [setVisemeFunction, setSetVisemeFunction] = useState<
+    ((viseme: string, intensity: number) => void) | null
+  >(null);
+  const [setExpressionFunction, setSetExpressionFunction] = useState<
+    ((expression: string, weight: number) => void) | null
+  >(null);
   const [, setLatestMetadata] = useState<VoiceInterfaceMetadata | null>(null);
   const [conversationHistory, setConversationHistory] = useState<ConversationHistoryItem[]>([]);
   const [showSettingsPanel, setShowSettingsPanel] = useState(false);
@@ -375,7 +75,6 @@ export default function Home() {
     useState<SettingsPanelPropsFromSource | null>(null);
   const playKeyframeAnimationRef = useRef<((data: CharacterAnimationData) => void) | null>(null);
   const lastVrmControlPlayedRef = useRef<unknown>(null);
-  /** Set when vrm_control playback runs before keyframe control ref is ready; flushed in onKeyframeAnimationControl. */
   const pendingVrmPlaybackRef = useRef<CharacterAnimationData | null>(null);
   const lastTranscriptRef = useRef<string>('');
   const lastResponseRef = useRef<string>('');
@@ -499,7 +198,6 @@ export default function Home() {
     }
   }, [kioskPhase, kioskVoiceLocked]);
 
-  /** Physical/sensor mode: hide main kiosk buttons; settings gear still opens SettingsPanel. */
   const showKioskScreenChrome = triggerMode !== 'device';
 
   useEffect(() => {
@@ -524,7 +222,6 @@ export default function Home() {
   const handleSettingsPanelPropsChange = useCallback(
     (props: SettingsPanelPropsFromSource) => {
       settingsPanelPropsRef.current = props;
-      // Avoid re-rendering the whole page when settings panel is closed.
       if (showSettingsPanel) {
         setSettingsPanelProps(props);
       }
@@ -540,19 +237,22 @@ export default function Home() {
     }
   }, [showSettingsPanel]);
 
-  const startPresentation = useCallback((language: 'ja' | 'en') => {
-    clearReturnToIdleTimer();
-    setCurrentLanguage(language);
-    setKioskPhase('slides');
+  const startPresentation = useCallback(
+    (language: 'ja' | 'en') => {
+      clearReturnToIdleTimer();
+      setCurrentLanguage(language);
+      setKioskPhase('slides');
 
-    window.setTimeout(() => {
-      window.dispatchEvent(
-        new CustomEvent('autoStartPresentation', {
-          detail: { autoPlay: true, language },
-        }),
-      );
-    }, 150);
-  }, [clearReturnToIdleTimer]);
+      window.setTimeout(() => {
+        window.dispatchEvent(
+          new CustomEvent('autoStartPresentation', {
+            detail: { autoPlay: true, language },
+          }),
+        );
+      }, 150);
+    },
+    [clearReturnToIdleTimer],
+  );
 
   const handleCloseSlides = useCallback(() => {
     clearReturnToIdleTimer();
@@ -572,664 +272,381 @@ export default function Home() {
         }}
       />
       <VoiceInterface
-      language={currentLanguage}
-      onLanguageChange={setCurrentLanguage}
-      wakeWordEnabled={false}
-      autoResumeListeningAfterAssistant={
-        micInputMode === 'push_to_talk' ? false : kioskVoiceLocked
-      }
-      onVisemeControl={setVisemeFunction}
-      showDefaultUI={false}
-      onMetadataChange={setLatestMetadata}
-      onAssistantPlaybackEnd={() => {
-        if (kioskPhaseRef.current === 'voice') {
-          scheduleReturnToIdle();
+        language={currentLanguage}
+        onLanguageChange={setCurrentLanguage}
+        wakeWordEnabled={false}
+        autoResumeListeningAfterAssistant={
+          micInputMode === 'push_to_talk' ? false : kioskVoiceLocked
         }
-      }}
-      onAssistantPlaybackStart={({ metadata: playbackMetadata }) => {
-        const vc = playbackMetadata?.vrm_control;
-        if (!vc) {
-          return;
-        }
-        if (playKeyframeAnimationRef.current) {
-          if (lastVrmControlPlayedRef.current !== vc) {
-            lastVrmControlPlayedRef.current = vc;
-            playKeyframeAnimationRef.current(vc);
-          }
-          pendingVrmPlaybackRef.current = null;
-        } else {
-          pendingVrmPlaybackRef.current = vc;
-        }
-      }}
-    >
-      {(voice) => {
-        kioskVoiceCleanupRef.current = () => {
-          voice.cancelSession();
-          voice.clearConversation();
-        };
-        const labels = overlayLabels[voice.currentLanguage];
-        const receptionTriggerType =
-          triggerMode === 'device' ? 'sensor_trigger' : 'button_press';
-        kioskPlayWelcomeRef.current = async () => {
-          if (!armWelcomeCooldown()) {
-            return;
-          }
-          markAudioUserInteraction();
-          clearReturnToIdleTimer();
-          setWelcomeMemberOcrSessionKey((n) => n + 1);
-          setWelcomeMemberOcrOpen(true);
-          try {
-            const result = await startReception({
-              session_id: voice.sessionId,
-              language: voice.currentLanguage,
-              trigger_type: receptionTriggerType,
-            });
-            await voice.speakPreparedText(result.greeting, null);
-          } catch {
-            const fallback =
-              voice.currentLanguage === 'ja'
-                ? 'エンジニアカフェへようこそ。ご用件をお聞かせください。'
-                : 'Welcome to Engineer Cafe. How can I help you today?';
-            await voice.speakPreparedText(fallback, null);
-          } finally {
+        onVisemeControl={setVisemeFunction}
+        showDefaultUI={false}
+        onMetadataChange={setLatestMetadata}
+        onAssistantPlaybackEnd={() => {
+          if (kioskPhaseRef.current === 'voice') {
             scheduleReturnToIdle();
           }
-        };
-        const showSlideMode = kioskPhase === 'slides';
-        const stageBackgroundStyle = getStageBackgroundStyle(characterBackground);
-        const isListening = voice.sessionState === 'listening';
-        const isSpeaking = voice.sessionState === 'speaking';
-        const visualState: VoiceSessionState =
-          voice.sessionState === 'speaking'
-            ? 'speaking'
-            : voice.sessionState === 'listening'
-              ? 'listening'
-              : voice.sessionState === 'processing' || voice.isLoading
-                ? 'processing'
-                : 'idle';
-        const isProcessing = visualState === 'processing';
-        const showConversationReset =
-          Boolean(voice.transcript) || Boolean(voice.response) || Boolean(voice.metadata);
-        const canCancelTurn = voice.sessionState !== 'idle' || voice.isLoading;
-        const waveformBars = (
-          isListening || isSpeaking ? voice.waveformBars : [0.2, 0.28, 0.18, 0.26, 0.2]
-        ).map((value) => Math.max(value, 0.16));
-        const bubbleBody =
-          voice.response || (voice.isLoading && voice.loadingMessage) || labels.defaultPrompt;
-        const micButtonLabel = labels[buttonCopy[visualState]];
-        const isInputDisabled = isListening || isProcessing;
-
-        const screenPadding = {
-          paddingTop: 'max(1.5rem, env(safe-area-inset-top))',
-          paddingBottom: 'max(1.5rem, env(safe-area-inset-bottom))',
-          paddingLeft: 'max(1.5rem, env(safe-area-inset-left))',
-          paddingRight: 'max(1.5rem, env(safe-area-inset-right))',
-        } satisfies CSSProperties;
-
-        const characterCameraOffset = showSlideMode
-          ? { x: 0.2, y: 0, z: 0.0 }
-          : { x: 0, y: 0, z: 0 };
-        const characterModelOffset = showSlideMode
-          ? { x: -0.7, y: 0, z: 0 }
-          : { x: 0, y: 0, z: 0 };
-        const characterRotationOffset = showSlideMode
-          ? { x: 0, y: 0.35, z: 0 }
-          : { x: 0, y: -0.2, z: 0 };
-
-        const submitTextDraft = async () => {
-          markAudioUserInteraction();
-          const trimmed = textDraft.trim();
-          if (!trimmed) {
+        }}
+        onAssistantPlaybackStart={({ metadata: playbackMetadata }) => {
+          const vc = playbackMetadata?.vrm_control;
+          if (!vc) {
             return;
           }
+          if (playKeyframeAnimationRef.current) {
+            if (lastVrmControlPlayedRef.current !== vc) {
+              lastVrmControlPlayedRef.current = vc;
+              playKeyframeAnimationRef.current(vc);
+            }
+            pendingVrmPlaybackRef.current = null;
+          } else {
+            pendingVrmPlaybackRef.current = vc;
+          }
+        }}
+      >
+        {(voice) => {
+          kioskVoiceCleanupRef.current = () => {
+            voice.cancelSession();
+            voice.clearConversation();
+          };
+          const labels = overlayLabels[voice.currentLanguage];
+          const receptionTriggerType =
+            triggerMode === 'device' ? 'sensor_trigger' : 'button_press';
+          kioskPlayWelcomeRef.current = async () => {
+            if (!armWelcomeCooldown()) {
+              return;
+            }
+            markAudioUserInteraction();
+            clearReturnToIdleTimer();
+            setWelcomeMemberOcrSessionKey((n) => n + 1);
+            setWelcomeMemberOcrOpen(true);
+            try {
+              const result = await startReception({
+                session_id: voice.sessionId,
+                language: voice.currentLanguage,
+                trigger_type: receptionTriggerType,
+              });
+              await voice.speakPreparedText(result.greeting, null);
+            } catch {
+              const fallback =
+                voice.currentLanguage === 'ja'
+                  ? 'エンジニアカフェへようこそ。ご用件をお聞かせください。'
+                  : 'Welcome to Engineer Cafe. How can I help you today?';
+              await voice.speakPreparedText(fallback, null);
+            } finally {
+              scheduleReturnToIdle();
+            }
+          };
+          const showSlideMode = kioskPhase === 'slides';
+          const stageBackgroundStyle = getStageBackgroundStyle(characterBackground);
 
-          await voice.sendMessage(trimmed);
-          setTextDraft('');
-        };
+          const screenPadding = {
+            paddingTop: 'max(1.5rem, env(safe-area-inset-top))',
+            paddingBottom: 'max(1.5rem, env(safe-area-inset-bottom))',
+            paddingLeft: 'max(1.5rem, env(safe-area-inset-left))',
+            paddingRight: 'max(1.5rem, env(safe-area-inset-right))',
+          } satisfies CSSProperties;
 
-        const pushToTalk = micInputMode === 'push_to_talk';
-        const setOcrStatusMessage = (
-          kind: 'member_card' | 'handwriting' | 'error',
-          text: string,
-        ) => {
-          setOcrStatus({
-            kind,
-            text,
-            visibleUntil: Date.now() + 5000,
-          });
-        };
-        const handleOcrSuccess = (result: OcrResponse) => {
-          clearReturnToIdleTimer();
-          setKioskPhase('idle');
+          const characterCameraOffset = showSlideMode
+            ? { x: 0.2, y: 0, z: 0.0 }
+            : { x: 0, y: 0, z: 0 };
+          const characterModelOffset = showSlideMode
+            ? { x: -0.7, y: 0, z: 0 }
+            : { x: 0, y: 0, z: 0 };
+          const characterRotationOffset = showSlideMode
+            ? { x: 0, y: 0.35, z: 0 }
+            : { x: 0, y: -0.2, z: 0 };
 
-          if (result.mode === 'member_card') {
+          const setOcrStatusMessage = (
+            kind: 'member_card' | 'handwriting' | 'error',
+            text: string,
+          ) => {
+            setOcrStatus({
+              kind,
+              text,
+              visibleUntil: Date.now() + 5000,
+            });
+          };
+
+          const handleOcrSuccess = (result: OcrResponse) => {
+            clearReturnToIdleTimer();
+            setKioskPhase('idle');
+
+            if (result.mode === 'member_card') {
+              const memberText =
+                result.member_number !== null
+                  ? `${labels.ocrMemberResult}: ${result.member_number}`
+                  : labels.ocrReadFailed;
+              setOcrStatusMessage('member_card', memberText);
+              return;
+            }
+
+            const recognized = (result.recognized_text ?? '').trim();
+            if (!recognized) {
+              setOcrStatusMessage('error', labels.ocrReadFailed);
+              return;
+            }
+
+            setOcrStatusMessage('handwriting', `${labels.ocrHandwritingResult}: ${recognized}`);
+            void voice.sendMessage(recognized);
+          };
+
+          const handleWelcomeMemberOcrSuccess = (result: OcrResponse) => {
+            setWelcomeMemberOcrOpen(false);
+            clearReturnToIdleTimer();
+            setKioskPhase('idle');
             const memberText =
               result.member_number !== null
                 ? `${labels.ocrMemberResult}: ${result.member_number}`
                 : labels.ocrReadFailed;
             setOcrStatusMessage('member_card', memberText);
-            return;
-          }
+          };
 
-          const recognized = (result.recognized_text ?? '').trim();
-          if (!recognized) {
-            setOcrStatusMessage('error', labels.ocrReadFailed);
-            return;
-          }
+          const handleWelcomeMemberOcrEndSilent = () => {
+            setWelcomeMemberOcrOpen(false);
+          };
 
-          setOcrStatusMessage('handwriting', `${labels.ocrHandwritingResult}: ${recognized}`);
-          void voice.sendMessage(recognized);
-        };
-
-        const handleWelcomeMemberOcrSuccess = (result: OcrResponse) => {
-          setWelcomeMemberOcrOpen(false);
-          clearReturnToIdleTimer();
-          setKioskPhase('idle');
-          const memberText =
-            result.member_number !== null
-              ? `${labels.ocrMemberResult}: ${result.member_number}`
-              : labels.ocrReadFailed;
-          setOcrStatusMessage('member_card', memberText);
-        };
-
-        const handleWelcomeMemberOcrEndSilent = () => {
-          setWelcomeMemberOcrOpen(false);
-        };
-
-        const handleMicPointerDown = (e: ReactPointerEvent<HTMLButtonElement>) => {
-          if (!pushToTalk || isProcessing || isSpeaking) {
-            return;
-          }
-          e.preventDefault();
-          e.currentTarget.setPointerCapture(e.pointerId);
-          markAudioUserInteraction();
-          if (!isListening) {
-            void voice.startListening();
-          }
-        };
-
-        const handleMicPointerUp = (e: ReactPointerEvent<HTMLButtonElement>) => {
-          if (!pushToTalk) {
-            return;
-          }
-          e.preventDefault();
-          if (e.currentTarget.hasPointerCapture(e.pointerId)) {
-            e.currentTarget.releasePointerCapture(e.pointerId);
-          }
-          if (isListening) {
-            voice.stopListening();
-          }
-        };
-
-        const handleMicPointerCancel = (e: ReactPointerEvent<HTMLButtonElement>) => {
-          if (!pushToTalk) {
-            return;
-          }
-          if (e.currentTarget.hasPointerCapture(e.pointerId)) {
-            e.currentTarget.releasePointerCapture(e.pointerId);
-          }
-          if (isListening) {
-            voice.stopListening();
-          }
-        };
-
-        return (
-          <>
-            <ConversationHistoryEffects
-              transcript={voice.transcript}
-              response={voice.response}
-              lastTranscriptRef={lastTranscriptRef}
-              lastResponseRef={lastResponseRef}
-              setConversationHistory={setConversationHistory}
-            />
-            <main className="relative h-[100svh] w-screen overflow-hidden">
-              <div className="absolute inset-0 -z-10" style={stageBackgroundStyle}>
-                <CharacterAvatar
-                  modelPath="/characters/models/sakura.vrm"
-                  sessionState={voice.sessionState}
-                  background={characterBackground}
-                  lightingIntensity={lightingIntensity}
-                  cameraPositionOffset={characterCameraOffset}
-                  modelPositionOffset={characterModelOffset}
-                  modelRotationOffset={characterRotationOffset}
-                  enableClickAnimation={!showSlideMode}
-                  showControls={showAvatarControls && !showSlideMode && kioskPhase === 'voice'}
-                  volume={Math.round(voice.volume * 100)}
-                  isMuted={voice.isMuted}
-                  onVolumeChange={(value) => voice.setVolume(value / 100)}
-                  onMuteToggle={() => voice.setMuted(!voice.isMuted)}
-                  onVisemeControl={(setViseme) => {
-                    setSetVisemeFunction(() => setViseme);
-                  }}
-                  onExpressionControl={(setExpression) => {
-                    setSetExpressionFunction(() => setExpression);
-                  }}
-                  onKeyframeAnimationControl={(play) => {
-                    playKeyframeAnimationRef.current = play;
-                    const pending = pendingVrmPlaybackRef.current;
-                    if (pending && lastVrmControlPlayedRef.current !== pending) {
-                      lastVrmControlPlayedRef.current = pending;
-                      play(pending);
-                      pendingVrmPlaybackRef.current = null;
-                    }
-                  }}
-                  onBackgroundChange={setCharacterBackground}
-                  onLightingChange={setLightingIntensity}
-                  settingsPanelPropsRef={settingsPanelPropsRef}
-                  onSettingsPanelPropsChange={handleSettingsPanelPropsChange}
-                />
-              </div>
-
-              <div
-                className="pointer-events-none absolute inset-0 z-30"
-                aria-hidden={!showSettingsPanel}
-              >
-                <div
-                  className="pointer-events-auto absolute"
-                  style={{
-                    top: screenPadding.paddingTop,
-                    right: screenPadding.paddingRight,
-                  }}
-                >
-                  <button
-                    data-testid="kiosk-settings-button"
-                    type="button"
-                    onClick={() => setShowSettingsPanel(true)}
-                    aria-label={voice.currentLanguage === 'ja' ? '設定' : 'Settings'}
-                    className="inline-flex size-11 shrink-0 items-center justify-center rounded-full border border-white/15 bg-black/45 text-white shadow-lg backdrop-blur-md transition-transform duration-200 ease-out hover:scale-105"
-                  >
-                    <Settings className="size-5" />
-                  </button>
-                </div>
-              </div>
-
-              {welcomeMemberOcrOpen && kioskPhase !== 'ocr' && !showSlideMode ? (
-                <div
-                  className="pointer-events-auto absolute z-[38] w-[min(92vw,13.5rem)] rounded-xl border border-white/25 bg-white/95 p-3 shadow-2xl backdrop-blur-md"
-                  style={{
-                    top: 'calc(max(1.5rem, env(safe-area-inset-top)) + 3.25rem)',
-                    right: 'max(1rem, env(safe-area-inset-right))',
-                  }}
-                  onPointerDownCapture={bumpUserActivity}
-                >
-                  <p className="mb-2 text-center text-xs font-semibold text-slate-800">
-                    {labels.kioskOcrMember}
-                  </p>
-                  <OcrCameraView
-                    key={welcomeMemberOcrSessionKey}
-                    mode="member_card"
-                    autoStart
-                    compact
-                    hideSkip
-                    sessionId={voice.sessionId}
-                    onSuccess={handleWelcomeMemberOcrSuccess}
-                    onFallback={handleWelcomeMemberOcrEndSilent}
-                    onSkip={handleWelcomeMemberOcrEndSilent}
-                    onCameraInitFailed={handleWelcomeMemberOcrEndSilent}
+          return (
+            <>
+              <ConversationHistoryEffects
+                transcript={voice.transcript}
+                response={voice.response}
+                lastTranscriptRef={lastTranscriptRef}
+                lastResponseRef={lastResponseRef}
+                setConversationHistory={setConversationHistory}
+              />
+              <main className="relative h-[100svh] w-screen overflow-hidden">
+                <div className="absolute inset-0 -z-10" style={stageBackgroundStyle}>
+                  <CharacterAvatar
+                    modelPath="/characters/models/sakura.vrm"
+                    sessionState={voice.sessionState}
+                    background={characterBackground}
+                    lightingIntensity={lightingIntensity}
+                    cameraPositionOffset={characterCameraOffset}
+                    modelPositionOffset={characterModelOffset}
+                    modelRotationOffset={characterRotationOffset}
+                    enableClickAnimation={!showSlideMode}
+                    showControls={showAvatarControls && !showSlideMode && kioskPhase === 'voice'}
+                    volume={Math.round(voice.volume * 100)}
+                    isMuted={voice.isMuted}
+                    onVolumeChange={(value) => voice.setVolume(value / 100)}
+                    onMuteToggle={() => voice.setMuted(!voice.isMuted)}
+                    onVisemeControl={(setViseme) => {
+                      setSetVisemeFunction(() => setViseme);
+                    }}
+                    onExpressionControl={(setExpression) => {
+                      setSetExpressionFunction(() => setExpression);
+                    }}
+                    onKeyframeAnimationControl={(play) => {
+                      playKeyframeAnimationRef.current = play;
+                      const pending = pendingVrmPlaybackRef.current;
+                      if (pending && lastVrmControlPlayedRef.current !== pending) {
+                        lastVrmControlPlayedRef.current = pending;
+                        play(pending);
+                        pendingVrmPlaybackRef.current = null;
+                      }
+                    }}
+                    onBackgroundChange={setCharacterBackground}
+                    onLightingChange={setLightingIntensity}
+                    settingsPanelPropsRef={settingsPanelPropsRef}
+                    onSettingsPanelPropsChange={handleSettingsPanelPropsChange}
                   />
                 </div>
-              ) : null}
 
-              {showSettingsPanel && settingsPanelProps ? (
                 <div
-                  className="absolute inset-0 z-40 pointer-events-none"
+                  className="pointer-events-none absolute inset-0 z-30"
                   aria-hidden={!showSettingsPanel}
                 >
                   <div
-                    className="pointer-events-auto absolute top-0 flex max-h-full justify-end"
+                    className="pointer-events-auto absolute"
                     style={{
                       top: screenPadding.paddingTop,
                       right: screenPadding.paddingRight,
                     }}
                   >
-                    <SettingsPanel
-                      {...settingsPanelProps}
-                      kiosk_language={voice.currentLanguage}
-                      kiosk_trigger_mode={triggerMode}
-                      kiosk_mic_mode={micInputMode}
-                      on_kiosk_language_change={(language) => {
-                        setCurrentLanguage(language);
-                      }}
-                      on_kiosk_trigger_mode_change={(mode) => {
-                        setTriggerMode(mode);
-                        writeKioskTriggerMode(mode);
-                      }}
-                      on_kiosk_mic_mode_change={(mode) => {
-                        setMicInputMode(mode);
-                        writeKioskMicMode(mode);
-                      }}
-                      volume={Math.round(voice.volume * 100)}
-                      is_muted={voice.isMuted}
-                      on_volume_change={(value) => {
-                        voice.setVolume(value / 100);
-                      }}
-                      on_mute_toggle={() => {
-                        voice.setMuted(!voice.isMuted);
-                      }}
-                      show_close_button
-                      on_close={() => setShowSettingsPanel(false)}
-                      extra_tab={{
-                        label: voice.currentLanguage === 'ja' ? '会話履歴' : 'Conversation',
-                        content: (
-                          <div className="space-y-2 overflow-y-auto pr-1">
-                            {conversationHistory.length === 0 ? (
-                              <p className="text-sm text-gray-600">{labels.helperPrompt}</p>
-                            ) : (
-                              conversationHistory.map((item) => (
-                                <div
-                                  key={item.id}
-                                  className={cn(
-                                    'rounded-2xl px-3 py-2 text-sm leading-6',
-                                    item.role === 'user'
-                                      ? 'bg-gray-100 text-gray-800'
-                                      : 'bg-blue-50 text-gray-800',
-                                  )}
-                                >
-                                  <p className="text-xs font-medium text-gray-500">
-                                    {item.role === 'user'
-                                      ? voice.currentLanguage === 'ja'
-                                        ? 'あなた'
-                                        : 'You'
-                                      : 'Navigator'}
-                                  </p>
-                                  <p className="mt-1 whitespace-pre-wrap">{item.text}</p>
-                                </div>
-                              ))
-                            )}
-                          </div>
-                        ),
-                      }}
-                      slide_mode_open={showSlideMode}
-                      on_open_slides={() => startPresentation(voice.currentLanguage)}
-                      on_close_slides={handleCloseSlides}
-                      open_slides_label={labels.openSlides}
-                      close_slides_label={labels.closeSlides}
-                    />
+                    <button
+                      data-testid="kiosk-settings-button"
+                      type="button"
+                      onClick={() => setShowSettingsPanel(true)}
+                      aria-label={voice.currentLanguage === 'ja' ? '設定' : 'Settings'}
+                      className="inline-flex size-11 shrink-0 items-center justify-center rounded-full border border-white/15 bg-black/45 text-white shadow-lg backdrop-blur-md transition-transform duration-200 ease-out hover:scale-105"
+                    >
+                      <Settings className="size-5" />
+                    </button>
                   </div>
                 </div>
-              ) : null}
 
-              {(kioskPhase === 'idle' || kioskPhase === 'voice' || kioskPhase === 'notice') && (
-                <div
-                  className="pointer-events-auto absolute inset-x-0 bottom-0 z-[25] flex justify-center pb-[max(0.75rem,env(safe-area-inset-bottom))] pl-[max(1rem,env(safe-area-inset-left))] pr-[max(1rem,env(safe-area-inset-right))] pt-2"
-                >
-                  <div className="flex w-full max-w-5xl flex-col items-stretch justify-center gap-2 sm:gap-3">
-                    {(() => {
-                      const isVoiceCaptureActive = kioskPhase === 'voice' && kioskVoiceLocked;
-                      const isPushToTalk = micInputMode === 'push_to_talk';
-                      const handleKioskVoiceStart = () => {
-                        markAudioUserInteraction();
-                        clearReturnToIdleTimer();
-                        setWelcomeMemberOcrOpen(false);
-                        setKioskPhase('voice');
-                        setKioskVoiceLocked(true);
-                        void voice.startListening();
-                      };
-                      const handleKioskVoiceStop = () => {
-                        setKioskVoiceLocked(false);
-                        if (isPushToTalk) {
-                          voice.stopListening();
-                          return;
-                        }
-                        // Toggle: end utterance and run STT/QA if still listening; otherwise drop session.
-                        if (voice.sessionState === 'listening') {
-                          voice.stopListening();
-                          return;
-                        }
-                        voice.cancelSession();
-                      };
+                <KioskWelcomeOverlay
+                  open={welcomeMemberOcrOpen}
+                  welcomeMemberOcrSessionKey={welcomeMemberOcrSessionKey}
+                  kioskPhase={kioskPhase}
+                  showSlideMode={showSlideMode}
+                  labels={labels}
+                  sessionId={voice.sessionId}
+                  bumpUserActivity={bumpUserActivity}
+                  onMemberOcrSuccess={handleWelcomeMemberOcrSuccess}
+                  onMemberOcrEnd={handleWelcomeMemberOcrEndSilent}
+                />
 
-                      return (
-                        <>
-                    <KioskVoiceStatusStack
-                      enabled={kioskPhase === 'voice' || kioskPhase === 'idle' || kioskPhase === 'notice'}
-                      phase={kioskPhase}
-                      labels={labels}
-                      transcript={voice.transcript}
-                      response={voice.response}
-                      error={voice.error}
-                      ocrStatus={ocrStatus}
-                      isLoading={voice.isLoading}
-                      loadingMessage={voice.loadingMessage}
-                      sessionState={voice.sessionState}
-                    />
-                    {showKioskScreenChrome ? (
-                    <div className="flex w-full flex-row flex-wrap items-stretch justify-center gap-2 sm:gap-3">
-                    <button
-                      type="button"
-                      onClick={() => {
-                        void kioskPlayWelcomeRef.current?.();
-                      }}
-                      disabled={
-                        isVoiceCaptureActive || voice.isLoading || welcomeCooldown
-                      }
-                      className={cn(
-                        'flex min-h-[72px] min-w-[min(100%,7rem)] flex-1 flex-col items-center justify-center gap-1 rounded-2xl px-3 py-3 shadow-md backdrop-blur-sm transition-transform sm:min-h-[80px] sm:flex-initial sm:px-5',
-                        isVoiceCaptureActive || voice.isLoading || welcomeCooldown
-                          ? 'cursor-not-allowed border border-slate-500/40 bg-slate-600/40 text-slate-300'
-                          : 'border border-white/35 bg-white/15 text-white hover:scale-[1.02]',
-                      )}
-                    >
-                      <Sparkles className="size-6 shrink-0 sm:size-7" aria-hidden />
-                      <span className="text-center text-xs font-semibold leading-tight sm:text-sm">
-                        {labels.kioskWelcome}
-                      </span>
-                    </button>
-                    <button
-                      data-testid="kiosk-voice-button"
-                      type="button"
-                      onPointerDown={(event) => {
-                        if (!isPushToTalk) {
-                          return;
-                        }
-                        event.preventDefault();
-                        event.currentTarget.setPointerCapture(event.pointerId);
-                        if (!isVoiceCaptureActive) {
-                          handleKioskVoiceStart();
-                        }
-                      }}
-                      onPointerUp={(event) => {
-                        if (!isPushToTalk) {
-                          return;
-                        }
-                        if (event.currentTarget.hasPointerCapture(event.pointerId)) {
-                          event.currentTarget.releasePointerCapture(event.pointerId);
-                        }
-                        if (isVoiceCaptureActive) {
-                          handleKioskVoiceStop();
-                        }
-                      }}
-                      onPointerCancel={(event) => {
-                        if (!isPushToTalk) {
-                          return;
-                        }
-                        if (event.currentTarget.hasPointerCapture(event.pointerId)) {
-                          event.currentTarget.releasePointerCapture(event.pointerId);
-                        }
-                        if (isVoiceCaptureActive) {
-                          handleKioskVoiceStop();
-                        }
-                      }}
-                      onClick={(event) => {
-                        if (isPushToTalk) {
-                          event.preventDefault();
-                          return;
-                        }
-                        if (isVoiceCaptureActive) {
-                          handleKioskVoiceStop();
-                          return;
-                        }
-                        handleKioskVoiceStart();
-                      }}
-                      className={cn(
-                        'flex min-h-[72px] min-w-[min(100%,7rem)] flex-1 flex-col items-center justify-center gap-1 rounded-2xl px-3 py-3 shadow-md backdrop-blur-sm transition-transform sm:min-h-[80px] sm:flex-initial sm:px-5',
-                        isVoiceCaptureActive
-                          ? 'border border-emerald-300/70 bg-emerald-500/55 text-white shadow-lg'
-                          : 'border border-white/35 bg-white/15 text-white hover:scale-[1.02]',
-                      )}
-                    >
-                      <Mic className="size-6 shrink-0 sm:size-7" aria-hidden />
-                      <span className="text-center text-xs font-semibold leading-tight sm:text-sm">
-                        {labels.kioskVoice}
-                      </span>
-                    </button>
-                    <button
-                      type="button"
-                      onClick={() => {
-                        markAudioUserInteraction();
-                        setWelcomeMemberOcrOpen(false);
-                        setOcrMode('member_card');
-                        setKioskPhase('ocr');
-                      }}
-                      disabled={isVoiceCaptureActive}
-                      className={cn(
-                        'flex min-h-[72px] min-w-[min(100%,7rem)] flex-1 flex-col items-center justify-center gap-1 rounded-2xl px-3 py-3 shadow-md backdrop-blur-sm transition-transform sm:min-h-[80px] sm:flex-initial sm:px-5',
-                        isVoiceCaptureActive
-                          ? 'cursor-not-allowed border border-slate-500/40 bg-slate-600/40 text-slate-300'
-                          : 'border border-white/35 bg-white/15 text-white hover:scale-[1.02]',
-                      )}
-                    >
-                      <Camera className="size-6 shrink-0 sm:size-7" aria-hidden />
-                      <span className="text-center text-xs font-semibold leading-tight sm:text-sm">
-                        {labels.kioskOcrMember}
-                      </span>
-                    </button>
-                    <button
-                      type="button"
-                      onClick={() => {
-                        markAudioUserInteraction();
-                        setWelcomeMemberOcrOpen(false);
-                        setOcrMode('handwriting');
-                        setKioskPhase('ocr');
-                      }}
-                      disabled={isVoiceCaptureActive}
-                      className={cn(
-                        'flex min-h-[72px] min-w-[min(100%,7rem)] flex-1 flex-col items-center justify-center gap-1 rounded-2xl px-3 py-3 shadow-md backdrop-blur-sm transition-transform sm:min-h-[80px] sm:flex-initial sm:px-5',
-                        isVoiceCaptureActive
-                          ? 'cursor-not-allowed border border-slate-500/40 bg-slate-600/40 text-slate-300'
-                          : 'border border-white/35 bg-white/15 text-white hover:scale-[1.02]',
-                      )}
-                    >
-                      <PenLine className="size-6 shrink-0 sm:size-7" aria-hidden />
-                      <span className="text-center text-xs font-semibold leading-tight sm:text-sm">
-                        {labels.kioskOcrHandwriting}
-                      </span>
-                    </button>
-                    <button
-                      data-testid="kiosk-slides-button"
-                      type="button"
-                      onClick={() => {
-                        markAudioUserInteraction();
-                        setWelcomeMemberOcrOpen(false);
-                        startPresentation(voice.currentLanguage);
-                      }}
-                      disabled={isVoiceCaptureActive}
-                      className={cn(
-                        'flex min-h-[72px] min-w-[min(100%,7rem)] flex-1 flex-col items-center justify-center gap-1 rounded-2xl px-3 py-3 shadow-md backdrop-blur-sm transition-transform sm:min-h-[80px] sm:flex-initial sm:px-5',
-                        isVoiceCaptureActive
-                          ? 'cursor-not-allowed border border-slate-500/40 bg-slate-600/40 text-slate-300'
-                          : 'border border-white/35 bg-white/15 text-white hover:scale-[1.02]',
-                      )}
-                    >
-                      <Presentation className="size-6 shrink-0 sm:size-7" aria-hidden />
-                      <span className="text-center text-xs font-semibold leading-tight sm:text-sm">
-                        {labels.kioskSlides}
-                      </span>
-                    </button>
-                    </div>
-                    ) : null}
-                        </>
-                      );
-                    })()}
-                  </div>
-                </div>
-              )}
-
-              {kioskPhase === 'ocr' && showKioskScreenChrome ? (
-                <div
-                  className="absolute inset-0 z-40 overflow-y-auto bg-black/60 p-4"
-                  onPointerDownCapture={bumpUserActivity}
-                >
-                  <div className="mx-auto max-w-lg rounded-[28px] border border-white/15 bg-white/95 p-5 shadow-xl md:p-8">
-                    <h3 className="mb-4 text-center text-lg font-semibold text-slate-900">
-                      {ocrMode === 'member_card'
-                        ? labels.kioskOcrMember
-                        : labels.kioskOcrHandwriting}
-                    </h3>
-                    <OcrCameraView
-                      key={ocrMode}
-                      mode={ocrMode}
-                      autoStart
-                      sessionId={voice.sessionId}
-                      onSuccess={handleOcrSuccess}
-                      onFallback={() => {
-                        clearReturnToIdleTimer();
-                        setKioskPhase('idle');
-                        setOcrStatusMessage('error', labels.ocrReadFailed);
-                      }}
-                      onSkip={() => {
-                        clearReturnToIdleTimer();
-                        setKioskPhase('idle');
-                      }}
-                    />
-                    <div className="mt-6 flex justify-center">
-                      <button
-                        type="button"
-                        onClick={() => {
-                          clearReturnToIdleTimer();
-                          setKioskPhase('idle');
-                        }}
-                        className="inline-flex min-h-11 items-center justify-center rounded-full bg-slate-900 px-6 py-3 text-sm font-medium text-white transition-colors hover:bg-slate-800"
-                      >
-                        {labels.kioskBackIdle}
-                      </button>
-                    </div>
-                  </div>
-                </div>
-              ) : null}
-
-              {showSlideMode ? (
-                <div
-                  className="pointer-events-none absolute inset-y-0 right-0 z-30 flex w-full justify-end"
-                  style={screenPadding}
-                >
+                {showSettingsPanel && settingsPanelProps ? (
                   <div
-                    className="pointer-events-auto flex h-full w-full max-w-6xl transform-gpu rounded-[32px] bg-white/95 shadow-2xl transition-all duration-300 ease-out"
-                    onPointerDownCapture={bumpUserActivity}
+                    className="absolute inset-0 z-40 pointer-events-none"
+                    aria-hidden={!showSettingsPanel}
                   >
-                    <div className="relative flex h-full w-full flex-col overflow-hidden rounded-[32px]">
-                      <button
-                        type="button"
-                        onClick={handleCloseSlides}
-                        aria-label={labels.closeSlides}
-                        className="absolute right-4 top-4 z-10 inline-flex size-11 items-center justify-center rounded-full bg-black/70 text-white shadow-lg transition-transform duration-200 ease-out hover:scale-105"
-                      >
-                        <X className="size-5" />
-                      </button>
-                      <div className="h-full w-full pt-4">
-                        <MarpViewer
-                          language={voice.currentLanguage}
-                          onVisemeControl={setVisemeFunction}
-                          onExpressionControl={setExpressionFunction}
-                          volume={Math.round(voice.volume * 100)}
-                          onPresentationComplete={() => {
-                            if (kioskPhaseRef.current === 'slides') {
-                              scheduleReturnToIdle();
-                            }
-                          }}
-                        />
+                    <div
+                      className="pointer-events-auto absolute top-0 flex max-h-full justify-end"
+                      style={{
+                        top: screenPadding.paddingTop,
+                        right: screenPadding.paddingRight,
+                      }}
+                    >
+                      <SettingsPanel
+                        {...settingsPanelProps}
+                        kiosk_language={voice.currentLanguage}
+                        kiosk_trigger_mode={triggerMode}
+                        kiosk_mic_mode={micInputMode}
+                        on_kiosk_language_change={(language) => {
+                          setCurrentLanguage(language);
+                        }}
+                        on_kiosk_trigger_mode_change={(mode) => {
+                          setTriggerMode(mode);
+                          writeKioskTriggerMode(mode);
+                        }}
+                        on_kiosk_mic_mode_change={(mode) => {
+                          setMicInputMode(mode);
+                          writeKioskMicMode(mode);
+                        }}
+                        volume={Math.round(voice.volume * 100)}
+                        is_muted={voice.isMuted}
+                        on_volume_change={(value) => {
+                          voice.setVolume(value / 100);
+                        }}
+                        on_mute_toggle={() => {
+                          voice.setMuted(!voice.isMuted);
+                        }}
+                        show_close_button
+                        on_close={() => setShowSettingsPanel(false)}
+                        extra_tab={{
+                          label: voice.currentLanguage === 'ja' ? '会話履歴' : 'Conversation',
+                          content: (
+                            <div className="space-y-2 overflow-y-auto pr-1">
+                              {conversationHistory.length === 0 ? (
+                                <p className="text-sm text-gray-600">{labels.helperPrompt}</p>
+                              ) : (
+                                conversationHistory.map((item) => (
+                                  <div
+                                    key={item.id}
+                                    className={cn(
+                                      'rounded-2xl px-3 py-2 text-sm leading-6',
+                                      item.role === 'user'
+                                        ? 'bg-gray-100 text-gray-800'
+                                        : 'bg-blue-50 text-gray-800',
+                                    )}
+                                  >
+                                    <p className="text-xs font-medium text-gray-500">
+                                      {item.role === 'user'
+                                        ? voice.currentLanguage === 'ja'
+                                          ? 'あなた'
+                                          : 'You'
+                                        : 'Navigator'}
+                                    </p>
+                                    <p className="mt-1 whitespace-pre-wrap">{item.text}</p>
+                                  </div>
+                                ))
+                              )}
+                            </div>
+                          ),
+                        }}
+                        slide_mode_open={showSlideMode}
+                        on_open_slides={() => startPresentation(voice.currentLanguage)}
+                        on_close_slides={handleCloseSlides}
+                        open_slides_label={labels.openSlides}
+                        close_slides_label={labels.closeSlides}
+                      />
+                    </div>
+                  </div>
+                ) : null}
+
+                {(kioskPhase === 'idle' || kioskPhase === 'voice' || kioskPhase === 'notice') && (
+                  <KioskBottomBar
+                    kioskPhase={kioskPhase}
+                    setKioskPhase={setKioskPhase}
+                    kioskVoiceLocked={kioskVoiceLocked}
+                    setKioskVoiceLocked={setKioskVoiceLocked}
+                    micInputMode={micInputMode}
+                    showKioskScreenChrome={showKioskScreenChrome}
+                    welcomeCooldown={welcomeCooldown}
+                    labels={labels}
+                    ocrStatus={ocrStatus}
+                    voice={voice}
+                    onPlayWelcome={() => kioskPlayWelcomeRef.current?.()}
+                    onStartPresentation={() => startPresentation(voice.currentLanguage)}
+                    clearReturnToIdleTimer={clearReturnToIdleTimer}
+                    setWelcomeMemberOcrOpen={setWelcomeMemberOcrOpen}
+                    setOcrMode={setOcrMode}
+                  />
+                )}
+
+                <KioskOcrOverlay
+                  visible={kioskPhase === 'ocr' && showKioskScreenChrome}
+                  ocrMode={ocrMode}
+                  labels={labels}
+                  sessionId={voice.sessionId}
+                  bumpUserActivity={bumpUserActivity}
+                  onSuccess={handleOcrSuccess}
+                  onFallback={() => {
+                    clearReturnToIdleTimer();
+                    setKioskPhase('idle');
+                    setOcrStatusMessage('error', labels.ocrReadFailed);
+                  }}
+                  onSkip={() => {
+                    clearReturnToIdleTimer();
+                    setKioskPhase('idle');
+                  }}
+                  onBackToIdle={() => {
+                    clearReturnToIdleTimer();
+                    setKioskPhase('idle');
+                  }}
+                />
+
+                {showSlideMode ? (
+                  <div
+                    className="pointer-events-none absolute inset-y-0 right-0 z-30 flex w-full justify-end"
+                    style={screenPadding}
+                  >
+                    <div
+                      className="pointer-events-auto flex h-full w-full max-w-6xl transform-gpu rounded-[32px] bg-white/95 shadow-2xl transition-all duration-300 ease-out"
+                      onPointerDownCapture={bumpUserActivity}
+                    >
+                      <div className="relative flex h-full w-full flex-col overflow-hidden rounded-[32px]">
+                        <button
+                          type="button"
+                          onClick={handleCloseSlides}
+                          aria-label={labels.closeSlides}
+                          className="absolute right-4 top-4 z-10 inline-flex size-11 items-center justify-center rounded-full bg-black/70 text-white shadow-lg transition-transform duration-200 ease-out hover:scale-105"
+                        >
+                          <X className="size-5" />
+                        </button>
+                        <div className="h-full w-full pt-4">
+                          <MarpViewer
+                            language={voice.currentLanguage}
+                            onVisemeControl={setVisemeFunction}
+                            onExpressionControl={setExpressionFunction}
+                            volume={Math.round(voice.volume * 100)}
+                            onPresentationComplete={() => {
+                              if (kioskPhaseRef.current === 'slides') {
+                                scheduleReturnToIdle();
+                              }
+                            }}
+                          />
+                        </div>
                       </div>
                     </div>
                   </div>
-                </div>
-              ) : null}
-
-
-            </main>
-          </>
-        );
-      }}
-    </VoiceInterface>
+                ) : null}
+              </main>
+            </>
+          );
+        }}
+      </VoiceInterface>
     </>
   );
 }

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { markAudioUserInteraction } from '@/lib/audio/audio-user-interaction-gate';
+import { startSensorPolling, stopSensorPolling } from '@/lib/api/device-webhook';
 import { overlayLabels } from '@/lib/kiosk-labels';
 import {
   KIOSK_IDLE_MS,
@@ -467,6 +468,18 @@ export default function Home() {
       window.removeEventListener('device-detection', onDeviceDetection);
     };
   }, []);
+
+  useEffect(() => {
+    if (triggerMode === 'device' && kioskPhase === 'idle') {
+      startSensorPolling();
+    } else {
+      stopSensorPolling();
+    }
+
+    return () => {
+      stopSensorPolling();
+    };
+  }, [kioskPhase, triggerMode]);
 
   useEffect(() => {
     if (kioskPhase === 'ocr' || kioskPhase === 'voice') {

--- a/frontend/src/lib/api/device-webhook.ts
+++ b/frontend/src/lib/api/device-webhook.ts
@@ -12,7 +12,8 @@ const DEFAULT_SENSOR_POLL_INTERVAL_MS = 1000;
 
 let sensorPollingIntervalId: number | null = null;
 let lastSeenSensorTimestampByDevice = new Map<string, number>();
-let pollingRequestInFlight = false;
+let activePollingSessionToken = 0;
+let pollingInFlightSessionToken: number | null = null;
 
 /**
  * Future: server webhooks or edge hardware can call the same entry points as the kiosk
@@ -26,18 +27,26 @@ export function handleDeviceDetection(event: DeviceDetectionEvent): void {
   window.dispatchEvent(new CustomEvent('device-detection', { detail: event }));
 }
 
-async function pollSensorStatus(deviceId: string): Promise<void> {
-  if (pollingRequestInFlight) {
+async function pollSensorStatus(deviceId: string, sessionToken: number): Promise<void> {
+  if (sessionToken !== activePollingSessionToken) {
     return;
   }
 
-  pollingRequestInFlight = true;
+  if (pollingInFlightSessionToken === sessionToken) {
+    return;
+  }
+
+  pollingInFlightSessionToken = sessionToken;
 
   try {
     const data = await getSensorStatus(
       deviceId,
       lastSeenSensorTimestampByDevice.get(deviceId) ?? 0
     );
+
+    if (sessionToken !== activePollingSessionToken) {
+      return;
+    }
 
     if (!data.triggered || typeof data.timestamp !== 'number') {
       return;
@@ -56,7 +65,9 @@ async function pollSensorStatus(deviceId: string): Promise<void> {
   } catch {
     // Best-effort polling; transient network errors should not break kiosk idle mode.
   } finally {
-    pollingRequestInFlight = false;
+    if (pollingInFlightSessionToken === sessionToken) {
+      pollingInFlightSessionToken = null;
+    }
   }
 }
 
@@ -69,13 +80,16 @@ export function startSensorPolling(
   }
 
   stopSensorPolling();
-  void pollSensorStatus(deviceId);
+  activePollingSessionToken += 1;
+  const sessionToken = activePollingSessionToken;
+  void pollSensorStatus(deviceId, sessionToken);
   sensorPollingIntervalId = window.setInterval(() => {
-    void pollSensorStatus(deviceId);
+    void pollSensorStatus(deviceId, sessionToken);
   }, intervalMs);
 }
 
 export function stopSensorPolling(): void {
+  activePollingSessionToken += 1;
   if (sensorPollingIntervalId !== null) {
     clearInterval(sensorPollingIntervalId);
     sensorPollingIntervalId = null;

--- a/frontend/src/lib/api/device-webhook.ts
+++ b/frontend/src/lib/api/device-webhook.ts
@@ -1,9 +1,18 @@
+import { getSensorStatus } from '@/lib/reception-api';
+
 export interface DeviceDetectionEvent {
   type: 'sensor_triggered' | 'nfc_detected' | 'button_pressed';
   device_id?: string;
   timestamp: string;
   data?: Record<string, unknown>;
 }
+
+const DEFAULT_DEVICE_ID = 'm5stack-001';
+const DEFAULT_SENSOR_POLL_INTERVAL_MS = 1000;
+
+let sensorPollingIntervalId: number | null = null;
+let lastSeenSensorTimestampByDevice = new Map<string, number>();
+let pollingRequestInFlight = false;
 
 /**
  * Future: server webhooks or edge hardware can call the same entry points as the kiosk
@@ -15,6 +24,62 @@ export interface DeviceDetectionEvent {
 /** Dispatch a custom event; kiosk home (`page.tsx`) plays the welcome greeting when phase is idle. */
 export function handleDeviceDetection(event: DeviceDetectionEvent): void {
   window.dispatchEvent(new CustomEvent('device-detection', { detail: event }));
+}
+
+async function pollSensorStatus(deviceId: string): Promise<void> {
+  if (pollingRequestInFlight) {
+    return;
+  }
+
+  pollingRequestInFlight = true;
+
+  try {
+    const data = await getSensorStatus(
+      deviceId,
+      lastSeenSensorTimestampByDevice.get(deviceId) ?? 0
+    );
+
+    if (!data.triggered || typeof data.timestamp !== 'number') {
+      return;
+    }
+
+    lastSeenSensorTimestampByDevice.set(deviceId, data.timestamp);
+    handleDeviceDetection({
+      type: 'sensor_triggered',
+      device_id: data.device_id ?? deviceId,
+      timestamp: new Date(data.timestamp * 1000).toISOString(),
+      data: {
+        sensor_type: data.sensor_type,
+        distance_mm: data.distance_mm,
+      },
+    });
+  } catch {
+    // Best-effort polling; transient network errors should not break kiosk idle mode.
+  } finally {
+    pollingRequestInFlight = false;
+  }
+}
+
+export function startSensorPolling(
+  deviceId = DEFAULT_DEVICE_ID,
+  intervalMs = DEFAULT_SENSOR_POLL_INTERVAL_MS
+): void {
+  if (typeof window === 'undefined') {
+    return;
+  }
+
+  stopSensorPolling();
+  void pollSensorStatus(deviceId);
+  sensorPollingIntervalId = window.setInterval(() => {
+    void pollSensorStatus(deviceId);
+  }, intervalMs);
+}
+
+export function stopSensorPolling(): void {
+  if (sensorPollingIntervalId !== null) {
+    clearInterval(sensorPollingIntervalId);
+    sensorPollingIntervalId = null;
+  }
 }
 
 // Expose globally for external device integration (M5Stack, NFC readers, etc.)

--- a/frontend/src/lib/get-stage-background-style.ts
+++ b/frontend/src/lib/get-stage-background-style.ts
@@ -1,0 +1,19 @@
+import type { CSSProperties } from 'react';
+import type { BackgroundOption } from '@/app/components/BackgroundSelector';
+
+export function getStageBackgroundStyle(background: BackgroundOption): CSSProperties {
+  if (background.type === 'image') {
+    return {
+      backgroundImage: `url(${background.value})`,
+      backgroundPosition: 'center',
+      backgroundRepeat: 'no-repeat',
+      backgroundSize: 'cover',
+    };
+  }
+
+  if (background.type === 'gradient') {
+    return { background: background.value };
+  }
+
+  return background.value ? { backgroundColor: background.value } : {};
+}

--- a/frontend/src/lib/reception-api.ts
+++ b/frontend/src/lib/reception-api.ts
@@ -64,6 +64,14 @@ export interface ReceptionStatusResponse {
   purpose: string | null;
 }
 
+export interface SensorStatusResponse {
+  triggered: boolean;
+  device_id?: string;
+  sensor_type?: string;
+  distance_mm?: number;
+  timestamp?: number;
+}
+
 interface ApiErrorPayload {
   error?: string;
   details?: string;
@@ -131,4 +139,19 @@ export async function getReceptionStatus(
     `/api/reception/status/${receptionSessionId}?${search}`,
     { method: 'GET' }
   );
+}
+
+export async function getSensorStatus(
+  deviceId: string,
+  since = 0
+): Promise<SensorStatusResponse> {
+  const search = new URLSearchParams({
+    device_id: deviceId,
+    since: String(since),
+  }).toString();
+
+  return requestReceptionApi<SensorStatusResponse>(`/api/reception/sensor-status?${search}`, {
+    method: 'GET',
+    cache: 'no-store',
+  });
 }

--- a/supabase/snippets/create_sensor_events.sql
+++ b/supabase/snippets/create_sensor_events.sql
@@ -1,0 +1,28 @@
+-- Sensor events table for M5Stack device trigger persistence.
+-- Enables multi-instance Cloud Run deployments to share sensor state.
+
+CREATE TABLE IF NOT EXISTS public.sensor_events (
+    id           bigint GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+    device_id    text        NOT NULL,
+    sensor_type  text        NOT NULL,
+    distance_mm  integer     NOT NULL,
+    triggered_at timestamptz NOT NULL DEFAULT now()
+);
+
+-- Fast lookup: latest event per device
+CREATE INDEX IF NOT EXISTS idx_sensor_events_device_triggered
+    ON public.sensor_events (device_id, triggered_at DESC);
+
+-- Auto-cleanup safety net (application-level TTL is 30 s)
+CREATE INDEX IF NOT EXISTS idx_sensor_events_triggered_at
+    ON public.sensor_events (triggered_at);
+
+-- RLS: service-role only (backend writes, backend reads)
+ALTER TABLE public.sensor_events ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "Service role can do anything on sensor_events"
+    ON public.sensor_events
+    FOR ALL
+    TO service_role
+    USING (true)
+    WITH CHECK (true);


### PR DESCRIPTION
## Summary

- **Backend**: `POST /api/reception/sensor-trigger` persists events to Supabase `sensor_events` table (+ in-memory); new `GET /api/reception/sensor-status` reads Supabase first with in-memory fallback
- **Frontend**: Adds polling (`startSensorPolling` / `stopSensorPolling`) that calls `sensor-status` every 1 s when kiosk is idle in device trigger mode, then dispatches the existing `device-detection` CustomEvent → triggers `kioskPlayWelcome()` → welcome greeting
- **Supabase**: New `sensor_events` table with RLS + indexes for multi-instance Cloud Run support
- **Repository**: `ReceptionRepository` gains `store_sensor_event` / `get_latest_sensor_event` methods
- **Tests**: Backend (sensor-status endpoint, DB mock fixture) + Frontend (polling flow, proxy contract)

Closes #404

## Data Flow

```
M5Stack ──HTTP POST──> Backend /api/reception/sensor-trigger
                          ├→ Supabase INSERT (sensor_events table)
                          └→ in-memory cache (fallback)

Frontend (idle) ──1s poll──> GET /api/reception/sensor-status
                                ├→ Supabase SELECT latest
                                └→ in-memory fallback on DB failure
                                   └→ { triggered: true, ... }
                                      └→ handleDeviceDetection()
                                         └→ CustomEvent('device-detection')
                                            └→ kioskPlayWelcome() → 「いらっしゃいませ」
```

## Changed Files

| File | Change |
|---|---|
| `supabase/snippets/create_sensor_events.sql` | **New** — table + indexes + RLS |
| `backend/api/reception.py` | Supabase write in trigger, Supabase-first read in status |
| `backend/utils/reception_repository.py` | `store_sensor_event` / `get_latest_sensor_event` |
| `backend/tests/api/test_reception_api.py` | DB mock fixture + sensor-status tests |
| `frontend/src/lib/reception-api.ts` | `SensorStatusResponse` type, `getSensorStatus()` |
| `frontend/src/lib/api/device-webhook.ts` | `startSensorPolling()` / `stopSensorPolling()` |
| `frontend/src/app/page.tsx` | Polling lifecycle tied to idle + device mode |
| `frontend/src/app/api/reception/sensor-status/route.ts` | **New** — GET proxy route |
| `frontend/src/__tests__/device-webhook.test.ts` | **New** — polling + detection tests |
| `frontend/src/__tests__/api-proxy-contract.test.ts` | sensor-status proxy test |

## Deployment Checklist

- [ ] Run `create_sensor_events.sql` against Supabase production database
- [ ] Deploy backend to Cloud Run
- [ ] Deploy frontend to Vercel
- [ ] Set kiosk to device trigger mode (`localStorage.engineer_cafe_kiosk_trigger_mode = 'device'`)

## CI Verification

```bash
# Backend
cd backend && ruff check . && black --check .
pytest tests/api/test_reception_api.py  # 30 passed

# Frontend
cd frontend && pnpm typecheck
node --import tsx --test src/__tests__/device-webhook.test.ts src/__tests__/api-proxy-contract.test.ts  # 8 passed
```