### PR TITLE
Fix kiosk visit cleanup on idle return

### DIFF
--- a/frontend/e2e/reception-flow.spec.ts
+++ b/frontend/e2e/reception-flow.spec.ts
@@ -24,10 +24,11 @@ const QA_CHAT_URL = '/api/qa';
 
 /** Dismiss the initial-settings modal so the kiosk reaches the idle phase. */
 async function dismissInitialModal(page: import('@playwright/test').Page) {
-  // The modal renders with a "閉じてはじめる" / "Close and continue" button.
-  const closeButton = page.getByRole('button', { name: /閉じてはじめる|Close and continue/ });
+  const modal = page.getByRole('dialog');
+  const closeButton = page.getByTestId('initial-settings-close');
   if (await closeButton.isVisible({ timeout: 3_000 }).catch(() => false)) {
     await closeButton.click();
+    await expect(modal).toBeHidden({ timeout: 5_000 });
   }
   // Wait for the idle phase — the Welcome button should be visible.
   await expect(page.getByRole('button', { name: 'Welcome' })).toBeVisible({ timeout: 5_000 });
@@ -203,6 +204,28 @@ test.describe('Reception flow — member card OCR', () => {
 
     // Should return to idle — Welcome button visible again.
     await expect(page.getByRole('button', { name: 'Welcome' })).toBeVisible({ timeout: 5_000 });
+  });
+  test('back-to-menu clears the anonymous visitor id', async ({ page }) => {
+    await dismissInitialModal(page);
+    await page.waitForFunction(
+      () => window.localStorage.getItem('engineer_cafe_visitor_id') !== null,
+    );
+    const initialVisitorId = await page.evaluate(() =>
+      window.localStorage.getItem('engineer_cafe_visitor_id'),
+    );
+    expect(initialVisitorId).toBeTruthy();
+
+    await page.getByRole('button', { name: /会員証|Member card/ }).click();
+    await page.getByRole('button', { name: /メニューに戻る|Back to menu/ }).click();
+
+    await page.waitForFunction(
+      () => window.localStorage.getItem('engineer_cafe_visitor_id') === null,
+    );
+    const visitorIdAfterReturn = await page.evaluate(() =>
+      window.localStorage.getItem('engineer_cafe_visitor_id'),
+    );
+
+    expect(visitorIdAfterReturn).toBeNull();
   });
 });
 

