### PR TITLE
feat(backend): TTS実長をリップシンクに反映 (#463)

### DIFF
--- a/backend/agents/voice_agent.py
+++ b/backend/agents/voice_agent.py
@@ -929,3 +929,41 @@ class VoiceAgent:
                     "error": f"Failed to generate speech: {str(e)}",
                     "emotion": "confused",
                 }
+
+    async def probe_synthesis_duration_seconds(self, text: str, language: str) -> Optional[float]:
+        """
+        Same preprocessing and TTS engine selection as text_to_speech, without ambiguity handling.
+        Used to align CharacterControlAgent lip-sync duration with actual synthesized audio length.
+        """
+        from backend.utils.tts_audio_duration import audio_duration_seconds_from_base64
+
+        try:
+            cleaned = clean_text_for_tts(text)
+            processed = preprocess_tts(cleaned, language)
+            if len(processed.encode("utf-8")) > 5000:
+                processed = truncate_by_bytes(processed, 5000)
+            if not processed.strip():
+                return None
+
+            vrm_emotion = "neutral"
+            if self.tts_provider == "piper":
+                audio_b64 = await self.tts_client.synthesize_wav_base64(processed, language)
+            elif language == "en":
+                if self.kokoro_client:
+                    audio_b64 = await self.kokoro_client.synthesize_wav_base64(processed, language)
+                else:
+                    audio_b64 = await self.tts_client.synthesize_wav_base64(processed, language)
+            elif self.tts_provider == "voicevox":
+                audio_b64 = await self.tts_client.synthesize_wav_base64(processed, language)
+            else:
+                tts_emotion = map_vrm_to_tts_emotion(vrm_emotion)
+                audio_b64 = await self.tts_client.synthesize_mp3_base64(
+                    processed, language, tts_emotion
+                )
+
+            duration = audio_duration_seconds_from_base64(audio_b64)
+            if duration is not None and duration > 0:
+                return duration
+        except Exception as e:
+            logger.warning("probe_synthesis_duration_seconds failed: %s", e, exc_info=False)
+        return None

--- a/backend/main.py
+++ b/backend/main.py
@@ -287,7 +287,13 @@ class ChatRequest(BaseModel):
     query: str = Field(max_length=2000)
     session_id: Optional[str] = None
     language: Optional[str] = Field(default="ja", max_length=10)
-    context: Optional[Dict[str, Any]] = None
+    context: Optional[Dict[str, Any]] = Field(
+        default=None,
+        description=(
+            "Optional client context. If audio_duration (seconds, float) is set, it takes "
+            "precedence over server-side TTS duration probing for CharacterControlAgent lip-sync."
+        ),
+    )
     visitor_id: Optional[str] = None  # Cross-session visitor identification
     image_data: str | None = None  # Base64 encoded image
 
@@ -534,7 +540,6 @@ class VoiceResponse(BaseModel):
     interruptStatus: Optional[str] = None
 
 
-_voice_agent: Optional[Any] = None  # VoiceAgent (lazy-loaded)
 _stt_agent: Optional[Any] = None  # STTAgent (lazy-loaded)
 _slide_agent: Optional[Any] = None  # SlideAgent (lazy-loaded)
 _session_task_manager: Optional[Any] = None
@@ -548,13 +553,9 @@ def _get_stm():
 
 
 def _get_voice_agent():
-    global _voice_agent
-    if _voice_agent is None:
-        from backend.agents.voice_agent import VoiceAgent
+    from backend.utils.voice_agent_provider import get_voice_agent
 
-        tts_provider = os.getenv("TTS_PROVIDER", "voicevox")
-        _voice_agent = VoiceAgent(tts_provider=tts_provider)
-    return _voice_agent
+    return get_voice_agent()
 
 
 def _get_stt_agent():

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -28,6 +28,7 @@ psycopg[binary]>=3.1.0
 vosk>=0.3.45
 soundfile>=0.12.1
 pydub>=0.25.1
+mutagen>=1.47.0
 qwen-asr>=0.0.6
 
 # Translation (CTranslate2 + Helsinki-NLP/opus-mt)

--- a/backend/tests/e2e/test_production_fixes_e2e.py
+++ b/backend/tests/e2e/test_production_fixes_e2e.py
@@ -492,11 +492,8 @@ class TestVoiceAPIUnit:
             }
         )
 
