### PR TITLE
feat(admin): Voice Lab 管理画面と TTS API 拡張 (#465)

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -518,6 +518,11 @@ class VoiceRequest(BaseModel):
     streaming: Optional[bool] = False
     conversationStage: Optional[str] = None
     emotion: Optional[str] = None  # Emotion for TTS synthesis
+    outputEncoding: Optional[str] = Field(default=None, max_length=10)  # e.g. "mp3" for WAV→MP3
+    ttsProvider: Optional[str] = Field(
+        default=None,
+        max_length=20,
+    )  # voicevox | piper | google — overrides TTS_PROVIDER for this request
 
 
 class VoiceResponse(BaseModel):
@@ -535,6 +540,8 @@ class VoiceResponse(BaseModel):
 
 
 _voice_agent: Optional[Any] = None  # VoiceAgent (lazy-loaded)
+_voice_agents_by_provider: dict[str, Any] = {}
+_ALLOWED_TTS_PROVIDERS = frozenset({"voicevox", "piper", "google"})
 _stt_agent: Optional[Any] = None  # STTAgent (lazy-loaded)
 _slide_agent: Optional[Any] = None  # SlideAgent (lazy-loaded)
 _session_task_manager: Optional[Any] = None
@@ -547,6 +554,27 @@ def _get_stm():
     return _session_task_manager
 
 
+def _normalize_tts_provider_override(raw: str) -> str:
+    key = raw.lower().strip()
+    if key not in _ALLOWED_TTS_PROVIDERS:
+        allowed = ", ".join(sorted(_ALLOWED_TTS_PROVIDERS))
+        raise HTTPException(
+            status_code=400,
+            detail=f"Invalid ttsProvider: {raw!r} (allowed: {allowed})",
+        )
+    return key
+
+
+def _get_voice_agent_for_provider_key(provider_key: str):
+    """Lazily construct and cache VoiceAgent per TTS provider (for per-request override)."""
+    global _voice_agents_by_provider
+    if provider_key not in _voice_agents_by_provider:
+        from backend.agents.voice_agent import VoiceAgent
+
+        _voice_agents_by_provider[provider_key] = VoiceAgent(tts_provider=provider_key)
+    return _voice_agents_by_provider[provider_key]
+
+
 def _get_voice_agent():
     global _voice_agent
     if _voice_agent is None:
@@ -555,6 +583,13 @@ def _get_voice_agent():
         tts_provider = os.getenv("TTS_PROVIDER", "voicevox")
         _voice_agent = VoiceAgent(tts_provider=tts_provider)
     return _voice_agent
+
+
+def _resolve_tts_agent(body: VoiceRequest):
+    """Default env-based singleton, or a cached agent when ttsProvider is set."""
+    if body.ttsProvider and body.ttsProvider.strip():
+        return _get_voice_agent_for_provider_key(_normalize_tts_provider_override(body.ttsProvider))
+    return _get_voice_agent()
 
 
 def _get_stt_agent():
@@ -615,7 +650,17 @@ async def voice_get_api(action: str = ""):
                 {"code": "en", "name": "English"},
             ]
         }
-    return {"status": "ok", "actions": ["speech_to_text", "text_to_speech", "supported_languages"]}
+    default_tts = (os.getenv("TTS_PROVIDER", "voicevox") or "voicevox").strip().lower()
+    return {
+        "status": "ok",
+        "actions": ["speech_to_text", "text_to_speech", "supported_languages"],
+        "defaultTtsProvider": default_tts,
+        "ttsProviders": [
+            {"id": "voicevox", "label": "VoiceVox"},
+            {"id": "piper", "label": "Piper-plus"},
+            {"id": "google", "label": "Google Cloud TTS"},
+        ],
+    }
 
 
 _CALENDAR_TIME_RANGES = {"today", "thisWeek", "nextWeek", "thisMonth"}
