### PR TITLE
fix(backend): STT/TTS Cloud Run provider fix + Piper Plus deployment

### DIFF
--- a/backend/agents/stt_agent.py
+++ b/backend/agents/stt_agent.py
@@ -465,14 +465,17 @@ class LocalSTTClient:
 
 class GoogleSTTClient:
     def __init__(self):
-        self.project_id = os.getenv("GOOGLE_CLOUD_PROJECT_ID")
+        self.project_id = os.getenv("GOOGLE_CLOUD_PROJECT_ID") or os.getenv("GOOGLE_CLOUD_PROJECT")
         self.credentials_source = os.getenv("GOOGLE_CLOUD_CREDENTIALS") or os.getenv(
             "GOOGLE_APPLICATION_CREDENTIALS"
         )
-        logger.info("GoogleSTTClient initialized (credentials must be configured for use)")
+        logger.info("GoogleSTTClient initialized (project=%s)", self.project_id)
 
     def is_available(self) -> bool:
         """Google Cloud STT の認証情報が設定されているか確認"""
+        # On Cloud Run, the service account is attached via Workload Identity
+        if os.getenv("ENVIRONMENT") == "production":
+            return bool(self.project_id or os.getenv("GOOGLE_CLOUD_PROJECT"))
         return bool(self.credentials_source)
 
     def _sync_transcribe(self, audio_data: bytes, language: str = "ja") -> str:
