### PR TITLE
fix(backend): Qwen STT language code normalization and auto-detect

### DIFF
--- a/backend/agents/stt_agent.py
+++ b/backend/agents/stt_agent.py
@@ -542,6 +542,16 @@ class QwenSTTClient:
         "vi": "Vietnamese",
     }
 
+    # Reverse map: Qwen display names → ISO 639-1 codes
+    LANGUAGE_CODES: Dict[str, str] = {v.lower(): k for k, v in LANGUAGE_NAMES.items()}
+
+    def _normalize_language_code(self, qwen_language: Optional[str]) -> Optional[str]:
+        """Convert Qwen display name (e.g. 'Japanese') to ISO code ('ja')."""
+        if qwen_language is None:
+            return None
+        lower = qwen_language.lower()
+        return self.LANGUAGE_CODES.get(lower, qwen_language)
+
     def __init__(
         self,
         model_variant: str = "1.7b",
@@ -632,11 +642,12 @@ class QwenSTTClient:
         if not text:
             raise RuntimeError("Qwen3-ASR returned empty recognition result")
 
+        normalized_lang = self._normalize_language_code(detected_language)
         logger.info("Qwen transcription success (%s): %s", self.model_variant, text[:100])
         return TranscriptionResult(
             text=text,
             confidence=None,
-            language=detected_language or lang_code or self.default_language,
+            language=normalized_lang or lang_code or self.default_language,
             word_confidences=[],
         )
 
@@ -907,6 +918,9 @@ class STTAgent:
         try:
             if language is None and isinstance(self.stt_client, LocalSTTClient):
                 result = await self.stt_client.transcribe_auto_detect(audio_data, grammar=grammar)
+            elif language is None and isinstance(self.stt_client, QwenSTTClient):
+                # Qwen supports auto-detect: pass language=None
+                result = await self.stt_client.transcribe(audio_data, language=None)
             else:
                 lang = language or getattr(self.stt_client, "default_language", "ja")
                 if isinstance(self.stt_client, LocalSTTClient):

--- a/backend/tests/agents/test_stt_agent.py
+++ b/backend/tests/agents/test_stt_agent.py
@@ -593,6 +593,47 @@ class TestQwenSTTClient:
         assert result.text == "hello"
         assert result.language == "en"
 
+    @pytest.mark.asyncio
+    async def test_language_name_normalized_to_code(self, test_wav_16khz):
+        """Qwen returns display names ('Japanese'); verify they map to codes ('ja')."""
+        client = QwenSTTClient(model_variant="0.6b", device="cpu")
+        client._model = MagicMock()
+        client._model.transcribe.return_value = [
+            SimpleNamespace(text="こんにちは", language="Japanese")
+        ]
+
+        with patch.object(client, "_load_model"):
+            result = await client.transcribe(test_wav_16khz, language="ja")
+
+        assert result.language == "ja"
+
+    @pytest.mark.asyncio
+    async def test_language_name_english_normalized(self, test_wav_16khz):
+        """Qwen 'English' display name maps to 'en' code."""
+        client = QwenSTTClient(model_variant="0.6b", device="cpu")
+        client._model = MagicMock()
+        client._model.transcribe.return_value = [
+            SimpleNamespace(text="hello world", language="English")
+        ]
+
+        with patch.object(client, "_load_model"):
+            result = await client.transcribe(test_wav_16khz, language="en")
+
+        assert result.language == "en"
+
+    @pytest.mark.asyncio
+    async def test_auto_detect_passes_none_to_qwen(self, test_wav_16khz):
+        """When language=None, Qwen auto-detect is used (no forced default)."""
+        client = QwenSTTClient(model_variant="0.6b", device="cpu")
+        client._model = MagicMock()
+        client._model.transcribe.return_value = [SimpleNamespace(text="hello", language="English")]
+
+        with patch.object(client, "_load_model"):
+            result = await client.transcribe(test_wav_16khz, language=None)
+
+        assert result.text == "hello"
+        assert result.language == "en"
+
 
 # ==============================================================================
 # STTAgent Tests (Provider Switching + Auto-Detection)


### PR DESCRIPTION
## Summary
- Qwen STT が返す表示名 ("Japanese"/"English") を ISO 639-1 コード ("ja"/"en") に正規化
- `language=None` (自動検出) 時に Qwen の auto-detect を維持 (強制 "ja" 変換を修正)
- 回帰テスト3件追加

## Follow-up for
PR #408 (Codex CLI レビューで発見された P2 指摘2件)

## 変更ファイル
- `backend/agents/stt_agent.py` — `LANGUAGE_CODES` 逆引きマップ + `_normalize_language_code()` + auto-detect分岐
- `backend/tests/agents/test_stt_agent.py` — テスト3件追加 (71 passed)

## Test plan
- [x] `ruff check .` PASS
- [x] `black --check .` PASS
- [x] `pytest tests/agents/test_stt_agent.py` — 71 passed
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)