### PR TITLE
fix(frontend): prevent stale sensor events from auto-triggering welcome flow

### DIFF
--- a/frontend/src/lib/api/device-webhook.ts
+++ b/frontend/src/lib/api/device-webhook.ts
@@ -82,6 +82,10 @@ export function startSensorPolling(
   stopSensorPolling();
   activePollingSessionToken += 1;
   const sessionToken = activePollingSessionToken;
+  // Initialize since to now so pre-existing (stale) events are ignored
+  if (!lastSeenSensorTimestampByDevice.has(deviceId)) {
+    lastSeenSensorTimestampByDevice.set(deviceId, Date.now() / 1000);
+  }
   void pollSensorStatus(deviceId, sessionToken);
   sensorPollingIntervalId = window.setInterval(() => {
     void pollSensorStatus(deviceId, sessionToken);


### PR DESCRIPTION
## Summary
- ページリロード時に `lastSeenSensorTimestamp` が 0 にリセットされ、Supabase `sensor_events` テーブルの古いイベントを「新規」として検出 → Welcome Agent が勝手に起動する問題を修正
- `startSensorPolling()` 初回呼び出し時に `since` を `Date.now() / 1000` で初期化し、ページロード前のイベントを無視

## 根本原因
Cloud Run ログから確認:
- JST 19:18:50: stale event で Welcome Agent が自動起動 (200 OK)
- JST 19:21:44: M5Stack が実際に発火 (sensor-trigger 200 OK)
- JST 19:22:00: reception/start が 422 (既に session active)

## 変更ファイル
- `frontend/src/lib/api/device-webhook.ts` — 4行追加

## Test plan
- [x] `pnpm lint` PASS
- [x] `pnpm typecheck` PASS
- [x] `device-webhook.test.ts` 4/4 PASS
- [ ] CI green
- [ ] M5Stack 実機で stale event が無視されることを確認 (明日の実地検証)

🤖 Generated with [Claude Code](https://claude.com/claude-code)