### PR TITLE
docs: unify frontend origin source of truth

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,6 +15,7 @@ env:
   NODE_VERSION: '20'
   PNPM_VERSION: '10'
   PYTHON_VERSION: '3.11'
+  DEFAULT_FRONTEND_PRODUCTION_ORIGIN: 'https://frontend-delta-six-20.vercel.app'
 
 jobs:
   # Detect which parts changed
@@ -467,6 +468,7 @@ jobs:
 
       - name: Deploy to Cloud Run
         run: |
+          FRONTEND_PRODUCTION_ORIGIN="${FRONTEND_PRODUCTION_ORIGIN:-$DEFAULT_FRONTEND_PRODUCTION_ORIGIN}"
           gcloud run deploy engineer-cafe-backend \
             --image asia-northeast1-docker.pkg.dev/aipartner-426616/cloud-run-source-deploy/engineer-cafe-backend:${{ github.sha }} \
             --region asia-northeast1 \
@@ -477,8 +479,10 @@ jobs:
             --cpu 2 \
             --min-instances 1 \
             --max-instances 3 \
-            --update-env-vars "ENVIRONMENT=production,TTS_PROVIDER=piper,STT_PROVIDER=qwen-primary,QWEN_STT_TIMEOUT=10,HF_HOME=/app/.hf_cache,ALLOWED_ORIGINS=https://frontend-delta-six-20.vercel.app" \
+            --update-env-vars "ENVIRONMENT=production,TTS_PROVIDER=piper,STT_PROVIDER=qwen-primary,QWEN_STT_TIMEOUT=10,HF_HOME=/app/.hf_cache,FRONTEND_PRODUCTION_ORIGIN=${FRONTEND_PRODUCTION_ORIGIN},ALLOWED_ORIGINS=${FRONTEND_PRODUCTION_ORIGIN}" \
             --update-secrets "OPENROUTER_API_KEY=OPENROUTER_API_KEY:latest,SUPABASE_URL=SUPABASE_URL:latest,SUPABASE_KEY=SUPABASE_KEY:latest,SUPABASE_DB_URI=SUPABASE_DB_URI:latest,API_SECRET_KEY=API_SECRET_KEY:latest,TAVILY_API_KEY=TAVILY_API_KEY:latest"
+        env:
+          FRONTEND_PRODUCTION_ORIGIN: ${{ vars.FRONTEND_PRODUCTION_ORIGIN }}
 
       - name: Smoke test deployed service
         run: |

--- a/backend/main.py
+++ b/backend/main.py
@@ -233,9 +233,10 @@ async def verify_api_key(request: Request) -> None:
         raise HTTPException(status_code=403, detail="Invalid or missing API key")
 
 
