### PR TITLE
feat: M5Stack sensor trigger → Frontend welcome polling bridge (#404)

### DIFF
--- a/backend/api/reception.py
+++ b/backend/api/reception.py
@@ -90,6 +90,7 @@ def _reset_session_storage() -> None:
     _session_repository = None
     _active_sessions.clear()
     _sensor_trigger_cooldowns.clear()
+    _latest_sensor_events.clear()
 
 
 def _serialize_session(session: ReceptionSession, *, status: str = "active") -> dict[str, Any]:
@@ -317,12 +318,22 @@ class SensorTriggerResponse(BaseModel):
     message: Optional[str] = None
 
 
+class SensorStatusResponse(BaseModel):
+    triggered: bool
+    device_id: Optional[str] = None
+    sensor_type: Optional[str] = None
+    distance_mm: Optional[int] = None
+    timestamp: Optional[float] = None
+
+
 # ---------------------------------------------------------------------------
 # Per-device rate limiting for sensor triggers
 # ---------------------------------------------------------------------------
 
 _sensor_trigger_cooldowns: dict[str, float] = {}
+_latest_sensor_events: dict[str, dict[str, Any]] = {}
 SENSOR_TRIGGER_RATE_LIMIT_SECONDS = 5
+SENSOR_TRIGGER_EVENT_TTL_SECONDS = 30
 
 
 @reception_router.post("/sensor-trigger", response_model=SensorTriggerResponse)
@@ -337,6 +348,12 @@ async def sensor_trigger(request: SensorTriggerRequest) -> SensorTriggerResponse
             message=f"Device {request.device_id} is rate limited",
         )
     _sensor_trigger_cooldowns[request.device_id] = now
+    _latest_sensor_events[request.device_id] = {
+        "device_id": request.device_id,
+        "sensor_type": request.sensor_type,
+        "distance_mm": request.distance_mm,
+        "timestamp": now,
+    }
 
     logger.info(
         "Sensor trigger received: device=%s sensor=%s distance=%dmm",
@@ -349,6 +366,34 @@ async def sensor_trigger(request: SensorTriggerRequest) -> SensorTriggerResponse
         action="trigger_received",
         message=f"Sensor trigger from {request.device_id} acknowledged",
     )
+
+
+@reception_router.get(
+    "/sensor-status",
+    response_model=SensorStatusResponse,
+    response_model_exclude_none=True,
+)
+async def get_sensor_status(
+    device_id: str = Query(default="m5stack-001", max_length=100),
+    since: float = Query(default=0),
+) -> SensorStatusResponse:
+    """Return whether a new sensor trigger exists for polling clients.
+
+    Note: this uses in-memory storage and only reflects events seen by the
+    current Cloud Run instance.
+    """
+    event = _latest_sensor_events.get(device_id)
+    if event is None:
+        return SensorStatusResponse(triggered=False)
+
+    if time.time() - float(event["timestamp"]) > SENSOR_TRIGGER_EVENT_TTL_SECONDS:
+        _latest_sensor_events.pop(device_id, None)
+        return SensorStatusResponse(triggered=False)
+
+    if float(event["timestamp"]) <= since:
+        return SensorStatusResponse(triggered=False)
+
+    return SensorStatusResponse(triggered=True, **event)
 
 
 @reception_router.post("/start", response_model=ReceptionStartResponse)

--- a/backend/api/reception.py
+++ b/backend/api/reception.py
@@ -354,6 +354,12 @@ async def sensor_trigger(request: SensorTriggerRequest) -> SensorTriggerResponse
         "distance_mm": request.distance_mm,
         "timestamp": now,
     }