--- a/frontend/src/app/components/VoiceInterface.tsx
+++ b/frontend/src/app/components/VoiceInterface.tsx
@@ -70,6 +70,7 @@ export interface VoiceInterfaceRenderProps {
   stopListening: () => void;
   cancelSession: () => void;
   clearConversation: () => void;
+  clearVisitState: () => void;
   sendMessage: (message: string) => Promise<void>;
   /** Speak fixed text (e.g. reception greeting) without running QA. */
   speakPreparedText: (
@@ -104,6 +105,7 @@ interface VoiceInterfaceProps {
 }
 
 const DEFAULT_WAKE_WORDS = ['すみません', 'hello'];
+const VISITOR_ID_STORAGE_KEY = 'engineer_cafe_visitor_id';
 
 const STATUS_LABELS: Record<'ja' | 'en', Record<VoiceSessionState, string>> = {
   ja: {
@@ -156,15 +158,22 @@ const getOrCreateVisitorId = (): string => {
     return 'anonymous';
   }
 
-  const key = 'engineer_cafe_visitor_id';
-  const existing = window.localStorage.getItem(key);
+  const existing = window.localStorage.getItem(VISITOR_ID_STORAGE_KEY);
   if (existing) {
     return existing;
   }
 
   const created = generateUuid();
-  window.localStorage.setItem(key, created);
+  window.localStorage.setItem(VISITOR_ID_STORAGE_KEY, created);
   return created;
+};
+
+const clearVisitorId = (): void => {
+  if (typeof window === 'undefined') {
+    return;
+  }
+
+  window.localStorage.removeItem(VISITOR_ID_STORAGE_KEY);
 };
 
 const createSessionId = (): string =>
@@ -316,6 +325,16 @@ export default function VoiceInterface({
     sessionIdRef.current = createSessionId();
   }, []);
 
+  const ensureVisitorId = useCallback((): string => {
+    if (visitorIdRef.current !== 'anonymous') {
+      return visitorIdRef.current;
+    }
+
+    const nextVisitorId = getOrCreateVisitorId();
+    visitorIdRef.current = nextVisitorId;
+    return nextVisitorId;
+  }, []);
+
   const scheduleLipSyncFrames = useCallback(
     (frames: LipSyncFrame[]) => {
       if (!onVisemeControl) {
@@ -447,6 +466,7 @@ export default function VoiceInterface({
 
       const abortController = new AbortController();
       requestAbortRef.current = abortController;
+      const visitorId = ensureVisitorId();
 
       try {
         const qaResponse = await fetch('/api/qa', {
@@ -460,7 +480,7 @@ export default function VoiceInterface({
             text: trimmed,
             sessionId: sessionIdRef.current,
             language: currentLanguage,
-            visitorId: visitorIdRef.current,
+            visitorId,
           }),
           signal: abortController.signal,
         });
@@ -532,6 +552,7 @@ export default function VoiceInterface({
     [
       cancelPendingRequest,
       currentLanguage,
+      ensureVisitorId,
       playAssistantAudio,
       skipAssistantTurnAutoResume,
       stopPlayback,
@@ -806,6 +827,13 @@ export default function VoiceInterface({
     resetConversation();
   }, [cancelSession, resetConversation]);
 
+  const clearVisitState = useCallback(() => {
+    cancelSession();
+    resetConversation();
+    clearVisitorId();
+    visitorIdRef.current = 'anonymous';
+  }, [cancelSession, resetConversation]);
+
   const toggleLanguage = useCallback(() => {
     const nextLanguage = currentLanguage === 'ja' ? 'en' : 'ja';
     setCurrentLanguage(nextLanguage);
@@ -869,6 +897,7 @@ export default function VoiceInterface({
       stopListening,
       cancelSession,
       clearConversation,
+      clearVisitState,
       sendMessage,
       speakPreparedText,
       setVolume,
@@ -878,6 +907,7 @@ export default function VoiceInterface({
     [
       cancelSession,
       clearConversation,
+      clearVisitState,
       currentLanguage,
       error,
       isLoading,

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -85,7 +85,7 @@ export default function Home() {
   const lastTranscriptRef = useRef<string>('');
   const lastResponseRef = useRef<string>('');
   const returnToIdleTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
-  const kioskVoiceCleanupRef = useRef<(() => void) | null>(null);
+  const kioskVisitCleanupRef = useRef<(() => void) | null>(null);
   const kioskPlayWelcomeRef = useRef<(() => Promise<void>) | null>(null);
   const prevTriggerModeRef = useRef<KioskTriggerMode>(triggerMode);
   const welcomeCooldownTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
@@ -130,18 +130,25 @@ export default function Home() {
     }
   }, []);
 
+  const resetConversationHistory = useCallback(() => {
+    lastTranscriptRef.current = '';
+    lastResponseRef.current = '';
+    setConversationHistory([]);
+  }, []);
+
+  const returnToIdle = useCallback(() => {
+    clearReturnToIdleTimer();
+    kioskVisitCleanupRef.current?.();
+    setKioskPhase('idle');
+  }, [clearReturnToIdleTimer]);
+
   const scheduleReturnToIdle = useCallback(() => {
     clearReturnToIdleTimer();
     returnToIdleTimerRef.current = setTimeout(() => {
       returnToIdleTimerRef.current = null;
-      const phase = kioskPhaseRef.current;
-      if (phase === 'voice') {
-        kioskVoiceCleanupRef.current?.();
-      }
-      setWelcomeMemberOcrOpen(false);
-      setKioskPhase('idle');
+      returnToIdle();
     }, KIOSK_IDLE_MS);
-  }, [clearReturnToIdleTimer]);
+  }, [clearReturnToIdleTimer, returnToIdle]);
 
   const bumpUserActivity = useCallback(() => {
     const phase = kioskPhaseRef.current;
@@ -216,14 +223,8 @@ export default function Home() {
     if (kioskPhase === 'idle' || kioskPhase === 'notice') {
       return;
     }
-    clearReturnToIdleTimer();
-    if (kioskPhase === 'voice') {
-      kioskVoiceCleanupRef.current?.();
-    }
-    setKioskVoiceLocked(false);
-    setWelcomeMemberOcrOpen(false);
-    setKioskPhase('idle');
-  }, [clearReturnToIdleTimer, kioskPhase, triggerMode]);
+    returnToIdle();
+  }, [kioskPhase, returnToIdle, triggerMode]);
 
   const handleSettingsPanelPropsChange = useCallback(
     (props: SettingsPanelPropsFromSource) => {
@@ -261,9 +262,8 @@ export default function Home() {
   );
 
   const handleCloseSlides = useCallback(() => {
-    clearReturnToIdleTimer();
-    setKioskPhase('idle');
-  }, [clearReturnToIdleTimer]);
+    returnToIdle();
+  }, [returnToIdle]);
 
   return (
     <>
@@ -309,9 +309,12 @@ export default function Home() {
         }}
       >
         {(voice) => {
-          kioskVoiceCleanupRef.current = () => {
-            voice.cancelSession();
-            voice.clearConversation();
+          kioskVisitCleanupRef.current = () => {
+            voice.clearVisitState();
+            setKioskVoiceLocked(false);
+            setWelcomeMemberOcrOpen(false);
+            setOcrStatus(null);
+            resetConversationHistory();
           };
           const labels = overlayLabels[voice.currentLanguage];
           const receptionTriggerType =
@@ -374,36 +377,34 @@ export default function Home() {
 
           const handleOcrSuccess = (result: OcrResponse) => {
             clearReturnToIdleTimer();
-            setKioskPhase('idle');
 
             if (result.mode === 'member_card') {
-              const memberText =
-                result.member_number !== null
-                  ? `${labels.ocrMemberResult}: ${result.member_number}`
-                  : labels.ocrReadFailed;
-              setOcrStatusMessage('member_card', memberText);
+              returnToIdle();
+              if (result.member_number === null) {
+                setOcrStatusMessage('error', labels.ocrReadFailed);
+              }
               return;
             }
 
             const recognized = (result.recognized_text ?? '').trim();
             if (!recognized) {
+              returnToIdle();
               setOcrStatusMessage('error', labels.ocrReadFailed);
               return;
             }
 
-            setOcrStatusMessage('handwriting', `${labels.ocrHandwritingResult}: ${recognized}`);
+            setOcrStatus(null);
+            setKioskVoiceLocked(false);
+            setKioskPhase('voice');
             void voice.sendMessage(recognized);
           };
 
           const handleWelcomeMemberOcrSuccess = (result: OcrResponse) => {
-            setWelcomeMemberOcrOpen(false);
             clearReturnToIdleTimer();
-            setKioskPhase('idle');
-            const memberText =
-              result.member_number !== null
-                ? `${labels.ocrMemberResult}: ${result.member_number}`
-                : labels.ocrReadFailed;
-            setOcrStatusMessage('member_card', memberText);
+            returnToIdle();
+            if (result.member_number === null) {
+              setOcrStatusMessage('error', labels.ocrReadFailed);
+            }
           };
 
           const handleWelcomeMemberOcrEndSilent = () => {
@@ -599,17 +600,14 @@ export default function Home() {
                   bumpUserActivity={bumpUserActivity}
                   onSuccess={handleOcrSuccess}
                   onFallback={() => {
-                    clearReturnToIdleTimer();
-                    setKioskPhase('idle');
+                    returnToIdle();
                     setOcrStatusMessage('error', labels.ocrReadFailed);
                   }}
                   onSkip={() => {
-                    clearReturnToIdleTimer();
-                    setKioskPhase('idle');
+                    returnToIdle();
                   }}
                   onBackToIdle={() => {
-                    clearReturnToIdleTimer();
-                    setKioskPhase('idle');
+                    returnToIdle();
                   }}
                 />
 


### PR DESCRIPTION
## 概要

Issue #396 の A のみ対応しました。  
kiosk では `idle` 復帰を 1 来訪の終了として扱い、前利用者の匿名 visitor state が次利用者に引き継がれないようにしています。

## この方針にした理由

共有 kiosk では利用者の入れ替わりを frontend 側で正確に検知できません。  
一方で、匿名利用者向けの `visitor_id` は frontend が生成して `localStorage` に保持しているため、そのままだと前利用者の匿名 ID・会話 state・OCR 由来 state が次利用者に引き継がれる可能性がありました。

そのため、kiosk において利用者の区切りを明確に置ける唯一の安定した境界として `idle` 復帰を「来訪終了」とみなし、そのタイミングで来訪単位の state を破棄する方針を採用しています。

## 変更内容

- `idle` に戻す経路を来訪終了処理に集約
- 来訪終了時に anonymous visitor state を破棄
  - `engineer_cafe_visitor_id`
  - 会話 state
  - OCR 由来の state
  - 画面上の会話履歴 / OCR status
- kiosk 設定値は保持
  - language
  - mic mode
  - trigger mode
- `visitor_id` は会話開始時に必要になったタイミングで再生成するように変更
- handwriting OCR 成功時は即 `idle` に戻さず `voice` に遷移させ、回答完了後の `idle` 復帰で来訪終了処理が走るように調整

## 対象外

- Issue #396 の B（応答テキスト残留）は今回の PR では対象外です

## 動作確認

### 自動確認

- `pnpm run typecheck`
- `pnpm exec playwright test e2e/reception-flow.spec.ts -g "back-to-menu" --project=chromium --workers 1`

### 手動確認手順

1. kiosk 画面を開き、初期設定モーダルを閉じて `idle` に遷移する
2. 開発者ツールの Application タブで `localStorage.engineer_cafe_visitor_id` が存在することを確認する
3. `会員証` もしくは `筆談` を開く
4. `メニューに戻る` を押して `idle` に戻る
5. `localStorage.engineer_cafe_visitor_id` が削除されていることを確認する
6. 再度音声会話や OCR から会話を開始し、新しい `engineer_cafe_visitor_id` が生成されることを確認する
7. 前回利用時の会話表示や OCR 結果が引き継がれていないことを確認する
8. language / mic mode / trigger mode の設定値は維持されていることを確認する

### 追加確認観点

- idle timeout で `idle` に戻った場合も同様に visitor state が破棄されること
- slides close で `idle` に戻った場合も同様に visitor state が破棄されること
- trigger mode 変更によって `idle` に戻る場合も同様に visitor state が破棄されること
- handwriting OCR 成功後は `idle` に即戻らず、回答完了後の `idle` 復帰で cleanup されること
