### PR TITLE
refactor(backend): SupportedLanguage統一 + TIME_RANGE_LABELS多言語化 + アンカリングテスト #400

### DIFF
--- a/backend/agents/general_knowledge_agent.py
+++ b/backend/agents/general_knowledge_agent.py
@@ -28,12 +28,15 @@ from backend.llm.openrouter import OpenRouterProvider
 from backend.llm.models import get_model_config
 from backend.tools.enhanced_rag import EnhancedRAGSearch
 from backend.tools.tavily_search import TavilySearchTool
-from backend.utils.language_types import DEFAULT_ERROR_RESPONSE, LANGUAGE_INSTRUCTION
+from backend.utils.language_types import (
+    DEFAULT_ERROR_RESPONSE,
+    LANGUAGE_INSTRUCTION,
+    SupportedLanguage,
+)
 from backend.utils.memory_interface import MemorySystemInterface
 
 logger = logging.getLogger(__name__)
 
-SupportedLanguage = Literal["ja", "en"]
 EmotionType = Literal["helpful", "apologetic", "neutral", "happy", "sad", "relaxed", "surprised"]
 
 

--- a/backend/config/prompts/event_prompts.py
+++ b/backend/config/prompts/event_prompts.py
@@ -10,10 +10,10 @@ from backend.utils.language_types import LANGUAGE_INSTRUCTION
 
 # 時間範囲ラベル
 TIME_RANGE_LABELS: Dict[str, Dict[str, str]] = {
-    "today": {"ja": "本日", "en": "today"},
-    "thisWeek": {"ja": "今週", "en": "this week"},
-    "nextWeek": {"ja": "来週", "en": "next week"},
-    "thisMonth": {"ja": "今月", "en": "this month"},
+    "today": {"ja": "本日", "en": "today", "zh": "今天", "ko": "오늘"},
+    "thisWeek": {"ja": "今週", "en": "this week", "zh": "本周", "ko": "이번 주"},
+    "nextWeek": {"ja": "来週", "en": "next week", "zh": "下周", "ko": "다음 주"},
+    "thisMonth": {"ja": "今月", "en": "this month", "zh": "本月", "ko": "이번 달"},
 }
 
 

--- a/backend/tests/tools/test_enhanced_rag.py
+++ b/backend/tests/tools/test_enhanced_rag.py
@@ -637,3 +637,24 @@ class TestQueryExpansionMap:
         assert "営業時間" in QUERY_EXPANSION_MAP["opening hours"]
         assert "料金" in QUERY_EXPANSION_MAP["price"]
         assert "アクセス" in QUERY_EXPANSION_MAP["location"]
+
+
+# ==============================================================================
+# Entity Anchoring Tests
+# ==============================================================================
+
+
+class TestEntityAnchoring:
+    """エンティティアンカリングのテスト"""
+
+    def test_anchoring_applied_for_short_non_general_query(self, rag_search):
+        """短い非generalクエリにアンカリングが適用される"""
+        result = rag_search._expand_query("営業時間", "hours", "ja")
+        assert result.startswith("エンジニアカフェ ")
+
+    def test_anchoring_skipped_when_already_contains_anchor(self, rag_search):
+        """クエリに既にエンジニアカフェが含まれている場合スキップ"""
+        query = "エンジニアカフェの料金"
+        result = rag_search._expand_query(query, "pricing", "ja")
+        # 二重にアンカリングされていないことを確認
+        assert result.count("エンジニアカフェ") == 1

--- a/backend/tools/tavily_search.py
+++ b/backend/tools/tavily_search.py
@@ -6,11 +6,11 @@ Tavily APIを使用したWeb検索ツール。
 
 import logging
 import os
-from typing import Dict, Any, List, Literal
+from typing import Dict, Any, List
+
+from backend.utils.language_types import SupportedLanguage
 
 logger = logging.getLogger(__name__)
-
-SupportedLanguage = Literal["ja", "en"]
 
 
 class TavilySearchTool:

