### PR TITLE
refactor(frontend): clarify kiosk response display state

### DIFF
--- a/frontend/src/__tests__/kiosk-response-display.test.ts
+++ b/frontend/src/__tests__/kiosk-response-display.test.ts
@@ -1,0 +1,60 @@
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+import { getKioskResponseDisplayState } from '@/lib/kiosk-response-display';
+
+test('shows the default prompt instead of a stale response when returning to idle', () => {
+  const now = 10_000;
+
+  const result = getKioskResponseDisplayState({
+    response: 'Thanks for visiting.',
+    sessionState: 'idle',
+    responseVisibleUntil: now - 1,
+    defaultPromptVisibleUntil: now + 5_000,
+    now,
+    defaultPrompt: 'Ask a question to get started.',
+  });
+
+  assert.deepEqual(result, {
+    text: 'Ask a question to get started.',
+    showBubble: true,
+    isLiveResponse: false,
+  });
+});
+
+test('keeps showing the response while its visibility window is still active', () => {
+  const now = 10_000;
+
+  const result = getKioskResponseDisplayState({
+    response: 'Thanks for visiting.',
+    sessionState: 'idle',
+    responseVisibleUntil: now + 5_000,
+    defaultPromptVisibleUntil: now + 5_000,
+    now,
+    defaultPrompt: 'Ask a question to get started.',
+  });
+
+  assert.deepEqual(result, {
+    text: 'Thanks for visiting.',
+    showBubble: true,
+    isLiveResponse: true,
+  });
+});
+
+test('hides the bubble when neither a live response nor the default prompt should be visible', () => {
+  const now = 10_000;
+
+  const result = getKioskResponseDisplayState({
+    response: '',
+    sessionState: 'idle',
+    responseVisibleUntil: now - 1,
+    defaultPromptVisibleUntil: now - 1,
+    now,
+    defaultPrompt: 'Ask a question to get started.',
+  });
+
+  assert.deepEqual(result, {
+    text: '',
+    showBubble: false,
+    isLiveResponse: false,
+  });
+});

--- a/frontend/src/app/components/KioskVoiceStatusStack.tsx
+++ b/frontend/src/app/components/KioskVoiceStatusStack.tsx
@@ -11,6 +11,7 @@ import {
   XCircle,
 } from 'lucide-react';
 import { useEffect, useRef, useState } from 'react';
+import { getKioskResponseDisplayState } from '@/lib/kiosk-response-display';
 import type { VoiceLoadingPhase, VoiceSessionState } from './VoiceInterface';
 
 export function KioskVoiceStatusStack({
@@ -144,14 +145,15 @@ export function KioskVoiceStatusStack({
     isLoading && response.length > 0 && sessionState !== 'speaking';
   const isErrorVisible = Boolean(error) && errorVisibleUntil > now;
   const isOcrStatusVisible = Boolean(ocrStatus && ocrStatus.visibleUntil > now);
-  const isDefaultPromptVisible =
-    response.length === 0 &&
-    sessionState === 'idle' &&
-    defaultPromptVisibleUntil > now;
-  const displayResponse = response || (isDefaultPromptVisible ? labels.defaultPrompt : '');
-  const isResponseVisible =
-    displayResponse.length > 0 &&
-    (sessionState === 'speaking' || responseVisibleUntil > now || isDefaultPromptVisible);
+  const responseDisplay = getKioskResponseDisplayState({
+    response,
+    sessionState,
+    responseVisibleUntil,
+    defaultPromptVisibleUntil,
+    now,
+    defaultPrompt: labels.defaultPrompt,
+  });
+  const isResponseVisible = responseDisplay.showBubble;
   const isTranscriptVisible =
     transcript.length > 0 && !isSttLoading && transcriptVisibleUntil > now;
 
@@ -206,7 +208,9 @@ export function KioskVoiceStatusStack({
         >
           <Volume2 className="size-4 shrink-0" />
           <span data-testid="response-text">
-            {response ? `${labels.responseLabel}: ${response}` : displayResponse}
+            {responseDisplay.isLiveResponse
+              ? `${labels.responseLabel}: ${responseDisplay.text}`
+              : responseDisplay.text}
           </span>
         </div>
       ) : null}

--- a/frontend/src/lib/kiosk-response-display.ts
+++ b/frontend/src/lib/kiosk-response-display.ts
@@ -1,0 +1,51 @@
+export type KioskResponseSessionState = 'idle' | 'listening' | 'processing' | 'speaking';
+
+export function getKioskResponseDisplayState({
+  response,
+  sessionState,
+  responseVisibleUntil,
+  defaultPromptVisibleUntil,
+  now,
+  defaultPrompt,
+}: {
+  response: string;
+  sessionState: KioskResponseSessionState;
+  responseVisibleUntil: number;
+  defaultPromptVisibleUntil: number;
+  now: number;
+  defaultPrompt: string;
+}): {
+  text: string;
+  showBubble: boolean;
+  isLiveResponse: boolean;
+} {
+  const isLiveResponse =
+    response.length > 0 &&
+    (sessionState === 'speaking' || responseVisibleUntil > now);
+  const isDefaultPrompt =
+    sessionState === 'idle' &&
+    defaultPromptVisibleUntil > now &&
+    !isLiveResponse;
+
+  if (isLiveResponse) {
+    return {
+      text: response,
+      showBubble: true,
+      isLiveResponse: true,
+    };
+  }
+
+  if (isDefaultPrompt) {
+    return {
+      text: defaultPrompt,
+      showBubble: true,
+      isLiveResponse: false,
+    };
+  }
+
+  return {
+    text: '',
+    showBubble: false,
+    isLiveResponse: false,
+  };
+}


### PR DESCRIPTION
## 概要
`KioskVoiceStatusStack` に分散していた kiosk の応答表示判定を整理し、`response` / `default prompt` / 非表示の3状態を純粋関数に切り出しました。あわせて、表示優先順位を固定する単体テストを追加しています。

## 背景
issue #396 の B で想定されていた「idle 復帰時に前回応答が残る」不具合本体は、既存コミット `46cd6ff` (`Fix kiosk visit cleanup on idle return`) で `returnToIdle()` 時の `voice.clearVisitState()` が入っており、現行コードでは概ね解消済みです。

今回の PR はその修正の上で、表示ロジックを明確化する follow-up のリファクタです。

## 変更内容
- `frontend/src/lib/kiosk-response-display.ts` を追加
- `KioskVoiceStatusStack` から表示判定を切り出し
- `live response` / `default prompt` / `hidden` の3状態を明示
- `frontend/src/__tests__/kiosk-response-display.test.ts` を追加
- stale な response を表示しない条件をテストで固定

## 動作確認手順
1. `frontend` で `pnpm dev` を起動
2. 初期設定モーダルを閉じて idle にする
3. `筆談` または `会員証` を開く
4. `メニューに戻る` を押して idle に戻る
5. idle 復帰後に古い応答ではなく、idle 状態の表示のみになることを確認する

## テスト
- `pnpm exec tsx --test src/__tests__/kiosk-response-display.test.ts`

## 補足
- `pnpm run typecheck` は今回の変更とは別件で `ReceptionPdfGuide.tsx` の `pdfjs-dist` 解決エラーにより未通過