+    try:
+        await _get_session_repository().store_sensor_event(
+            request.device_id, request.sensor_type, request.distance_mm
+        )
+    except Exception as exc:
+        logger.warning("Sensor event persistence failed; in-memory only: %s", exc)
 
     logger.info(
         "Sensor trigger received: device=%s sensor=%s distance=%dmm",
@@ -379,9 +385,34 @@ async def get_sensor_status(
 ) -> SensorStatusResponse:
     """Return whether a new sensor trigger exists for polling clients.
 
-    Note: this uses in-memory storage and only reflects events seen by the
-    current Cloud Run instance.
+    Reads from Supabase first (shared across Cloud Run instances),
+    falling back to in-memory storage when the database is unavailable.
     """
+    # Try Supabase first (shared across Cloud Run instances)
+    try:
+        record = await _get_session_repository().get_latest_sensor_event(
+            device_id, since_epoch=since
+        )
+        if record is not None:
+            triggered_at = record["triggered_at"]
+            if isinstance(triggered_at, str):
+                from datetime import datetime as _dt, timezone as _tz
+
+                triggered_at = _dt.fromisoformat(triggered_at).replace(tzinfo=_tz.utc)
+            event_epoch = triggered_at.timestamp()
+            if event_epoch <= since:
+                return SensorStatusResponse(triggered=False)
+            return SensorStatusResponse(
+                triggered=True,
+                device_id=device_id,
+                sensor_type=record["sensor_type"],
+                distance_mm=record["distance_mm"],
+                timestamp=event_epoch,
+            )
+    except Exception as exc:
+        logger.warning("Sensor status DB read failed; falling back to in-memory: %s", exc)
+
+    # Fallback: in-memory
     event = _latest_sensor_events.get(device_id)
     if event is None:
         return SensorStatusResponse(triggered=False)

--- a/backend/tests/api/test_reception_api.py
+++ b/backend/tests/api/test_reception_api.py
@@ -586,3 +586,46 @@ class TestSensorTriggerEndpoint:
         resp_b = client.post("/api/reception/sensor-trigger", json=payload_b)
         assert resp_b.status_code == 200
         assert resp_b.json()["success"] is True
+
+    def test_sensor_status_returns_new_event(self):
+        payload = {
+            "sensor_type": "tof",
+            "distance_mm": 500,
+            "device_id": "m5stack-status-test",
+        }
+
+        trigger_response = client.post("/api/reception/sensor-trigger", json=payload)
+        assert trigger_response.status_code == 200
+
+        status_response = client.get(
+            "/api/reception/sensor-status",
+            params={"device_id": payload["device_id"]},
+        )
+        assert status_response.status_code == 200
+        data = status_response.json()
+        assert data["triggered"] is True
+        assert data["device_id"] == payload["device_id"]
+        assert data["sensor_type"] == payload["sensor_type"]
+        assert data["distance_mm"] == payload["distance_mm"]
+        assert isinstance(data["timestamp"], float)
+
+    def test_sensor_status_ignores_already_seen_event(self):
+        payload = {
+            "sensor_type": "tof",
+            "distance_mm": 500,
+            "device_id": "m5stack-seen-test",
+        }
+
+        client.post("/api/reception/sensor-trigger", json=payload)
+        status_response = client.get(
+            "/api/reception/sensor-status",
+            params={"device_id": payload["device_id"]},
+        )
+        timestamp = status_response.json()["timestamp"]
+
+        seen_response = client.get(
+            "/api/reception/sensor-status",
+            params={"device_id": payload["device_id"], "since": timestamp},
+        )
+        assert seen_response.status_code == 200
+        assert seen_response.json() == {"triggered": False}

--- a/backend/tests/api/test_reception_api.py
+++ b/backend/tests/api/test_reception_api.py
@@ -95,6 +95,37 @@ def mock_canonical_classifier():
         yield
 
 
+@pytest.fixture(autouse=True)
+def mock_sensor_event_db():
+    """Stub Supabase sensor-event calls so tests run without a real DB."""
+    from backend.utils.reception_repository import ReceptionRepository
+
+    fake_repo = ReceptionRepository.__new__(ReceptionRepository)
+    fake_repo._supabase = None
+
+    async def _store_sensor_event(device_id, sensor_type, distance_mm):
+        pass  # no-op; in-memory path is what tests assert against
+
+    async def _get_latest_sensor_event(device_id, since_epoch=0):
+        return None  # forces in-memory fallback
+
+    fake_repo.store_sensor_event = _store_sensor_event
+    fake_repo.get_latest_sensor_event = _get_latest_sensor_event
+
+    # Delegate other calls to a real repository (mocked at method level elsewhere)
+    real_repo = ReceptionRepository()
+    fake_repo.store_session = real_repo.store_session
+    fake_repo.get_session_record = real_repo.get_session_record
+    fake_repo.get_session_by_conversation_id = real_repo.get_session_by_conversation_id
+    fake_repo.complete_session = real_repo.complete_session
+    fake_repo.list_active_sessions = real_repo.list_active_sessions
+    fake_repo.cleanup_expired = real_repo.cleanup_expired
+
+    reception_module._session_repository = fake_repo
+    yield
+    reception_module._session_repository = None
+
+
 def _start_session(session_id: str = "sess-001", language: str = "ja") -> dict:
     response = client.post(
         "/api/reception/start",

--- a/backend/tests/api/test_reception_persistence.py
+++ b/backend/tests/api/test_reception_persistence.py
@@ -57,6 +57,10 @@ class _FakeTableQuery:
         self._filters.append(("lt", column, value))
         return self
 
+    def gt(self, column: str, value: Any) -> _FakeTableQuery:
+        self._filters.append(("gt", column, value))
+        return self
+
     def order(self, column: str, desc: bool = False) -> _FakeTableQuery:
         self._order_by = (column, desc)
         return self
@@ -113,6 +117,9 @@ class _FakeTableQuery:
                 return False
             if operation == "lt":
                 if _parse_timestamp(actual) >= _parse_timestamp(expected):
+                    return False
+            if operation == "gt":
+                if _parse_timestamp(actual) <= _parse_timestamp(expected):
                     return False
         return True
 
@@ -237,6 +244,72 @@ async def test_repository_cleanup_expired_sessions() -> None:
     assert expired_count == 1
     assert fake_client.storage["reception_sessions"]["expired-session"]["status"] == "expired"
     assert [row["id"] for row in active_sessions] == ["active-session"]
+
+
+@pytest.mark.asyncio
+async def test_repository_get_latest_sensor_event_returns_fresh_event_only() -> None:
+    fake_client = _FakeSupabaseClient()
+    repo = ReceptionRepository(fake_client)  # type: ignore[arg-type]
+
+    fake_client.storage["sensor_events"] = {
+        "1": {
+            "id": 1,
+            "device_id": "m5stack-001",
+            "sensor_type": "pir_sr04",
+            "distance_mm": 65,
+            "triggered_at": datetime.now(timezone.utc).isoformat(),
+        }
+    }
+
+    event = await repo.get_latest_sensor_event("m5stack-001")
+
+    assert event is not None
+    assert event["device_id"] == "m5stack-001"
+    assert event["distance_mm"] == 65
+
+
+@pytest.mark.asyncio
+async def test_repository_get_latest_sensor_event_ignores_stale_event() -> None:
+    fake_client = _FakeSupabaseClient()
+    repo = ReceptionRepository(fake_client)  # type: ignore[arg-type]
+
+    fake_client.storage["sensor_events"] = {
+        "1": {
+            "id": 1,
+            "device_id": "m5stack-001",
+            "sensor_type": "pir_sr04",
+            "distance_mm": 65,
+            "triggered_at": (datetime.now(timezone.utc) - timedelta(minutes=5)).isoformat(),
+        }
+    }
+
+    event = await repo.get_latest_sensor_event("m5stack-001")
+
+    assert event is None
+
+
+@pytest.mark.asyncio
+async def test_repository_get_latest_sensor_event_respects_since_epoch() -> None:
+    fake_client = _FakeSupabaseClient()
+    repo = ReceptionRepository(fake_client)  # type: ignore[arg-type]
+    triggered_at = datetime.now(timezone.utc) - timedelta(seconds=5)
+
+    fake_client.storage["sensor_events"] = {
+        "1": {
+            "id": 1,
+            "device_id": "m5stack-001",
+            "sensor_type": "pir_sr04",
+            "distance_mm": 65,
+            "triggered_at": triggered_at.isoformat(),
+        }
+    }
+
+    event = await repo.get_latest_sensor_event(
+        "m5stack-001",
+        since_epoch=(triggered_at + timedelta(seconds=1)).timestamp(),
+    )
+
+    assert event is None
 
 
 def test_reception_api_session_survives_restart() -> None:

--- a/backend/utils/reception_repository.py
+++ b/backend/utils/reception_repository.py
@@ -143,3 +143,51 @@ class ReceptionRepository:
             .execute()
         )
         return len(result.data) if result.data else 0
+
+    # ------------------------------------------------------------------
+    # Sensor events
+    # ------------------------------------------------------------------
+
+    async def store_sensor_event(self, device_id: str, sensor_type: str, distance_mm: int) -> None:
+        """Insert a new sensor trigger event into ``sensor_events``."""
+        client = await self._get_client()
+        client.table("sensor_events").insert(
+            {
+                "device_id": device_id,
+                "sensor_type": sensor_type,
+                "distance_mm": distance_mm,
+            }
+        ).execute()
+
+    async def get_latest_sensor_event(
+        self, device_id: str, since_epoch: float = 0
+    ) -> Optional[dict[str, Any]]:
+        """Return the most recent sensor event for *device_id*.
+
+        If *since_epoch* is provided (UNIX seconds), only events after that
+        timestamp are considered.  Returns ``None`` when no matching row
+        exists or the event is older than 30 seconds.
+        """
+        client = await self._get_client()
+        query = (
+            client.table("sensor_events")
+            .select("device_id, sensor_type, distance_mm, triggered_at")
+            .eq("device_id", device_id)
+            .order("triggered_at", desc=True)
+            .limit(1)
+        )
+
+        if since_epoch > 0:
+            since_dt = datetime.fromtimestamp(since_epoch, tz=timezone.utc).isoformat()
+            query = query.gt("triggered_at", since_dt)
+
+        result = query.execute()
+        if not result.data:
+            return None
+
+        row = result.data[0]
+        triggered_at = row["triggered_at"]
+        if isinstance(triggered_at, str):
+            triggered_at = datetime.fromisoformat(triggered_at).replace(tzinfo=timezone.utc)
+        row["triggered_at"] = triggered_at
+        return row

--- a/backend/utils/reception_repository.py
+++ b/backend/utils/reception_repository.py
@@ -188,6 +188,10 @@ class ReceptionRepository:
         row = result.data[0]
         triggered_at = row["triggered_at"]
         if isinstance(triggered_at, str):
-            triggered_at = datetime.fromisoformat(triggered_at).replace(tzinfo=timezone.utc)
+            triggered_at = datetime.fromisoformat(triggered_at.replace("Z", "+00:00"))
+
+        if triggered_at < datetime.now(timezone.utc) - timedelta(seconds=30):
+            return None
+
         row["triggered_at"] = triggered_at
         return row

--- a/frontend/src/__tests__/api-proxy-contract.test.ts
+++ b/frontend/src/__tests__/api-proxy-contract.test.ts
@@ -97,6 +97,29 @@ test(
 );
 
 test(
+  'reception sensor-status GET forwards query params and backend payloads',
+  { concurrency: false },
+  async () => {
+    process.env.BACKEND_API_URL = 'https://backend.example.com';
+    (process.env as Record<string, string | undefined>).NODE_ENV = 'test';
+    mockBackendJsonResponse({ triggered: true, device_id: 'm5stack-001' }, 200);
+
+    const { GET } = await import('../app/api/reception/sensor-status/route');
+    const response = await GET(
+      new NextRequest(
+        'https://example.com/api/reception/sensor-status?device_id=m5stack-001&since=123'
+      )
+    );
+
+    assert.equal(response.status, 200);
+    assert.deepEqual(await response.json(), {
+      triggered: true,
+      device_id: 'm5stack-001',
+    });
+  }
+);
+
+test(
   'slides route no longer exports a GET handler',
   { concurrency: false },
   async () => {

--- a/frontend/src/__tests__/device-webhook.test.ts
+++ b/frontend/src/__tests__/device-webhook.test.ts
@@ -83,3 +83,120 @@ test('startSensorPolling dispatches device-detection when backend reports a new 
     distance_mm: 65,
   });
 });
