### PR TITLE
fix(backend): Qwen STT auto-detect passthrough — preserve language=None

### DIFF
--- a/backend/agents/stt_agent.py
+++ b/backend/agents/stt_agent.py
@@ -618,7 +618,7 @@ class QwenSTTClient:
         else:
             audio_data = convert_audio_to_wav_bytes(audio_data)
 
-        lang_code = language or self.default_language
+        lang_code = language  # preserve None for auto-detect
         qwen_language = self.LANGUAGE_NAMES.get(lang_code, lang_code) if lang_code else None
 
         try:

--- a/backend/tests/agents/test_stt_agent.py
+++ b/backend/tests/agents/test_stt_agent.py
@@ -633,6 +633,11 @@ class TestQwenSTTClient:
 
         assert result.text == "hello"
         assert result.language == "en"
+        # Verify language kwarg was NOT passed to Qwen (auto-detect)
+        call_kwargs = client._model.transcribe.call_args
+        assert (
+            "language" not in call_kwargs.kwargs
+        ), "language should not be passed to Qwen when auto-detect is intended"
 
 
 # ==============================================================================


### PR DESCRIPTION
## Summary
- `_sync_transcribe()` で `lang_code = language or self.default_language` → `lang_code = language` に変更
- language=None 時に Qwen の auto-detect が正しく動作するようになった
- 反証テスト追加: Qwen model に `language` kwarg が渡されていないことを検証

## Follow-up for
PR #411 (reviewer-411 HIGH finding: auto-detect が default_language にフォールバックしていた)

## Test plan
- [x] `pytest tests/agents/test_stt_agent.py` — 71 passed
- [x] `ruff check .` PASS
- [x] `black --check .` PASS
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)