### PR TITLE
fix(backend): PR #407 reviewer findings — PIPER_SPEED, non-root, fallback guard

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -63,7 +63,7 @@ APP_URL=http://localhost:3000
 # tsukuyomi-chan-6lang モデルで日本語・英語等に対応。モデルは自動ダウンロード。
 # セットアップ: docker-compose --profile piper up piper-plus
 # PIPER_PLUS_API_URL=http://localhost:8090
-# PIPER_SPEED=0.87          # 話速 (1.0=標準, <1.0=遅い, >1.0=速い)
+# PIPER_SPEED=0.65          # 話速 (1.0=標準, <1.0=遅い, >1.0=速い)
 
 # LangSmith tracing (Optional)
 # LANGSMITH_API_KEY=

--- a/backend/agents/voice_agent.py
+++ b/backend/agents/voice_agent.py
@@ -600,7 +600,7 @@ class PiperPlusTTSClient:
     tsukuyomi-chan-6lang モデルで日本語・英語等に対応。
     Docker で起動した piper-plus HTTP API (POST /synthesize) を使用します。
 
-    話速は PIPER_SPEED 環境変数でサーバー側に設定済み (default: 0.87 ≒ やや遅め)。
+    話速は PIPER_SPEED 環境変数でサーバー側に設定済み (default: 0.65 ≒ ゆっくり)。
     """
 
     def __init__(self, api_url: str = "http://localhost:8090"):
@@ -863,10 +863,20 @@ class VoiceAgent:
                             fb_text, language
                         )
                     else:
+                        if language not in ("ja",):
+                            logger.warning(
+                                "piper fallback to VoiceVox for unsupported language: %s",
+                                language,
+                            )
                         logger.warning("piper failed, falling back to VoiceVox for %s", language)
-                        audio_b64 = await self.voicevox_fallback_client.synthesize_wav_base64(
-                            fb_text, language
-                        )
+                        if self.voicevox_fallback_client:
+                            audio_b64 = await self.voicevox_fallback_client.synthesize_wav_base64(
+                                fb_text, language
+                            )
+                        else:
+                            raise RuntimeError(
+                                "No VoiceVox fallback client available for piper TTS fallback"
+                            )
                     audio_format = "audio/wav"
                 elif language == "en":
                     # 英語フォールバック → Kokoro TTS

--- a/backend/scripts/generate_tts_samples.py
+++ b/backend/scripts/generate_tts_samples.py
@@ -24,7 +24,7 @@ from piper import PiperVoice
 
 MODEL_REPO = os.getenv("PIPER_MODEL_REPO", "ayousanz/piper-plus-tsukuyomi-chan")
 MODEL_DIR = Path(os.getenv("PIPER_MODEL_DIR", str(Path.home() / ".cache/piper")))
-SPEED = float(os.getenv("PIPER_SPEED", "0.87"))  # 1.0=標準, <1.0=遅い
+SPEED = float(os.getenv("PIPER_SPEED", "0.65"))  # 1.0=標準, <1.0=遅い
 
 OUT_DIR = Path(__file__).parent / "tts_samples_piper"
 
@@ -109,7 +109,7 @@ def main() -> None:
     print()
 
     # --- 日本語サンプル ---
-    print("=== 日本語サンプル (tsukuyomi, speed=0.87) ===")
+    print("=== 日本語サンプル (tsukuyomi, speed=0.65) ===")
     for i, text in enumerate(JA_SAMPLES, 1):
         out_path = OUT_DIR / f"ja_{i:02d}_piper_tsukuyomi.wav"
         print(f"  [{i:02d}/10] {text[:30]}...")
@@ -120,7 +120,7 @@ def main() -> None:
     print()
 
     # --- 英語サンプル ---
-    print("=== 英語サンプル (tsukuyomi, speed=0.87) ===")
+    print("=== 英語サンプル (tsukuyomi, speed=0.65) ===")
     for i, text in enumerate(EN_SAMPLES, 1):
         out_path = OUT_DIR / f"en_{i:02d}_piper_tsukuyomi.wav"
         print(f"  [{i:02d}/03] {text[:50]}...")

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -122,7 +122,7 @@ services:
       - PIPER_MODEL_REPO=ayousanz/piper-plus-tsukuyomi-chan
       - PIPER_MODEL_DIR=/models/piper
       - HF_HOME=/models/hf
-      - PIPER_SPEED=0.87
+      - PIPER_SPEED=0.65
       - PIPER_USE_CUDA=false
     volumes:
       - piper-models:/models

--- a/docker/piper-plus/Dockerfile
+++ b/docker/piper-plus/Dockerfile
@@ -36,8 +36,12 @@ EXPOSE 8090
 ENV PIPER_MODEL_REPO=ayousanz/piper-plus-tsukuyomi-chan \
     PIPER_MODEL_DIR=/models/piper \
     HF_HOME=/models/hf \
-    PIPER_SPEED=0.87 \
+    PIPER_SPEED=0.65 \
     PIPER_USE_CUDA=false
+
+RUN useradd --create-home --shell /bin/bash piper && \
+    chown -R piper:piper /models
+USER piper
 
 HEALTHCHECK --interval=15s --timeout=10s --retries=5 --start-period=60s \
     CMD python -c "import urllib.request; urllib.request.urlopen('http://localhost:8090/health')"

--- a/docker/piper-plus/entrypoint.sh
+++ b/docker/piper-plus/entrypoint.sh
@@ -7,7 +7,7 @@ set -e
 echo "=== piper-plus TTS Server ==="
 echo "model repo   : ${PIPER_MODEL_REPO:-ayousanz/piper-plus-tsukuyomi-chan}"
 echo "model dir    : ${PIPER_MODEL_DIR:-/models/piper}"
-echo "speed        : ${PIPER_SPEED:-0.87}"
+echo "speed        : ${PIPER_SPEED:-0.65}"
 echo "use_cuda     : ${PIPER_USE_CUDA:-false}"
 echo ""
 echo "Starting piper-plus HTTP API server on :8090 ..."

--- a/docker/piper-plus/server.py
+++ b/docker/piper-plus/server.py
@@ -7,7 +7,7 @@ tsukuyomi-chan-6lang モデル（全言語共通）で日本語・英語等を�
 環境変数:
     PIPER_MODEL_REPO  : HuggingFace モデルリポジトリ ID
     PIPER_MODEL_DIR   : モデルキャッシュディレクトリ (default: /models/piper)
-    PIPER_SPEED       : 話速 (default: 0.87 ≒ やや遅め・自然な発話感)
+    PIPER_SPEED       : 話速 (default: 0.65 ≒ ゆっくり・聞き取りやすい発話)
                         1.0=標準, <1.0=遅い, >1.0=速い
     PIPER_USE_CUDA    : GPU 使用 (default: false)
 """