+
+test('stopSensorPolling suppresses a stale in-flight sensor response', async () => {
+  const windowMock = createWindow();
+  (global as unknown as { window: Window & typeof globalThis }).window =
+    windowMock as unknown as Window & typeof globalThis;
+
+  const events: Array<Record<string, unknown>> = [];
+  windowMock.addEventListener('device-detection', (event) => {
+    events.push((event as CustomEvent<Record<string, unknown>>).detail);
+  });
+
+  let resolveFetch: ((value: Response) => void) | null = null;
+  global.fetch =
+    ((async () =>
+      await new Promise<Response>((resolve) => {
+        resolveFetch = resolve;
+      })) as unknown as typeof fetch);
+
+  const { startSensorPolling, stopSensorPolling } = await import('../lib/api/device-webhook');
+  startSensorPolling('m5stack-stop-test', 60_000);
+  stopSensorPolling();
+
+  const stopTestResolver = resolveFetch as ((value: Response) => void) | null;
+  if (stopTestResolver) {
+    stopTestResolver(
+      new Response(
+        JSON.stringify({
+          triggered: true,
+          device_id: 'm5stack-stop-test',
+          sensor_type: 'pir_sr04',
+          distance_mm: 70,
+          timestamp: 1712221539.085,
+        }),
+        {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' },
+        }
+      )
+    );
+  }
+
+  await new Promise((resolve) => setTimeout(resolve, 0));
+  await new Promise((resolve) => setTimeout(resolve, 0));
+
+  assert.equal(events.length, 0);
+});
+
+test('restartSensorPolling immediately polls new session even if old request is in flight', async () => {
+  const windowMock = createWindow();
+  (global as unknown as { window: Window & typeof globalThis }).window =
+    windowMock as unknown as Window & typeof globalThis;
+
+  const events: Array<Record<string, unknown>> = [];
+  windowMock.addEventListener('device-detection', (event) => {
+    events.push((event as CustomEvent<Record<string, unknown>>).detail);
+  });
+
+  let resolveFirstFetch: ((value: Response) => void) | null = null;
+  let fetchCount = 0;
+  global.fetch = (async () => {
+    fetchCount += 1;
+    if (fetchCount === 1) {
+      return await new Promise<Response>((resolve) => {
+        resolveFirstFetch = resolve;
+      });
+    }
+
+    return new Response(
+      JSON.stringify({
+        triggered: true,
+        device_id: 'm5stack-restart-test',
+        sensor_type: 'pir_sr04',
+        distance_mm: 80,
+        timestamp: 1712221540.085,
+      }),
+      {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      }
+    );
+  }) as typeof fetch;
+
+  const { startSensorPolling, stopSensorPolling } = await import('../lib/api/device-webhook');
+  startSensorPolling('m5stack-restart-test', 60_000);
+  stopSensorPolling();
+  startSensorPolling('m5stack-restart-test', 60_000);
+
+  await new Promise((resolve) => setTimeout(resolve, 0));
+  await new Promise((resolve) => setTimeout(resolve, 0));
+
+  assert.equal(fetchCount, 2);
+  assert.equal(events.length, 1);
+
+  const restartTestResolver = resolveFirstFetch as ((value: Response) => void) | null;
+  if (restartTestResolver) {
+    restartTestResolver(
+      new Response(
+        JSON.stringify({
+          triggered: true,
+          device_id: 'm5stack-restart-test',
+          sensor_type: 'pir_sr04',
+          distance_mm: 90,
+          timestamp: 1712221541.085,
+        }),
+        {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' },
+        }
+      )
+    );
+  }
+
+  await new Promise((resolve) => setTimeout(resolve, 0));
+  await new Promise((resolve) => setTimeout(resolve, 0));
+
+  assert.equal(events.length, 1);
+});

