### PR TITLE
fix: harden Playwright live voice and merge gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,6 +32,8 @@ jobs:
             frontend:
               - 'frontend/**'
               - 'pnpm-lock.yaml'
+              - '.github/workflows/ci.yml'
+              - '.github/workflows/voice-e2e-nightly.yml'
             backend:
               - 'backend/**'
 
@@ -132,6 +134,7 @@ jobs:
     needs: [changes, frontend-build]
     if: needs.changes.outputs.frontend == 'true'
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     steps:
       - uses: actions/checkout@v4
 
@@ -161,6 +164,7 @@ jobs:
           e2e/smoke.spec.ts
           e2e/reception-flow.spec.ts
           e2e/webgl-fallback.spec.ts
+          --project=chromium
         working-directory: frontend
         env:
           CI: true
@@ -171,6 +175,100 @@ jobs:
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY || 'placeholder-openai-key' }}
           NEXT_PUBLIC_BACKEND_API_URL: ${{ secrets.NEXT_PUBLIC_BACKEND_API_URL || 'https://engineer-cafe-backend-639959525777.asia-northeast1.run.app' }}
           BACKEND_API_URL: ${{ secrets.BACKEND_API_URL || 'https://engineer-cafe-backend-639959525777.asia-northeast1.run.app' }}
+
+  # Frontend: Playwright browser voice E2E against live backend
+  frontend-playwright-voice-live:
+    needs: [changes, frontend-build]
+    if: needs.changes.outputs.frontend == 'true' && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.fork == false)
+    runs-on: ubuntu-latest
+    timeout-minutes: 25
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v2
+        with:
+          version: ${{ env.PNPM_VERSION }}
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+          cache: 'pnpm'
+          cache-dependency-path: frontend/pnpm-lock.yaml
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+        working-directory: frontend
+
+      - name: Install Playwright Chromium
+        run: pnpm exec playwright install chromium --with-deps
+        working-directory: frontend
+
+      - name: Validate live backend secret
+        shell: bash
+        working-directory: frontend
+        run: |
+          if [[ -z "${BACKEND_API_KEY:-}" ]]; then
+            echo "error: BACKEND_API_KEY is required for frontend-playwright-voice-live." >&2
+            exit 1
+          fi
+          echo "voice-live secret check passed"
+        env:
+          BACKEND_API_KEY: ${{ secrets.BACKEND_API_KEY }}
+
+      - name: Warm up live backend
+        shell: bash
+        working-directory: frontend
+        run: |
+          BACKEND_URL="${BACKEND_API_URL:-https://engineer-cafe-backend-639959525777.asia-northeast1.run.app}"
+          echo "Probing $BACKEND_URL/health ..."
+          for attempt in 1 2 3 4 5 6; do
+            if curl -fsS --max-time 60 "$BACKEND_URL/health" > /tmp/voice-live-health.json; then
+              echo "health (attempt $attempt): $(cat /tmp/voice-live-health.json)"
+              exit 0
+            fi
+            echo "cold-start attempt $attempt failed, retrying in 10s..."
+            sleep 10
+          done
+          echo "error: backend /health probe failed after 6 attempts" >&2
+          exit 1
+        env:
+          BACKEND_API_URL: ${{ secrets.BACKEND_API_URL }}
+
+      - name: Run Playwright E2E (voice live)
+        run: >-
+          pnpm exec playwright test
+          e2e/voice-live.spec.ts
+          --project=chromium-voice-live
+        working-directory: frontend
+        env:
+          CI: true
+          PLAYWRIGHT_VOICE_LIVE: '1'
+          NEXT_PUBLIC_SUPABASE_URL: ${{ secrets.NEXT_PUBLIC_SUPABASE_URL || 'https://placeholder.supabase.co' }}
+          NEXT_PUBLIC_SUPABASE_ANON_KEY: ${{ secrets.NEXT_PUBLIC_SUPABASE_ANON_KEY || 'placeholder-anon-key' }}
+          SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.SUPABASE_SERVICE_ROLE_KEY || 'placeholder-service-role-key' }}
+          GOOGLE_GENERATIVE_AI_API_KEY: ${{ secrets.GOOGLE_GENERATIVE_AI_API_KEY || 'placeholder-google-ai-key' }}
+          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY || 'placeholder-openai-key' }}
+          NEXT_PUBLIC_BACKEND_API_URL: ${{ secrets.NEXT_PUBLIC_BACKEND_API_URL || 'https://engineer-cafe-backend-639959525777.asia-northeast1.run.app' }}
+          BACKEND_API_URL: ${{ secrets.BACKEND_API_URL || 'https://engineer-cafe-backend-639959525777.asia-northeast1.run.app' }}
+          BACKEND_API_KEY: ${{ secrets.BACKEND_API_KEY }}
+
+      - name: Upload Playwright HTML report
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-voice-live-report
+          path: frontend/playwright-report
+          retention-days: 14
+
+      - name: Upload Playwright test results
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-voice-live-test-results
+          path: frontend/test-results
+          retention-days: 14
 
       - name: Upload Playwright HTML report
         if: failure()
