### PR TITLE
fix(frontend): show voice/OCR buttons in device mode + fix React #418 hydration

### DIFF
--- a/frontend/src/app/components/KioskBottomBar.tsx
+++ b/frontend/src/app/components/KioskBottomBar.tsx
@@ -88,8 +88,8 @@ export function KioskBottomBar({
           loadingPhase={voice.loadingPhase}
           sessionState={voice.sessionState}
         />
-        {showKioskScreenChrome ? (
-          <div className="flex w-full flex-row flex-wrap items-stretch justify-center gap-2 sm:gap-3">
+        <div className="flex w-full flex-row flex-wrap items-stretch justify-center gap-2 sm:gap-3">
+            {showKioskScreenChrome && (
             <button
               type="button"
               onClick={() => {
@@ -108,6 +108,7 @@ export function KioskBottomBar({
                 {labels.kioskWelcome}
               </span>
             </button>
+            )}
             <button
               data-testid="kiosk-voice-button"
               type="button"
@@ -230,7 +231,6 @@ export function KioskBottomBar({
               </span>
             </button>
           </div>
-        ) : null}
       </div>
     </div>
   );

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -44,8 +44,14 @@ export default function Home() {
   const kioskPhaseRef = useRef<KioskPhase>('notice');
   const [kioskVoiceLocked, setKioskVoiceLocked] = useState(false);
   const [currentLanguage, setCurrentLanguage] = useState<'ja' | 'en'>('ja');
-  const [triggerMode, setTriggerMode] = useState<KioskTriggerMode>(() => readKioskTriggerMode());
-  const [micInputMode, setMicInputMode] = useState<KioskMicMode>(() => readKioskMicMode());
+  const [triggerMode, setTriggerMode] = useState<KioskTriggerMode>('screen');
+  const [micInputMode, setMicInputMode] = useState<KioskMicMode>('toggle');
+
+  // Hydration-safe: read localStorage only on client after mount
+  useEffect(() => {
+    setTriggerMode(readKioskTriggerMode());
+    setMicInputMode(readKioskMicMode());
+  }, []);
   const [ocrMode, setOcrMode] = useState<'member_card' | 'handwriting'>('member_card');
   const [welcomeMemberOcrOpen, setWelcomeMemberOcrOpen] = useState(false);
   const [welcomeMemberOcrSessionKey, setWelcomeMemberOcrSessionKey] = useState(0);


### PR DESCRIPTION
## Summary
1. **KioskBottomBar**: device モードでも音声/OCR/プレゼンボタンを表示。Welcome ボタンのみ非表示 (物理発火のみ)
2. **React #418 hydration fix**: `triggerMode`/`micInputMode` の localStorage 読み取りを `useEffect` に移動し、SSR/CSR 不一致を解消

## 根本原因
- device モード時 `showKioskScreenChrome=false` → 全ボタンが `null` → 音声操作不可
- `readKioskTriggerMode()` が SSR 時 `'screen'`、CSR 時 `'device'` を返す → hydration mismatch

## 変更ファイル
- `frontend/src/app/components/KioskBottomBar.tsx` — Welcome ボタンのみ条件付き非表示に変更
- `frontend/src/app/page.tsx` — useState 初期値を SSR-safe デフォルトに、useEffect で localStorage 読み取り

## Test plan
- [x] `pnpm lint` PASS
- [x] `pnpm typecheck` PASS
- [ ] CI green
- [ ] 実機で device モード時に音声ボタンが表示されること
- [ ] React #418 エラーが消えること

🤖 Generated with [Claude Code](https://claude.com/claude-code)