--- a/frontend/src/__tests__/device-webhook.test.ts
+++ b/frontend/src/__tests__/device-webhook.test.ts
@@ -1,0 +1,85 @@
+import assert from 'node:assert/strict';
+import { afterEach, test } from 'node:test';
+
+type DeviceWindow = EventTarget & {
+  __engineerCafe?: Record<string, unknown>;
+  setInterval: typeof global.setInterval;
+};
+
+const originalWindow = global.window;
+const originalFetch = global.fetch;
+
+function createWindow(): DeviceWindow {
+  return Object.assign(new EventTarget(), {
+    setInterval: global.setInterval,
+  }) as DeviceWindow;
+}
+
+afterEach(async () => {
+  global.fetch = originalFetch;
+  (global as typeof globalThis & { window?: Window & typeof globalThis }).window = originalWindow;
+
+  const deviceWebhook = await import('../lib/api/device-webhook');
+  deviceWebhook.stopSensorPolling();
+});
+
+test('handleDeviceDetection dispatches the browser device-detection event', async () => {
+  const windowMock = createWindow();
+  (global as unknown as { window: Window & typeof globalThis }).window =
+    windowMock as unknown as Window & typeof globalThis;
+
+  const events: Array<Record<string, unknown>> = [];
+  windowMock.addEventListener('device-detection', (event) => {
+    events.push((event as CustomEvent<Record<string, unknown>>).detail);
+  });
+
+  const { handleDeviceDetection } = await import('../lib/api/device-webhook');
+  handleDeviceDetection({
+    type: 'sensor_triggered',
+    device_id: 'm5stack-001',
+    timestamp: '2026-04-04T10:00:00.000Z',
+  });
+
+  assert.equal(events.length, 1);
+  assert.equal(events[0].device_id, 'm5stack-001');
+});
+
+test('startSensorPolling dispatches device-detection when backend reports a new trigger', async () => {
+  const windowMock = createWindow();
+  (global as unknown as { window: Window & typeof globalThis }).window =
+    windowMock as unknown as Window & typeof globalThis;
+
+  const events: Array<Record<string, unknown>> = [];
+  windowMock.addEventListener('device-detection', (event) => {
+    events.push((event as CustomEvent<Record<string, unknown>>).detail);
+  });
+
+  global.fetch = (async () =>
+    new Response(
+      JSON.stringify({
+        triggered: true,
+        device_id: 'm5stack-poll-test',
+        sensor_type: 'pir_sr04',
+        distance_mm: 65,
+        timestamp: 1712221538.085,
+      }),
+      {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      }
+    )) as typeof fetch;
+
+  const { startSensorPolling } = await import('../lib/api/device-webhook');
+  startSensorPolling('m5stack-poll-test', 60_000);
+
+  await new Promise((resolve) => setTimeout(resolve, 0));
+  await new Promise((resolve) => setTimeout(resolve, 0));
+
+  assert.equal(events.length, 1);
+  assert.equal(events[0].device_id, 'm5stack-poll-test');
+  assert.equal(events[0].type, 'sensor_triggered');
+  assert.deepEqual(events[0].data, {
+    sensor_type: 'pir_sr04',
+    distance_mm: 65,
+  });
+});