@@ -405,6 +503,7 @@ jobs:
       - frontend-typecheck
       - frontend-build
       - frontend-playwright-e2e
+      - frontend-playwright-voice-live
       - backend-lint
       - backend-test
     if: always()
@@ -422,6 +521,7 @@ jobs:
             "${{ needs.frontend-typecheck.result }}" \
             "${{ needs.frontend-build.result }}" \
             "${{ needs.frontend-playwright-e2e.result }}" \
+            "${{ needs.frontend-playwright-voice-live.result }}" \
             "${{ needs.backend-lint.result }}" \
             "${{ needs.backend-test.result }}"; do
             if [[ "$job_result" == "failure" ]] || [[ "$job_result" == "cancelled" ]]; then

--- a/.github/workflows/voice-e2e-nightly.yml
+++ b/.github/workflows/voice-e2e-nightly.yml
@@ -1,14 +1,11 @@
 name: Voice E2E (live backend)
 
 on:
-  # NOTE: GitHub only evaluates `schedule` triggers from the repository's
-  # default branch (`main`). This workflow is merged to `develop` first and
-  # runs on-demand via workflow_dispatch. The nightly cron will be enabled
-  # in a follow-up PR that lands the same workflow on `main` (or via the
-  # develop -> main release PR), after which the following schedule block
-  # can be re-introduced at that time:
-  #   schedule:
-  #     - cron: '17 18 * * *'  # 03:17 JST (18:17 UTC previous day)
+  # GitHub evaluates `schedule` triggers from the repository's default
+  # branch. This repository's default branch is `develop`, so the nightly
+  # cron is active here as well as workflow_dispatch.
+  schedule:
+    - cron: '17 18 * * *'  # 03:17 JST (18:17 UTC previous day)
   workflow_dispatch: {}
 
 permissions:

--- a/frontend/e2e/fixtures/voice/README.md
+++ b/frontend/e2e/fixtures/voice/README.md
@@ -1,8 +1,10 @@
 # Voice Fixture: `sample.wav`
 
 Deterministic audio payload used by `frontend/e2e/voice-live.spec.ts` to drive the
-real browser voice pipeline against a live Cloud Run backend. CI does **not**
-regenerate this file; it is committed as a binary fixture.
+browser voice pipeline against a live Cloud Run backend. The Playwright spec
+injects this WAV through a deterministic `MediaRecorder` shim so the merge gate
+does not depend on headless Chromium's flaky fake-microphone behavior. CI does
+**not** regenerate this file; it is committed as a binary fixture.
 
 ## Details
 
@@ -60,7 +62,7 @@ not literal transcript content.
 
 - `16 kHz mono PCM16` matches the Qwen STT preprocessor's native sample rate,
   so backend-side resampling is skipped.
-- `audio/wav` with a real RIFF header is what `VoiceRecorder.onstop` would
-  normally emit. Using the same MIME type keeps `VoiceInterface.handleRecordedAudio`
-  on its happy path.
+- `audio/wav` with a real RIFF header is what the Playwright recorder shim emits
+  into `VoiceRecorder.onstop`, so `VoiceInterface.handleRecordedAudio` stays on
+  its production path.
 - ≤ 80 KB target keeps the fixture well inside git (no LFS required).

--- a/frontend/e2e/voice-live.spec.ts
+++ b/frontend/e2e/voice-live.spec.ts
@@ -1,3 +1,6 @@
+import fs from 'node:fs';
+import path from 'node:path';
+
 import { expect, test, type Page, type Request } from '@playwright/test';
 
 const voiceLive = process.env.PLAYWRIGHT_VOICE_LIVE === '1';
@@ -8,14 +11,33 @@ interface ObservedCall {
   method: string;
 }
 
+function normalizeText(value: string | null | undefined): string {
+  return (value ?? '')
+    .replace(/\[\/?[a-zA-Z_]+(?::\d*\.?\d+)?\]/g, '')
+    .replace(/^(応答|Response)\s*:\s*/i, '')
+    .replace(/\s+/g, ' ')
+    .trim();
+}
+
+async function installDeterministicVoiceRecorder(page: Page): Promise<void> {
+  const sampleAudioBase64 = fs
+    .readFileSync(path.resolve(__dirname, 'fixtures/voice/sample.wav'))
+    .toString('base64');
+
+  await page.addInitScript(({ audioBase64 }) => {
+    (window as Window & { __PLAYWRIGHT_VOICE_AUDIO_BASE64__?: string }).__PLAYWRIGHT_VOICE_AUDIO_BASE64__ =
+      audioBase64;
+  }, { audioBase64: sampleAudioBase64 });
+}
+
 async function selectEnglishAndClose(page: Page, timeout = 15_000): Promise<void> {
-  const dialog = page.getByRole('dialog');
+  const dialog = page.getByRole('dialog', { name: /初期設定|Initial Settings/i });
   await expect(dialog).toBeVisible({ timeout });
-  await page.getByRole('button', { name: 'English' }).click();
-  await page.getByTestId('initial-settings-close').click();
-  await expect
-    .poll(async () => (await dialog.isHidden().catch(() => true)) === true, { timeout })
-    .toBe(true);
+  await page.waitForTimeout(500);
+  const closeButton = dialog.getByTestId('initial-settings-close');
+  await expect(closeButton).toBeVisible({ timeout });
+  await closeButton.click();
+  await expect(dialog).toBeHidden({ timeout });
 }
 
 function parseAction(request: Request): string | undefined {
@@ -29,14 +51,21 @@ function parseAction(request: Request): string | undefined {
   }
 }
 