@@ -38,9 +38,9 @@ MODEL_REPO = os.getenv("PIPER_MODEL_REPO", "ayousanz/piper-plus-tsukuyomi-chan")
 MODEL_DIR = Path(os.getenv("PIPER_MODEL_DIR", "/models/piper"))
 USE_CUDA = os.getenv("PIPER_USE_CUDA", "false").lower() == "true"
 
-# 話速デフォルト: 0.87 ≒ length_scale=1.15（やや遅め・自然な発話感）
+# 話速デフォルト: 0.65 ≒ length_scale=1.54（ゆっくり・聞き取りやすい発話）
 # 1.0=標準, <1.0=遅い, >1.0=速い
-DEFAULT_SPEED = float(os.getenv("PIPER_SPEED", "0.87"))
+DEFAULT_SPEED = float(os.getenv("PIPER_SPEED", "0.65"))
 
 _voice: Optional[PiperVoice] = None
 _voice_lock = threading.Lock()


### PR DESCRIPTION
## Summary
- PIPER_SPEED デフォルト 0.87 → 0.65 (定例合意値) — server.py, Dockerfile, docker-compose.yml, .env.example, generate_tts_samples.py, entrypoint.sh, voice_agent.py docstring
- Dockerfile non-root ユーザー追加 (piper user)
- voicevox_fallback_client None チェック追加
- zh/ko フォールバック警告ログ追加

Follow-up for PR #407 reviewer findings (CRITICAL x2, HIGH x2).

## Test plan
- [x] ruff/black PASS
- [x] pytest tests/agents/test_voice_agent.py — 16/16 PASS
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)