@@ -650,7 +695,7 @@ async def voice_api(request: Request, body: VoiceRequest):
                 await _get_stm().register_session(body.sessionId)
 
             tts_task = asyncio.create_task(
-                _get_voice_agent().text_to_speech(
+                _resolve_tts_agent(body).text_to_speech(
                     text=body.text,
                     language=body.language or "ja",
                     emotion=body.emotion,  # Use requested emotion for TTS
@@ -661,13 +706,6 @@ async def voice_api(request: Request, body: VoiceRequest):
 
             result = await tts_task
 
-            if body.sessionId and result.get("audioResponse"):
-                try:
-                    audio_bytes = base64.b64decode(result["audioResponse"])
-                    await _get_stm().set_tts_buffer(body.sessionId, BytesIO(audio_bytes))
-                except Exception:
-                    logger.debug("Failed to register TTS buffer for session %s", body.sessionId)
-
             if not result.get("success"):
                 return VoiceResponse(
                     success=False,
@@ -677,10 +715,38 @@ async def voice_api(request: Request, body: VoiceRequest):
                     sessionId=body.sessionId,
                 )
 
+            audio_b64 = result.get("audioResponse")
+            audio_format = result.get("format")
+
+            if (
+                body.outputEncoding
+                and body.outputEncoding.lower() == "mp3"
+                and audio_format == "audio/wav"
+                and audio_b64
+            ):
+                try:
+                    from backend.utils.audio_encode import wav_base64_to_mp3_base64
+
+                    audio_b64 = wav_base64_to_mp3_base64(audio_b64)
+                    audio_format = "audio/mpeg"
+                except Exception as e:
+                    logger.exception("WAV to MP3 conversion failed: %s", e)
+                    raise HTTPException(
+                        status_code=502,
+                        detail="Audio encoding to MP3 failed (ensure ffmpeg is installed).",
+                    )
+
+            if body.sessionId and audio_b64:
+                try:
+                    audio_bytes = base64.b64decode(audio_b64)
+                    await _get_stm().set_tts_buffer(body.sessionId, BytesIO(audio_bytes))
+                except Exception:
+                    logger.debug("Failed to register TTS buffer for session %s", body.sessionId)
+
             return VoiceResponse(
                 success=True,
-                audioResponse=result.get("audioResponse"),
-                audioFormat=result.get("format"),
+                audioResponse=audio_b64,
+                audioFormat=audio_format,
                 emotion=result.get("emotion"),
                 sessionId=body.sessionId,
             )

--- a/backend/main.py
+++ b/backend/main.py
@@ -12,6 +12,7 @@ import os
 import re
 import sys
 import time
+import wave
 from contextlib import asynccontextmanager
 from io import BytesIO
 
@@ -523,6 +524,8 @@ class VoiceRequest(BaseModel):
         default=None,
         max_length=20,
     )  # voicevox | piper | google — overrides TTS_PROVIDER for this request
+    # True: CharacterControlAgent → chat metadata.vrm_control 相当
+    includeVrmControl: Optional[bool] = False
 
 
 class VoiceResponse(BaseModel):
@@ -537,6 +540,9 @@ class VoiceResponse(BaseModel):
     detectedLanguage: Optional[str] = None
     confidence: Optional[float] = None
     interruptStatus: Optional[str] = None
+    cleanText: Optional[str] = None  # TTS 前処理後（includeVrmControl 時）
+    # CharacterControlAgent.process（チャット metadata 相当）
+    vrmControl: Optional[Dict[str, Any]] = None
 
 
 _voice_agent: Optional[Any] = None  # VoiceAgent (lazy-loaded)
@@ -609,6 +615,39 @@ def _get_slide_agent():
 
         _slide_agent = SlideAgent()
     return _slide_agent
+
+
+async def _generate_vrm_control_for_lab_tts(
+    *, clean_text: str, emotion: Optional[str], tts_wav_b64: Optional[str]
+) -> Optional[Dict[str, Any]]:
+    """Voice Lab: /api/chat の metadata.vrm_control と同系のキーフレームを生成。"""
+    try:
+        ctx: Optional[Dict[str, Any]] = None
+        duration_sec: Optional[float] = None
+        if tts_wav_b64:
+            ctx = {"audio_data": tts_wav_b64}
+            try:
+                raw = base64.b64decode(tts_wav_b64)
+                with wave.open(BytesIO(raw), "rb") as wf:
+                    nframes = wf.getnframes()
+                    rate = wf.getframerate()
+                    if rate and nframes >= 0:
+                        duration_sec = nframes / float(rate)
+            except Exception:
+                duration_sec = None
+
+        from backend.agents.character_control_agent import CharacterControlAgent
+
+        agent = CharacterControlAgent()
+        return await agent.process(
+            emotion=emotion or "neutral",
+            text=clean_text,
+            audio_duration=duration_sec,
+            context=ctx,
+        )
+    except Exception as e:
+        logger.warning("includeVrmControl: CharacterControlAgent failed: %s", e, exc_info=True)
+        return None
 
 
 async def _handle_stt(body: VoiceRequest) -> VoiceResponse:
@@ -717,6 +756,9 @@ async def voice_api(request: Request, body: VoiceRequest):
 
             audio_b64 = result.get("audioResponse")
             audio_format = result.get("format")
+            tts_wav_b64_for_vrm: Optional[str] = None
+            if audio_format == "audio/wav" and audio_b64:
+                tts_wav_b64_for_vrm = audio_b64
 
             if (
                 body.outputEncoding
@@ -743,12 +785,24 @@ async def voice_api(request: Request, body: VoiceRequest):
                 except Exception:
                     logger.debug("Failed to register TTS buffer for session %s", body.sessionId)
 
+            clean_txt = (result.get("cleanText") or "").strip() or body.text.strip()
+            emo_for_vrm = result.get("emotion") or body.emotion
+            vrm_out: Optional[Dict[str, Any]] = None
+            if body.includeVrmControl:
+                vrm_out = await _generate_vrm_control_for_lab_tts(
+                    clean_text=clean_txt,
+                    emotion=emo_for_vrm if isinstance(emo_for_vrm, str) else None,
+                    tts_wav_b64=tts_wav_b64_for_vrm,
+                )
+
             return VoiceResponse(
                 success=True,
                 audioResponse=audio_b64,
                 audioFormat=audio_format,
                 emotion=result.get("emotion"),
                 sessionId=body.sessionId,
+                cleanText=clean_txt if body.includeVrmControl else None,
+                vrmControl=vrm_out if body.includeVrmControl else None,
             )
 
         elif body.action == "set_language":

--- a/backend/tests/api/test_voice_api.py
+++ b/backend/tests/api/test_voice_api.py
@@ -26,6 +26,8 @@ class VoiceRequest(BaseModel):
     text: Optional[str] = None
     streaming: Optional[bool] = False
     conversationStage: Optional[str] = None
+    emotion: Optional[str] = None
+    outputEncoding: Optional[str] = None
 
 
 class VoiceResponse(BaseModel):
@@ -33,6 +35,7 @@ class VoiceResponse(BaseModel):
     transcript: Optional[str] = None
     response: Optional[str] = None
     audioResponse: Optional[str] = None
+    audioFormat: Optional[str] = None
     emotion: Optional[str] = None
     sessionId: Optional[str] = None
     error: Optional[str] = None
@@ -95,19 +98,41 @@ async def voice_api(request: VoiceRequest):
             result = await mock_voice_agent.text_to_speech(
                 text=request.text,
                 language=request.language or "ja",
-                emotion=None,
+                emotion=request.emotion,
             )
             if not result.get("success"):
                 return VoiceResponse(
                     success=False,
                     error=result.get("error", "TTS failed"),
                     emotion=result.get("emotion"),
+                    audioFormat=result.get("format"),
                     sessionId=request.sessionId,
                 )
 
+            audio_b64 = result.get("audioResponse")
+            audio_format = result.get("format")
+
+            if (
+                request.outputEncoding
+                and request.outputEncoding.lower() == "mp3"
+                and audio_format == "audio/wav"
+                and audio_b64
+            ):
+                try:
+                    from backend.utils.audio_encode import wav_base64_to_mp3_base64
+
+                    audio_b64 = wav_base64_to_mp3_base64(audio_b64)
+                    audio_format = "audio/mpeg"
+                except Exception:
+                    raise HTTPException(
+                        status_code=502,
+                        detail="Audio encoding to MP3 failed (ensure ffmpeg is installed).",
+                    )
+
             return VoiceResponse(
                 success=True,
-                audioResponse=result.get("audioResponse"),
+                audioResponse=audio_b64,
+                audioFormat=audio_format,
                 emotion=result.get("emotion"),
                 sessionId=request.sessionId,
             )
@@ -271,6 +296,109 @@ class TestTextToSpeech:
         )
 
         assert resp.status_code == 500
+
+
+# =============================================================================
+# outputEncoding mp3 (WAV → MP3)
+# =============================================================================
+
+
+class TestOutputEncodingMp3:
+    """outputEncoding=mp3 で WAV を MP3 に変換する経路"""
+
+    def test_tts_output_mp3_converts_wav(self, monkeypatch):
+        def fake_wav_to_mp3(wav_b64: str) -> str:
+            assert wav_b64 == "d2F2LTE="
+            return "bXAz"
+
+        monkeypatch.setattr(
+            "backend.utils.audio_encode.wav_base64_to_mp3_base64",
+            fake_wav_to_mp3,
+        )
+        mock_voice_agent.text_to_speech = AsyncMock(
+            return_value={
+                "success": True,
+                "audioResponse": "d2F2LTE=",
+                "format": "audio/wav",
+                "emotion": "neutral",
+            }
+        )
+
+        resp = client.post(
+            "/api/voice",
+            json={
+                "action": "text_to_speech",
+                "text": "テスト",
+                "outputEncoding": "mp3",
+                "sessionId": SAMPLE_SESSION_ID,
+            },
+        )
+
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["success"] is True
+        assert body["audioResponse"] == "bXAz"
+        assert body["audioFormat"] == "audio/mpeg"
+
+    def test_tts_output_mp3_skips_when_already_mpeg(self, monkeypatch):
+        def should_not_run(_wav_b64: str) -> str:
+            raise AssertionError("wav_base64_to_mp3_base64 should not run for audio/mpeg")
+
+        monkeypatch.setattr(
+            "backend.utils.audio_encode.wav_base64_to_mp3_base64",
+            should_not_run,
+        )
+        mock_voice_agent.text_to_speech = AsyncMock(
+            return_value={
+                "success": True,
+                "audioResponse": "Z29vZ2xl",
+                "format": "audio/mpeg",
+                "emotion": "neutral",
+            }
+        )
+
+        resp = client.post(
+            "/api/voice",
+            json={
+                "action": "text_to_speech",
+                "text": "hello",
+                "outputEncoding": "mp3",
+            },
+        )
+
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["audioResponse"] == "Z29vZ2xl"
+        assert body["audioFormat"] == "audio/mpeg"
+
+    def test_tts_output_mp3_conversion_failure_returns_502(self, monkeypatch):
+        def boom(_wav_b64: str) -> str:
+            raise RuntimeError("ffmpeg missing")
+
+        monkeypatch.setattr(
+            "backend.utils.audio_encode.wav_base64_to_mp3_base64",
+            boom,
+        )
+        mock_voice_agent.text_to_speech = AsyncMock(
+            return_value={
+                "success": True,
+                "audioResponse": "d2F2",
+                "format": "audio/wav",
+                "emotion": "neutral",
+            }
+        )
+
+        resp = client.post(
+            "/api/voice",
+            json={
+                "action": "text_to_speech",
+                "text": "テスト",
+                "outputEncoding": "mp3",
+            },
+        )
+
+        assert resp.status_code == 502
+        assert "MP3" in resp.json()["detail"]
 
 
 # =============================================================================

--- a/backend/tests/test_main_endpoints.py
+++ b/backend/tests/test_main_endpoints.py
@@ -209,6 +209,40 @@ class TestVoiceEndpoint:
                 await voice_api(_mock_request(), body)
             assert "credential" not in exc_info.value.detail.lower()
 
+    @pytest.mark.asyncio
+    async def test_voice_invalid_tts_provider_returns_400(self):
+        from backend.main import voice_api, VoiceRequest
+        from fastapi import HTTPException
+
+        body = VoiceRequest(action="text_to_speech", text="hello", ttsProvider="vocaloid")
+        with pytest.raises(HTTPException) as exc_info:
+            await voice_api(_mock_request(), body)
+        assert exc_info.value.status_code == 400
+        detail_lower = exc_info.value.detail.lower()
+        assert "ttsprovider" in detail_lower and "vocaloid" in detail_lower
+
+    @pytest.mark.asyncio
+    async def test_voice_tts_provider_piper_uses_per_provider_agent(self):
+        mock_agent = AsyncMock()
+        mock_agent.text_to_speech = AsyncMock(
+            return_value={
+                "success": True,
+                "audioResponse": "d2F2",
+                "format": "audio/wav",
+                "emotion": "neutral",
+            }
+        )
+        with patch("backend.main._get_voice_agent_for_provider_key", return_value=mock_agent) as get_p:
+            with patch("backend.main._get_voice_agent") as get_default:
+                from backend.main import voice_api, VoiceRequest
+
+                body = VoiceRequest(action="text_to_speech", text="hello", ttsProvider="piper")
+                resp = await voice_api(_mock_request(), body)
+                get_p.assert_called_once_with("piper")
+                get_default.assert_not_called()
+                assert resp.success is True
+                assert resp.audioResponse == "d2F2"
+
 
 class TestSlidesEndpoint:
     @pytest.mark.asyncio

--- a/backend/tests/test_main_endpoints.py
+++ b/backend/tests/test_main_endpoints.py
@@ -232,7 +232,9 @@ class TestVoiceEndpoint:
                 "emotion": "neutral",
             }
         )