-        original = main_mod._voice_agent
-        main_mod._voice_agent = mock_agent
-
-        try:
-            transport = ASGITransport(app=main_mod.app)
+        transport = ASGITransport(app=main_mod.app)
+        with patch.object(main_mod, "_get_voice_agent", return_value=mock_agent):
             async with AsyncClient(transport=transport, base_url="http://test") as ac:
                 resp = await ac.post(
                     "/api/voice",
@@ -510,8 +507,6 @@ class TestVoiceAPIUnit:
                 data = resp.json()
                 assert data["success"] is True
                 assert data["audioResponse"] == "dGVzdA=="
-        finally:
-            main_mod._voice_agent = original
 
     async def test_interrupt_action_without_session_id(self):
         """interrupt action で sessionId 未指定時に 400 が返ること"""

--- a/backend/tests/integration/test_voice_api_chain.py
+++ b/backend/tests/integration/test_voice_api_chain.py
@@ -118,7 +118,7 @@ def _patch_singletons(
     if stt_mock is not None:
         patches.append(patch("backend.main._stt_agent", stt_mock))
     if voice_mock is not None:
-        patches.append(patch("backend.main._voice_agent", voice_mock))
+        patches.append(patch("backend.main._get_voice_agent", return_value=voice_mock))
     patches.append(patch("backend.main._session_task_manager", stm_mock))
     if workflow_mock is not None:
         patches.append(

--- a/backend/tests/utils/test_tts_audio_duration.py
+++ b/backend/tests/utils/test_tts_audio_duration.py
@@ -3,8 +3,6 @@
 import io
 import wave
 
-import pytest
-
 from backend.utils.tts_audio_duration import (
     audio_duration_seconds_from_audio_bytes,
     audio_duration_seconds_from_base64,

--- a/backend/tests/utils/test_tts_audio_duration.py
+++ b/backend/tests/utils/test_tts_audio_duration.py
@@ -1,0 +1,40 @@
+"""Tests for backend.utils.tts_audio_duration."""
+
+import io
+import wave
+
+import pytest
+
+from backend.utils.tts_audio_duration import (
+    audio_duration_seconds_from_audio_bytes,
+    audio_duration_seconds_from_base64,
+)
+
+
+def _minimal_wav_bytes(duration_sec: float = 0.5, sample_rate: int = 16000) -> bytes:
+    """Build a minimal valid WAV (silence) in memory."""
+    nframes = int(duration_sec * sample_rate)
+    buf = io.BytesIO()
+    with wave.open(buf, "wb") as wf:
+        wf.setnchannels(1)
+        wf.setsampwidth(2)
+        wf.setframerate(sample_rate)
+        wf.writeframes(b"\x00\x00" * nframes)
+    return buf.getvalue()
+
+
+def test_wav_duration_from_bytes():
+    raw = _minimal_wav_bytes(duration_sec=0.25, sample_rate=8000)
+    d = audio_duration_seconds_from_audio_bytes(raw)
+    assert d is not None
+    assert abs(d - 0.25) < 0.01
+
+
+def test_wav_duration_from_base64():
+    import base64
+
+    raw = _minimal_wav_bytes(0.1, 8000)
+    b64 = base64.b64encode(raw).decode("ascii")
+    d = audio_duration_seconds_from_base64(b64)
+    assert d is not None
+    assert abs(d - 0.1) < 0.02

--- a/backend/tests/workflows/conftest.py
+++ b/backend/tests/workflows/conftest.py
@@ -12,3 +12,9 @@ def _freeze_workflow_time():
     """Keep workflow tests deterministic unless they patch time explicitly."""
     with patch("backend.utils.time_utils.get_now_jst", return_value=SAFE_WORKFLOW_TIME_JST):
         yield
+
+
+@pytest.fixture(autouse=True)
+def _disable_vrm_tts_duration_probe(monkeypatch):
+    """Avoid real TTS calls in _format_response_node unless a test enables probing."""
+    monkeypatch.setenv("VRM_TTS_DURATION_PROBE", "0")

--- a/backend/tests/workflows/test_main_workflow.py
+++ b/backend/tests/workflows/test_main_workflow.py
@@ -714,9 +714,104 @@ class TestOrchestratorIntegration:
             assert result["metadata"]["agent"] == "BusinessInfoAgent"
             assert result["metadata"]["vrm_control"]["name"] == "idle"
             assert result["metadata"]["lipsync_data"] == [{"time": 0}]
+            mock_character.process.assert_called_once()
+            call_kw = mock_character.process.call_args
+            assert call_kw[1]["audio_duration"] is None
+            assert call_kw[0][1] == "9時から22時です。"
             assert len(result["messages"]) == 2
             assert result["messages"][0].content == "営業時間は？"
             assert result["messages"][1].content == "9時から22時です。"
+
+    @pytest.mark.asyncio
+    @patch("backend.workflows.main_workflow.OrchestratorAgent")
+    async def test_format_response_node_uses_client_audio_duration(
+        self, mock_orchestrator_class, monkeypatch
+    ):
+        """context.audio_duration があれば TTS プローブより優先される。"""
+        monkeypatch.setenv("VRM_TTS_DURATION_PROBE", "1")
+
+        from backend.workflows.main_workflow import MainWorkflow
+
+        mock_orchestrator_class.return_value = AsyncMock()
+
+        with (
+            patch("backend.utils.memory_helper.get_memory_helper") as mock_get_helper,
+            patch("backend.workflows.main_workflow.CharacterControlAgent") as mock_character_class,
+            patch(
+                "backend.workflows.main_workflow._probe_tts_duration_for_chat_answer",
+                new=AsyncMock(return_value=99.0),
+            ) as mock_probe,
+        ):
+            mock_helper = AsyncMock()
+            mock_helper.store_message = AsyncMock()
+            mock_get_helper.return_value = mock_helper
+            mock_character = AsyncMock()
+            mock_character.process = AsyncMock(
+                return_value={"name": "idle", "duration": 1000, "keyframes": [{"time": 0}]}
+            )
+            mock_character_class.return_value = mock_character
+
+            workflow = MainWorkflow()
+
+            state = {
+                "query": "営業時間は？",
+                "answer": "9時から22時です。",
+                "session_id": "test-session",
+                "emotion": "neutral",
+                "metadata": {"agent": "BusinessInfoAgent"},
+                "context": {"audio_duration": 12.34},
+            }
+
+            await workflow._format_response_node(state, _mock_runtime())
+
+            mock_probe.assert_not_called()
+            mock_character.process.assert_called_once()
+            assert mock_character.process.call_args[1]["audio_duration"] == 12.34
+
+    @pytest.mark.asyncio
+    @patch("backend.workflows.main_workflow.OrchestratorAgent")
+    async def test_format_response_node_uses_probe_when_enabled(
+        self, mock_orchestrator_class, monkeypatch
+    ):
+        """VRM_TTS_DURATION_PROBE=1 かつクライアント未指定ならプローブ結果を渡す。"""
+        monkeypatch.setenv("VRM_TTS_DURATION_PROBE", "1")
+
+        from backend.workflows.main_workflow import MainWorkflow
+
+        mock_orchestrator_class.return_value = AsyncMock()
+
+        with (
+            patch("backend.utils.memory_helper.get_memory_helper") as mock_get_helper,
+            patch("backend.workflows.main_workflow.CharacterControlAgent") as mock_character_class,
+            patch(
+                "backend.workflows.main_workflow._probe_tts_duration_for_chat_answer",
+                new=AsyncMock(return_value=12.5),
+            ) as mock_probe,
+        ):
+            mock_helper = AsyncMock()
+            mock_helper.store_message = AsyncMock()
+            mock_get_helper.return_value = mock_helper
+            mock_character = AsyncMock()
+            mock_character.process = AsyncMock(
+                return_value={"name": "idle", "duration": 1000, "keyframes": [{"time": 0}]}
+            )
+            mock_character_class.return_value = mock_character
+
+            workflow = MainWorkflow()
+
+            state = {
+                "query": "営業時間は？",
+                "answer": "9時から22時です。",
+                "session_id": "test-session",
+                "emotion": "neutral",
+                "metadata": {"agent": "BusinessInfoAgent"},
+                "context": {},
+            }
+
+            await workflow._format_response_node(state, _mock_runtime())
+
+            mock_probe.assert_called_once()
+            assert mock_character.process.call_args[1]["audio_duration"] == 12.5
 
     @pytest.mark.asyncio
     @patch("backend.workflows.main_workflow.OrchestratorAgent")

--- a/backend/utils/tts_audio_duration.py
+++ b/backend/utils/tts_audio_duration.py
@@ -1,0 +1,61 @@
+"""Decode TTS output bytes and return duration in seconds (WAV / MP3)."""
+
+from __future__ import annotations
+
+import io
+import logging
+import wave
+from typing import Optional
+
+logger = logging.getLogger(__name__)
+
+
+def audio_duration_seconds_from_audio_bytes(data: bytes) -> Optional[float]:
+    """
+    Return playback duration for raw WAV or MP3 bytes.
+
+    WAV: stdlib wave module.
+    MP3: mutagen (no ffmpeg required).
+    """
+    if not data or len(data) < 12:
+        return None
+
+    if data[:4] == b"RIFF" and data[8:12] == b"WAVE":
+        try:
+            with wave.open(io.BytesIO(data), "rb") as wf:
+                frames = wf.getnframes()
+                rate = wf.getframerate()
+                if rate <= 0:
+                    return None
+                return frames / float(rate)
+        except Exception as e:
+            logger.debug("WAV duration parse failed: %s", e)
+            return None
+
+    try:
+        from mutagen.mp3 import MP3
+
+        mp3 = MP3(io.BytesIO(data))
+        length = mp3.info.length
+        if length and length > 0:
+            return float(length)
+    except Exception as e:
+        logger.debug("MP3 duration parse failed: %s", e)
+    return None
+
+
+def audio_duration_seconds_from_base64(b64: str) -> Optional[float]:
+    """Decode base64 audio and return duration in seconds."""
+    import base64
+
+    try:
+        cleaned = b64
+        if "," in cleaned:
+            cleaned = cleaned.split(",", 1)[1]
+        _b64 = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/="
+        cleaned = "".join(c for c in cleaned if c in _b64)
+        raw = base64.b64decode(cleaned, validate=False)
+    except Exception as e:
+        logger.debug("base64 decode failed: %s", e)
+        return None
+    return audio_duration_seconds_from_audio_bytes(raw)

--- a/backend/utils/voice_agent_provider.py
+++ b/backend/utils/voice_agent_provider.py
@@ -1,0 +1,28 @@
+"""Lazy singleton VoiceAgent for TTS (shared by main API and workflow)."""
+
+from __future__ import annotations
+
+import os
+from typing import TYPE_CHECKING, Optional
+
+if TYPE_CHECKING:
+    from backend.agents.voice_agent import VoiceAgent
+
+_voice_agent: Optional["VoiceAgent"] = None
+
+
+def get_voice_agent() -> "VoiceAgent":
+    """Return a process-wide VoiceAgent (TTS_PROVIDER from env, default voicevox)."""
+    global _voice_agent
+    if _voice_agent is None:
+        from backend.agents.voice_agent import VoiceAgent
+
+        tts_provider = os.getenv("TTS_PROVIDER", "voicevox")
+        _voice_agent = VoiceAgent(tts_provider=tts_provider)
+    return _voice_agent
+
+
+def reset_voice_agent_for_tests() -> None:
+    """Clear singleton (tests only)."""
+    global _voice_agent
+    _voice_agent = None

--- a/backend/workflows/main_workflow.py
+++ b/backend/workflows/main_workflow.py
@@ -63,6 +63,14 @@ _TRAG_PREAMBLE_RE = re.compile(
 )
 
 
+async def _probe_tts_duration_for_chat_answer(tts_text: str, language: str) -> Optional[float]:
+    """TTS と同じ前処理で合成し、実音声長（秒）を返す（失敗時 None）。"""
+    from backend.utils.voice_agent_provider import get_voice_agent
+
+    lang = language if language in ("ja", "en") else "ja"
+    return await get_voice_agent().probe_synthesis_duration_seconds(tts_text, lang)
+
+
 def _get_trag_client() -> "_httpx.AsyncClient":
     """Return a shared httpx client for tRAG translation."""
     global _trag_http_client
@@ -1205,32 +1213,6 @@ class MainWorkflow:
         if not isinstance(state_context, dict):
             state_context = {}
 
-        vrm_control = None
-        lipsync_data: list[dict[str, Any]] = []
-        if self._character_control_agent is not None:
-            try:
-                audio_duration = state_context.get("audio_duration") or state_context.get(
-                    "audioDuration"
-                )
-                vrm_control = await self._character_control_agent.process(
-                    state.get("emotion") or "neutral",
-                    raw_answer,
-                    audio_duration=audio_duration,
-                    context=state_context,
-                )
-                lipsync_data = vrm_control.get("keyframes", [])
-            except Exception as character_error:
-                logger.warning(
-                    "Character control generation failed, continuing without VRM metadata: %s",
-                    character_error,
-                    exc_info=True,
-                )
-
-        metadata = {
-            **state_metadata,
-            "vrm_control": vrm_control,
-            "lipsync_data": lipsync_data,
-        }
         # PII Defense-in-Depth: ワークフロー層でもスキャン（API層に加えて二重防御）
         try:
             masked, pii_items = scan_and_mask(answer)
@@ -1268,6 +1250,54 @@ class MainWorkflow:
                     "Response translation failed, using original: %s",
                     trans_err,
                 )
+
+        tts_text = answer
+        tts_lang = language if language in ("ja", "en") else "ja"
+
+        audio_duration: Optional[float] = None
+        raw_ad = state_context.get("audio_duration") or state_context.get("audioDuration")
+        if raw_ad is not None:
+            try:
+                audio_duration = float(raw_ad)
+                if audio_duration <= 0:
+                    audio_duration = None
+            except (TypeError, ValueError):
+                audio_duration = None
+
+        probe_enabled = os.getenv("VRM_TTS_DURATION_PROBE", "1").lower() not in (
+            "0",
+            "false",
+            "no",
+        )
+        if audio_duration is None and probe_enabled and tts_text.strip():
+            try:
+                audio_duration = await _probe_tts_duration_for_chat_answer(tts_text, tts_lang)
+            except Exception as probe_err:
+                logger.warning("TTS duration probe failed, using char estimate: %s", probe_err)
+
+        vrm_control = None
+        lipsync_data: list[dict[str, Any]] = []
+        if self._character_control_agent is not None:
+            try:
+                vrm_control = await self._character_control_agent.process(
+                    state.get("emotion") or "neutral",
+                    tts_text,
+                    audio_duration=audio_duration,
+                    context=state_context,
+                )
+                lipsync_data = vrm_control.get("keyframes", [])
+            except Exception as character_error:
+                logger.warning(
+                    "Character control generation failed, continuing without VRM metadata: %s",
+                    character_error,
+                    exc_info=True,
+                )
+
+        metadata = {
+            **state_metadata,
+            "vrm_control": vrm_control,
+            "lipsync_data": lipsync_data,
+        }
 
         # アシスタント応答を保存
         try:


### PR DESCRIPTION
## 概要

チャット応答（`/api/chat`）で `CharacterControlAgent.process` に、**実際のTTS音声長（秒）**を渡すよう変更しました。フロントの `/api/voice` と同じ前処理・TTSエンジン分岐で一度合成し、`tts_audio_duration` で WAV / MP3 から長さを取得します。

## 変更内容

- **`_format_response_node`**: PII マスク・JA→EN 翻訳**後**の `tts_text` を `process` の本文に使用。`audio_duration` は `context.audio_duration`（クライアント優先）→ TTS プローブ → 未設定（従来の文字数推定）。
- **`VoiceAgent.probe_synthesis_duration_seconds`**: `text_to_speech` と同等の合成分岐（曖昧性解消なし）。
- **`backend/utils/tts_audio_duration.py`**: WAV（`wave`）/ MP3（`mutagen`）。
- **`backend/utils/voice_agent_provider.py`**: `VoiceAgent` 共有（`main._get_voice_agent` と統合）。
- **`ChatRequest.context`**: `audio_duration` の意味と優先度を Field description で記載。
- **テスト**: workflows の conftest で `VRM_TTS_DURATION_PROBE=0`（実TTSを避ける）、ユニット・統合テストを追加。

## 運用メモ

- 本番で TTS が二重になるため、負荷時は `VRM_TTS_DURATION_PROBE=0` でプローブ無効化を検討してください。

## 関連Issue

Closes #463

Made with [Cursor](https://cursor.com)