@@ -703,7 +706,10 @@ class STTAgent:
             fallback_client: Google STT client for fallback.
                 If None and provider is 'vosk', creates one.
         """
-        self.stt_provider = stt_provider or os.getenv("STT_PROVIDER", "qwen0.6b-cpu")
+        self.stt_provider = stt_provider or os.getenv(
+            "STT_PROVIDER",
+            "google" if os.getenv("ENVIRONMENT") == "production" else "qwen0.6b-cpu",
+        )
         self.use_grammar = use_grammar
         self.confidence_threshold = confidence_threshold
         if stt_client:

--- a/backend/agents/voice_agent.py
+++ b/backend/agents/voice_agent.py
@@ -698,10 +698,15 @@ class VoiceAgent:
         self.clarification_agent = clarification_agent
         logger.info("Clarification handler initialized for voice_agent")
 
-        # Kokoro TTSクライアントを追加（英語TTS用 / piper障害時の英語フォールバック）
-        kokoro_api_url = os.getenv("KOKORO_API_URL", "http://localhost:8880")
-        self.kokoro_client = KokoroTTSClient(api_url=kokoro_api_url)
-        logger.info("Kokoro TTS client initialized: %s", kokoro_api_url)
+        # Kokoro TTSクライアント（英語TTS用 / piper障害時の英語フォールバック）
+        # Cloud Run環境でKOKORO_API_URL未設定の場合は初期化しない
+        kokoro_api_url = os.getenv("KOKORO_API_URL")
+        if kokoro_api_url:
+            self.kokoro_client = KokoroTTSClient(api_url=kokoro_api_url)
+            logger.info("Kokoro TTS client initialized: %s", kokoro_api_url)
+        else:
+            self.kokoro_client = None
+            logger.info("Kokoro TTS client not configured (KOKORO_API_URL not set)")
 
         # piper障害時の日本語フォールバック用 VoiceVox クライアント
         if tts_provider == "piper":
@@ -828,7 +833,11 @@ class VoiceAgent:
                 audio_format = "audio/wav"
             elif language == "en":
                 # 英語 → Kokoro TTS (voicevox/google の場合)
-                audio_b64 = await self.kokoro_client.synthesize_wav_base64(processed, language)
+                if self.kokoro_client:
+                    audio_b64 = await self.kokoro_client.synthesize_wav_base64(processed, language)
+                else:
+                    # Kokoro unavailable, fall through to main client (limited English support)
+                    audio_b64 = await self.tts_client.synthesize_wav_base64(processed, language)
                 audio_format = "audio/wav"
             elif self.tts_provider == "voicevox":
                 # 日本語 → VoiceVox
@@ -859,9 +868,14 @@ class VoiceAgent:
                     # piper障害時: 日本語 → VoiceVox、英語 → Kokoro にフォールバック
                     if language == "en":
                         logger.warning("piper failed, falling back to Kokoro for en")
-                        audio_b64 = await self.kokoro_client.synthesize_wav_base64(
-                            fb_text, language
-                        )
+                        if self.kokoro_client:
+                            audio_b64 = await self.kokoro_client.synthesize_wav_base64(
+                                fb_text, language
+                            )
+                        else:
+                            raise RuntimeError(
+                                "Piper unavailable and Kokoro not configured for English TTS"
+                            )
                     else:
                         if language not in ("ja",):
                             logger.warning(
@@ -880,7 +894,14 @@ class VoiceAgent:
                     audio_format = "audio/wav"
                 elif language == "en":
                     # 英語フォールバック → Kokoro TTS
-                    audio_b64 = await self.kokoro_client.synthesize_wav_base64(fb_text, language)
+                    if self.kokoro_client:
+                        audio_b64 = await self.kokoro_client.synthesize_wav_base64(
+                            fb_text, language
+                        )
+                    else:
+                        raise RuntimeError(
+                            "English TTS failed and Kokoro not configured for fallback"
+                        )
                     audio_format = "audio/wav"
                 elif self.tts_provider == "voicevox":
                     # 日本語フォールバック → VoiceVox

--- a/backend/tests/agents/test_voice_agent.py
+++ b/backend/tests/agents/test_voice_agent.py
@@ -166,6 +166,7 @@ async def test_text_to_speech_fallback_on_error(monkeypatch):
 @pytest.mark.asyncio
 async def test_text_to_speech_routes_english_to_kokoro(monkeypatch):
     """英語テキストがKokoro TTSにルーティングされることを確認"""
+    monkeypatch.setenv("KOKORO_API_URL", "http://localhost:8880")
     agent = VoiceAgent(tts_provider="voicevox")
     kokoro_called = {"called": False}
 
@@ -214,6 +215,7 @@ async def test_text_to_speech_routes_japanese_to_voicevox(monkeypatch):
 @pytest.mark.asyncio
 async def test_text_to_speech_auto_detects_language_and_routes(monkeypatch):
     """言語自動検出が正しく動作し、適切なTTSエンジンにルーティングされることを確認"""
+    monkeypatch.setenv("KOKORO_API_URL", "http://localhost:8880")
     agent = VoiceAgent(tts_provider="voicevox")
     kokoro_called = {"called": False}
     voicevox_called = {"called": False}
@@ -339,6 +341,7 @@ async def test_text_to_speech_piper_fallback_japanese_to_voicevox(monkeypatch):
 @pytest.mark.asyncio
 async def test_text_to_speech_piper_fallback_english_to_kokoro(monkeypatch):
     """piper が英語合成に失敗したとき、Kokoro にフォールバックすること"""
+    monkeypatch.setenv("KOKORO_API_URL", "http://localhost:8880")
     agent = VoiceAgent(tts_provider="piper")
 
     async def fake_piper_fail(text, lang):

--- a/docker/piper-plus/Dockerfile
+++ b/docker/piper-plus/Dockerfile
@@ -28,9 +28,6 @@ RUN pip install --no-cache-dir -r requirements.txt
 # アプリケーションファイル
 COPY server.py .
 
-# モデルキャッシュ用ボリューム
-VOLUME ["/models"]
-
 EXPOSE 8090
 
 ENV PIPER_MODEL_REPO=ayousanz/piper-plus-tsukuyomi-chan \
@@ -39,9 +36,13 @@ ENV PIPER_MODEL_REPO=ayousanz/piper-plus-tsukuyomi-chan \
     PIPER_SPEED=0.65 \
     PIPER_USE_CUDA=false
 
-RUN useradd --create-home --shell /bin/bash piper && \
+RUN mkdir -p /models && \
+    useradd --create-home --shell /bin/bash piper && \
     chown -R piper:piper /models
 USER piper
+
+# Declare volume AFTER chown so permissions persist
+VOLUME ["/models"]
 
 HEALTHCHECK --interval=15s --timeout=10s --retries=5 --start-period=60s \
     CMD python -c "import urllib.request; urllib.request.urlopen('http://localhost:8090/health')"


### PR DESCRIPTION
## 概要

Cloud Run環境でSTT（音声認識）とTTS（音声合成）が動作しない問題を修正します。

## 根本原因

### STT
- PR #408 でデフォルトSTTプロバイダーが `qwen0.6b-cpu` に変更されたが、Cloud RunのDockerイメージに `qwen-asr` / `torch` パッケージが含まれていない
- Cloud Runのエラーログ（過去24時間で7回以上）:
  ```
  STT failed (qwen0.6b-cpu): PermissionError at /nonexistent when downloading Qwen/Qwen3-ASR-0.6B
  ```
- Cloud Runは非rootユーザー（home=/nonexistent）で実行されるため、HuggingFaceキャッシュへの書き込みも不可

### TTS
- Cloud Runで `TTS_PROVIDER=voicevox` だったが、Piper PlusがメインのTTSになるべき
- Kokoro クライアントが常に初期化されていた（`KOKORO_API_URL` が未設定でも `http://localhost:8880` に接続を試みる）
- 英語TTSがKokoroに依存していたため、Cloud Runで英語TTSが失敗

## 修正内容

### 1. STT プロバイダー (`backend/agents/stt_agent.py`)
- **デフォルトプロバイダー変更**: `ENVIRONMENT=production` の場合、デフォルトを `google` に変更（Google Cloud STT）
- ローカル開発時は引き続き `qwen0.6b-cpu` を使用
- `GoogleSTTClient.is_available()`: Cloud Run環境ではWorkload Identity経由の認証を認識
- `GoogleSTTClient.__init__()`: `GOOGLE_CLOUD_PROJECT` 環境変数からのフォールバック追加

### 2. TTS プロバイダー (`backend/agents/voice_agent.py`)
- **Kokoroクライアントの条件付き初期化**: `KOKORO_API_URL` が設定されている場合のみ初期化
- 英語TTSルーティング: Kokoroが利用できない場合、メインTTSクライアントにフォールバック
- 全Kokoro呼び出し箇所にnull-safetyチェックを追加

### 3. Piper Plus Dockerfile (`docker/piper-plus/Dockerfile`)
- `VOLUME ["/models"]` の宣言を `RUN chown` の後に移動
- `mkdir -p /models` を追加してchownが確実に動作するように修正

## インフラ変更（既に適用済み）

### Piper Plus Cloud Run デプロイ
- **サービスURL**: `https://piper-plus-639959525777.asia-northeast1.run.app`
- **リージョン**: asia-northeast1
- **リソース**: 2 vCPU / 2Gi メモリ / min 0 instances
- **認証**: 認証あり（バックエンドSAのみ呼び出し可能）

### バックエンド Cloud Run 環境変数更新
```
TTS_PROVIDER=piper          # voicevox → piper に変更
PIPER_PLUS_API_URL=https://piper-plus-639959525777.asia-northeast1.run.app  # 新規追加
STT_PROVIDER=google          # 新規追加
GOOGLE_CLOUD_PROJECT=aipartner-426616  # 既存確認
```
※ `VOICEVOX_API_URL` はpiper障害時のフォールバックとして保持

### IAM権限
- バックエンドのCompute SA (`639959525777-compute@...`) に piper-plus の `roles/run.invoker` を付与済み

## マージ前チェックリスト

- [x] `cd backend && ruff check .` 通過
- [x] `cd backend && black --check .` 通過
- [x] Python import 確認済み (`STTAgent`, `VoiceAgent`)
- [x] Piper Plus Cloud Run デプロイ済み
- [x] バックエンド環境変数更新済み
- [ ] CI通過確認
- [ ] 本番でのSTT/TTS動作確認