-ALLOWED_ORIGINS = os.getenv("ALLOWED_ORIGINS", "https://frontend-delta-six-20.vercel.app").split(
-    ","
+DEFAULT_FRONTEND_PRODUCTION_ORIGIN = os.getenv(
+    "FRONTEND_PRODUCTION_ORIGIN", "https://frontend-delta-six-20.vercel.app"
 )
+ALLOWED_ORIGINS = os.getenv("ALLOWED_ORIGINS", DEFAULT_FRONTEND_PRODUCTION_ORIGIN).split(",")
 app.add_middleware(
     CORSMiddleware,
     allow_origins=ALLOWED_ORIGINS,

--- a/backend/tests/integration/test_supabase_memory_integration.py
+++ b/backend/tests/integration/test_supabase_memory_integration.py
@@ -35,6 +35,8 @@ _REQUIRED_TABLES = (
     "conversation_sessions",
     "conversation_history",
     "knowledge_base",
+    "reception_sessions",
+    "visits",
 )
 _MISSING_SCHEMA_TABLES: tuple[str, ...] = ()
 
@@ -612,4 +614,16 @@ class TestDatabaseSchema:
         response = (
             memory_helper.supabase.table("conversation_history").select("id").limit(0).execute()
         )
+        assert response is not None
+
+    async def test_reception_sessions_table_exists(self, memory_helper):
+        """reception_sessionsテーブルが存在する"""
+        response = (
+            memory_helper.supabase.table("reception_sessions").select("id").limit(0).execute()
+        )
+        assert response is not None
+
+    async def test_visits_table_exists(self, memory_helper):
+        """visitsテーブルが存在する"""
+        response = memory_helper.supabase.table("visits").select("id").limit(0).execute()
         assert response is not None

--- a/backend/tests/test_main_endpoints.py
+++ b/backend/tests/test_main_endpoints.py
@@ -295,7 +295,10 @@ class TestCORSConfiguration:
     def test_cors_uses_frontend_origin_override(self, monkeypatch):
         """FRONTEND_PRODUCTION_ORIGIN becomes the default when ALLOWED_ORIGINS is absent."""
         monkeypatch.delenv("ALLOWED_ORIGINS", raising=False)
-        monkeypatch.setenv("FRONTEND_PRODUCTION_ORIGIN", "https://frontend-qwbhreahe-kousukes-projects-8e2831b8.vercel.app")
+        monkeypatch.setenv(
+            "FRONTEND_PRODUCTION_ORIGIN",
+            "https://frontend-qwbhreahe-kousukes-projects-8e2831b8.vercel.app",
+        )
         import importlib
         import backend.main
 

--- a/backend/tests/test_main_endpoints.py
+++ b/backend/tests/test_main_endpoints.py
@@ -285,11 +285,25 @@ class TestCORSConfiguration:
     def test_cors_default_origins(self, monkeypatch):
         """Without ALLOWED_ORIGINS env var, production default is used"""
         monkeypatch.delenv("ALLOWED_ORIGINS", raising=False)
+        monkeypatch.delenv("FRONTEND_PRODUCTION_ORIGIN", raising=False)
         import importlib
         import backend.main
 
         importlib.reload(backend.main)
         assert "https://frontend-delta-six-20.vercel.app" in backend.main.ALLOWED_ORIGINS
+
+    def test_cors_uses_frontend_origin_override(self, monkeypatch):
+        """FRONTEND_PRODUCTION_ORIGIN becomes the default when ALLOWED_ORIGINS is absent."""
+        monkeypatch.delenv("ALLOWED_ORIGINS", raising=False)
+        monkeypatch.setenv("FRONTEND_PRODUCTION_ORIGIN", "https://frontend-qwbhreahe-kousukes-projects-8e2831b8.vercel.app")
+        import importlib
+        import backend.main
+
+        importlib.reload(backend.main)
+        assert (
+            "https://frontend-qwbhreahe-kousukes-projects-8e2831b8.vercel.app"
+            in backend.main.ALLOWED_ORIGINS
+        )
 
     def test_cors_custom_origins(self, monkeypatch):
         """With ALLOWED_ORIGINS set, custom origins are used"""
@@ -302,6 +316,7 @@ class TestCORSConfiguration:
         assert "https://app.example.com" in backend.main.ALLOWED_ORIGINS
         # Restore
         monkeypatch.delenv("ALLOWED_ORIGINS", raising=False)
+        monkeypatch.delenv("FRONTEND_PRODUCTION_ORIGIN", raising=False)
         importlib.reload(backend.main)
 
 

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -10,7 +10,7 @@ Browser / Kiosk
      |
      v
 Vercel  (Next.js 15 frontend — App Router)
-  Production URL: https://frontend-delta-six-20.vercel.app
+  Production domain: Vercel project primary production alias
   Auto-deploy: push to `develop` (Vercel Git integration / deploy hook)
      |
      v
@@ -31,6 +31,12 @@ Cloud Run: engineer-cafe-backend   asia-northeast1   GCP: aipartner-426616
 | Backend | Cloud Run `engineer-cafe-backend` | `asia-northeast1` | FastAPI + LangGraph agents |
 | VoiceVox | Cloud Run `voicevox-proto` | `asia-northeast2` | Japanese TTS (when configured; not bundled in default staging deploy) |
 | Database | Supabase (PostgreSQL + pgvector) | Managed | Chat history, knowledge base, sessions |
+
+### Source of truth for frontend origin
+
+- The canonical frontend production origin is the **Vercel project's primary production domain**, not an arbitrary preview deployment URL.
+- Operators should verify it in the Vercel dashboard or `vercel list --yes`.
+- Backend deploys mirror that value through the GitHub Actions repo variable `FRONTEND_PRODUCTION_ORIGIN` and write it to both `FRONTEND_PRODUCTION_ORIGIN` and `ALLOWED_ORIGINS` on Cloud Run.
 
 ### Legacy (pre-2026-04): Cloudflare Workers
 
@@ -62,7 +68,7 @@ Typical **staging / production-aligned** flags from CI include:
 
 - `--memory 8Gi --cpu 2 --min-instances 1 --max-instances 3`
 - Non-secret env (example from workflow):  
-  `ENVIRONMENT=production`, `TTS_PROVIDER=piper`, `STT_PROVIDER=qwen-primary`, `ALLOWED_ORIGINS=https://frontend-delta-six-20.vercel.app`
+  `ENVIRONMENT=production`, `TTS_PROVIDER=piper`, `STT_PROVIDER=qwen-primary`, `FRONTEND_PRODUCTION_ORIGIN=<vercel-production-origin>`, `ALLOWED_ORIGINS=<vercel-production-origin>`
 - Secrets via `--update-secrets` (never `--set-secrets` in a way that drops existing bindings)
 
 | Variable | Required | Description |
@@ -84,7 +90,7 @@ Use `gcloud run services update --update-env-vars` to change individual vars. **
 ### Frontend: Vercel
 
 1. Merge to `develop` (or trigger the configured **Deploy Hook** if you use hook-based deploys).
-2. Vercel builds from the linked Git repo; production URL: https://frontend-delta-six-20.vercel.app
+2. Vercel builds from the linked Git repo; use the project's **Production** domain shown in Vercel as the canonical frontend URL.
 
 Local checks before shipping:
 
@@ -127,7 +133,8 @@ Confirm image, env vars, and secret bindings match expectations.
 **Frontend (Vercel)**
 
 - Dashboard: Vercel project → Deployments / Domains.  
-- CLI (if installed): `vercel ls` for recent deployments.
+- CLI (if installed): `vercel list --yes` for recent deployments.
+- Repo/CI source of truth: GitHub Actions repo variable `FRONTEND_PRODUCTION_ORIGIN` should match the Vercel Production domain.
 
 **Health**
 
@@ -145,7 +152,8 @@ curl -sf "$(gcloud run services describe engineer-cafe-backend --region asia-nor
 - [ ] CI green on the branch being deployed
 - [ ] `API_SECRET_KEY` set on Cloud Run for production
 - [ ] `ADMIN_API_SECRET` set in **Vercel** (not Cloudflare) for the frontend project
-- [ ] `ALLOWED_ORIGINS` on the backend includes https://frontend-delta-six-20.vercel.app (and preview URLs if you use them)
+- [ ] `FRONTEND_PRODUCTION_ORIGIN` matches the Vercel Production domain
+- [ ] `ALLOWED_ORIGINS` on the backend includes that same production origin (and preview URLs if you use them)
 - [ ] No new env vars without documentation
 - [ ] Supabase migrations applied if schema changed
 - [ ] Backend image built with `--platform linux/amd64` when building on Apple Silicon

--- a/docs/DEVELOPER-GUIDE.md
+++ b/docs/DEVELOPER-GUIDE.md
@@ -91,7 +91,7 @@ Frontend API routes proxy requests to the backend:
 | Local Frontend | http://localhost:3000 |
 | Local Backend | http://localhost:8000 |
 | Local Backend Docs | http://localhost:8000/docs (Swagger UI) |
-| Production Frontend | https://frontend-delta-six-20.vercel.app |
+| Production Frontend | Vercel Production domain (`docs/DEPLOYMENT.md` を参照) |
 | Production Backend | https://engineer-cafe-backend-639959525777.asia-northeast1.run.app |
 | Backend Health | `GET /api/health` |
 

--- a/docs/api/API-ja.md
+++ b/docs/api/API-ja.md
@@ -8,7 +8,7 @@
 
 Engineer Cafe Navigator は 2 層構成の API を採用しています。
 
-- 公開クライアントは通常 `https://frontend-delta-six-20.vercel.app/api` 配下のフロントエンド route を呼び出します。
+- 公開クライアントは通常 `<frontend-production-origin>/api` 配下のフロントエンド route を呼び出します。ここでいう origin は `docs/DEPLOYMENT.md` に記載した Vercel の Production domain です。
 - フロントエンドの `/api/*` route は FastAPI バックエンドへプロキシし、`BACKEND_API_KEY` を使って `X-API-Key` を自動付与します。
 - `/api/admin/*`、`/api/cron/*`、`/api/monitoring/*` はフロントエンド側で `Authorization: Bearer <ADMIN_API_SECRET>` により保護されます。
 - `/api/chat` などのコアなバックエンド route は、通常ブラウザから直接呼び出す想定ではありません。
@@ -16,7 +16,7 @@ Engineer Cafe Navigator は 2 層構成の API を採用しています。
 ## ベース URL
 
 ```text
-フロントエンド本番: https://frontend-delta-six-20.vercel.app/api
+フロントエンド本番: <frontend-production-origin>/api
 フロントエンド local: http://localhost:3000/api
 バックエンド local:   http://localhost:8000
 ```
@@ -33,7 +33,7 @@ Engineer Cafe Navigator は 2 層構成の API を採用しています。
 
 - `BACKEND_API_KEY` は Next.js フロントエンドがバックエンドへプロキシするためのサーバー側シークレットです。
 - `ADMIN_API_SECRET` はフロントエンド middleware により `/api/admin/*`、`/api/cron/*`、`/api/monitoring/*` に適用されます。
-- バックエンドの CORS は `https://frontend-delta-six-20.vercel.app` と local 開発 origin を許可しています。
+- バックエンドの CORS は設定された Vercel Production origin と local 開発 origin を許可しています。
 
 ## アーキテクチャ補足
 

--- a/docs/api/API.md
+++ b/docs/api/API.md
@@ -8,7 +8,7 @@ Updated for the current Vercel + Cloud Run deployment.
 
 Engineer Cafe Navigator uses a two-tier API architecture:
 
-- Public clients usually call the frontend routes at `https://frontend-delta-six-20.vercel.app/api`.
+- Public clients usually call the frontend routes at `<frontend-production-origin>/api` where the origin is the Vercel Production domain documented in `docs/DEPLOYMENT.md`.
 - Those frontend `/api/*` routes proxy to the FastAPI backend and attach `X-API-Key` automatically via `BACKEND_API_KEY`.
 - Admin, cron, and monitoring routes are protected at the frontend edge with `Authorization: Bearer <ADMIN_API_SECRET>`.
 - Core backend application routes such as `/api/chat` are not meant to be called directly from browsers.
@@ -16,7 +16,7 @@ Engineer Cafe Navigator uses a two-tier API architecture:
 ## Base URLs
 
 ```text
-Frontend production: https://frontend-delta-six-20.vercel.app/api
+Frontend production: <frontend-production-origin>/api
 Frontend local:      http://localhost:3000/api
 Backend local:       http://localhost:8000
 ```
@@ -33,7 +33,7 @@ Notes:
 
 - `BACKEND_API_KEY` is a server-side secret used by the Next.js frontend when proxying requests to the backend.
 - `ADMIN_API_SECRET` is enforced by frontend middleware on `/api/admin/*`, `/api/cron/*`, and `/api/monitoring/*`.
-- The backend also restricts CORS to `https://frontend-delta-six-20.vercel.app` plus local development origins.
+- The backend also restricts CORS to the configured Vercel Production origin plus local development origins.
 
 ## Architecture Note
 

--- a/docs/setup-guide.md
+++ b/docs/setup-guide.md
@@ -389,7 +389,7 @@ Q&A:      ブラウザ → /api/qa (FE proxy) → Backend /api/chat → LangGrap
 
 | サービス | URL |
 |----------|-----|
-| フロントエンド (Vercel) | https://frontend-delta-six-20.vercel.app |
+| フロントエンド (Vercel) | Vercel の Production domain を参照 (`vercel list --yes` または `docs/DEPLOYMENT.md`) |
 | バックエンド (Cloud Run) | https://engineer-cafe-backend-639959525777.asia-northeast1.run.app |
 | VoiceVox (Cloud Run) | https://voicevox-proto-639959525777.asia-northeast2.run.app |
 


### PR DESCRIPTION
## Summary
- unify the frontend production origin across deploy docs, API docs, setup docs, and backend CORS defaults
- make Cloud Run deploys read FRONTEND_PRODUCTION_ORIGIN and mirror it into ALLOWED_ORIGINS
- extend the Supabase schema probe to require reception_sessions and visits in addition to the existing memory/chat tables

## Verification
- uv run pytest backend/tests/test_main_endpoints.py -q
- uv run pytest backend/tests/integration/test_supabase_memory_integration.py -q
- rg in docs confirms only legacy Cloudflare references remain outside archive/plans

Closes #448
Closes #449