### PR TITLE
ci: Cloud Run 8Gi memory for Qwen+Vosk STT

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -314,7 +314,7 @@ jobs:
             --platform managed \
             --allow-unauthenticated \
             --port 8000 \
-            --memory 4Gi \
+            --memory 8Gi \
             --cpu 2 \
             --min-instances 1 \
             --max-instances 3 \


### PR DESCRIPTION
## Summary
- Cloud Run deploy memory: 4Gi → 8Gi
- 4GiB causes OOM (4270 MiB used) when Qwen 0.6B + Vosk load in parallel
- Production already running 8Gi successfully (rev 00077-rjb)

Closes #431

## Evidence
```
Memory limit of 4096 MiB exceeded with 4270 MiB used
Container terminated on signal 9
```

## Test plan
- [x] Production validated at 8Gi: STT ja 2.5s, STT en 4.1s, no OOM
- [ ] CI workflow syntax valid

🤖 Generated with [Claude Code](https://claude.com/claude-code)