### PR TITLE
feat(frontend): キオスク画面に時計表示を追加

### DIFF
--- a/frontend/src/app/components/ClockBadge.tsx
+++ b/frontend/src/app/components/ClockBadge.tsx
@@ -1,0 +1,53 @@
+'use client';
+
+import { useEffect, useMemo, useState } from 'react';
+
+type ClockBadgeProps = {
+  language: 'ja' | 'en';
+};
+
+const pad2 = (value: number): string => String(value).padStart(2, '0');
+
+export default function ClockBadge({ language }: ClockBadgeProps) {
+  const [currentTime, setCurrentTime] = useState<Date>(() => new Date());
+  const [mounted, setMounted] = useState(false);
+
+  useEffect(() => {
+    setMounted(true);
+    const timerId = window.setInterval(() => {
+      setCurrentTime(new Date());
+    }, 1000);
+    return () => {
+      window.clearInterval(timerId);
+    };
+  }, []);
+
+  const locale = language === 'ja' ? 'ja-JP' : 'en-US';
+  const weekday = useMemo(() => {
+    if (!mounted) {
+      return '---';
+    }
+    return currentTime.toLocaleDateString(locale, { weekday: 'short' });
+  }, [currentTime, locale, mounted]);
+
+  const dateText = mounted
+    ? `${currentTime.getFullYear().toString().slice(-2)}/${pad2(currentTime.getMonth() + 1)}/${pad2(currentTime.getDate())} ${weekday}`
+    : '--/--/-- ---';
+
+  const timeText = mounted
+    ? currentTime.toLocaleTimeString(locale, {
+        hour: '2-digit',
+        minute: '2-digit',
+        second: '2-digit',
+        hour12: false,
+      })
+    : '--:--:--';
+
+  return (
+    <div className="rounded-lg border border-white/15 bg-black/45 px-3 py-1.5 font-mono text-lg tabular-nums text-white shadow-lg backdrop-blur-md">
+      <div className="text-md leading-6 opacity-90">{dateText}</div>
+      <div className="text-2xl leading-12 opacity-90">{timeText}</div>
+    </div>
+  );
+}
+

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -31,6 +31,7 @@ import { KioskWelcomeOverlay } from './components/KioskWelcomeOverlay';
 import InitialSettingsModal from './components/InitialSettingsModal';
 import MarpViewer from './components/MarpViewer';
 import ReceptionPdfGuide from './components/ReceptionPdfGuide';
+import ClockBadge from './components/ClockBadge';
 import SettingsPanel, {
   type SettingsPanelPropsFromSource,
 } from './components/SettingsPanel';
@@ -473,6 +474,15 @@ export default function Home() {
                   aria-hidden={!showSettingsPanel}
                 >
                   <div
+                  className="pointer-events-none absolute"
+                  style={{
+                    top: screenPadding.paddingTop,
+                    left: screenPadding.paddingLeft,
+                  }}
+                >
+                  <ClockBadge language={voice.currentLanguage} />
+                </div>
+                <div
                     className="pointer-events-auto absolute"
                     style={{
                       top: screenPadding.paddingTop,


### PR DESCRIPTION
## 概要
キオスク画面左上に、現在の日付・曜日・時刻を表示します。言語（ja/en）に応じて `toLocaleDateString` / `toLocaleTimeString` のロケールを切り替えます。

## 変更内容
- 時計表示ロジックを `ClockBadge` コンポーネント（`src/app/components/ClockBadge.tsx`）に切り出し
- `page.tsx` では配置のみとし、`ClockBadge` を import して利用
- クライアントマウント後に 1 秒間隔で更新（ハイドレーションずれ対策のプレースホルダ表示あり）

## 関連
- Issue #418（該当する場合）

## 確認
- [ ] `cd frontend && pnpm lint && pnpm typecheck && pnpm build`

## Capture
### 日本語表示
<img width="833" height="829" alt="image" src="https://github.com/user-attachments/assets/339fc8f9-b511-4cc4-a9d2-fb9113815226" />

### 英語表示 (曜日)
<img width="837" height="829" alt="image" src="https://github.com/user-attachments/assets/3c665b60-acb9-4958-b9ba-2d5cf4002d52" />

Made with [Cursor](https://cursor.com)