### PR TITLE
feat: Qwen3-ASR primary STT + Vosk parallel fallback (#427)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -314,11 +314,11 @@ jobs:
             --platform managed \
             --allow-unauthenticated \
             --port 8000 \
-            --memory 2Gi \
+            --memory 4Gi \
             --cpu 2 \
             --min-instances 1 \
             --max-instances 3 \
-            --update-env-vars "ENVIRONMENT=production,TTS_PROVIDER=piper,STT_PROVIDER=vosk,ALLOWED_ORIGINS=https://frontend-delta-six-20.vercel.app" \
+            --update-env-vars "ENVIRONMENT=production,TTS_PROVIDER=piper,STT_PROVIDER=qwen-primary,QWEN_STT_TIMEOUT=10,HF_HOME=/app/.hf_cache,ALLOWED_ORIGINS=https://frontend-delta-six-20.vercel.app" \
             --update-secrets "OPENROUTER_API_KEY=OPENROUTER_API_KEY:latest,SUPABASE_URL=SUPABASE_URL:latest,SUPABASE_KEY=SUPABASE_KEY:latest,SUPABASE_DB_URI=SUPABASE_DB_URI:latest,API_SECRET_KEY=API_SECRET_KEY:latest,TAVILY_API_KEY=TAVILY_API_KEY:latest"
 
       - name: Smoke test deployed service
@@ -327,8 +327,8 @@ jobs:
           echo "Testing $SERVICE_URL/health ..."
           for i in 1 2 3; do
             HEALTH=$(curl -sf --max-time 30 "$SERVICE_URL/health") && break
-            echo "Attempt $i failed (cold start?), retrying in 10s..."
-            sleep 10
+            echo "Attempt $i failed (cold start / Qwen model loading?), retrying in 15s..."
+            sleep 15
           done
           echo "$HEALTH"
           echo "$HEALTH" | python3 -c "import sys,json; d=json.load(sys.stdin); assert d['status']=='ok', f'Health check failed: {d}'"

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -63,9 +63,16 @@ FROM base AS production
 # Copy application code
 COPY . .
 
+# Set HuggingFace cache to writable path (avoids /nonexistent home dir issue)
+ENV HF_HOME=/app/.hf_cache
+RUN mkdir -p $HF_HOME
+
 # Download Vosk STT models (~88MB) — required for Cloud Run where
 # volume mounts are not available.
 RUN bash scripts/download_vosk_models.sh models
+
+# Download Qwen3-ASR 0.6B model (~1.2GB) — primary STT provider (ADR-007)
+RUN bash scripts/download_qwen_model.sh
 
 # Set ownership and switch to non-root user
 RUN chown -R appuser:appuser /app
@@ -74,8 +81,8 @@ USER appuser
 # Expose port
 EXPOSE 8000
 
-# Healthcheck for production
-HEALTHCHECK --interval=30s --timeout=10s --start-period=15s --retries=3 \
+# Healthcheck for production (start-period=45s for Qwen model loading)
+HEALTHCHECK --interval=30s --timeout=10s --start-period=45s --retries=3 \
     CMD python scripts/healthcheck.py || exit 1
 
 # Run with production settings

--- a/backend/agents/stt_agent.py
+++ b/backend/agents/stt_agent.py
@@ -709,7 +709,8 @@ class STTAgent:
 
         Args:
             stt_provider: STT provider name
-                ('vosk', 'google', 'qwen', or 'qwen0.6b-cpu').
+                ('vosk', 'google', 'qwen', 'qwen0.6b-cpu',
+                or 'qwen-primary').
                 If None, uses ``STT_PROVIDER`` env var; if that is also unset,
                 defaults to ``google`` when ``ENVIRONMENT=production``, else
                 ``qwen0.6b-cpu``. Cloud Run でイメージ同梱の Vosk を使う場合は
@@ -747,6 +748,11 @@ class STTAgent:
             self.stt_client = Qwen06BCpuSTTClient(
                 default_language=os.getenv("QWEN_STT_LANGUAGE", "ja"),
             )
+        elif self.stt_provider == "qwen-primary":
+            self.stt_client = Qwen06BCpuSTTClient(
+                default_language=os.getenv("QWEN_STT_LANGUAGE", "ja"),
+            )
+            self._vosk_fallback_client = LocalSTTClient()
         else:
             raise ValueError(f"Unknown STT provider: {self.stt_provider}")
 
@@ -967,6 +973,69 @@ class STTAgent:
 
         return transcript
 
+    async def _transcribe_qwen_primary(
+        self,
+        audio_data: bytes,
+        language: Optional[str] = None,
+    ) -> Dict[str, Any]:
+        """Qwen primary + Vosk parallel fallback (ADR-007).
+
+        ``asyncio.gather`` で Qwen と Vosk を同時実行し、Qwen が
+        ``QWEN_STT_TIMEOUT`` 秒以内に成功すればその結果を返す。
+        タイムアウトまたはエラー時は Vosk の結果にフォールバックする。
+        """
+        timeout = float(os.getenv("QWEN_STT_TIMEOUT", "10"))
+
+        async def _run_qwen():
+            return await asyncio.wait_for(
+                self.stt_client.transcribe(audio_data, language=language),
+                timeout=timeout,
+            )
+
+        async def _run_vosk():
+            if language is None:
+                return await self._vosk_fallback_client.transcribe_auto_detect(audio_data)
+            return await self._vosk_fallback_client.transcribe(audio_data, language)
+
+        qwen_result, vosk_result = await asyncio.gather(
+            _run_qwen(), _run_vosk(), return_exceptions=True
+        )
+
+        # Qwen success
+        if isinstance(qwen_result, TranscriptionResult):
+            return {
+                "success": True,
+                "transcript": qwen_result.text,
+                "confidence": qwen_result.confidence,
+                "language": qwen_result.language,
+                "provider": "qwen-primary",
+            }
+
+        # Qwen failed -> Vosk fallback
+        logger.warning(
+            "Qwen STT failed, using Vosk fallback: %s",
+            qwen_result,
+        )
+        if isinstance(vosk_result, TranscriptionResult):
+            transcript = vosk_result.text
+            postprocessed = False
+            if os.getenv("STT_LLM_POSTPROCESS", "false").lower() == "true":
+                corrected = await self._llm_post_process(transcript, vosk_result.language)
+                if corrected != transcript:
+                    postprocessed = True
+                    transcript = corrected
+            return {
+                "success": True,
+                "transcript": transcript,
+                "confidence": vosk_result.confidence,
+                "language": vosk_result.language,
+                "provider": "vosk-fallback",
+                "postprocessed": postprocessed,
+            }
+
+        # Both failed
+        raise RuntimeError(f"Both Qwen and Vosk STT failed: qwen={qwen_result}, vosk={vosk_result}")
+
     def _resolve_grammar(self, conversation_stage: Optional[str]) -> Optional[Dict[str, List[str]]]:
         """会話ステージに応じた Grammar 辞書を解決する。
 
@@ -1023,6 +1092,8 @@ class STTAgent:
                 - fallback_used (bool): Whether Google fallback was used. Optional.
         """
         provider = self.stt_provider
+        if provider == "qwen-primary":
+            return await self._transcribe_qwen_primary(audio_data, language)
         grammar = self._resolve_grammar(conversation_stage)
         try:
             if language is None and isinstance(self.stt_client, LocalSTTClient):

--- a/backend/agents/stt_agent.py
+++ b/backend/agents/stt_agent.py
@@ -732,6 +732,8 @@ class STTAgent:
         )
         self.use_grammar = use_grammar
         self.confidence_threshold = confidence_threshold
