### PR TITLE
docs: align ADRs and issue tracking with current state

### DIFF
--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -111,7 +111,7 @@ Manual deploy (operators): follow the same `docker build --platform linux/amd64`
 
 ## CI/CD
 
-- **Pull requests** to `main` / `develop`: lint, typecheck, build, backend tests, and (when `frontend/**` changes) Playwright E2E subset (`smoke`, `reception-flow`). Additional specs such as `e2e/webgl-fallback.spec.ts` can be run locally or added to CI as needed.
+- **Pull requests** to `main` / `develop`: lint, typecheck, build, backend tests, and (when `frontend/**` changes) Playwright merge-gate coverage for `smoke`, `reception-flow`, `webgl-fallback`, plus the live browser voice round-trip job `voice-live` against Cloud Run.
 - **Backend auto-deploy:** push to `develop` → GitHub Actions → Cloud Run (see workflow).
 - **Frontend auto-deploy:** push to `develop` → Vercel (Git or deploy hook).
 

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -167,7 +167,7 @@ The following items were identified during the 2026-03-14 hardening audit and ar
 
 **Browser and device validation**: Audio pipeline changes (WebM-to-WAV conversion, Web Audio API autoplay fixes) and VRM compatibility fixes from recent PRs have not been confirmed on all target kiosk browsers and tablet hardware. This is a deployment risk, not an authentication risk, but it belongs in a production sign-off checklist.
 
-**Frontend E2E coverage is thin**: Most current test coverage is at the unit and integration level. Playwright coverage does not yet cover admin authentication flows end-to-end.
+**Frontend E2E coverage is focused on kiosk core flows**: Playwright now gates smoke, reception, WebGL fallback, and live browser voice round-trip flows. Admin authentication and other backoffice paths are still not covered end-to-end.
 
 ---
 

--- a/docs/adr/006-langgraph-workflow-redesign.md
+++ b/docs/adr/006-langgraph-workflow-redesign.md
@@ -120,11 +120,14 @@ LangGraph ワークフローを再設計し、キーワード fast-path 導入�
 
 ## Implementation Notes
 
-What was actually implemented versus the original plan, as of 2026-03-29:
+What was actually implemented versus the original plan, as of 2026-04-13:
 
-### D1: キーワード Fast-Path — In Progress (#377)
+### D1: キーワード Fast-Path — DONE (#377)
 
-実装未着手。グラフ構造変更（reception_check → keyword_router 分岐）は Wave 7 後半で対応予定。
+- `main_workflow.py` に `reception_check` と `keyword_router` を追加
+- グラフ構造を `START → reception_check → { active_reception: memory_loader, no_reception: keyword_router }` に変更
+- FAQ 系クエリは `keyword_router` から agent に直行し、mixed-intent / anaphora / memory 依存クエリは `memory_loader` にフォールバック
+- fast-path でも最低限の会話履歴は保存するようにした
 
 ### D2: Reception ワークフロー一本化 — DONE (PR #390)
 
@@ -150,6 +153,12 @@ What was actually implemented versus the original plan, as of 2026-03-29:
 - 新評価ランナー `run_multilingual_eval.py`（言語別スコア分解）
 - bilingual FAQ エントリの knowledge_base への追加は未実施
 
+### Browser / Live E2E Verification — DONE (#139, PR #455 / #456)
+
+- Playwright merge gate が `smoke.spec.ts`、`reception-flow.spec.ts`、`webgl-fallback.spec.ts` を実行
+- `voice-live.spec.ts` がブラウザから live backend に対して `STT -> /api/qa -> /api/chat -> TTS` の round-trip を検証
+- backend 側にも live LangGraph scenario / voice round-trip テストを追加し、UI 経由と API 経由の両方でワークフロー確認を行う体制にした
+
 ### D5: D-RAG — Deferred (Phase 2, post 4/11)
 
 計画通り延期。日英クロスバリデーションは Phase 2 で対応。
@@ -172,5 +181,5 @@ What was actually implemented versus the original plan, as of 2026-03-29:
 - Sub Issues: #377, #378, #379, #380, #381, #382
 - #117 (受付フロー統合)
 - #138 (多言語品質改善)
-- #139 (E2Eテスト)
+- #139 (E2Eテスト, closed 2026-04-13)
 - #367 (Wave 6計画)

--- a/docs/adr/007-stt-parallel-architecture.md
+++ b/docs/adr/007-stt-parallel-architecture.md
@@ -59,10 +59,12 @@ Engineer Cafe Navigator のアルファテストに向けて、STT (Speech-to-Te
 
 | 変数 | デフォルト | 説明 |
 |---|---|---|
-| `STT_PROVIDER` | `vosk` | STT プロバイダー選択 |
+| `STT_PROVIDER` | コード既定: production=`google`, non-production=`qwen0.6b-cpu`; Cloud Run deploy は `qwen-primary` を明示設定 | STT プロバイダー選択 |
 | `QWEN_STT_TIMEOUT` | `10` | Qwen タイムアウト (秒) |
 | `STT_LLM_POSTPROCESS` | `false` | Vosk フォールバック時の LLM 後処理 |
 | `HF_HOME` | `/app/.hf_cache` | HuggingFace モデルキャッシュ |
+
+この ADR が意図する本番構成は `qwen-primary` であり、実際の Cloud Run デプロイも `.github/workflows/ci.yml` から `STT_PROVIDER=qwen-primary` を明示している。`STTAgent` クラスの未設定時フォールバック値はローカル/移行互換のために残っている実装詳細であり、本番ではそれに依存しない。
 
 ## Cloud Run 要件
 
@@ -129,6 +131,10 @@ Cloud Run revision 00077-rjb にデプロイし、本番環境で検証を実施
 - 初回リクエスト: ~40s (モデルロード) → 500 エラー
 - 2回目以降: 2-5s (モデル常駐)
 - min-instances=1 でコールドスタート回避
+
+### 2026-04-13 時点の追加運用確認
+- GitHub Actions の `frontend-playwright-voice-live` が live backend に対するブラウザ音声 round-trip を merge gate として実行
+- このジョブは UI 音声入力経路、`/api/qa` プロキシ、LangGraph 応答、TTS 応答の接続健全性を継続的に確認する
 
 ### 未解決課題
 1. **日本語 STT 精度**: カタカナ語 ("エンジニア") の認識が弱い


### PR DESCRIPTION
## Summary
- update current deployment and security docs to reflect the Playwright merge-gate suite
- refresh ADR-006 and ADR-007 so they match the implemented LangGraph and STT architecture
- close #139 and document the remaining manual VRM validation scope on #190

## Validation
- git diff --check
- verified #139 is now CLOSED
- verified #190 remains OPEN as the remaining VRM validation ticket