+const ENGINEER_CAFE_PATTERN = /engineer\s*cafe|エンジニア\s*カフェ/i;
+
 test.describe('Voice live (browser voice round-trip against live backend)', () => {
   test.skip(
     !voiceLive || !process.env.BACKEND_API_URL || !process.env.BACKEND_API_KEY,
     'Set PLAYWRIGHT_VOICE_LIVE=1 + BACKEND_API_URL + BACKEND_API_KEY to run live voice E2E.',
   );
 
-  test('mic click drives STT → QA → TTS with live backend', async ({ page }) => {
+  test('mic click drives STT → QA → TTS with live backend', async ({ page, context, baseURL }) => {
     test.setTimeout(240_000);
+
+    await context.grantPermissions(['microphone'], {
+      origin: baseURL ?? 'http://127.0.0.1:3000',
+    });
+    await installDeterministicVoiceRecorder(page);
 
     const apiCalls: ObservedCall[] = [];
     page.on('request', (request) => {
@@ -47,7 +76,7 @@ test.describe('Voice live (browser voice round-trip against live backend)', () =
       apiCalls.push({ url, method, action: parseAction(request) });
     });
 
-    await page.goto('/', { waitUntil: 'networkidle' });
+    await page.goto('/', { waitUntil: 'domcontentloaded' });
     await selectEnglishAndClose(page);
 
     const voiceButton = page.getByTestId('kiosk-voice-button');
@@ -82,20 +111,31 @@ test.describe('Voice live (browser voice round-trip against live backend)', () =
     );
 
     await voiceButton.click();
-    // KioskVoiceStatusStack mirrors VoiceInterface's sessionState as a
-    // data-session-state attribute. Listening is the first post-click
-    // state; processing/speaking follow after STT returns.
-    const voiceStatus = page.getByTestId('kiosk-voice-status');
-    await expect(voiceStatus).toHaveAttribute('data-session-state', 'listening', {
+    await expect(page.getByTestId('kiosk-voice-status')).toHaveAttribute(
+      'data-session-state',
+      'listening',
+      {
+        timeout: 15_000,
+      },
+    );
+    await expect(page.getByRole('button', { name: 'Welcome' })).toBeDisabled({
       timeout: 15_000,
     });
-    // Brief pause to let Chromium's fake audio device feed at least one
-    // chunk of the 1.8s fixture WAV into the real MediaRecorder.
-    await page.waitForTimeout(2500);
+    const voiceStatus = page.getByTestId('kiosk-voice-status');
+    await page.waitForTimeout(250);
     await voiceButton.click();
 
     const sttResponse = await sttResponsePromise;
     expect(sttResponse.ok()).toBeTruthy();
+    const sttPayload = (await sttResponse.json().catch(() => null)) as {
+      transcript?: unknown;
+      success?: unknown;
+    } | null;
+    expect(sttPayload).not.toBeNull();
+    expect(sttPayload?.success ?? true).not.toBe(false);
+    const transcript = typeof sttPayload?.transcript === 'string' ? sttPayload.transcript : '';
+    expect(transcript.length).toBeGreaterThan(5);
+    expect(transcript).toMatch(ENGINEER_CAFE_PATTERN);
 
     const qaResponse = await qaResponsePromise;
     expect(qaResponse.ok()).toBeTruthy();
@@ -106,6 +146,9 @@ test.describe('Voice live (browser voice round-trip against live backend)', () =
     expect(qaPayload).not.toBeNull();
     expect(qaPayload?.success ?? true).not.toBe(false);
     expect(typeof qaPayload?.answer === 'string' && qaPayload.answer.length > 0).toBe(true);
+    const qaAnswer = normalizeText(typeof qaPayload?.answer === 'string' ? qaPayload.answer : '');
+    expect(qaAnswer.length).toBeGreaterThan(20);
+    expect(qaAnswer).toMatch(ENGINEER_CAFE_PATTERN);
 
     const ttsResponse = await ttsResponsePromise;
     expect(ttsResponse.ok()).toBeTruthy();
@@ -125,11 +168,13 @@ test.describe('Voice live (browser voice round-trip against live backend)', () =
       })
       .not.toBe(baselineText);
 
-    const finalText = ((await responseText.textContent()) ?? '').trim();
+    const finalText = normalizeText((await responseText.textContent()) ?? '');
     expect(finalText.length).toBeGreaterThan(20);
     expect(finalText).toMatch(/[A-Za-z\u3040-\u30ff\u4e00-\u9fff]/);
     expect(finalText.toLowerCase()).not.toContain('internal server error');
     expect(finalText).not.toMatch(/stack trace|500 internal/i);
+    expect(finalText).toMatch(ENGINEER_CAFE_PATTERN);
+    expect(finalText).toBe(qaAnswer);
 
     // Session must return to idle after speaking. Unlike kioskVoiceLocked
     // (which is user-driven — it drops immediately on the stop click),

--- a/frontend/e2e/webgl-fallback.spec.ts
+++ b/frontend/e2e/webgl-fallback.spec.ts
@@ -30,7 +30,14 @@ test.describe('WebGL fallback', () => {
     expect(response).not.toBeNull();
     expect(response?.status()).toBe(200);
     await dismissInitialSettingsModal(page);
+    await expect(page.getByTestId('character-avatar-root')).toHaveAttribute(
+      'data-avatar-render-mode',
+      'fallback',
+    );
     await expect(page.getByTestId('character-avatar-fallback')).toBeVisible();
     await expect(page.getByTestId('response-bubble')).toBeVisible();
+    await expect(page.getByTestId('kiosk-voice-button')).toBeVisible();
+    await expect(page.getByTestId('kiosk-settings-button')).toBeVisible();
+    await expect(page.getByTestId('kiosk-slides-button')).toBeVisible();
   });
 });

--- a/frontend/playwright.config.ts
+++ b/frontend/playwright.config.ts
@@ -6,7 +6,7 @@ import { defineConfig, devices } from '@playwright/test';
 loadEnv({ path: '.env.local' });
 loadEnv({ path: '.env' });
 
-const baseURL = process.env.PLAYWRIGHT_BASE_URL ?? 'http://localhost:3000';
+const baseURL = process.env.PLAYWRIGHT_BASE_URL ?? 'http://127.0.0.1:3000';
 
 export default defineConfig({
   testDir: './e2e',
@@ -27,7 +27,12 @@ export default defineConfig({
     {
       name: 'chromium',
       testIgnore: /voice-live\.spec\.ts/,
-      use: { ...devices['Desktop Chrome'] },
+      use: {
+        ...devices['Desktop Chrome'],
+        launchOptions: {
+          args: ['--disable-gpu'],
+        },
+      },
     },
     {
       name: 'chromium-voice-live',
@@ -48,7 +53,7 @@ export default defineConfig({
   webServer: process.env.PLAYWRIGHT_BASE_URL
     ? undefined
     : {
-        command: 'pnpm exec next dev --hostname localhost --port 3000',
+        command: 'pnpm exec next dev --hostname 127.0.0.1 --port 3000',
         url: baseURL,
         reuseExistingServer: !process.env.CI,
         timeout: 120_000,

--- a/frontend/src/app/api/voice/route.ts
+++ b/frontend/src/app/api/voice/route.ts
@@ -26,6 +26,7 @@ export async function POST(request: NextRequest) {
         text,
         streaming: streaming || false,
       },
+      timeoutMs: 75_000,
     });
 
     if (!response.ok) {
@@ -47,6 +48,7 @@ export async function GET(request: NextRequest) {
     const response = await backendFetch('/api/voice', {
       method: 'GET',
       params: action ? { action } : undefined,
+      timeoutMs: 75_000,
     });
 
     if (!response.ok) {

--- a/frontend/src/app/components/CharacterAvatar.tsx
+++ b/frontend/src/app/components/CharacterAvatar.tsx
@@ -221,6 +221,9 @@ export default function CharacterAvatar({
   const lipSyncAnalyzerRef = useRef<LipSyncAnalyzer | null>(null);
   const expressionControllerRef = useRef<ExpressionController | null>(null);
   const autoBlinkCleanupRef = useRef<(() => void) | null>(null);
+  const onVisemeControlRef = useRef(onVisemeControl);
+  const onExpressionControlRef = useRef(onExpressionControl);
+  const onKeyframeAnimationControlRef = useRef(onKeyframeAnimationControl);
   const currentExpressionRef = useRef<{ expression: string; weight: number }>({ expression: 'neutral', weight: 1.0 });
   const expressionTimeoutRef = useRef<NodeJS.Timeout | null>(null);
   const keyframeAnimationTimeoutsRef = useRef<NodeJS.Timeout[]>([]);
@@ -233,6 +236,12 @@ export default function CharacterAvatar({
   const expressionWeightsUiRef = useRef<Record<string, number>>({});
   const lastManualExpressionUpdateMsRef = useRef<Record<string, number>>({});
   const lastSettingsPanelEmitMsRef = useRef(0);
+
+  useEffect(() => {
+    onVisemeControlRef.current = onVisemeControl;
+    onExpressionControlRef.current = onExpressionControl;
+    onKeyframeAnimationControlRef.current = onKeyframeAnimationControl;
+  }, [onExpressionControl, onKeyframeAnimationControl, onVisemeControl]);
   const initializeSceneRef = useRef<() => { ok: boolean; disposeResize?: () => void }>(() => ({ ok: false }));
   const loadCharacterRef = useRef<() => Promise<void>>(async () => {});
   const cleanupRef = useRef<() => void>(() => {});
@@ -1155,10 +1164,10 @@ export default function CharacterAvatar({
 
   useEffect(() => {
     if (avatarRenderMode !== 'fallback') return;
-    onVisemeControl?.(() => {});
-    onExpressionControl?.(() => {});
-    onKeyframeAnimationControl?.(() => {});
-  }, [avatarRenderMode, onVisemeControl, onExpressionControl, onKeyframeAnimationControl]);
+    onVisemeControlRef.current?.(() => {});
+    onExpressionControlRef.current?.(() => {});
+    onKeyframeAnimationControlRef.current?.(() => {});
+  }, [avatarRenderMode]);
 
   useEffect(() => {
     if (avatarRenderMode === 'fallback') return;
@@ -1535,7 +1544,11 @@ export default function CharacterAvatar({
   }
 
   return (
-    <div className="relative h-full bg-gray-100 rounded-lg overflow-hidden">
+    <div
+      data-testid="character-avatar-root"
+      data-avatar-render-mode={avatarRenderMode}
+      className="relative h-full bg-gray-100 rounded-lg overflow-hidden"
+    >
       {avatarRenderMode === 'fallback' ? (
         <div
           data-testid="character-avatar-fallback"

--- a/frontend/src/app/components/InitialSettingsModal.tsx
+++ b/frontend/src/app/components/InitialSettingsModal.tsx
@@ -96,7 +96,7 @@ export default function InitialSettingsModal({
     ...initialSettingsModalLabels[uiLanguage],
   };
 
-  const handleClose = useCallback(async () => {
+  const handleClose = useCallback(() => {
     writeKioskTriggerMode(triggerMode);
     writeKioskMicMode(micMode);
     onPreferencesSaved?.({
@@ -105,13 +105,15 @@ export default function InitialSettingsModal({
       micMode,
     });
     markAudioUserInteraction();
-    try {
-      const { AudioInteractionManager } = await import('@/lib/audio/audio-interaction-manager');
-      await AudioInteractionManager.getInstance().ensureAudioContext();
-    } catch {
-      // Autoplay gate may still block until further gesture; kiosk flow continues.
-    }
     onClose();
+    void (async () => {
+      try {
+        const { AudioInteractionManager } = await import('@/lib/audio/audio-interaction-manager');
+        await AudioInteractionManager.getInstance().ensureAudioContext();
+      } catch {
+        // Autoplay gate may still block until further gesture; kiosk flow continues.
+      }
+    })();
   }, [micMode, onClose, onPreferencesSaved, triggerMode, uiLanguage]);
 
   if (!open) {
@@ -130,7 +132,7 @@ export default function InitialSettingsModal({
         <div className="pointer-events-auto relative max-h-[min(90vh,720px)] w-full overflow-y-auto rounded-[28px] border border-white/20 bg-slate-900/95 p-6 text-white shadow-2xl backdrop-blur-md md:p-8">
           <button
             type="button"
-            onClick={() => void handleClose()}
+            onClick={handleClose}
             className="absolute right-4 top-4 inline-flex size-10 items-center justify-center rounded-full bg-white/10 text-white transition-transform hover:scale-105"
             aria-label={labels.close}
           >
@@ -230,7 +232,7 @@ export default function InitialSettingsModal({
           <div className="mt-6 flex justify-end">
             <button
               type="button"
-              onClick={() => void handleClose()}
+              onClick={handleClose}
               data-testid="initial-settings-close"
               className="inline-flex min-h-11 min-w-[140px] items-center justify-center rounded-full bg-white px-6 py-3 text-sm font-semibold text-slate-900 shadow-lg transition-transform hover:scale-[1.02]"
             >

--- a/frontend/src/app/components/VoiceInterface.tsx
+++ b/frontend/src/app/components/VoiceInterface.tsx
@@ -176,8 +176,7 @@ const clearVisitorId = (): void => {
   window.localStorage.removeItem(VISITOR_ID_STORAGE_KEY);
 };
 
-const createSessionId = (): string =>
-  `voice-session-${Date.now()}-${Math.random().toString(36).slice(2, 11)}`;
+const createSessionId = (): string => generateUuid();
 
 const toLocale = (language: 'ja' | 'en'): string => (language === 'ja' ? 'ja-JP' : 'en-US');
 

--- a/frontend/src/app/hooks/useVoiceWaveform.ts
+++ b/frontend/src/app/hooks/useVoiceWaveform.ts
@@ -64,6 +64,14 @@ export function useVoiceWaveform({
       return;
     }
 
+    if (stream.getAudioTracks().length === 0) {
+      setIsAnalyzing(false);
+      setAverageLevel(0);
+      setLevels(createLevels(barCount));
+      setError(null);
+      return;
+    }
+
     const AudioContextConstructor = getAudioContextConstructor();
     if (!AudioContextConstructor) {
       setError('AudioContext is not supported in this browser');

--- a/frontend/src/lib/api/backend-proxy.ts
+++ b/frontend/src/lib/api/backend-proxy.ts
@@ -24,6 +24,8 @@ export interface BackendProxyOptions {
   readonly params?: Readonly<Record<string, string>>;
   /** Abort signal for request cancellation. */
   readonly signal?: AbortSignal;
+  /** Optional timeout for the generated abort signal when no explicit signal is provided. */
+  readonly timeoutMs?: number;
 }
 
 export interface BackendProxyResult<T = unknown> {
@@ -43,7 +45,7 @@ export async function backendFetch<T = unknown>(
   path: string,
   opts: BackendProxyOptions = {},
 ): Promise<BackendProxyResult<T>> {
-  const { method = "POST", body, headers = {}, params, signal } = opts;
+  const { method = "POST", body, headers = {}, params, signal, timeoutMs } = opts;
   const apiKey = process.env.BACKEND_API_KEY || "";
 
   const url = buildUrl(path, params);
@@ -58,9 +60,10 @@ export async function backendFetch<T = unknown>(
     mergedHeaders["X-API-Key"] = apiKey;
   }
 
-  // 35s > backend's 30s workflow timeout, so the backend can return its
-  // graceful timeout response before the frontend aborts the connection.
-  const effectiveSignal = signal ?? AbortSignal.timeout(35_000);
+  // Default to 35s so the backend can return its graceful timeout response
+  // before the frontend aborts. Some voice endpoints need a higher ceiling
+  // to absorb cold starts and TTS/STT latency during live verification.
+  const effectiveSignal = signal ?? AbortSignal.timeout(timeoutMs ?? 35_000);
 
   const fetchInit: RequestInit = {
     method,

--- a/frontend/src/lib/voice-recorder.ts
+++ b/frontend/src/lib/voice-recorder.ts
@@ -1,3 +1,9 @@
+declare global {
+  interface Window {
+    __PLAYWRIGHT_VOICE_AUDIO_BASE64__?: string;
+  }
+}
+
 export class VoiceRecorder {
   private mediaRecorder: MediaRecorder | null = null;
   private audioChunks: Blob[] = [];
@@ -11,104 +17,187 @@ export class VoiceRecorder {
     private onHardwareReleased?: () => void,
   ) {}
 
+  private createDeterministicMediaRecorder(audioBase64: string): MediaRecorder {
+    const bytes = Uint8Array.from(atob(audioBase64), (char) => char.charCodeAt(0));
+
+    const recorder = {
+      mimeType: 'audio/wav',
+      state: 'inactive' as RecordingState,
+      ondataavailable: null as ((event: BlobEvent) => void) | null,
+      onstop: null as ((event: Event) => void) | null,
+      onerror: null as ((event: Event) => void) | null,
+      start() {
+        recorder.state = 'recording';
+      },
+      stop() {
+        if (recorder.state === 'inactive') {
+          return;
+        }
+
+        recorder.state = 'inactive';
+        const blob = new Blob([bytes], { type: recorder.mimeType });
+
+        queueMicrotask(() => {
+          recorder.ondataavailable?.({ data: blob } as BlobEvent);
+          recorder.onstop?.(new Event('stop'));
+        });
+      },
+      pause() {
+        if (recorder.state === 'recording') {
+          recorder.state = 'paused';
+        }
+      },
+      resume() {
+        if (recorder.state === 'paused') {
+          recorder.state = 'recording';
+        }
+      },
+    };
+
+    return recorder as unknown as MediaRecorder;
+  }
+
   async initialize(): Promise<void> {
     try {
-      if (typeof navigator === 'undefined') {
-        this.onError(new Error('navigator is undefined'));
-        return;
-      }
+      const playwrightAudioBase64 =
+        typeof window !== 'undefined' ? window.__PLAYWRIGHT_VOICE_AUDIO_BASE64__ : undefined;
 
-      // Check if we're on HTTPS (required for getUserMedia on iOS)
-      if (window.location.protocol !== 'https:' && window.location.hostname !== 'localhost') {
-        this.onError(new Error('Microphone access requires HTTPS connection. Please use HTTPS or localhost.'));
-        return;
-      }
-
-      // Check if mediaDevices is available
-      if (!navigator.mediaDevices) {
-        this.onError(new Error('navigator.mediaDevices is not available. Please ensure you are using a modern browser.'));
-        return;
-      }
-
-      // Normalize getUserMedia across browsers
-      let getUserMediaFunc: ((c: MediaStreamConstraints) => Promise<MediaStream>) | null = null;
-
-      if (navigator.mediaDevices?.getUserMedia) {
-        getUserMediaFunc = navigator.mediaDevices.getUserMedia.bind(navigator.mediaDevices);
+      if (typeof playwrightAudioBase64 === 'string' && playwrightAudioBase64.length > 0) {
+        this.stream = new MediaStream();
+        this.mediaRecorder = this.createDeterministicMediaRecorder(playwrightAudioBase64);
       } else {
-        const legacy = (navigator as any).webkitGetUserMedia || (navigator as any).mozGetUserMedia || (navigator as any).msGetUserMedia;
-        if (legacy) {
-          getUserMediaFunc = (constraints: MediaStreamConstraints) => new Promise((res, rej) => legacy.call(navigator, constraints, res, rej));
+        if (typeof navigator === 'undefined') {
+          this.onError(new Error('navigator is undefined'));
+          return;
         }
-      }
 
-      if (!getUserMediaFunc) {
-        this.onError(new Error('getUserMedia API is not available. Please check browser permissions.'));
-        return;
-      }
+        const hostname = window.location.hostname;
+        const isLocalDevHost =
+          hostname === 'localhost' ||
+          hostname === '127.0.0.1' ||
+          hostname === '::1' ||
+          hostname === '[::1]';
 
-      // iOS-specific audio constraints
-      const isIOS = /iPad|iPhone|iPod/.test(navigator.userAgent) && !(window as any).MSStream;
-      
-      const audioConstraints = isIOS
-        ? {
-            echoCancellation: true,
-            noiseSuppression: true,
-            autoGainControl: true,
-          }
-        : {
-            // Avoid exact sampleRate/channelCount: some Chrome builds keep the capture
-            // pipeline (and tab mic indicator) active longer than necessary.
-            echoCancellation: true,
-            noiseSuppression: true,
-            autoGainControl: true,
-          };
+        // Check if we're on HTTPS (required for getUserMedia outside local development).
+        if (window.location.protocol !== 'https:' && !isLocalDevHost) {
+          this.onError(
+            new Error(
+              'Microphone access requires HTTPS connection. Please use HTTPS or localhost.',
+            ),
+          );
+          return;
+        }
 
-      try {
-        const selectedDeviceId =
-          typeof window !== 'undefined'
-            ? window.localStorage.getItem(VoiceRecorder.SELECTED_MIC_DEVICE_ID_STORAGE_KEY)
-            : null;
-        const audio =
-          selectedDeviceId && selectedDeviceId !== 'default'
-            ? { ...audioConstraints, deviceId: { exact: selectedDeviceId } }
-            : audioConstraints;
-        this.stream = await getUserMediaFunc({ audio });
-      } catch (error: any) {
-        // Handle specific error cases
-        if (error.name === 'NotAllowedError') {
-          this.onError(new Error('Microphone permission denied. Please allow microphone access and try again.'));
-        } else if (error.name === 'NotFoundError') {
-          this.onError(new Error('No microphone found. Please connect a microphone and try again.'));
-        } else if (error.name === 'NotReadableError') {
-          this.onError(new Error('Microphone is in use by another application. Please close other apps using the microphone.'));
-        } else if (error.name === 'OverconstrainedError') {
-          this.onError(new Error('Selected microphone is unavailable. Please choose another microphone.'));
+        // Check if mediaDevices is available
+        if (!navigator.mediaDevices) {
+          this.onError(
+            new Error(
+              'navigator.mediaDevices is not available. Please ensure you are using a modern browser.',
+            ),
+          );
+          return;
+        }
+
+        // Normalize getUserMedia across browsers
+        let getUserMediaFunc: ((c: MediaStreamConstraints) => Promise<MediaStream>) | null = null;
+
+        if (navigator.mediaDevices?.getUserMedia) {
+          getUserMediaFunc = navigator.mediaDevices.getUserMedia.bind(navigator.mediaDevices);
         } else {
-          this.onError(new Error(`Failed to access microphone: ${error.message || error.name}`));
+          const legacy =
+            (navigator as any).webkitGetUserMedia ||
+            (navigator as any).mozGetUserMedia ||
+            (navigator as any).msGetUserMedia;
+          if (legacy) {
+            getUserMediaFunc = (constraints: MediaStreamConstraints) =>
+              new Promise((res, rej) => legacy.call(navigator, constraints, res, rej));
+          }
         }
-        return;
-      }
 
-      // Check if MediaRecorder is available
-      if (typeof MediaRecorder === 'undefined') {
-        this.onError(new Error('MediaRecorder API is not available. Please use a browser that supports audio recording.'));
-        this.stream.getTracks().forEach(track => track.stop());
-        this.stream = null;
-        return;
-      }
+        if (!getUserMediaFunc) {
+          this.onError(
+            new Error('getUserMedia API is not available. Please check browser permissions.'),
+          );
+          return;
+        }
 
-      const mimeType = this.getSupportedMimeType();
-      const recorderOptions: MediaRecorderOptions = mimeType ? { mimeType } : {};
-      
-      try {
-        this.mediaRecorder = new MediaRecorder(this.stream, recorderOptions);
-      } catch (recorderError: any) {
-        console.error('MediaRecorder creation failed:', recorderError);
-        this.onError(new Error(`Failed to create MediaRecorder: ${recorderError.message || 'Unknown error'}`));
-        this.stream.getTracks().forEach(track => track.stop());
-        this.stream = null;
-        return;
+        // iOS-specific audio constraints
+        const isIOS = /iPad|iPhone|iPod/.test(navigator.userAgent) && !(window as any).MSStream;
+
+        const audioConstraints = isIOS
+          ? {
+              echoCancellation: true,
+              noiseSuppression: true,
+              autoGainControl: true,
+            }
+          : {
+              // Avoid exact sampleRate/channelCount: some Chrome builds keep the capture
+              // pipeline (and tab mic indicator) active longer than necessary.
+              echoCancellation: true,
+              noiseSuppression: true,
+              autoGainControl: true,
+            };
+
+        try {
+          const selectedDeviceId =
+            typeof window !== 'undefined'
+              ? window.localStorage.getItem(VoiceRecorder.SELECTED_MIC_DEVICE_ID_STORAGE_KEY)
+              : null;
+          const audio =
+            selectedDeviceId && selectedDeviceId !== 'default'
+              ? { ...audioConstraints, deviceId: { exact: selectedDeviceId } }
+              : audioConstraints;
+          this.stream = await getUserMediaFunc({ audio });
+        } catch (error: any) {
+          // Handle specific error cases
+          if (error.name === 'NotAllowedError') {
+            this.onError(
+              new Error(
+                'Microphone permission denied. Please allow microphone access and try again.',
+              ),
+            );
+          } else if (error.name === 'NotFoundError') {
+            this.onError(new Error('No microphone found. Please connect a microphone and try again.'));
+          } else if (error.name === 'NotReadableError') {
+            this.onError(
+              new Error(
+                'Microphone is in use by another application. Please close other apps using the microphone.',
+              ),
+            );
+          } else if (error.name === 'OverconstrainedError') {
+            this.onError(new Error('Selected microphone is unavailable. Please choose another microphone.'));
+          } else {
+            this.onError(new Error(`Failed to access microphone: ${error.message || error.name}`));
+          }
+          return;
+        }
+
+        // Check if MediaRecorder is available
+        if (typeof MediaRecorder === 'undefined') {
+          this.onError(
+            new Error(
+              'MediaRecorder API is not available. Please use a browser that supports audio recording.',
+            ),
+          );
+          this.stream.getTracks().forEach((track) => track.stop());
+          this.stream = null;
+          return;
+        }
+
+        const mimeType = this.getSupportedMimeType();
+        const recorderOptions: MediaRecorderOptions = mimeType ? { mimeType } : {};
+
+        try {
+          this.mediaRecorder = new MediaRecorder(this.stream, recorderOptions);
+        } catch (recorderError: any) {
+          console.error('MediaRecorder creation failed:', recorderError);
+          this.onError(
+            new Error(`Failed to create MediaRecorder: ${recorderError.message || 'Unknown error'}`),
+          );
+          this.stream.getTracks().forEach((track) => track.stop());
+          this.stream = null;
+          return;
+        }
       }
 
       this.mediaRecorder.ondataavailable = (event) => {


### PR DESCRIPTION
## Summary
- harden the browser voice pipeline for deterministic Playwright runs and tolerate live backend latency
- make WebGL fallback and kiosk voice state observable so Playwright can assert the fallback and voice lifecycle reliably
- add the live voice Playwright job into the main CI merge gate and re-enable the nightly workflow on develop

## Verification
- cd frontend && pnpm exec playwright test e2e/webgl-fallback.spec.ts --project=chromium
- cd frontend && CI=1 pnpm exec playwright test e2e/smoke.spec.ts e2e/reception-flow.spec.ts --project=chromium --workers=1
- cd frontend && BACKEND_API_URL='https://engineer-cafe-backend-639959525777.asia-northeast1.run.app' BACKEND_API_KEY=*** CI=1 PLAYWRIGHT_VOICE_LIVE=1 pnpm exec playwright test e2e/voice-live.spec.ts --project=chromium-voice-live --workers=1

Closes #450