+        self._vosk_fallback_client = None
+        self._qwen_timeout = None
         if stt_client:
             self.stt_client = stt_client
         elif self.stt_provider == "vosk":
@@ -753,6 +755,7 @@ class STTAgent:
                 default_language=os.getenv("QWEN_STT_LANGUAGE", "ja"),
             )
             self._vosk_fallback_client = LocalSTTClient()
+            self._qwen_timeout = float(os.getenv("QWEN_STT_TIMEOUT", "10"))
         else:
             raise ValueError(f"Unknown STT provider: {self.stt_provider}")
 
@@ -984,12 +987,11 @@ class STTAgent:
         ``QWEN_STT_TIMEOUT`` 秒以内に成功すればその結果を返す。
         タイムアウトまたはエラー時は Vosk の結果にフォールバックする。
         """
-        timeout = float(os.getenv("QWEN_STT_TIMEOUT", "10"))
 
         async def _run_qwen():
             return await asyncio.wait_for(
                 self.stt_client.transcribe(audio_data, language=language),
-                timeout=timeout,
+                timeout=self._qwen_timeout,
             )
 
         async def _run_vosk():

--- a/backend/scripts/download_qwen_model.sh
+++ b/backend/scripts/download_qwen_model.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+# Download Qwen3-ASR 0.6B model via qwen_asr library
+# Caches model weights in HF_HOME for Docker build layer reuse.
+#
+# Usage:
+#   bash scripts/download_qwen_model.sh
+#   HF_HOME=/custom/cache bash scripts/download_qwen_model.sh
+
+set -e
+
+MODEL_ID="${QWEN_ASR_MODEL_ID:-Qwen/Qwen3-ASR-0.6B}"
+HF_HOME="${HF_HOME:-/app/.hf_cache}"
+export HF_HOME
+
+echo "[download] Qwen3-ASR model: $MODEL_ID -> $HF_HOME ..."
+
+python -c "
+from qwen_asr import Qwen3ASRModel
+import torch
+
+model = Qwen3ASRModel.from_pretrained(
+    '${MODEL_ID}',
+    torch_dtype=torch.float32,
+    device_map='cpu',
+    low_cpu_mem_usage=True,
+    max_new_tokens=256,
+)
+print('[done] Qwen model cached at ${HF_HOME}')
+"

--- a/backend/scripts/download_qwen_model.sh
+++ b/backend/scripts/download_qwen_model.sh
@@ -8,22 +8,25 @@
 
 set -e
 
-MODEL_ID="${QWEN_ASR_MODEL_ID:-Qwen/Qwen3-ASR-0.6B}"
-HF_HOME="${HF_HOME:-/app/.hf_cache}"
-export HF_HOME
+export QWEN_ASR_MODEL_ID="${QWEN_ASR_MODEL_ID:-Qwen/Qwen3-ASR-0.6B}"
+export HF_HOME="${HF_HOME:-/app/.hf_cache}"
 
-echo "[download] Qwen3-ASR model: $MODEL_ID -> $HF_HOME ..."
+echo "[download] Qwen3-ASR model: $QWEN_ASR_MODEL_ID -> $HF_HOME ..."
 
 python -c "
+import os
 from qwen_asr import Qwen3ASRModel
 import torch
 
+model_id = os.environ['QWEN_ASR_MODEL_ID']
+hf_home = os.environ.get('HF_HOME', '/app/.hf_cache')
+
 model = Qwen3ASRModel.from_pretrained(
-    '${MODEL_ID}',
+    model_id,
     torch_dtype=torch.float32,
     device_map='cpu',
     low_cpu_mem_usage=True,
     max_new_tokens=256,
 )
-print('[done] Qwen model cached at ${HF_HOME}')
+print(f'[done] Qwen model cached at {hf_home}')
 "

--- a/backend/tests/agents/test_stt_agent.py
+++ b/backend/tests/agents/test_stt_agent.py
@@ -1640,6 +1640,7 @@ class TestQwenPrimaryParallel:
         )
         agent.stt_provider = "qwen-primary"
         agent._vosk_fallback_client = mock_vosk
+        agent._qwen_timeout = 10.0
         return agent
 
     @pytest.mark.asyncio
@@ -1670,11 +1671,9 @@ class TestQwenPrimaryParallel:
         assert result["transcript"] == "こんにちは"
 
     @pytest.mark.asyncio
-    async def test_qwen_timeout_vosk_fallback(self, monkeypatch):
+    async def test_qwen_timeout_vosk_fallback(self):
         """Qwen times out -> Vosk fallback with provider='vosk-fallback'"""
         import asyncio
-
-        monkeypatch.setenv("QWEN_STT_TIMEOUT", "0.1")
 
         async def slow_qwen(*args, **kwargs):
             await asyncio.sleep(20)
@@ -1692,6 +1691,7 @@ class TestQwenPrimaryParallel:
         )
 
         agent = self._make_agent(mock_qwen, mock_vosk)
+        agent._qwen_timeout = 0.1
         result = await agent.speech_to_text(b"audio", language="ja")
 
         assert result["success"] is True
@@ -1788,6 +1788,38 @@ class TestQwenPrimaryParallel:
         assert result["language"] == "en"
         mock_qwen.transcribe.assert_called_once_with(b"audio", language=None)
         mock_vosk.transcribe_auto_detect.assert_called_once_with(b"audio")
+
+    @pytest.mark.asyncio
+    async def test_vosk_fallback_with_llm_postprocess(self, monkeypatch):
+        """Qwen fails, Vosk falls back, LLM post-processing runs"""
+        monkeypatch.setenv("STT_LLM_POSTPROCESS", "true")
+        monkeypatch.setenv("OPENROUTER_API_KEY", "test-key")
+
+        mock_qwen = MagicMock()
+        mock_qwen.transcribe = AsyncMock(side_effect=RuntimeError("Qwen OOM"))
+        mock_vosk = MagicMock(spec=LocalSTTClient)
+        mock_vosk.transcribe = AsyncMock(
+            return_value=TranscriptionResult(
+                text="えんじにあかふぇ",
+                confidence=0.7,
+                language="ja",
+            )
+        )
+
+        agent = self._make_agent(mock_qwen, mock_vosk)
+        with patch.object(
+            agent,
+            "_llm_post_process",
+            new_callable=AsyncMock,
+            return_value="エンジニアカフェ",
+        ) as mock_llm:
+            result = await agent.speech_to_text(b"audio", language="ja")
+
+        assert result["success"] is True
+        assert result["provider"] == "vosk-fallback"
+        assert result["transcript"] == "エンジニアカフェ"
+        assert result["postprocessed"] is True
+        mock_llm.assert_called_once_with("えんじにあかふぇ", "ja")
 
 
 if __name__ == "__main__":

--- a/backend/tests/agents/test_stt_agent.py
+++ b/backend/tests/agents/test_stt_agent.py
@@ -1622,5 +1622,173 @@ class TestSTTLLMPostProcess:
             assert result["postprocessed"] is True
 
 
+# ==============================================================================
+# Qwen Primary + Vosk Parallel Fallback (ADR-007)
+# ==============================================================================
+
+
+class TestQwenPrimaryParallel:
+    """Tests for qwen-primary provider with Vosk parallel fallback."""
+
+    def _make_agent(self, mock_qwen, mock_vosk):
+        """Create STTAgent wired for qwen-primary with mock clients."""
+        agent = STTAgent(
+            stt_provider="vosk",
+            stt_client=mock_qwen,
+            fallback_client=None,
+            language_processor=None,
+        )
+        agent.stt_provider = "qwen-primary"
+        agent._vosk_fallback_client = mock_vosk
+        return agent
+
+    @pytest.mark.asyncio
+    async def test_qwen_primary_success(self):
+        """Qwen succeeds -> provider='qwen-primary'"""
+        mock_qwen = MagicMock()
+        mock_qwen.transcribe = AsyncMock(
+            return_value=TranscriptionResult(
+                text="こんにちは",
+                confidence=0.95,
+                language="ja",
+            )
+        )
+        mock_vosk = MagicMock(spec=LocalSTTClient)
+        mock_vosk.transcribe = AsyncMock(
+            return_value=TranscriptionResult(
+                text="こんにちわ",
+                confidence=0.7,
+                language="ja",
+            )
+        )
+
+        agent = self._make_agent(mock_qwen, mock_vosk)
+        result = await agent.speech_to_text(b"audio", language="ja")
+
+        assert result["success"] is True
+        assert result["provider"] == "qwen-primary"
+        assert result["transcript"] == "こんにちは"
+
+    @pytest.mark.asyncio
+    async def test_qwen_timeout_vosk_fallback(self, monkeypatch):
+        """Qwen times out -> Vosk fallback with provider='vosk-fallback'"""
+        import asyncio
+
+        monkeypatch.setenv("QWEN_STT_TIMEOUT", "0.1")
+
+        async def slow_qwen(*args, **kwargs):
+            await asyncio.sleep(20)
+            return TranscriptionResult(text="late", confidence=0.9, language="ja")
+
+        mock_qwen = MagicMock()
+        mock_qwen.transcribe = slow_qwen
+        mock_vosk = MagicMock(spec=LocalSTTClient)
+        mock_vosk.transcribe = AsyncMock(
+            return_value=TranscriptionResult(
+                text="vosk result",
+                confidence=0.8,
+                language="ja",
+            )
+        )
+
+        agent = self._make_agent(mock_qwen, mock_vosk)
+        result = await agent.speech_to_text(b"audio", language="ja")
+
+        assert result["success"] is True
+        assert result["provider"] == "vosk-fallback"
+        assert result["transcript"] == "vosk result"
+
+    @pytest.mark.asyncio
+    async def test_qwen_error_vosk_fallback(self):
+        """Qwen raises exception -> Vosk fallback"""
+        mock_qwen = MagicMock()
+        mock_qwen.transcribe = AsyncMock(side_effect=RuntimeError("Model OOM"))
+        mock_vosk = MagicMock(spec=LocalSTTClient)
+        mock_vosk.transcribe = AsyncMock(
+            return_value=TranscriptionResult(
+                text="fallback ok",
+                confidence=0.75,
+                language="en",
+            )
+        )
+
+        agent = self._make_agent(mock_qwen, mock_vosk)
+        result = await agent.speech_to_text(b"audio", language="en")
+
+        assert result["success"] is True
+        assert result["provider"] == "vosk-fallback"
+        assert result["transcript"] == "fallback ok"
+
+    @pytest.mark.asyncio
+    async def test_both_fail_raises(self):
+        """Both Qwen and Vosk fail -> RuntimeError"""
+        mock_qwen = MagicMock()
+        mock_qwen.transcribe = AsyncMock(side_effect=RuntimeError("Qwen OOM"))
+        mock_vosk = MagicMock(spec=LocalSTTClient)
+        mock_vosk.transcribe = AsyncMock(side_effect=RuntimeError("Vosk model missing"))
+
+        agent = self._make_agent(mock_qwen, mock_vosk)
+        with pytest.raises(RuntimeError, match="Both"):
+            await agent.speech_to_text(b"audio", language="ja")
+
+    @pytest.mark.asyncio
+    async def test_vosk_ready_before_qwen(self):
+        """Vosk completes first but Qwen still wins when it succeeds"""
+        import asyncio
+
+        async def slow_qwen(*args, **kwargs):
+            await asyncio.sleep(0.05)
+            return TranscriptionResult(
+                text="qwen wins",
+                confidence=0.95,
+                language="ja",
+            )
+
+        mock_qwen = MagicMock()
+        mock_qwen.transcribe = slow_qwen
+        mock_vosk = MagicMock(spec=LocalSTTClient)
+        mock_vosk.transcribe = AsyncMock(
+            return_value=TranscriptionResult(
+                text="vosk fast",
+                confidence=0.8,
+                language="ja",
+            )
+        )
+
+        agent = self._make_agent(mock_qwen, mock_vosk)
+        result = await agent.speech_to_text(b"audio", language="ja")
+
+        assert result["provider"] == "qwen-primary"
+        assert result["transcript"] == "qwen wins"
+
+    @pytest.mark.asyncio
+    async def test_language_auto_detect(self):
+        """language=None -> Qwen called with language=None, Vosk uses auto_detect"""
+        mock_qwen = MagicMock()
+        mock_qwen.transcribe = AsyncMock(
+            return_value=TranscriptionResult(
+                text="hello world",
+                confidence=0.9,
+                language="en",
+            )
+        )
+        mock_vosk = MagicMock(spec=LocalSTTClient)
+        mock_vosk.transcribe_auto_detect = AsyncMock(
+            return_value=TranscriptionResult(
+                text="hello",
+                confidence=0.7,
+                language="en",
+            )
+        )
+
+        agent = self._make_agent(mock_qwen, mock_vosk)
+        result = await agent.speech_to_text(b"audio", language=None)
+
+        assert result["provider"] == "qwen-primary"
+        assert result["language"] == "en"
+        mock_qwen.transcribe.assert_called_once_with(b"audio", language=None)
+        mock_vosk.transcribe_auto_detect.assert_called_once_with(b"audio")
+
+
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])

--- a/docs/STT-Migration-Guide-qwen3-asr.md
+++ b/docs/STT-Migration-Guide-qwen3-asr.md
@@ -522,7 +522,7 @@ RUN if [ "$STT_PROVIDER" = "qwen3" ]; then \
 #### 5.3 モデルダウンロードスクリプト
 
 ```bash
-# backend/scripts/download_qwen3_model.sh
+# backend/scripts/download_qwen_model.sh
 #!/bin/bash
 set -e
 
@@ -868,7 +868,7 @@ qwen3-asr-service (新規)
 | `backend/agents/stt_providers/google_provider.py` | Google STT 実装 (既存ロジック移動) |
 | `backend/agents/stt_providers/qwen3_provider.py` | qwen3-asr 実装 (新規) |
 | `backend/tests/agents/test_stt_providers.py` | Provider テスト |
-| `backend/scripts/download_qwen3_model.sh` | モデルダウンロードスクリプト |
+| `backend/scripts/download_qwen_model.sh` | モデルダウンロードスクリプト |
 
 ### 修正
 
@@ -900,7 +900,7 @@ cd backend
 pip install transformers torch torchaudio sentencepiece
 
 # 3. モデルダウンロード (テスト用、0.6B 推奨)
-QWEN3_ASR_MODEL_PATH=Qwen/Qwen3-ASR-0.6B bash scripts/download_qwen3_model.sh
+QWEN3_ASR_MODEL_PATH=Qwen/Qwen3-ASR-0.6B bash scripts/download_qwen_model.sh
 
 # 4. テスト実行
 pytest tests/agents/test_stt_providers.py -v

--- a/docs/adr/007-stt-parallel-architecture.md
+++ b/docs/adr/007-stt-parallel-architecture.md
@@ -2,7 +2,7 @@
 
 ## Status
 
-Proposed (2026-04-11)
+Accepted (2026-04-11)
 
 ## Context
 


### PR DESCRIPTION
## Summary
- Qwen3-ASR 0.6B をプライマリ STT に昇格、Vosk を `asyncio.gather` 並列フォールバックとして実装 (ADR-007)
- `_transcribe_qwen_primary()`: Qwen タイムアウト (10s) 時に Vosk 結果を即返却、両方失敗で RuntimeError
- Dockerfile: `HF_HOME=/app/.hf_cache` + Qwen モデルビルド時 DL + HEALTHCHECK start-period 45s
- CI/CD: Cloud Run `--memory 4Gi` + `STT_PROVIDER=qwen-primary` (IaC 乖離解消)
- Migration Guide の命名統一 (`download_qwen3_model.sh` → `download_qwen_model.sh`)

## Changes by Issue
| Issue | Commit | Files |
|-------|--------|-------|
| #429 | `feat(backend): add Qwen primary STT` | `stt_agent.py` |
| #428 | `feat(backend): add Qwen model download script` | `Dockerfile`, `download_qwen_model.sh` |
| #430 | `test(backend): add parallel STT tests` | `test_stt_agent.py` (+6 tests, 84 total) |
| #431 | `ci: update Cloud Run to 4Gi` | `ci.yml` |
| #432 | `docs: update ADR-007 status` | ADR-007, Migration Guide |

## Rollback
```bash
gcloud run services update engineer-cafe-backend \
  --region asia-northeast1 \
  --update-env-vars "STT_PROVIDER=vosk"
```
Vosk モデルは同一イメージに同梱 → 再デプロイ不要で即時復旧

## Test plan
- [x] `ruff check .` + `black --check .` — all passed
- [x] `pytest tests/agents/test_stt_agent.py` — 84/84 passed
- [x] 6 new parallel tests: success, timeout, error, both-fail, vosk-first, auto-detect
- [ ] CI pipeline green (backend lint + test + frontend build)
- [ ] Post-deploy smoke test: `/health` + `/api/voice` provider field verification

🤖 Generated with [Claude Code](https://claude.com/claude-code)