-        with patch("backend.main._get_voice_agent_for_provider_key", return_value=mock_agent) as get_p:
+        with patch(
+            "backend.main._get_voice_agent_for_provider_key", return_value=mock_agent
+        ) as get_p:
             with patch("backend.main._get_voice_agent") as get_default:
                 from backend.main import voice_api, VoiceRequest
 

--- a/backend/utils/audio_encode.py
+++ b/backend/utils/audio_encode.py
@@ -1,0 +1,17 @@
+"""Audio re-encoding helpers (pydub + ffmpeg)."""
+
+from __future__ import annotations
+
+import base64
+from io import BytesIO
+
+
+def wav_base64_to_mp3_base64(wav_b64: str) -> str:
+    """Decode base64 WAV, export as MP3, return base64 MP3."""
+    from pydub import AudioSegment
+
+    wav_bytes = base64.b64decode(wav_b64)
+    segment = AudioSegment.from_file(BytesIO(wav_bytes), format="wav")
+    out = BytesIO()
+    segment.export(out, format="mp3")
+    return base64.b64encode(out.getvalue()).decode("utf-8")

--- a/frontend/src/app/(admin)/admin/voice-lab/page.tsx
+++ b/frontend/src/app/(admin)/admin/voice-lab/page.tsx
@@ -1,0 +1,397 @@
+'use client';
+
+import Link from 'next/link';
+import { useCallback, useEffect, useRef, useState } from 'react';
+
+const VRM_EMOTIONS = [
+  { value: '', label: '指定なし（テキスト内タグ優先）' },
+  { value: 'neutral', label: 'neutral' },
+  { value: 'happy', label: 'happy' },
+  { value: 'sad', label: 'sad' },
+  { value: 'angry', label: 'angry' },
+  { value: 'surprised', label: 'surprised' },
+  { value: 'relaxed', label: 'relaxed' },
+] as const;
+
+type TtsPreview = {
+  url: string;
+  format: string;
+  durationMs: number | null;
+};
+
+async function measureAudioDurationMs(blob: Blob): Promise<number | null> {
+  if (typeof window === 'undefined') {
+    return null;
+  }
+  const w = window as Window & { webkitAudioContext?: typeof AudioContext };
+  const AC = typeof AudioContext !== 'undefined' ? AudioContext : w.webkitAudioContext ?? null;
+  if (!AC) {
+    return null;
+  }
+  const ctx = new AC();
+  try {
+    const ab = await blob.arrayBuffer();
+    const audioBuffer = await ctx.decodeAudioData(ab.slice(0));
+    const ms = Math.round(audioBuffer.duration * 1000);
+    return Number.isFinite(ms) && ms >= 0 ? ms : null;
+  } catch {
+    return null;
+  } finally {
+    void ctx.close();
+  }
+}
+
+function extensionForMime(mime: string): string {
+  if (mime === 'audio/mpeg') return 'mp3';
+  if (mime === 'audio/wav') return 'wav';
+  return 'bin';
+}
+
+const FALLBACK_TTS_PROVIDERS: { id: string; label: string }[] = [
+  { id: 'voicevox', label: 'VoiceVox' },
+  { id: 'piper', label: 'Piper-plus' },
+  { id: 'google', label: 'Google Cloud TTS' },
+];
+
+function parseTtsProviders(data: unknown): { id: string; label: string }[] {
+  if (!data || typeof data !== 'object' || !('ttsProviders' in data)) {
+    return FALLBACK_TTS_PROVIDERS;
+  }
+  const raw = (data as { ttsProviders: unknown }).ttsProviders;
+  if (!Array.isArray(raw) || raw.length === 0) {
+    return FALLBACK_TTS_PROVIDERS;
+  }
+  const out: { id: string; label: string }[] = [];
+  for (const item of raw) {
+    if (item && typeof item === 'object' && 'id' in item) {
+      const id = String((item as { id: unknown }).id);
+      if (id) {
+        const label =
+          'label' in item && typeof (item as { label: unknown }).label === 'string'
+            ? (item as { label: string }).label
+            : id;
+        out.push({ id, label });
+      }
+    }
+  }
+  return out.length > 0 ? out : FALLBACK_TTS_PROVIDERS;
+}
+
+function parseDefaultTtsProvider(data: unknown): string | null {
+  if (!data || typeof data !== 'object' || !('defaultTtsProvider' in data)) {
+    return null;
+  }
+  const v = (data as { defaultTtsProvider: unknown }).defaultTtsProvider;
+  if (typeof v !== 'string' || !v.trim()) {
+    return null;
+  }
+  return v.trim().toLowerCase();
+}
+
+function labelForDefaultTtsOption(
+  metaLoaded: boolean,
+  defaultId: string | null,
+  options: { id: string; label: string }[],
+): string {
+  if (!metaLoaded) {
+    return 'サーバー既定（TTS_PROVIDER）';
+  }
+  if (!defaultId) {
+    return 'サーバー既定（TTS_PROVIDER）';
+  }
+  const opt = options.find((o) => o.id === defaultId);
+  const name = opt?.label ?? defaultId;
+  return `サーバー既定（${defaultId}）`;
+}
+
+export default function VoiceLabPage() {
+  const [text, setText] = useState('');
+  const [language, setLanguage] = useState<'ja' | 'en'>('ja');
+  const [emotion, setEmotion] = useState('');
+  const [ttsProviderId, setTtsProviderId] = useState('');
+  const [ttsProviderOptions, setTtsProviderOptions] =
+    useState<{ id: string; label: string }[]>(FALLBACK_TTS_PROVIDERS);
+  const [voiceMetaLoaded, setVoiceMetaLoaded] = useState(false);
+  const [serverDefaultTtsId, setServerDefaultTtsId] = useState<string | null>(null);
+  const [preferMp3, setPreferMp3] = useState(false);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [preview, setPreview] = useState<TtsPreview | null>(null);
+  const objectUrlRef = useRef<string | null>(null);
+
+  const releaseObjectUrl = useCallback(() => {
+    if (objectUrlRef.current) {
+      URL.revokeObjectURL(objectUrlRef.current);
+      objectUrlRef.current = null;
+    }
+  }, []);
+
+  useEffect(() => () => releaseObjectUrl(), [releaseObjectUrl]);
+
+  useEffect(() => {
+    let cancelled = false;
+    void (async () => {
+      try {
+        const res = await fetch('/api/voice');
+        if (!res.ok) {
+          if (!cancelled) {
+            setVoiceMetaLoaded(true);
+          }
+          return;
+        }
+        if (cancelled) return;
+        const data: unknown = await res.json();
+        if (cancelled) return;
+        setTtsProviderOptions(parseTtsProviders(data));
+        setServerDefaultTtsId(parseDefaultTtsProvider(data));
+        setVoiceMetaLoaded(true);
+      } catch {
+        /* keep fallback list */
+        if (!cancelled) {
+          setVoiceMetaLoaded(true);
+        }
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  const handleGenerate = useCallback(async () => {
+    const trimmed = text.trim();
+    if (!trimmed) {
+      setError('テキストを入力してください。');
+      return;
+    }
+
+    setError(null);
+    releaseObjectUrl();
+    setPreview(null);
+    setLoading(true);
+
+    try {
+      const body: Record<string, unknown> = {
+        action: 'text_to_speech',
+        text: trimmed,
+        language,
+      };
+      if (emotion.trim()) {
+        body.emotion = emotion.trim();
+      }
+      if (preferMp3) {
+        body.outputEncoding = 'mp3';
+      }
+      if (ttsProviderId.trim()) {
+        body.ttsProvider = ttsProviderId.trim();
+      }
+
+      const res = await fetch('/api/voice', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(body),
+      });
+
+      const data = (await res.json()) as Record<string, unknown>;
+
+      if (!res.ok) {
+        const msg =
+          typeof data.error === 'string'
+            ? data.error
+            : typeof data.detail === 'string'
+              ? data.detail
+              : `HTTP ${res.status}`;
+        setError(msg);
+        return;
+      }
+
+      if (data.success !== true) {
+        setError(typeof data.error === 'string' ? data.error : '音声の生成に失敗しました。');
+        return;
+      }
+
+      const b64 = data.audioResponse;
+      if (typeof b64 !== 'string' || b64.length === 0) {
+        setError('音声データが返されませんでした。');
+        return;
+      }
+
+      const mime =
+        typeof data.audioFormat === 'string' && data.audioFormat.length > 0
+          ? data.audioFormat
+          : 'audio/wav';
+
+      const binary = atob(b64);
+      const bytes = new Uint8Array(binary.length);
+      for (let i = 0; i < binary.length; i += 1) {
+        bytes[i] = binary.charCodeAt(i);
+      }
+
+      const blob = new Blob([bytes], { type: mime });
+      const durationMs = await measureAudioDurationMs(blob);
+      const url = URL.createObjectURL(blob);
+      objectUrlRef.current = url;
+      setPreview({ url, format: mime, durationMs });
+    } catch (e) {
+      setError(e instanceof Error ? e.message : '不明なエラーが発生しました。');
+    } finally {
+      setLoading(false);
+    }
+  }, [text, language, emotion, preferMp3, ttsProviderId, releaseObjectUrl]);
+
+  const downloadName = `voice-lab-${Date.now()}.${preview ? extensionForMime(preview.format) : 'wav'}`;
+
+  return (
+    <div className="min-h-screen bg-gray-50 p-8">
+      <div className="mx-auto max-w-3xl">
+        <div className="mb-6 flex items-center justify-between">
+          <h1 className="text-2xl font-bold text-gray-900">Voice Lab</h1>
+          <Link
+            href="/admin/knowledge"
+            className="text-sm font-medium text-gray-600 hover:text-gray-900"
+          >
+            管理トップへ
+          </Link>
+        </div>
+
+        <div className="rounded-lg border border-gray-200 bg-white p-6 shadow-sm">
+          <p className="mb-4 text-sm text-gray-600">
+            本番と同じ <code className="rounded bg-gray-100 px-1 py-0.5 text-xs">VoiceAgent.text_to_speech</code>{' '}
+            経路（<code className="rounded bg-gray-100 px-1 py-0.5 text-xs">POST /api/voice</code>
+            ）で音声を生成します。TTS
+            エンジンは環境変数{' '}
+            <code className="rounded bg-gray-100 px-1 py-0.5 text-xs">TTS_PROVIDER</code>{' '}
+            の既定、または下で選んだプロバイダー（<code className="rounded bg-gray-100 px-1 py-0.5 text-xs">ttsProvider</code>
+            ）を使います。Piper-plus を選ぶと{' '}
+            <code className="rounded bg-gray-100 px-1 py-0.5 text-xs">PIPER_PLUS_API_URL</code>{' '}
+            の HTTP API に接続します。既定は WAV 出力です。チェックを入れたときのみ MP3
+            変換を行います（WAV ソース時はサーバ側で変換、ffmpeg 必須。Google TTS など既に
+            MP3 の場合はそのまま）。
+          </p>
+
+          <div className="space-y-4">
+            <div>
+              <label htmlFor="voice-lab-tts" className="mb-1 block text-sm font-medium text-gray-700">
+                TTS エンジン
+              </label>
+              <select
+                id="voice-lab-tts"
+                value={ttsProviderId}
+                onChange={(e) => setTtsProviderId(e.target.value)}
+                className="w-full rounded-lg border border-gray-300 px-3 py-2 text-sm shadow-sm focus:border-blue-500 focus:outline-none focus:ring-1 focus:ring-blue-500"
+              >
+                <option value="">
+                  {labelForDefaultTtsOption(voiceMetaLoaded, serverDefaultTtsId, ttsProviderOptions)}
+                </option>
+                {ttsProviderOptions.map((p) => (
+                  <option key={p.id} value={p.id}>
+                    {p.label} ({p.id})
+                  </option>
+                ))}
+              </select>
+            </div>
+
+            <div>
+              <label htmlFor="voice-lab-text" className="mb-1 block text-sm font-medium text-gray-700">
+                テキスト
+              </label>
+              <textarea
+                id="voice-lab-text"
+                value={text}
+                onChange={(e) => setText(e.target.value)}
+                rows={6}
+                className="w-full rounded-lg border border-gray-300 px-3 py-2 text-sm shadow-sm focus:border-blue-500 focus:outline-none focus:ring-1 focus:ring-blue-500"
+                placeholder="合成したい文章を入力（感情タグ [happy] なども利用可能）"
+              />
+            </div>
+
+            <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
+              <div>
+                <label htmlFor="voice-lab-lang" className="mb-1 block text-sm font-medium text-gray-700">
+                  言語
+                </label>
+                <select
+                  id="voice-lab-lang"
+                  value={language}
+                  onChange={(e) => setLanguage(e.target.value as 'ja' | 'en')}
+                  className="w-full rounded-lg border border-gray-300 px-3 py-2 text-sm shadow-sm focus:border-blue-500 focus:outline-none focus:ring-1 focus:ring-blue-500"
+                >
+                  <option value="ja">日本語 (ja)</option>
+                  <option value="en">English (en)</option>
+                </select>
+              </div>
+
+              <div>
+                <label htmlFor="voice-lab-emotion" className="mb-1 block text-sm font-medium text-gray-700">
+                  感情（任意）
+                </label>
+                <select
+                  id="voice-lab-emotion"
+                  value={emotion}
+                  onChange={(e) => setEmotion(e.target.value)}
+                  className="w-full rounded-lg border border-gray-300 px-3 py-2 text-sm shadow-sm focus:border-blue-500 focus:outline-none focus:ring-1 focus:ring-blue-500"
+                >
+                  {VRM_EMOTIONS.map((opt) => (
+                    <option key={opt.value || 'none'} value={opt.value}>
+                      {opt.label}
+                    </option>
+                  ))}
+                </select>
+              </div>
+            </div>
+
+            <label className="flex cursor-pointer items-center gap-2 text-sm text-gray-700">
+              <input
+                type="checkbox"
+                checked={preferMp3}
+                onChange={(e) => setPreferMp3(e.target.checked)}
+                className="h-4 w-4 rounded border-gray-300 text-blue-600 focus:ring-blue-500"
+              />
+              MP3 で取得（オフのときは WAV のまま。オンで WAV→MP3 変換または既存 MP3 を返す）
+            </label>
+
+            <button
+              type="button"
+              onClick={() => void handleGenerate()}
+              disabled={loading}
+              className="rounded-lg bg-blue-600 px-4 py-2.5 text-sm font-medium text-white shadow-sm transition-colors hover:bg-blue-700 disabled:cursor-not-allowed disabled:opacity-50"
+            >
+              {loading ? '生成中…' : '音声を生成'}
+            </button>
+          </div>
+
+          {error ? (
+            <div className="mt-4 rounded-lg border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-800">
+              {error}
+            </div>
+          ) : null}
+
+          {preview ? (
+            <div className="mt-6 space-y-3 border-t border-gray-100 pt-6">
+              <div className="flex flex-wrap items-baseline justify-between gap-2">
+                <p className="text-sm font-medium text-gray-700">試聴</p>
+                <p className="text-sm text-gray-600">
+                  音声の長さ:{' '}
+                  {preview.durationMs !== null ? (
+                    <span className="font-medium tabular-nums text-gray-900">
+                      {preview.durationMs.toLocaleString('ja-JP')} ms
+                    </span>
+                  ) : (
+                    <span className="text-gray-500">計測できませんでした</span>
+                  )}
+                </p>
+              </div>
+              <audio controls className="w-full" src={preview.url} preload="auto" />
+              <a
+                href={preview.url}
+                download={downloadName}
+                className="inline-flex items-center justify-center rounded-lg border border-gray-300 bg-white px-4 py-2 text-sm font-medium text-gray-700 shadow-sm transition-colors hover:bg-gray-50"
+              >
+                ファイルを保存（.{extensionForMime(preview.format)}）
+              </a>
+            </div>
+          ) : null}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/app/(admin)/admin/voice-lab/page.tsx
+++ b/frontend/src/app/(admin)/admin/voice-lab/page.tsx
@@ -3,6 +3,8 @@
 import Link from 'next/link';
 import { useCallback, useEffect, useRef, useState } from 'react';
 
+import type { LipSyncData } from '@/lib/lip-sync-analyzer';
+
 const VRM_EMOTIONS = [
   { value: '', label: '指定なし（テキスト内タグ優先）' },
   { value: 'neutral', label: 'neutral' },
@@ -17,6 +19,13 @@ type TtsPreview = {
   url: string;
   format: string;
   durationMs: number | null;
+  /** LipSyncAnalyzer 形式（duration + frames）。解析失敗時は null */
+  lipSync: LipSyncData | null;
+  /** チャット metadata.vrm_control 相当（includeVrmControl 時・サーバー生成） */
+  vrmControl: Record<string, unknown> | null;
+  cleanText: string | null;
+  /** 生成リクエスト時に includeVrmControl がオンだったか（警告表示用） */
+  vrmControlWasRequested: boolean;
 };
 
 async function measureAudioDurationMs(blob: Blob): Promise<number | null> {
@@ -38,6 +47,20 @@ async function measureAudioDurationMs(blob: Blob): Promise<number | null> {
     return null;
   } finally {
     void ctx.close();
+  }
+}
+
+async function computeLipSyncFromBlob(blob: Blob): Promise<LipSyncData | null> {
+  try {
+    const { LipSyncAnalyzer } = await import('@/lib/lip-sync-analyzer');
+    const analyzer = new LipSyncAnalyzer();
+    try {
+      return await analyzer.analyzeLipSync(blob);
+    } finally {
+      analyzer.dispose();
+    }
+  } catch {
+    return null;
   }
 }
 
@@ -114,6 +137,7 @@ export default function VoiceLabPage() {
   const [voiceMetaLoaded, setVoiceMetaLoaded] = useState(false);
   const [serverDefaultTtsId, setServerDefaultTtsId] = useState<string | null>(null);
   const [preferMp3, setPreferMp3] = useState(false);
+  const [includeVrmControl, setIncludeVrmControl] = useState(false);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [preview, setPreview] = useState<TtsPreview | null>(null);
@@ -184,6 +208,9 @@ export default function VoiceLabPage() {
       if (ttsProviderId.trim()) {
         body.ttsProvider = ttsProviderId.trim();
       }
+      if (includeVrmControl) {
+        body.includeVrmControl = true;
+      }
 
       const res = await fetch('/api/voice', {
         method: 'POST',
@@ -227,18 +254,71 @@ export default function VoiceLabPage() {
       }
 
       const blob = new Blob([bytes], { type: mime });
-      const durationMs = await measureAudioDurationMs(blob);
+      const [durationMs, lipSync] = await Promise.all([
+        measureAudioDurationMs(blob),
+        computeLipSyncFromBlob(blob),
+      ]);
+      const vrmControl =
+        data.vrmControl &&
+        typeof data.vrmControl === 'object' &&
+        !Array.isArray(data.vrmControl)
+          ? (data.vrmControl as Record<string, unknown>)
+          : null;
+      const cleanText =
+        typeof data.cleanText === 'string' && data.cleanText.length > 0 ? data.cleanText : null;
       const url = URL.createObjectURL(blob);
       objectUrlRef.current = url;
-      setPreview({ url, format: mime, durationMs });
+      setPreview({
+        url,
+        format: mime,
+        durationMs,
+        lipSync,
+        vrmControl,
+        cleanText,
+        vrmControlWasRequested: includeVrmControl,
+      });
     } catch (e) {
       setError(e instanceof Error ? e.message : '不明なエラーが発生しました。');
     } finally {
       setLoading(false);
     }
-  }, [text, language, emotion, preferMp3, ttsProviderId, releaseObjectUrl]);
+  }, [text, language, emotion, preferMp3, includeVrmControl, ttsProviderId, releaseObjectUrl]);
 
   const downloadName = `voice-lab-${Date.now()}.${preview ? extensionForMime(preview.format) : 'wav'}`;
+
+  const downloadLipSyncJson = useCallback(() => {
+    if (!preview?.lipSync) return;
+    const payload = {
+      duration: preview.lipSync.duration,
+      frames: preview.lipSync.frames,
+    };
+    const jsonStr = `${JSON.stringify(payload, null, 2)}\n`;
+    const blob = new Blob([jsonStr], { type: 'application/json' });
+    const u = URL.createObjectURL(blob);
+    const a = document.createElement('a');
+    a.href = u;
+    a.download = `voice-lab-${Date.now()}.lipsync.json`;
+    a.rel = 'noopener';
+    a.click();
+    URL.revokeObjectURL(u);
+  }, [preview]);
+
+  const downloadVrmControlJson = useCallback(() => {
+    if (!preview?.vrmControl) return;
+    const payload =
+      preview.cleanText !== null
+        ? { cleanText: preview.cleanText, vrmControl: preview.vrmControl }
+        : { vrmControl: preview.vrmControl };
+    const jsonStr = `${JSON.stringify(payload, null, 2)}\n`;
+    const blob = new Blob([jsonStr], { type: 'application/json' });
+    const u = URL.createObjectURL(blob);
+    const a = document.createElement('a');
+    a.href = u;
+    a.download = `voice-lab-${Date.now()}.vrm-control.json`;
+    a.rel = 'noopener';
+    a.click();
+    URL.revokeObjectURL(u);
+  }, [preview]);
 
   return (
     <div className="min-h-screen bg-gray-50 p-8">
@@ -265,7 +345,16 @@ export default function VoiceLabPage() {
             <code className="rounded bg-gray-100 px-1 py-0.5 text-xs">PIPER_PLUS_API_URL</code>{' '}
             の HTTP API に接続します。既定は WAV 出力です。チェックを入れたときのみ MP3
             変換を行います（WAV ソース時はサーバ側で変換、ffmpeg 必須。Google TTS など既に
-            MP3 の場合はそのまま）。
+            MP3 の場合はそのまま）。生成後、ブラウザ側の{' '}
+            <code className="rounded bg-gray-100 px-1 py-0.5 text-xs">LipSyncAnalyzer</code>{' '}
+            でリップシンク JSON（<code className="rounded bg-gray-100 px-1 py-0.5 text-xs">duration</code>・
+            <code className="rounded bg-gray-100 px-1 py-0.5 text-xs">frames</code>
+            ）も出力できます。チェックを入れると、本番チャットの{' '}
+            <code className="rounded bg-gray-100 px-1 py-0.5 text-xs">metadata.vrm_control</code>{' '}
+            と同系のキーフレーム（<code className="rounded bg-gray-100 px-1 py-0.5 text-xs">
+              CharacterControlAgent
+            </code>
+            、TTS の WAV を渡して生成）をサーバーから取得し、JSON で保存できます。
           </p>
 
           <div className="space-y-4">
@@ -349,6 +438,17 @@ export default function VoiceLabPage() {
               MP3 で取得（オフのときは WAV のまま。オンで WAV→MP3 変換または既存 MP3 を返す）
             </label>
 
+            <label className="flex cursor-pointer items-center gap-2 text-sm text-gray-700">
+              <input
+                type="checkbox"
+                checked={includeVrmControl}
+                onChange={(e) => setIncludeVrmControl(e.target.checked)}
+                className="h-4 w-4 rounded border-gray-300 text-blue-600 focus:ring-blue-500"
+              />
+              VRM 制御 JSON を含める（<code className="rounded bg-gray-100 px-1 text-xs">includeVrmControl</code>
+              。WAV 生成時はその波形もリップ推定に利用）
+            </label>
+
             <button
               type="button"
               onClick={() => void handleGenerate()}
@@ -378,16 +478,64 @@ export default function VoiceLabPage() {
                   ) : (
                     <span className="text-gray-500">計測できませんでした</span>
                   )}
+                  {preview.lipSync ? (
+                    <>
+                      {' '}
+                      · クライアントリップシンク{' '}
+                      <span className="font-medium tabular-nums text-gray-900">
+                        {preview.lipSync.frames.length.toLocaleString('ja-JP')}
+                      </span>{' '}
+                      フレーム
+                    </>
+                  ) : null}
+                  {preview.vrmControl && Array.isArray(preview.vrmControl.keyframes) ? (
+                    <>
+                      {' '}
+                      · サーバー VRM キーフレーム{' '}
+                      <span className="font-medium tabular-nums text-gray-900">
+                        {(preview.vrmControl.keyframes as unknown[]).length.toLocaleString('ja-JP')}
+                      </span>{' '}
+                      件
+                    </>
+                  ) : null}
                 </p>
               </div>
               <audio controls className="w-full" src={preview.url} preload="auto" />
-              <a
-                href={preview.url}
-                download={downloadName}
-                className="inline-flex items-center justify-center rounded-lg border border-gray-300 bg-white px-4 py-2 text-sm font-medium text-gray-700 shadow-sm transition-colors hover:bg-gray-50"
-              >
-                ファイルを保存（.{extensionForMime(preview.format)}）
-              </a>
+              <div className="flex flex-wrap gap-2">
+                <a
+                  href={preview.url}
+                  download={downloadName}
+                  className="inline-flex items-center justify-center rounded-lg border border-gray-300 bg-white px-4 py-2 text-sm font-medium text-gray-700 shadow-sm transition-colors hover:bg-gray-50"
+                >
+                  音声を保存（.{extensionForMime(preview.format)}）
+                </a>
+                {preview.lipSync ? (
+                  <button
+                    type="button"
+                    onClick={downloadLipSyncJson}
+                    className="inline-flex items-center justify-center rounded-lg border border-gray-300 bg-white px-4 py-2 text-sm font-medium text-gray-700 shadow-sm transition-colors hover:bg-gray-50"
+                  >
+                    クライアントリップ JSON（.lipsync.json）
+                  </button>
+                ) : (
+                  <p className="self-center text-sm text-amber-800">
+                    クライアント側リップシンク JSON は生成できませんでした（音声形式またはブラウザの制限の可能性があります）。
+                  </p>
+                )}
+                {preview.vrmControl ? (
+                  <button
+                    type="button"
+                    onClick={downloadVrmControlJson}
+                    className="inline-flex items-center justify-center rounded-lg border border-gray-300 bg-white px-4 py-2 text-sm font-medium text-gray-700 shadow-sm transition-colors hover:bg-gray-50"
+                  >
+                    VRM 制御 JSON（.vrm-control.json）
+                  </button>
+                ) : preview.vrmControlWasRequested ? (
+                  <p className="self-center text-sm text-amber-800">
+                    サーバーから VRM 制御データを取得できませんでした。
+                  </p>
+                ) : null}
+              </div>
             </div>
           ) : null}
         </div>

--- a/frontend/src/app/api/voice/route.ts
+++ b/frontend/src/app/api/voice/route.ts
@@ -15,16 +15,31 @@ export async function POST(request: NextRequest) {
       return NextResponse.json({ error: 'Missing required field: action' }, { status: 400 });
     }
 
-    const { action, audioData, sessionId, language, text, streaming } = body;
+    const {
+      action,
+      audioData,
+      sessionId,
+      language,
+      text,
+      streaming,
+      emotion,
+      outputEncoding,
+      ttsProvider,
+    } = body as Record<string, unknown>;
 
     const response = await backendFetch('/api/voice', {
       body: {
         action,
         audioData,
         sessionId,
-        language: language || 'ja',
+        language: (language as string) || 'ja',
         text,
-        streaming: streaming || false,
+        streaming: (streaming as boolean) || false,
+        ...(typeof emotion === 'string' && emotion.length > 0 ? { emotion } : {}),
+        ...(typeof outputEncoding === 'string' && outputEncoding.length > 0
+          ? { outputEncoding }
+          : {}),
+        ...(typeof ttsProvider === 'string' && ttsProvider.length > 0 ? { ttsProvider } : {}),
       },
       timeoutMs: 75_000,
     });

--- a/frontend/src/app/api/voice/route.ts
+++ b/frontend/src/app/api/voice/route.ts
@@ -25,6 +25,7 @@ export async function POST(request: NextRequest) {
       emotion,
       outputEncoding,
       ttsProvider,
+      includeVrmControl,
     } = body as Record<string, unknown>;
 
     const response = await backendFetch('/api/voice', {
@@ -40,6 +41,7 @@ export async function POST(request: NextRequest) {
           ? { outputEncoding }
           : {}),
         ...(typeof ttsProvider === 'string' && ttsProvider.length > 0 ? { ttsProvider } : {}),
+        ...(includeVrmControl === true ? { includeVrmControl: true } : {}),
       },
       timeoutMs: 75_000,
     });

--- a/frontend/src/app/components/SettingsPanel.tsx
+++ b/frontend/src/app/components/SettingsPanel.tsx
@@ -262,7 +262,7 @@ export default function SettingsPanel({
         </div>
       ) : null}
 
-      {active_tab === 'controls' ? (
+      {show_admin_tab && active_tab === 'controls' ? (
         <div className="mb-4 space-y-3">
           <CharacterSettings
             state={controls_state}

--- a/frontend/src/app/components/SettingsPanel.tsx
+++ b/frontend/src/app/components/SettingsPanel.tsx
@@ -271,7 +271,7 @@ export default function SettingsPanel({
         </div>
       ) : null}
 
-      {show_admin_tab && active_tab === 'controls' ? (
+      {active_tab === 'controls' ? (
         <div className="mb-4 space-y-3">
           <CharacterSettings
             state={controls_state}

--- a/frontend/src/app/components/SettingsPanel.tsx
+++ b/frontend/src/app/components/SettingsPanel.tsx
@@ -259,6 +259,15 @@ export default function SettingsPanel({
           >
             Avatar Lab
           </a>
+          <a
+            href="./admin/voice-lab"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="inline-flex items-center justify-center gap-2 rounded-xl border border-gray-200 bg-white px-4 py-3 text-sm font-medium text-gray-700 shadow-sm transition-colors hover:bg-gray-50"
+            aria-label="Voice Lab"
+          >
+            Voice Lab
+          </a>
         </div>
       ) : null}
 


### PR DESCRIPTION
## 概要

Closes #465

本番と同じ **`POST /api/voice` → `VoiceAgent.text_to_speech`** 経路で、管理画面から TTS を試聴・保存できる **Voice Lab**（`/admin/voice-lab`）を追加します。あわせて TTS API の拡張と、リップシンク／VRM 制御用 JSON の出力・ダウンロードに対応します。

## 変更内容
### Frontend
- **Voice Lab**（`/admin/voice-lab`）
  - テキスト・言語・感情・TTS エンジン（VoiceVox / Piper-plus / Google Cloud TTS）・MP3 取得オプション
  - `GET /api/voice` の `ttsProviders` / `defaultTtsProvider` で一覧とサーバー既定（`TTS_PROVIDER`）を表示
  - 生成音声の長さ（ms）表示、既定は WAV（MP3 はオプション）
  - **LipSync JSON** の解析表示・ダウンロード、**VRM 制御メタデータ**（`includeVrmControl`）の表示・JSON ダウンロード
- **`/api/voice` プロキシ**: `emotion`・`outputEncoding`・`ttsProvider` などをバックエンドへ転送
- **設定パネル**: `show_admin_tab` 時のみ管理タブから Voice Lab へリンク（知識ベース管理などと同様）
### Backend
- **`VoiceRequest` 拡張**
  - `outputEncoding`: MP3 指定時は WAV 生成後に MP3 へ変換（`pydub` / ffmpeg 経路）
  - `ttsProvider`: リクエスト単位でエンジンを上書き（プロバイダ別キャッシュ）
- **`GET /api/voice`**: `ttsProviders`・`defaultTtsProvider` を返却
- **レスポンス**: VRM 制御生成時は `cleanText` 等を Voice Lab 向けに返却
- **テスト**: `test_voice_api`（MP3 変換）、`test_main_endpoints`（`ttsProvider` 検証）
## 動作確認の目安
- [ ] `pnpm lint && pnpm typecheck && pnpm build`（`frontend/`）
- [ ] `ruff check . && black --check .`（`backend/`）
- [ ] `pytest` 対象テスト（少なくとも `tests/api/test_voice_api.py` 関連）
- [ ] 管理タブから Voice Lab を開き、各 TTS で試聴・WAV/MP3 保存
- [ ] LipSync / VRM 制御 JSON の表示・ダウンロード（該当オプション ON 時）
## 環境構築の補足（ローカル / Docker）
### 前提
- リポジトリルートの **`docker-compose.yml`** または、バックエンドを **`backend/` で直接起動**する形のどちらかに合わせて URL を揃えます。
- フロントは **`frontend/.env`** 等で `BACKEND_API_URL`（および必要なら `BACKEND_API_KEY`）がバックエンドを指すこと。
### バックエンド環境変数（`backend/.env`）
`backend/.env.example` にコメント付きで例があります。

| 変数 | 説明 |
|------|------|
| `TTS_PROVIDER` | 既定エンジン: `voicevox`（デフォルト）\|`piper`\|`google` |
| `VOICEVOX_API_URL` | VoiceVox HTTP API（例: `http://localhost:50021` または compose 内ホスト名） |
| `PIPER_PLUS_API_URL` | Piper-plus の HTTP API。**Compose 内の backend から**は `http://piper-plus:8090`。**ホストから backend だけ起動**する場合は `http://127.0.0.1:8090` など |
| `KOKORO_API_URL` | 英語フォールバック等で利用する場合（Piper 失敗時の en 向けなど） |
### Docker Compose でフルスタックする場合
- **通常起動**（VoiceVox 等）: プロジェクトの README / `make dev` に従う。
- **Piper-plus を使う場合**（`TTS_PROVIDER=piper` または Voice Lab で Piper を選択）  
  - `piper-plus` サービスは **`profiles: piper`** のため、**`--profile piper` を付けて起動**する必要があります。  
  - 例: `docker compose --profile piper up -d`（既存の compose コマンドにプロファイルを追加）。  
  - 初回はモデル取得で時間がかかることがあります（`docker-compose.yml` の `PIPER_MODEL_REPO` 等）。
- **疎通確認**（切り分け用）  
  - `docker compose --profile piper ps` で `piper-plus` が **Up** か確認。  
  - backend コンテナから `http://piper-plus:8090/health` に届くか確認（`curl` または `python -c` で HTTP を取得）。
### Piper に繋がらないとき
- `PIPER_PLUS_API_URL` が **実行形態（compose 内 vs ホスト）と一致しているか**  
- **`piper-plus` コンテナが `--profile piper` なしでは起動しない**ことに注意  
- 接続失敗時は実装上一部 **VoiceVox 等へフォールバック**するため、「音声は出たが期待エンジンではない」場合はログと上記 URL を確認
### Google Cloud TTS
- `TTS_PROVIDER=google` または Voice Lab で Google を選ぶ場合は、既存どおり **GCP サービスアカウント**等の設定が必要です（プロジェクトの TTS 手順に従う）。

## スクリーンショット（必要な場合）

<img width="1680" height="2016" alt="image" src="https://github.com/user-attachments/assets/21e94c40-1502-4ad7-aaf1-6140462d9d44" />