--- a/backend/tools/web_search.py
+++ b/backend/tools/web_search.py
@@ -4,10 +4,6 @@ Determines whether a user query requires web search based on keyword matching.
 The actual web search is performed by TavilySearchTool.
 """
 
-from typing import Literal
-
-SupportedLanguage = Literal["ja", "en"]
-
 _WEB_SEARCH_KEYWORDS: list[str] = [
     # 最新情報・ニュース関連（日本語）
     "最新",

--- a/backend/utils/clarification_templates.py
+++ b/backend/utils/clarification_templates.py
@@ -11,10 +11,9 @@ import logging
 from typing import Literal, TypedDict
 
 from backend.utils.emotion_tagger import add_emotion_tag
+from backend.utils.language_types import SupportedLanguage
 
 logger = logging.getLogger(__name__)
-
-SupportedLanguage = Literal["ja", "en"]
 
 ClarificationCategory = Literal[
     "cafe-clarification-needed",

--- a/backend/utils/emergency_templates.py
+++ b/backend/utils/emergency_templates.py
@@ -11,10 +11,9 @@ import logging
 from typing import Literal, TypedDict
 
 from backend.utils.emotion_tagger import add_emotion_tag
+from backend.utils.language_types import SupportedLanguage
 
 logger = logging.getLogger(__name__)
-
-SupportedLanguage = Literal["ja", "en"]
 
 EmergencySubtype = Literal[
     "earthquake",

--- a/backend/utils/language_processor.py
+++ b/backend/utils/language_processor.py
@@ -15,7 +15,9 @@ TODO (専門エンジニア - Chie):
 import logging
 import re
 from dataclasses import dataclass
-from typing import Optional, Literal, TypedDict
+from typing import Literal, Optional, TypedDict
+
+from backend.utils.language_types import SupportedLanguage
 
 # TODO: 実装時に必要なインポート
 # from llm.openrouter import OpenRouterProvider
@@ -28,7 +30,6 @@ logger = logging.getLogger(__name__)
 # =============================================================================
 
 LanguageCode = Literal["ja", "en", "zh", "ko", "unknown"]
-SupportedLanguage = Literal["ja", "en", "zh", "ko"]
 
 
 class LanguageDetectionResult(TypedDict):

--- a/backend/utils/reception_templates.py
+++ b/backend/utils/reception_templates.py
@@ -12,10 +12,9 @@ from dataclasses import dataclass
 from typing import Literal, Optional, TypedDict
 
 from backend.utils.emotion_tagger import add_emotion_tag
+from backend.utils.language_types import SupportedLanguage
 
 logger = logging.getLogger(__name__)
-
-SupportedLanguage = Literal["ja", "en", "zh", "ko"]
 
 ReceptionType = Literal[
     "first_time",


### PR DESCRIPTION
## Summary

- `SupportedLanguage` 型を `backend/utils/language_types.py` に一本化（7箇所の重複定義を削除）
- `TIME_RANGE_LABELS` に zh/ko エントリを追加
- エンティティアンカリングのテスト2パターン追加

## 受入基準チェックリスト

- [x] `backend/utils/language_types.py` が canonical 定義場所
- [x] `language_processor.py` から `SupportedLanguage` 定義を削除し import に変更
- [x] `web_search.py` — 未使用の `SupportedLanguage` 定義を削除
- [x] `tavily_search.py` — import に変更
- [x] `clarification_templates.py` — import に変更
- [x] `reception_templates.py` — import に変更
- [x] `emergency_templates.py` — import に変更
- [x] `general_knowledge_agent.py` — import に変更
- [x] `TIME_RANGE_LABELS` に zh/ko 追加（today, thisWeek, nextWeek, thisMonth）
- [x] アンカリングテスト: 短い非generalクエリに適用されるケース
- [x] アンカリングテスト: 既にエンジニアカフェ含むクエリでスキップされるケース
- [x] `ruff check .` PASS
- [x] `black --check .` PASS
- [x] `pytest tests/tools/test_enhanced_rag.py tests/utils/ -v` 942 passed

## Test plan

- [x] backend lint: `ruff check . && black --check .`
- [x] unit tests: `pytest tests/tools/test_enhanced_rag.py tests/utils/ -v --tb=short -q` — 942 passed

Closes #400

🤖 Generated with [Claude Code](https://claude.com/claude-code)