--- a/frontend/src/app/api/reception/sensor-status/route.ts
+++ b/frontend/src/app/api/reception/sensor-status/route.ts
@@ -1,0 +1,17 @@
+import { NextRequest } from 'next/server';
+
+import { proxyReceptionRequest } from '../_shared';
+
+export async function GET(request: NextRequest) {
+  const deviceId = request.nextUrl.searchParams.get('device_id') ?? 'm5stack-001';
+  const since = request.nextUrl.searchParams.get('since') ?? '0';
+  const search = new URLSearchParams({
+    device_id: deviceId,
+    since,
+  }).toString();
+
+  return proxyReceptionRequest(`/api/reception/sensor-status?${search}`, {
+    method: 'GET',
+    headers: { 'Content-Type': 'application/json' },
+  });
+}

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { markAudioUserInteraction } from '@/lib/audio/audio-user-interaction-gate';
+import { startSensorPolling, stopSensorPolling } from '@/lib/api/device-webhook';
 import { getStageBackgroundStyle } from '@/lib/get-stage-background-style';
 import { overlayLabels } from '@/lib/kiosk-labels';
 import {
@@ -166,6 +167,18 @@ export default function Home() {
       window.removeEventListener('device-detection', onDeviceDetection);
     };
   }, []);
+
+  useEffect(() => {
+    if (triggerMode === 'device' && kioskPhase === 'idle') {
+      startSensorPolling();
+    } else {
+      stopSensorPolling();
+    }
+
+    return () => {
+      stopSensorPolling();
+    };
+  }, [kioskPhase, triggerMode]);
 
   useEffect(() => {
     if (kioskPhase === 'ocr' || kioskPhase === 'voice') {

--- a/frontend/src/lib/api/device-webhook.ts
+++ b/frontend/src/lib/api/device-webhook.ts
@@ -12,7 +12,8 @@ const DEFAULT_SENSOR_POLL_INTERVAL_MS = 1000;
 
 let sensorPollingIntervalId: number | null = null;
 let lastSeenSensorTimestampByDevice = new Map<string, number>();
-let pollingRequestInFlight = false;
+let activePollingSessionToken = 0;
+let pollingInFlightSessionToken: number | null = null;
 
 /**
  * Future: server webhooks or edge hardware can call the same entry points as the kiosk
@@ -26,18 +27,26 @@ export function handleDeviceDetection(event: DeviceDetectionEvent): void {
   window.dispatchEvent(new CustomEvent('device-detection', { detail: event }));
 }
 
-async function pollSensorStatus(deviceId: string): Promise<void> {
-  if (pollingRequestInFlight) {
+async function pollSensorStatus(deviceId: string, sessionToken: number): Promise<void> {
+  if (sessionToken !== activePollingSessionToken) {
     return;
   }
 
-  pollingRequestInFlight = true;
+  if (pollingInFlightSessionToken === sessionToken) {
+    return;
+  }
+
+  pollingInFlightSessionToken = sessionToken;
 
   try {
     const data = await getSensorStatus(
       deviceId,
       lastSeenSensorTimestampByDevice.get(deviceId) ?? 0
     );
+
+    if (sessionToken !== activePollingSessionToken) {
+      return;
+    }
 
     if (!data.triggered || typeof data.timestamp !== 'number') {
       return;
@@ -56,7 +65,9 @@ async function pollSensorStatus(deviceId: string): Promise<void> {
   } catch {
     // Best-effort polling; transient network errors should not break kiosk idle mode.
   } finally {
-    pollingRequestInFlight = false;
+    if (pollingInFlightSessionToken === sessionToken) {
+      pollingInFlightSessionToken = null;
+    }
   }
 }
 
@@ -69,13 +80,16 @@ export function startSensorPolling(
   }
 
   stopSensorPolling();
-  void pollSensorStatus(deviceId);
+  activePollingSessionToken += 1;
+  const sessionToken = activePollingSessionToken;
+  void pollSensorStatus(deviceId, sessionToken);
   sensorPollingIntervalId = window.setInterval(() => {
-    void pollSensorStatus(deviceId);
+    void pollSensorStatus(deviceId, sessionToken);
   }, intervalMs);
 }
 
 export function stopSensorPolling(): void {
+  activePollingSessionToken += 1;
   if (sensorPollingIntervalId !== null) {
     clearInterval(sensorPollingIntervalId);
     sensorPollingIntervalId = null;

--- a/frontend/src/lib/api/device-webhook.ts
+++ b/frontend/src/lib/api/device-webhook.ts
@@ -1,9 +1,18 @@
+import { getSensorStatus } from '@/lib/reception-api';
+
 export interface DeviceDetectionEvent {
   type: 'sensor_triggered' | 'nfc_detected' | 'button_pressed';
   device_id?: string;
   timestamp: string;
   data?: Record<string, unknown>;
 }
+
+const DEFAULT_DEVICE_ID = 'm5stack-001';
+const DEFAULT_SENSOR_POLL_INTERVAL_MS = 1000;
+
+let sensorPollingIntervalId: number | null = null;
+let lastSeenSensorTimestampByDevice = new Map<string, number>();
+let pollingRequestInFlight = false;
 
 /**
  * Future: server webhooks or edge hardware can call the same entry points as the kiosk
@@ -15,6 +24,62 @@ export interface DeviceDetectionEvent {
 /** Dispatch a custom event; kiosk home (`page.tsx`) plays the welcome greeting when phase is idle. */
 export function handleDeviceDetection(event: DeviceDetectionEvent): void {
   window.dispatchEvent(new CustomEvent('device-detection', { detail: event }));
+}
+
+async function pollSensorStatus(deviceId: string): Promise<void> {
+  if (pollingRequestInFlight) {
+    return;
+  }
+
+  pollingRequestInFlight = true;
+
+  try {
+    const data = await getSensorStatus(
+      deviceId,
+      lastSeenSensorTimestampByDevice.get(deviceId) ?? 0
+    );
+
+    if (!data.triggered || typeof data.timestamp !== 'number') {
+      return;
+    }
+
+    lastSeenSensorTimestampByDevice.set(deviceId, data.timestamp);
+    handleDeviceDetection({
+      type: 'sensor_triggered',
+      device_id: data.device_id ?? deviceId,
+      timestamp: new Date(data.timestamp * 1000).toISOString(),
+      data: {
+        sensor_type: data.sensor_type,
+        distance_mm: data.distance_mm,
+      },
+    });
+  } catch {
+    // Best-effort polling; transient network errors should not break kiosk idle mode.
+  } finally {
+    pollingRequestInFlight = false;
+  }
+}
+
+export function startSensorPolling(
+  deviceId = DEFAULT_DEVICE_ID,
+  intervalMs = DEFAULT_SENSOR_POLL_INTERVAL_MS
+): void {
+  if (typeof window === 'undefined') {
+    return;
+  }
+
+  stopSensorPolling();
+  void pollSensorStatus(deviceId);
+  sensorPollingIntervalId = window.setInterval(() => {
+    void pollSensorStatus(deviceId);
+  }, intervalMs);
+}
+
+export function stopSensorPolling(): void {
+  if (sensorPollingIntervalId !== null) {
+    clearInterval(sensorPollingIntervalId);
+    sensorPollingIntervalId = null;
+  }
 }
 
 // Expose globally for external device integration (M5Stack, NFC readers, etc.)

--- a/frontend/src/lib/reception-api.ts
+++ b/frontend/src/lib/reception-api.ts
@@ -64,6 +64,14 @@ export interface ReceptionStatusResponse {
   purpose: string | null;
 }
 
+export interface SensorStatusResponse {
+  triggered: boolean;
+  device_id?: string;
+  sensor_type?: string;
+  distance_mm?: number;
+  timestamp?: number;
+}
+
 interface ApiErrorPayload {
   error?: string;
   details?: string;
@@ -131,4 +139,19 @@ export async function getReceptionStatus(
     `/api/reception/status/${receptionSessionId}?${search}`,
     { method: 'GET' }
   );
+}
+
+export async function getSensorStatus(
+  deviceId: string,
+  since = 0
+): Promise<SensorStatusResponse> {
+  const search = new URLSearchParams({
+    device_id: deviceId,
+    since: String(since),
+  }).toString();
+
+  return requestReceptionApi<SensorStatusResponse>(`/api/reception/sensor-status?${search}`, {
+    method: 'GET',
+    cache: 'no-store',
+  });
 }

--- a/supabase/snippets/create_sensor_events.sql
+++ b/supabase/snippets/create_sensor_events.sql
@@ -1,0 +1,28 @@
+-- Sensor events table for M5Stack device trigger persistence.
+-- Enables multi-instance Cloud Run deployments to share sensor state.
+
+CREATE TABLE IF NOT EXISTS public.sensor_events (
+    id           bigint GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+    device_id    text        NOT NULL,
+    sensor_type  text        NOT NULL,
+    distance_mm  integer     NOT NULL,
+    triggered_at timestamptz NOT NULL DEFAULT now()
+);
+
+-- Fast lookup: latest event per device
+CREATE INDEX IF NOT EXISTS idx_sensor_events_device_triggered
+    ON public.sensor_events (device_id, triggered_at DESC);
+
+-- Auto-cleanup safety net (application-level TTL is 30 s)
+CREATE INDEX IF NOT EXISTS idx_sensor_events_triggered_at
+    ON public.sensor_events (triggered_at);
+
+-- RLS: service-role only (backend writes, backend reads)
+ALTER TABLE public.sensor_events ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "Service role can do anything on sensor_events"
+    ON public.sensor_events
+    FOR ALL
+    TO service_role
+    USING (true)
+    WITH CHECK (true);


### PR DESCRIPTION
## Summary

- Backend persists M5Stack sensor events to Supabase `sensor_events` with in-memory fallback
- Frontend polls `sensor-status` only while idle in device mode, then dispatches the existing `device-detection` event to trigger the welcome flow
- Fixes the review issues on PR #405 by enforcing DB TTL and preventing stale/in-flight polling responses from dispatching after stop/restart

Closes #404
Supersedes #405 (that PR's branch remained conflicted after develop advanced; this PR is the clean rebased replacement without force-pushing the old branch)

## Verification

```bash
cd backend && ruff check api/reception.py utils/reception_repository.py tests/api/test_reception_api.py tests/api/test_reception_persistence.py
cd backend && black --check api/reception.py utils/reception_repository.py tests/api/test_reception_api.py tests/api/test_reception_persistence.py
cd backend && pytest tests/api/test_reception_api.py tests/api/test_reception_persistence.py --tb=short -q

cd frontend && pnpm typecheck
cd frontend && node --import tsx --test src/__tests__/device-webhook.test.ts src/__tests__/api-proxy-contract.test.ts
```