### PR TITLE
docs: refresh operational status, ADR, and deployment runbooks

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,5 +1,25 @@
 # Changelog
 
+## [2026-04-19] - 運用監査の反映とガードレール計画の整理
+
+### Added
+- 運用検証と deploy guardrail を定義する ADR-008
+- 現在の follow-up plan として `docs/plans/production-readiness-followup-2026-04-19.md`
+- frontend -> backend auth drift 対策用の Issue `#468`
+
+### Changed
+- `docs/STATUS.md` を 2026-04-19 の codebase / live audit に同期
+- `docs/SECURITY.md` に `BACKEND_API_KEY` -> `API_SECRET_KEY` の auth chain を明記
+- `docs/DEPLOYMENT.md` を current Vercel + Cloud Run 運用と frontend-authenticated smoke check 前提に更新
+- `docs/README.md` で current docs と historical plan を明確に分離
+
+### Noted
+- 直近 3 日の Cloud Run logs で `POST /api/character` の `403` が繰り返し発生
+- 直近 3 日の Cloud Run logs で `/api/voice` に 60 秒超の latency spike を確認
+- Supabase CLI だけでは同等の runtime log inspection ができなかった
+
+---
+
 ## [2026-03-22] - Wave 1-3: OCR Integration, Reception Flow & Bug Fixes
 
 ### Added

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -1,98 +1,105 @@
-# Deployment Guide
+# デプロイガイド
 
-> Engineer Cafe Navigator production deployment reference.  
-> Last updated: 2026-04-12.
+> Engineer Cafe Navigator の production deployment 運用ガイド
+> Last updated: 2026-04-19
 
-## Infrastructure Overview
+## インフラ構成
 
-```
+```text
 Browser / Kiosk
      |
      v
-Vercel  (Next.js 15 frontend — App Router)
-  Production domain: Vercel project primary production alias
-  Auto-deploy: push to `develop` (Vercel Git integration / deploy hook)
+Vercel (Next.js 15 frontend)
+  - 本番公開面
+  - App Router + API proxy routes
      |
      v
-Cloud Run: engineer-cafe-backend   asia-northeast1   GCP: aipartner-426616
-  FastAPI + LangGraph
-  Auto-deploy: push to `develop` via GitHub Actions (`backend-deploy-staging` in `.github/workflows/ci.yml`)
+Cloud Run: engineer-cafe-backend (asia-northeast1)
+  - FastAPI + LangGraph
+  - protected API の本体
      |
-     +---> Supabase PostgreSQL + pgvector   (database)
+     +---> Supabase (PostgreSQL + pgvector)
      |
-     +---> Cloud Run: voicevox-proto        asia-northeast2  (optional TTS path; staging backend uses Piper per CI)
+     +---> Cloud Run: voicevox-proto (任意の TTS 経路)
 ```
 
 ### Service Registry
 
 | Service | Platform | Region | Purpose |
-|---------|----------|--------|---------|
+| --- | --- | --- | --- |
 | Frontend | Vercel | Global CDN | Next.js UI + API proxy routes |
 | Backend | Cloud Run `engineer-cafe-backend` | `asia-northeast1` | FastAPI + LangGraph agents |
-| VoiceVox | Cloud Run `voicevox-proto` | `asia-northeast2` | Japanese TTS (when configured; not bundled in default staging deploy) |
-| Database | Supabase (PostgreSQL + pgvector) | Managed | Chat history, knowledge base, sessions |
+| VoiceVox | Cloud Run `voicevox-proto` | `asia-northeast2` | 日本語 TTS 経路（利用時のみ） |
+| Database | Supabase (PostgreSQL + pgvector) | Managed | chat history, knowledge base, session data |
 
-### Source of truth for frontend origin
+### Frontend origin の source of truth
 
-- The canonical frontend production origin is the **Vercel project's primary production domain**, not an arbitrary preview deployment URL.
-- Operators should verify it in the Vercel dashboard or `vercel list --yes`.
-- Backend deploys mirror that value through the GitHub Actions repo variable `FRONTEND_PRODUCTION_ORIGIN` and write it to both `FRONTEND_PRODUCTION_ORIGIN` and `ALLOWED_ORIGINS` on Cloud Run.
+- canonical な production origin は Vercel project の primary production domain
+- arbitrary な preview URL を source of truth にしない
+- backend 側の `FRONTEND_PRODUCTION_ORIGIN` と `ALLOWED_ORIGINS` はこの値と一致させる
 
-### Legacy (pre-2026-04): Cloudflare Workers
+### Legacy note
 
-Earlier revisions of this project used **Cloudflare Workers** with `opennextjs-cloudflare` for the frontend. That path is **not** the current production default. If you still have a Workers deployment, treat it as legacy-only and prefer Vercel + the URLs above for operator truth.
+- 旧 Cloudflare Workers frontend は現行 production default ではない
+- 運用判断は Vercel + Cloud Run を正とする
 
----
-
-## Environment Variables
+## 環境変数
 
 ### Frontend (Vercel)
 
-Configure in the Vercel project: **Settings → Environment Variables** (per environment: Production / Preview). Values mirror what CI uses for `pnpm build` (see `frontend-build` and `frontend-playwright-e2e` in `.github/workflows/ci.yml`).
+Vercel project の Environment Variables に設定する。
 
 | Variable | Required | Description |
-|----------|----------|-------------|
-| `NEXT_PUBLIC_BACKEND_API_URL` | Yes | Public backend URL (Cloud Run) |
-| `BACKEND_API_URL` | Yes (server) | Server-side proxy target; often same as public URL |
-| `ADMIN_API_SECRET` | Yes | Protects admin API routes (`/api/admin/*`, cron, alerts) |
+| --- | --- | --- |
+| `NEXT_PUBLIC_BACKEND_API_URL` | Yes | browser から見える backend URL |
+| `BACKEND_API_URL` | Yes (server) | server-side proxy の転送先 |
+| `BACKEND_API_KEY` | Yes (server) | protected backend route へ送る `X-API-Key` |
+| `ADMIN_API_SECRET` | Yes | `/api/admin/*`, `/api/cron/*`, `/api/monitoring/*` を保護 |
+| `ALERT_WEBHOOK_SECRET` | If used | `/api/alerts/webhook` POST を保護 |
 | `NEXT_PUBLIC_SUPABASE_URL` | Yes | Supabase project URL |
-| `NEXT_PUBLIC_SUPABASE_ANON_KEY` | Yes | Supabase anonymous (public) key |
-| `SUPABASE_SERVICE_ROLE_KEY` | Yes | Service role — server-only, never exposed to the browser |
-| Other AI / optional keys | As needed | Same categories as local `.env` (see `frontend` README) |
+| `NEXT_PUBLIC_SUPABASE_ANON_KEY` | Yes | Supabase anon key |
+| `SUPABASE_SERVICE_ROLE_KEY` | Yes | server-only の service role |
+| Other AI / optional keys | As needed | frontend README と CI 設定に合わせる |
 
 ### Backend (Cloud Run)
 
-**Source of truth:** the `backend-deploy-staging` job in `.github/workflows/ci.yml` (image build + `gcloud run deploy`). Do **not** rely on a checked-in Knative YAML; use `gcloud` and the workflow.
+source of truth は `.github/workflows/ci.yml` の deploy job。
 
-Typical **staging / production-aligned** flags from CI include:
+典型的な deploy 設定:
 
 - `--memory 8Gi --cpu 2 --min-instances 1 --max-instances 3`
-- Non-secret env (example from workflow):  
-  `ENVIRONMENT=production`, `TTS_PROVIDER=piper`, `STT_PROVIDER=qwen-primary`, `FRONTEND_PRODUCTION_ORIGIN=<vercel-production-origin>`, `ALLOWED_ORIGINS=<vercel-production-origin>`
-- Secrets via `--update-secrets` (never `--set-secrets` in a way that drops existing bindings)
+- non-secret env 例:
+  - `ENVIRONMENT=production`
+  - `TTS_PROVIDER=piper`
+  - `STT_PROVIDER=qwen-primary`
+  - `FRONTEND_PRODUCTION_ORIGIN=<vercel-production-origin>`
+  - `ALLOWED_ORIGINS=<vercel-production-origin>`
+- secret は `--update-secrets` で更新する
 
 | Variable | Required | Description |
-|----------|----------|-------------|
-| `API_SECRET_KEY` | Yes (production) | Backend auth; startup fails if missing when `ENVIRONMENT=production` |
-| `ENVIRONMENT` | Yes | `production` on Cloud Run |
-| `OPENROUTER_API_KEY` | Yes | LLM (Gemini via LangChain) |
-| `SUPABASE_URL` / `SUPABASE_KEY` / `SUPABASE_DB_URI` | Yes | Supabase + direct Postgres |
-| `ALLOWED_ORIGINS` | Yes | CORS; include the Vercel production URL |
-| `TTS_PROVIDER` / `STT_PROVIDER` | Per deploy | CI staging uses Piper + Qwen-primary |
-| `VOICEVOX_API_URL` | If using VoiceVox | URL of `voicevox-proto` when that stack is active |
+| --- | --- | --- |
+| `API_SECRET_KEY` | Yes (production) | frontend -> backend 認証の正本 |
+| `ENVIRONMENT` | Yes | Cloud Run では `production` |
+| `OPENROUTER_API_KEY` | Yes | LLM provider |
+| `SUPABASE_URL` / `SUPABASE_KEY` / `SUPABASE_DB_URI` | Yes | Supabase / Postgres 接続 |
+| `ALLOWED_ORIGINS` | Yes | CORS origin |
+| `TTS_PROVIDER` / `STT_PROVIDER` | Per deploy | 音声経路設定 |
+| `VOICEVOX_API_URL` | If using VoiceVox | `voicevox-proto` URL |
 
-Use `gcloud run services update --update-env-vars` to change individual vars. **Do not** use `--set-env-vars` if it would wipe unrelated variables.
+注意:
 
----
+- Cloud Run の env 更新は `--update-env-vars` を使う
+- `--set-env-vars` で既存値を消さない
 
-## Deployment Procedures
+## デプロイ手順
 
 ### Frontend: Vercel
 
-1. Merge to `develop` (or trigger the configured **Deploy Hook** if you use hook-based deploys).
-2. Vercel builds from the linked Git repo; use the project's **Production** domain shown in Vercel as the canonical frontend URL.
+1. `develop` へ merge する
+2. Vercel の Git integration または deploy hook で build / deploy を走らせる
+3. production domain を canonical URL として扱う
 
-Local checks before shipping:
+release 前の local check:
 
 ```bash
 cd frontend
@@ -103,23 +110,25 @@ pnpm build
 
 ### Backend: Cloud Run
 
-Pushes to **`develop`** with backend path changes run tests, then **`backend-deploy-staging`** builds `linux/amd64`, pushes to Artifact Registry, and deploys `engineer-cafe-backend` in `asia-northeast1`.
+`develop` への push で backend path に変更がある場合、GitHub Actions の
+`backend-deploy-staging` が image build と Cloud Run deploy を実施する。
 
-Manual deploy (operators): follow the same `docker build --platform linux/amd64` + `gcloud run deploy` pattern as the workflow; keep secrets on `--update-secrets`.
+manual deploy をする場合も、workflow と同じ前提に寄せる:
 
----
+- `linux/amd64` build
+- Artifact Registry push
+- `gcloud run deploy`
+- secret は `--update-secrets`
 
-## CI/CD
+## CI / CD
 
-- **Pull requests** to `main` / `develop`: lint, typecheck, build, backend tests, and (when `frontend/**` changes) Playwright merge-gate coverage for `smoke`, `reception-flow`, `webgl-fallback`, plus the live browser voice round-trip job `voice-live` against Cloud Run.
-- **Backend auto-deploy:** push to `develop` → GitHub Actions → Cloud Run (see workflow).
-- **Frontend auto-deploy:** push to `develop` → Vercel (Git or deploy hook).
+- Pull request: lint, typecheck, build, backend tests, Playwright merge-gate
+- Backend auto-deploy: `develop` push -> GitHub Actions -> Cloud Run
+- Frontend auto-deploy: `develop` push -> Vercel
 
----
+## live 設定の確認方法
 
-## How to verify live configuration
-
-**Backend (Cloud Run)**
+### Backend (Cloud Run)
 
 ```bash
 gcloud run services describe engineer-cafe-backend \
@@ -128,51 +137,78 @@ gcloud run services describe engineer-cafe-backend \
   --format yaml
 ```
 
-Confirm image, env vars, and secret bindings match expectations.
+確認ポイント:
 
-**Frontend (Vercel)**
-
-- Dashboard: Vercel project → Deployments / Domains.  
-- CLI (if installed): `vercel list --yes` for recent deployments.
-- Repo/CI source of truth: GitHub Actions repo variable `FRONTEND_PRODUCTION_ORIGIN` should match the Vercel Production domain.
-
-**Health**
-
-```bash
-# Replace with the URL from gcloud describe
-curl -sf "$(gcloud run services describe engineer-cafe-backend --region asia-northeast1 --format='value(status.url)')/health"
-```
-
----
-
-## Pre-Deployment Checklist
-
-### Before every release
-
-- [ ] CI green on the branch being deployed
-- [ ] `API_SECRET_KEY` set on Cloud Run for production
-- [ ] `ADMIN_API_SECRET` set in **Vercel** (not Cloudflare) for the frontend project
-- [ ] `FRONTEND_PRODUCTION_ORIGIN` matches the Vercel Production domain
-- [ ] `ALLOWED_ORIGINS` on the backend includes that same production origin (and preview URLs if you use them)
-- [ ] No new env vars without documentation
-- [ ] Supabase migrations applied if schema changed
-- [ ] Backend image built with `--platform linux/amd64` when building on Apple Silicon
-
-### After deployment
-
-- [ ] Backend `/health` returns 200
-- [ ] Protected backend routes return 401 without credentials where expected
-- [ ] Frontend loads without critical console errors
-- [ ] Admin routes return 401 without `ADMIN_API_SECRET`
-- [ ] Voice path smoke-tested for the configured TTS/STT stack
-
----
-
-## Rollback
+- image
+- env vars
+- secret bindings
+- traffic / revision
 
 ### Frontend (Vercel)
 
-Use Vercel **Deployments** → promote a previous deployment or revert from the dashboard.
+- Vercel dashboard の Deployments / Domains を確認
+- CLI を使う場合は `vercel list --yes`
+- `FRONTEND_PRODUCTION_ORIGIN` が production domain と一致していることを確認
+
+### Recent log review
+
+- Cloud Run: deploy 後 15-60 分は `gcloud logging read` を見る
+- Vercel: deployment history を first signal とし、`vercel logs` だけに依存しない
+- Supabase: 現行 operator flow では CLI だけで十分な recent runtime log が取れない場合がある
+
+### Health
+
+```bash
+curl -sf "$(gcloud run services describe engineer-cafe-backend --region asia-northeast1 --format='value(status.url)')/health"
+```
+
+## リリース前チェック
+
+### Before every release
+
+- CI が green
+- Vercel target 環境に `BACKEND_API_KEY` がある
+- Cloud Run target 環境に `API_SECRET_KEY` がある
+- Vercel に `ADMIN_API_SECRET` がある
+- `FRONTEND_PRODUCTION_ORIGIN` が Vercel production domain と一致
+- backend の `ALLOWED_ORIGINS` が同じ origin を含む
+- 新しい env var を追加した場合は docs を更新済み
+- schema change がある場合は Supabase migration 適用済み
+- Apple Silicon で build する場合は `--platform linux/amd64`
+
+### After deployment
+
+- backend `/health` が `200`
+- backend protected route に `X-API-Key` なしで投げると `403`
+- frontend が critical console error なしで表示される
+- admin route は `ADMIN_API_SECRET` なしで `401`
+- voice path の smoke test が通る
+- production frontend 経由の `GET /api/voice?action=supported_languages` が `200`
+- production frontend 経由の `POST /api/character` が `200`
+- Cloud Run logs に immediate な `403` / `5xx` spike がない
+
+## Release Guardrails
+
+現在の最重要 release risk は、backend auth 自体の欠如ではなく、次の不整合です。
+
+- Vercel `BACKEND_API_KEY`
+- Cloud Run `API_SECRET_KEY`
+
+frontend は `BACKEND_API_KEY` が missing / stale でも startup 自体は止まりません。
+そのため release validation では、実際の Vercel -> Cloud Run 経路を通す必要があります。
+
+最低限の運用ルール:
+
+1. target production deployment を Vercel で特定する
+2. その deployment に対して frontend-authenticated smoke check を実行する
+3. 同じ時間帯の Cloud Run logs を確認する
+4. ここまで通って初めて healthy deploy とみなす
+
+## ロールバック
+
+### Frontend (Vercel)
+
+- Vercel Deployments から previous deployment を promote / revert
 
 ### Backend (Cloud Run)
 
@@ -188,21 +224,24 @@ gcloud run services update-traffic engineer-cafe-backend \
   --to-revisions REVISION_NAME=100
 ```
 
----
-
 ## Database: Supabase
 
-RLS is enabled on all tables. Server-side access uses the service role key.
+- RLS は有効
+- service role access は server-side only
 
 ```bash
 supabase db push
 ```
 
-Key tables include `knowledge_base`, `conversation_sessions`, `conversation_history`, `agent_memory`.
+代表 table:
 
----
+- `knowledge_base`
+- `conversation_sessions`
+- `conversation_history`
+- `agent_memory`
+- `reception_sessions`
 
-## Troubleshooting
+## トラブルシューティング
 
 ### Backend errors after deploy
 
@@ -216,18 +255,28 @@ gcloud logging read \
 
 ### Frontend admin routes misconfigured
 
-Confirm `ADMIN_API_SECRET` in **Vercel** matches what your server routes expect.
+- `ADMIN_API_SECRET` が Vercel 側と一致しているか確認
+
+### `POST /api/character` で `403` が増える
+
+まず deploy / config mismatch を疑う:
+
+- Vercel の `BACKEND_API_KEY` を確認
+- Cloud Run の `API_SECRET_KEY` を確認
+- frontend-authenticated smoke check を再実行
+- 同じ deploy window の Cloud Run logs を確認
 
 ### Supabase errors
 
-Confirm `SUPABASE_DB_URI` is not the CI placeholder (`postgresql://test:test@localhost:0/test`).
+- `SUPABASE_DB_URI` が CI placeholder になっていないか確認
 
----
+## 現在の production risk
 
-## Known production risks
+追跡先:
 
-Track remaining gaps in `docs/STATUS.md` and open issues (e.g. reception durability, rate limiting, E2E coverage for audio/VRM beyond the current CI subset).
-
----
+- `#468`: deploy-time auth drift guardrails
+- `#140`: latency / load baseline
+- `#458`: emotion / animation contract mismatch
+- `#138` / `#398`: multilingual quality closure
 
 [Back to docs index](README.md)

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,51 +1,64 @@
 # Documentation Map
 
-> 2026-03-14 時点での「どの文書を読めばよいか」を整理したインデックスです。古い Mastra 移行期の文書が残っているため、まずこのページから参照してください。
+> 2026-04-19 時点での現役ドキュメント案内です。まずこのページから参照してください。
 
 ## まず読む文書
 
 - [../README.md](../README.md): プロジェクト全体の現在地
-- [STATUS.md](STATUS.md): 実装状況、既知リスク、production gap、GitHub の open items
-- [plans/production-hardening-session-2026-03-14.md](plans/production-hardening-session-2026-03-14.md): 次セッション用の修正計画
-- [../frontend/README.md](../frontend/README.md): フロントエンドの現況
-- [../backend/README.md](../backend/README.md): バックエンドの現況
-- [DEVELOPER-GUIDE.md](DEVELOPER-GUIDE.md): 現在の開発導線
+- [STATUS.md](STATUS.md): 実装済み事項と、いま残っている本当の運用リスク
+- [SECURITY.md](SECURITY.md): 現在の auth 連鎖と残課題
+- [DEPLOYMENT.md](DEPLOYMENT.md): Vercel + Cloud Run の現行デプロイ運用
+- [plans/production-readiness-followup-2026-04-19.md](plans/production-readiness-followup-2026-04-19.md): 直近の実装計画
+- [adr/008-operational-verification-and-deployment-guardrails.md](adr/008-operational-verification-and-deployment-guardrails.md): 2026-04-19 監査を踏まえた運用上の意思決定
 
 ## 現役ドキュメント
 
-### プロジェクト全体
+### 運用と現況
 
 - [STATUS.md](STATUS.md)
+- [SECURITY.md](SECURITY.md)
+- [DEPLOYMENT.md](DEPLOYMENT.md)
 - [CHANGELOG.md](CHANGELOG.md)
+- [plans/production-readiness-followup-2026-04-19.md](plans/production-readiness-followup-2026-04-19.md)
 
-### 実装と運用
+### 実装と開発導線
 
 - [DEVELOPER-GUIDE.md](DEVELOPER-GUIDE.md)
 - [testing/TESTING-GUIDE.md](testing/TESTING-GUIDE.md)
-
-### コンポーネント別
-
 - [../frontend/README.md](../frontend/README.md)
 - [../backend/README.md](../backend/README.md)
 
+### 現行 ADR
+
+- [adr/005-backend-first-logic.md](adr/005-backend-first-logic.md)
+- [adr/006-langgraph-workflow-redesign.md](adr/006-langgraph-workflow-redesign.md)
+- [adr/007-stt-parallel-architecture.md](adr/007-stt-parallel-architecture.md)
+- [adr/008-operational-verification-and-deployment-guardrails.md](adr/008-operational-verification-and-deployment-guardrails.md)
+
+## 歴史資料として読む文書
+
+以下は履歴として残すが、現行の判断基準にはしない文書です。必要な場合は superseded 注記と
+[STATUS.md](STATUS.md) を先に確認してください。
+
+- `docs/plans/production-hardening-session-2026-03-14.md`
+- `docs/plans/alpha-trial-p1-remediation-2026-04-13.md`
+- `docs/plans/deployment-readiness-2026-03-15.md`
+
 ## 読むときに注意が必要な文書
 
-以下は内容の一部が現行実装とずれており、参照時に [STATUS.md](STATUS.md) で現況確認が必要です。
+以下は一部に旧構成や移行期前提が残っているため、参照時に現行コードと `STATUS.md` で確認が必要です。
 
 - `docs/api/`
 - `docs/architecture/`
-- `docs/DEPLOYMENT.md`
-- `docs/SECURITY.md`
 - `docs/development/` 配下の多くの文書
 - `docs/PRESENTATION-MODE-GUIDE.md`
 - `frontend/VOICE_UI_PLAN.md`
 
 主なズレ:
 
-- Mastra 前提の構成説明
-- RouterAgent / MemoryAgent / ClarificationAgent を現役として扱う説明
-- 2024-2025 時点の予定表や migration plan
-- 実際には未接続の env validation / auth / monitoring の説明不足
+- Mastra 移行期や旧エージェント構成の説明
+- 現在は閉じた blocker を open とみなす記述
+- 2026-03 時点の運用前提や release 手順
 
 ## アーカイブ
 
@@ -53,15 +66,8 @@
 - `archive/migration/`: Mastra -> LangGraph 移行期の詳細資料
 - `archive/frontend-docs-old/`: 旧 frontend 文書群
 
-## 今回の整理方針
-
-- README 群と `docs/STATUS.md` を現況ベースに更新
-- 現役 docs と履歴 docs の境界を明示
-- 重複ファイルを削除
-- 大規模な legacy docs は一括で書き直す前に、まず「現役ではない」ことを明示
-
 ## 直近の次アクション
 
-- `docs/development/` 配下の legacy 文書を「更新」「縮退」「archive 移動」に分類
-- API / architecture / security / deployment 文書を現行コードと現行インフラへ合わせる
-- 運用 runbook と production checklist を追加する
+- deploy smoke gate を実装し、`docs/DEPLOYMENT.md` の手順を自動化へ寄せる
+- API / architecture / development 文書の stale 記述を段階的に更新または archive に移す
+- Supabase の運用ログ確認手順を別途整備する

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -1,216 +1,204 @@
-# Security Documentation
+# セキュリティドキュメント
 
-> Last updated: 2026-04-12. This document reflects the current production topology: Vercel frontend, Cloud Run backend, and Supabase database.
+> Last updated: 2026-04-19. 現在の production 構成
+> (Vercel frontend / Cloud Run backend / Supabase) に合わせて更新しています。
 
-## Overview
+## 概要
 
-Engineer Cafe Navigator is a multilingual voice AI agent system deployed as a Vercel-hosted Next.js frontend backed by a Cloud Run FastAPI/LangGraph service and a Supabase database. The threat surface spans:
+Engineer Cafe Navigator の現行セキュリティモデルは、主に次の 3 層で成立しています。
 
-- Unauthenticated access to admin, cron, and monitoring API routes
-- Direct browser calls to backend services or the Supabase API
-- Injection through voice/text input reaching LLM prompts or SQL
-- Path traversal in resource identifiers (STT vocabulary, slide files)
-- Timing-oracle attacks on token comparison
-- Resource exhaustion through unbounded request rates
+1. frontend の operator-only route 保護
+2. Vercel から Cloud Run への server-side API key 認証
+3. Supabase service role を server-side のみに閉じること
 
-The sections below describe how each layer is protected as of 2026-03-15.
+いま一番大きいリスクは「認証なしの route が丸見え」ではありません。実際には、
+frontend `BACKEND_API_KEY` と backend `API_SECRET_KEY` の deploy-time drift により、
+protected route が一時的に `403` を返すことです。
 
----
+## 認証アーキテクチャ
 
-## Authentication Architecture
+### Layer 1: Frontend Middleware
 
-### Layer 1: Frontend Middleware (PR #233)
+**対象ファイル**: `frontend/src/middleware.ts`
 
-**File**: `frontend/src/middleware.ts`
+`/api/admin/*`, `/api/cron/*`, `/api/monitoring/*` は Next.js Edge Runtime middleware で保護されています。
 
-All routes under `/api/admin/*`, `/api/cron/*`, and `/api/monitoring/*` are protected by a Next.js Edge Runtime middleware that runs before any route handler.
+動作:
 
-**How it works**:
+1. `ADMIN_API_SECRET` を読む
+2. `NODE_ENV=production` で secret がなければ即 `401`
+3. secret がある場合は `Authorization: Bearer <ADMIN_API_SECRET>` を timing-safe に比較
+4. 不一致なら `401`
 
-1. The middleware reads the `ADMIN_API_SECRET` environment variable.
-2. If the secret is absent in a `NODE_ENV=production` environment, the middleware returns `401 Unauthorized` immediately (fail-closed). In non-production environments without the secret, the request proceeds, allowing local development without a secret.
-3. If the secret is present, the middleware extracts the `Authorization` header and compares it against `Bearer <ADMIN_API_SECRET>` using a SHA-256-based timing-safe comparison. Both strings are hashed before the byte-by-byte XOR comparison, which prevents timing oracles even on variable-length inputs in the Edge Runtime (where Node.js `crypto.timingSafeEqual` is unavailable).
-4. Any mismatch returns `401 Unauthorized`.
-
-**Protected route groups**:
+保護対象:
 
 | Pattern | Purpose |
 |---|---|
-| `/api/admin/:path*` | Knowledge base management, STT vocabulary, admin operations |
-| `/api/cron/:path*` | Scheduled slide updates and other cron jobs |
-| `/api/monitoring/:path*` | Internal health and metrics endpoints |
+| `/api/admin/:path*` | Knowledge base 管理、STT vocabulary、admin 操作 |
+| `/api/cron/:path*` | 定期 import や運用ジョブ |
+| `/api/monitoring/:path*` | internal health / metrics |
 
-**Excluded route**: `/api/alerts/webhook` is not covered by this middleware. It implements its own independent `ALERT_WEBHOOK_SECRET` verification.
+除外:
 
-**Required environment variable**: `ADMIN_API_SECRET` — must be set in the Vercel project environment for production deployments.
+- `/api/alerts/webhook` は middleware の対象外
+- こちらは `ALERT_WEBHOOK_SECRET` で独立保護
 
-### Layer 2: Backend API Key (PR #234)
+### Layer 2: Frontend -> Backend API Key
 
-**File**: `backend/main.py`
+**対象ファイル**:
 
-The FastAPI backend enforces an `API_SECRET_KEY` requirement at two points:
+- `frontend/src/lib/api/backend-proxy.ts`
+- `backend/main.py`
 
-1. **Startup gate**: If `ENVIRONMENT=production` and `API_SECRET_KEY` is absent or empty, the process calls `sys.exit(1)` and refuses to start. This prevents a misconfigured deployment from silently exposing write-capable endpoints.
+frontend proxy は Vercel server runtime の `BACKEND_API_KEY` を読み、backend への request に
+`X-API-Key` として付与します。
 
-2. **Per-request dependency**: Protected endpoints declare `verify_api_key` as a FastAPI dependency. The function reads the `X-API-Key` request header and compares it against `_API_SECRET_KEY` using `hmac.compare_digest`, which provides constant-time comparison in CPython. If the key is missing or incorrect, the endpoint returns `403 Forbidden`. If a `production`, `staging`, or `preview` instance is running without a key (defence in depth), it returns `503 Service Unavailable` rather than permitting access.
+backend は `API_SECRET_KEY` と `hmac.compare_digest` で照合します。
 
-**Required environment variable**: `API_SECRET_KEY` — must be set as a Cloud Run secret before deploying to production, and should also be set for any staging or preview environment that is expected to remain protected.
+重要な運用事実:
+
+- Cloud Run は `API_SECRET_KEY` がなければ production で起動失敗する
+- Vercel は `BACKEND_API_KEY` が stale / missing でも startup 自体は止まらない
+
+つまり backend 単体では fail-closed ですが、end-to-end の release は smoke check をしないと壊れたまま通る可能性があります。
+
+### Layer 3: Backend Startup Gate
+
+`backend/main.py` は次を保証します。
+
+- `ENVIRONMENT=production` かつ `API_SECRET_KEY` 未設定なら起動失敗
+- protected route に invalid / missing `X-API-Key` で来た request は `403`
 
 ### Defense-in-Depth Summary
 
-| Scenario | Frontend middleware | Backend dependency | Result |
-|---|---|---|---|
-| Valid Bearer token, valid X-API-Key | Pass | Pass | Request served |
-| Valid Bearer token, missing X-API-Key | Pass | 403 | Blocked at backend |
-| Invalid Bearer token | 401 | Not reached | Blocked at edge |
-| `ADMIN_API_SECRET` not set (production) | 401 | Not reached | Blocked at edge |
-| `API_SECRET_KEY` not set (production) | — | sys.exit(1) | Process never starts |
+| Scenario | Frontend middleware | Frontend proxy key | Backend dependency | Result |
+|---|---|---|---|---|
+| Valid Bearer token, valid `BACKEND_API_KEY`, valid `API_SECRET_KEY` | Pass | Pass | Pass | Request served |
+| Valid Bearer token, missing or stale `BACKEND_API_KEY` | Pass | Fail | 403 | Backend で block |
+| Invalid Bearer token | 401 | Not reached | Not reached | Edge で block |
+| `ADMIN_API_SECRET` missing in production | 401 | Not reached | Not reached | Edge で block |
+| `API_SECRET_KEY` missing in production | — | — | Startup exit | Process never starts |
 
----
+## Server-Side Data Access
 
-## STT Vocabulary Proxy (PR #235)
+Supabase service-role access は引き続き server-side に限定されています。
 
-Before PR #235, some browser clients called the backend STT vocabulary API directly, which required `NEXT_PUBLIC_BACKEND_API_URL` to be exposed as a public environment variable and allowed path traversal through unvalidated vocabulary IDs.
+- Next.js route handlers
+- FastAPI backend services
 
-After PR #235:
+主な table:
 
-- All STT vocabulary operations are routed through `/api/admin/stt`, which is now protected by the frontend middleware described above.
-- `NEXT_PUBLIC_BACKEND_API_URL` is no longer required by browser clients.
-- The route handler validates vocabulary IDs against a strict format pattern before forwarding requests to the backend, blocking path traversal attempts.
-
----
-
-## RAG Ingestion Proxy (PR #236)
-
-Before PR #236, some frontend admin routes read from and wrote to the Supabase `knowledge_base` table directly using the service role key, bypassing the backend's input validation and embedding pipeline.
-
-After PR #236:
-
-- All admin knowledge operations are proxied through `backendFetch`, which calls the authenticated FastAPI backend.
-- The backend performs input validation and uses OpenAI `text-embedding-3-small` (1536 dimensions) for all embeddings. There is no mixed-model path.
-- No frontend route accesses the `knowledge_base` table directly for write operations.
-
----
-
-## Database Security
-
-All PostgreSQL tables managed through Supabase have Row Level Security (RLS) enabled. The service role key, which bypasses RLS, is used only in server-side contexts (Next.js route handlers and the FastAPI backend). It is never exposed to browser clients.
-
-Key tables:
-
-| Table | Access |
+| Table | Access path |
 |---|---|
-| `knowledge_base` | Server-side only via backend proxy after PR #236 |
-| `conversation_sessions` | Server-side only |
-| `conversation_history` | Server-side only |
-| `agent_memory` | Server-side only; 3-minute TTL on entries |
-
----
+| `knowledge_base` | backend または authenticated frontend admin proxy |
+| `reception_sessions` | backend repository |
+| `conversation_sessions` | backend |
+| `conversation_history` | backend |
+| `agent_memory` | backend |
 
 ## Rate Limiting
 
-The FastAPI backend uses `slowapi` for rate limiting keyed by remote address. The import is no longer a soft no-op: if `slowapi` cannot be imported, `main.py` calls `sys.exit(1)` in production and raises `RuntimeError` in other environments. This ensures rate limiting is either active or the process does not start.
+FastAPI backend は `slowapi` を使用します。
 
-Infrastructure-level throttling (Cloud Run concurrency limits and Vercel/edge request limits) provides an additional layer.
+これはもう soft optional import ではありません。
 
----
+- production 相当環境で `slowapi` がなければ起動失敗
+- Cloud Run / Vercel の platform limit も補助的に効く
 
-## Input Validation
+## 入力検証
 
 ### Frontend
 
-Route handlers validate request bodies with Zod schemas before forwarding to the backend. Key schemas cover voice processing (action enum, audio size cap, UUID session ID), slide control (action enum, slide number range, safe filename pattern), and character control (action enum, animation name allowlist pattern).
+- route handler では必要に応じて Zod を使用
+- 通常の admin 操作で browser が backend URL を直接持つ必要はない
 
 ### Backend
 
-The backend uses Pydantic model validation on all request bodies. The `utils/input_sanitizer.py` module applies additional sanitization for inputs that reach LLM prompts, preventing prompt injection through voice transcripts or free-text fields.
+- FastAPI request model は Pydantic で検証
+- `backend/utils/input_sanitizer.py` に prompt-bound input の追加 sanitization がある
 
----
+## 環境変数契約
 
-## XSS and Content Isolation
-
-Marp slide HTML is sanitized before rendering. The `MarpViewer` component:
-
-- Strips `<script>` tags and their content.
-- Removes all `on*` event handler attributes from every element.
-- Removes `javascript:`, `data:text/html`, and `vbscript:` URLs from `href`, `src`, `action`, `formaction`, and `data` attributes.
-- Removes `<object>`, `<embed>`, `<applet>`, and dangerous `<meta>` and `<base>` tags.
-- Renders sanitized HTML inside a sandboxed `<iframe>` with `allow-scripts allow-same-origin allow-popups allow-forms` and without `allow-top-navigation` or `allow-modals`.
-
-Incoming `postMessage` events from the iframe are validated against an origin allowlist (`window.location.origin` and `"null"` for `srcDoc` content) before processing.
-
----
-
-## Environment Variable Contracts
-
-The following secrets must be configured before a production deployment is valid. Missing any secret in the column marked "Blocks startup" causes the process to refuse to start.
+production deploy に関わる主要変数:
 
 | Variable | Service | Blocks startup | Purpose |
 |---|---|---|---|
-| `ADMIN_API_SECRET` | Frontend (Vercel) | Yes (returns 401 in prod) | Protects `/api/admin/*`, `/api/cron/*`, `/api/monitoring/*` |
-| `API_SECRET_KEY` | Backend (Cloud Run) | Yes (`sys.exit(1)`) | Authenticates frontend-to-backend requests |
-| `ALERT_WEBHOOK_SECRET` | Frontend (Vercel) | No | Authenticates `/api/alerts/webhook` POST |
-| `SUPABASE_SERVICE_ROLE_KEY` | Frontend + Backend | No (but functionally required) | Server-side Supabase access |
-| `OPENAI_API_KEY` | Backend | No (but functionally required) | Text embeddings |
+| `ADMIN_API_SECRET` | Frontend (Vercel) | Yes, middleware behavior | `/api/admin/*`, `/api/cron/*`, `/api/monitoring/*` を保護 |
+| `BACKEND_API_KEY` | Frontend (Vercel server runtime) | No | protected backend route に `X-API-Key` を付ける |
+| `API_SECRET_KEY` | Backend (Cloud Run) | Yes (`sys.exit(1)`) | frontend -> backend request を検証 |
+| `ALERT_WEBHOOK_SECRET` | Frontend (Vercel) | No | `/api/alerts/webhook` POST を保護 |
+| `SUPABASE_SERVICE_ROLE_KEY` | Frontend + Backend | No, but functionally required | server-side Supabase access |
+| `OPENAI_API_KEY` / `OPENROUTER_API_KEY` | Backend | No, but functionally required | model / embedding provider |
 
-Do not use `--set-env-vars` on Cloud Run deployments — it overwrites all existing variables. Use `--update-env-vars` instead.
+運用ルール:
 
----
+- `BACKEND_API_KEY` と `API_SECRET_KEY` は 1 つの coupled contract として扱う
+- 片方だけを更新して smoke check を省略するのは release risk
 
-## Known Remaining Gaps
+## 現在の残課題
 
-The following items were identified during the 2026-03-14 hardening audit and are tracked under Issue #232. They are not yet resolved.
+### Deploy-time auth drift はまだ起こり得る
 
-**Reception session durability**: Active reception sessions are stored in a process-local `OrderedDict` in `backend/api/reception.py`. A Cloud Run restart or scale-out event will lose active sessions. The fix requires routing session storage through the Supabase-backed repository abstraction.
+2026-04-16 から 2026-04-19 UTC の Cloud Run ログで `POST /api/character` の `403` がまとまって出ている一方、
+最新 production frontend probe は後で `200` を返しています。
 
-**Frontend env contract drift**: `frontend/src/lib/env.ts` still declares several variables as required that recent proxy cleanup has made optional. The validation helpers are not enforced at runtime. These need to be reconciled with the actual runtime contract.
+解釈:
 
-**Browser and device validation**: Audio pipeline changes (WebM-to-WAV conversion, Web Audio API autoplay fixes) and VRM compatibility fixes from recent PRs have not been confirmed on all target kiosk browsers and tablet hardware. This is a deployment risk, not an authentication risk, but it belongs in a production sign-off checklist.
+- route protection 自体は機能している
+- release validation が足りない
 
-**Frontend E2E coverage is focused on kiosk core flows**: Playwright now gates smoke, reception, WebGL fallback, and live browser voice round-trip flows. Admin authentication and other backoffice paths are still not covered end-to-end.
+関連 Issue:
 
----
+- `#468`
+
+### Admin / backoffice E2E coverage は kiosk より薄い
+
+kiosk 側の smoke coverage の方が強く、operator-only surface の E2E はまだ薄いです。
+
+### Supabase runtime observability は通常の security checklist に入っていない
+
+この audit では linked project は確認できましたが、data layer の recent runtime log を同じ密度では追えていません。
 
 ## Security Testing
 
-**Pre-merge checks run automatically via CI**:
+### Pre-merge checks
 
-- `ruff check .` and `black --check .` (backend) flag insecure patterns caught by the rule sets.
-- `pnpm lint` and `pnpm typecheck` (frontend) catch type errors in auth logic.
+- `ruff check .`
+- `black --check .`
+- `pnpm lint`
+- `pnpm typecheck`
+- 既存 backend / frontend test suite
 
-**Manual checks required before each production deployment**:
+### Production 前の manual checks
 
-- Confirm `ADMIN_API_SECRET` and `API_SECRET_KEY` are set in the target environment.
-- Send a request to `/api/admin/knowledge` without an Authorization header and verify the response is `401`.
-- Send a request to the backend health endpoint without `X-API-Key` and verify the response is `403`.
-- Confirm the backend process refuses to start when `API_SECRET_KEY` is unset in a production-equivalent environment.
-
----
+- `ADMIN_API_SECRET`, `BACKEND_API_KEY`, `API_SECRET_KEY` が target 環境にあることを確認
+- `/api/admin/knowledge` に `Authorization` なしで投げて `401` を確認
+- backend に `X-API-Key` なしで投げて `403` を確認
+- frontend-authenticated smoke check として次を確認
+  - `GET /api/voice?action=supported_languages`
+  - `POST /api/character`
+- deploy 直後の Cloud Run ログに `403` / `5xx` スパイクがないことを確認
 
 ## Incident Response
 
 | Severity | Description | Target response |
 |---|---|---|
-| Critical | Data exfiltration, authentication bypass, process compromise | 30 minutes |
-| High | Exposed endpoint, secret rotation required, service disruption | 2 hours |
-| Medium | Anomalous access pattern, rate limit breach, dependency CVE | 24 hours |
-| Low | Lint-level finding, informational CVE with no exploit path | 1 week |
+| Critical | auth bypass, broad outage, data exfiltration | 30 minutes |
+| High | repeated 403 deploy drift, secret rotation, major disruption | 2 hours |
+| Medium | suspicious access pattern, rate-limit breach, dependency CVE | 24 hours |
+| Low | informational finding, low-risk dependency issue | 1 week |
 
-**Contact**: security@engineer-cafe.jp
+credential 漏えい時:
 
-**On credential exposure**: Rotate the affected secret immediately using Cloud Run `--update-env-vars` or the Vercel project environment settings. Do not reuse the exposed value. Audit access logs for the period between suspected exposure and rotation.
+- 該当 secret を即 rotate
+- rotate 後に frontend-authenticated smoke check を再実行
+- 該当時間帯の Cloud Run ログを確認
 
----
+## 参照
 
-## References
+- [DEPLOYMENT.md](DEPLOYMENT.md)
+- [STATUS.md](STATUS.md)
+- [plans/production-readiness-followup-2026-04-19.md](plans/production-readiness-followup-2026-04-19.md)
+- [adr/008-operational-verification-and-deployment-guardrails.md](adr/008-operational-verification-and-deployment-guardrails.md)
 
-- [OWASP Top 10](https://owasp.org/www-project-top-ten/)
-- [Web Crypto API — `SubtleCrypto.digest`](https://developer.mozilla.org/en-US/docs/Web/API/SubtleCrypto/digest)
-- [Python `hmac.compare_digest`](https://docs.python.org/3/library/hmac.html#hmac.compare_digest)
-- [Supabase Row Level Security](https://supabase.com/docs/guides/auth/row-level-security)
-- [Vercel Environment Variables](https://vercel.com/docs/projects/environment-variables)
-- [Cloud Run Secret Manager integration](https://cloud.google.com/run/docs/configuring/services/secrets)
-
----
-
-[Home](../README.md) | [API Documentation](API.md) | [Deployment](DEPLOYMENT.md) | [Status](STATUS.md)
+[Home](../README.md) | [API Documentation](api/API.md) | [Deployment](DEPLOYMENT.md) | [Status](STATUS.md)

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -1,235 +1,153 @@
-# Current Status
+# 現在の状態
 
-Last updated: 2026-03-22
+Last updated: 2026-04-19
 
-## Summary
+## 概要
 
-Engineer Cafe Navigator is in active stabilization after completing Waves 1-3 of production integration.
+このページは、`develop` 上の現行コードと 2026-04-19 に実施した live audit をもとに更新しています。
 
-Confirmed current-state signals:
+確認元:
 
-- All frontend routes proxy to the FastAPI backend via `backendFetch()`.
-- Wave 1 (PR #320): OCR frontend connection — `POST /api/ocr` endpoint added.
-- Wave 2 (PR #321): Reception workflow integration — orchestrator gates on reception status, Welcome screen, device webhook.
-- Wave 3 (PR #322): Bug fixes — TTS, slide rendering, character timeout.
-- RAGAS baseline: context_precision 1.000, answer_correctness 0.770, answer_relevancy 0.895, faithfulness 0.871.
+- 2026-04-16 から 2026-04-19 UTC の Cloud Run ログ
+- 2026-04-19 UTC の直近 Vercel production deploy
+- 現在 open の GitHub Issue
 
-Implication:
+Supabase については、CLI で linked project の確認まではできましたが、このセッションでは recent runtime log
+を同じ粒度で取得できませんでした。データ層の詳細な運用確認には、dashboard か token 付きの別フローが必要です。
 
-- Core functionality is complete including OCR, reception flow, and chat.
-- Reception flow integrated end-to-end: sensor/button → OCR or voice → reception workflow → main agent.
-- Remaining gaps are operational (auth hardening, durable sessions, device testing).
+現状の結論:
 
-## Current Architecture
+- キオスクのコアフロー自体は実装済み
+- 現在の主リスクは「未実装の基本機能」ではなく「運用と整合性」
+
+特に優先度が高いのは次の 4 点です。
+
+1. deploy 時の frontend -> backend 認証ドリフト
+2. voice / chat 系の本番レイテンシ悪化
+3. 感情タグと VRM / VRMA 契約の不整合
+4. 多言語品質の未完了部分
+
+## 実装済みとして確認できたこと
 
 ### Frontend
 
-- Next.js 15 App Router
-- UI, VRM, audio interaction, admin UI
-- `/api/*` routes act as backend proxies (voice, qa, slides, character, reception, ocr)
-- OCR route (`/api/ocr`) proxies image data to backend chat with vision capabilities
+- Next.js 15 App Router が現行 frontend
+- `frontend/src/lib/api/backend-proxy.ts` の `backendFetch()` 経由で backend proxy を実施
+- `backendFetch()` は server-side で `BACKEND_API_KEY` を `X-API-Key` として付与
+- `frontend/src/middleware.ts` で `/api/admin/*`, `/api/cron/*`, `/api/monitoring/*` を保護
+- `GET /api/voice?action=supported_languages` は実装済み
+- `GET /api/character?action=supported_features` は実装済み
 
 ### Backend
 
-- FastAPI entrypoint in `backend/main.py`
-- LangGraph workflow for chat and domain routing
-- Dedicated APIs for chat, voice, slides, character, knowledge, STT vocabulary, reception, and OCR
-- OrchestratorAgent gates on reception status before LLM routing
-- Agent prompts include oral/conversational style for natural TTS output
-- `clean_text_for_tts` strips Markdown and HTML before speech synthesis
-- Supabase-backed data and external integrations
+- `backend/main.py` は `ENVIRONMENT=production` かつ `API_SECRET_KEY` 未設定時に起動失敗
+- `verify_api_key` は fail-open ではなく fail-closed
+- `slowapi` は production 相当環境で必須
+- 受付セッションは `ReceptionRepository` 経由で永続化される
+- OCR / reception / voice / character / slides / admin knowledge API は存在し、現行構成に接続されている
 
-### Current GitHub context
+### ドキュメント基準
 
-Open issues / PRs that materially affect delivery:
+- `docs/STATUS.md`, `docs/SECURITY.md`, `docs/DEPLOYMENT.md` は 2026-04-19 の監査結果に合わせて更新済み
+- 2026-03-14 と 2026-04-13 の計画文書は履歴として残すが、現行計画ではないことを明示した
 
-- Issue `#301`: QA oral style improvements (merged via PR #313)
-- Issue `#315`: Slide cascade fix (merged via PR #318)
-- Issue `#314`: OCR frontend orchestration (merged via PR #320)
-- Issue `#165`: Reception-2025 integration boundary and shared data usage
-- Issue `#138`: Multi-language improvements (English OK, Korean/Chinese need work)
-- Issue `#117`: Autonomous reception flow integration
-- Issue `#128`: Non-camera visitor detection research
-- Issue `#113`: Event participation / hosting flow guidance
-- Issue `#114`: Feedback collection
+## 本番運用で確認した事実
 
-## Confirmed Risks
+### Critical: frontend -> backend auth drift により一時的な 403 が出る可能性がある
 
-### 1. Admin and ops routes are still exposed
+2026-04-16 から 2026-04-19 UTC の Cloud Run ログで確認したこと:
 
-Confirmed in code:
+- `403` 応答: 145 件
+- 該当 protected route: `POST /api/character`
 
-- [frontend/src/app/api/admin/knowledge/route.ts](/Users/teradakousuke/Developer/engineer-cafe-navigator2025/frontend/src/app/api/admin/knowledge/route.ts#L1) performs knowledge-base reads and writes with no auth check.
-- [frontend/src/app/api/cron/update-slides/route.ts](/Users/teradakousuke/Developer/engineer-cafe-navigator2025/frontend/src/app/api/cron/update-slides/route.ts#L1) allows unauthenticated slide import execution.
-- [frontend/src/app/api/alerts/webhook/route.ts](/Users/teradakousuke/Developer/engineer-cafe-navigator2025/frontend/src/app/api/alerts/webhook/route.ts#L165) exposes recent alert retrieval via `GET` without auth.
-- There is no `frontend/src/middleware.ts` in the repository as of 2026-03-14.
+一方、2026-04-19 08:17 UTC の最新 production frontend 経由の確認では:
 
-Risk:
+- `/api/character` は `200`
+- `/api/voice?action=supported_languages` は `200`
 
-- Unauthorized data access
-- Unauthorized operational actions
-- Monitoring leakage
+解釈:
 
-Required before production:
+- 常時故障ではない
+- `BACKEND_API_KEY` と `API_SECRET_KEY` の不整合、または deploy / promotion 時の検証不足が本質的なリスク
 
-- Route-level auth for admin, monitoring, alerts, and cron
-- Clear split between public proxy routes and operator-only routes
-- Tests for unauthorized access paths
+関連 Issue:
 
-### 2. Backend protection is optional if a secret is missing
+- `#468`: deploy smoke gate による auth drift 防止
 
-Confirmed in code:
+### Critical: live latency が production 水準としてはまだ弱い
 
-- [backend/main.py](/Users/teradakousuke/Developer/engineer-cafe-navigator2025/backend/main.py#L205) treats API key verification as optional.
-- [backend/main.py](/Users/teradakousuke/Developer/engineer-cafe-navigator2025/backend/main.py#L208) only logs a warning if `API_SECRET_KEY` is missing in production.
-- [backend/main.py](/Users/teradakousuke/Developer/engineer-cafe-navigator2025/backend/main.py#L214) returns early from auth when no secret is set.
+同じ 3 日間の Cloud Run ログで slow request を確認:
 
-Risk:
+- `/api/voice`: slow request 15 件、最大 `62.68s`
+- `/api/character`: slow threshold 超過が 8 件
+- `/api/chat`: slow threshold 超過が 7 件
 
-- A misconfigured production deploy can expose backend write-capable endpoints.
+解釈:
 
-Required before production:
+- 現在のサービスは利用可能だが、production latency baseline を主張できる状態ではない
+- 既存の backend test だけでは不十分で、live latency を release 判断に組み込む必要がある
 
-- Fail startup when `ENVIRONMENT=production` and `API_SECRET_KEY` is absent
-- Document secret ownership and rotation
-- Add deployment validation
+関連 Issue:
 
-### 3. Reception state is not durable
+- `#140`: 負荷テストとパフォーマンス検証
 
-Confirmed in code:
+### High: 感情タグとアニメーション契約はまだずれている
 
-- [backend/api/reception.py](/Users/teradakousuke/Developer/engineer-cafe-navigator2025/backend/api/reception.py#L54) stores active reception sessions in a process-local `OrderedDict`.
+現在のコードと live response の両方で、Issue `#458` の症状を確認:
 
-Risk:
+- backend emotion mapping は `happy: 0.8` のような partial intensity を返す
+- frontend 側に独自正規化が残っている
+- production 確認時の `/api/character` 応答でも mixed intensity を返した
 
-- Session loss on restart
-- Inconsistent state across multiple instances
-- Weak observability and no recovery path
+関連 Issue:
 
-Required before production:
+- `#458`: emotion / expression / animation の整合
+- `#190`: target-device での character validation
 
-- Use the reception repository abstraction for durable storage
-- Add cleanup / expiry semantics at the persistence layer
-- Add multi-instance or restart recovery tests
+### High: 多言語品質は改善済みだが未完了
 
-### 4. Env validation exists but is not authoritative
+現状:
 
-Confirmed in code:
+- query 側の multilingual tRAG translation は en / ko / zh に入っている
+- response language の安定性は ja / en が中心
+- ko / zh は response translation より multilingual generation 依存がまだ大きい
 
-- [frontend/src/lib/env.ts](/Users/teradakousuke/Developer/engineer-cafe-navigator2025/frontend/src/lib/env.ts#L1) still requires several vars that recent proxy cleanup has made optional.
-- The validation helpers are not used by the runtime.
+関連 Issue:
 
-Risk:
+- `#138`: 多言語品質改善
+- `#398`: multilingual RAGAS / response stabilization
 
-- Docs and code disagree on required configuration
-- False confidence from unused validation helpers
+### Medium: frontend env validation は補助的で authoritative ではない
 
-Required before production:
+- `frontend/src/lib/env.ts` は useful な contract を示している
+- ただし実行時はなお `process.env` の直接参照が多く、単独で authoritative とは言えない
 
-- Choose one env contract per service
-- Enforce it at startup or build time
-- Remove or rewrite unused validation layers
+### Medium: Supabase observability は CLI だけでは不足
 
-### 5. Rate limiting is soft, not guaranteed
+- `supabase projects list` は成功
+- ただし authenticated な remote inspect / recent log まではこのセッションで取得できなかった
 
-Confirmed in code:
+## いま重要な Open Issues
 
-- [backend/main.py](/Users/teradakousuke/Developer/engineer-cafe-navigator2025/backend/main.py#L188) makes rate limiting a no-op when `slowapi` is unavailable.
+- `#468`: deploy-time auth drift guardrails
+- `#140`: load / latency baseline
+- `#458`: emotion / expression / animation alignment
+- `#190`: live character validation
+- `#117`: autonomous reception flow integration
+- `#138`: multilingual quality improvements
+- `#398`: multilingual RAGAS improvement phase 2
 
-Risk:
+## 推奨する実装順
 
-- Accidental unbounded exposure in production
-- No explicit guarantee that abuse controls exist in every deploy
-
-Required before production:
-
-- Make rate limiting mandatory
-- Document infra-level throttling
-- Add deploy-time verification
-
-### 6. Recent fixes still need manual device validation
-
-Recent merged PRs:
-
-- `#223` frontend hardening
-- `#225` proxy unification
-- `#226` Mastra-remnant cleanup
-- `#227` env cleanup
-- `#229` WebM-to-WAV conversion for Vosk
-- `#231` test fix for closing-time warnings
-
-Risk:
-
-- Browser and tablet behavior can still regress even when CI is green
-- Audio and VRM fixes are especially prone to environment-specific failures
-
-Required before production:
-
-- Repeatable smoke tests for kiosk browsers and tablets
-- Device matrix with pass/fail history
-- Post-deploy canary checks
-
-### 7. Some frontend feature-discovery paths are inconsistent with backend behavior
-
-Confirmed in code review:
-
-- `LanguageSelector` requests `GET /api/voice?action=supported_languages`, but the backend currently implements `POST /api/voice` only.
-- `CharacterAvatar` expects `GET /api/character?action=supported_features`, while the Next.js route returns a stub health payload.
-- STT vocabulary admin calls still have paths that bypass the normal server-proxy pattern.
-
-Risk:
-
-- Silent fallback behavior in the UI
-- Broken admin surfaces when backend auth is enabled
-- Integration regressions that basic smoke coverage does not catch
-
-Required before production:
-
-- Align UI capability discovery with actual backend routes
-- Move remaining browser-direct backend calls behind authenticated server routes
-- Expand frontend E2E coverage beyond the current thin proxy smoke layer
-
-## Production Readiness Gaps
-
-The minimum additional work to call this production-ready is:
-
-1. Authentication and authorization
-2. Durable reception/session persistence
-3. Mandatory secret validation and rate limiting
-4. Operator runbooks for cron, alerts, and knowledge import
-5. Browser/device smoke coverage for audio, VRM, and slides
-6. Documentation cleanup so active docs are clearly separated from legacy docs
-
-## Documentation State
-
-### Updated in this pass
-
-- [../README.md](/Users/teradakousuke/Developer/engineer-cafe-navigator2025/README.md)
-- [../README-EN.md](/Users/teradakousuke/Developer/engineer-cafe-navigator2025/README-EN.md)
-- [README.md](/Users/teradakousuke/Developer/engineer-cafe-navigator2025/docs/README.md)
-- [plans/production-hardening-session-2026-03-14.md](/Users/teradakousuke/Developer/engineer-cafe-navigator2025/docs/plans/production-hardening-session-2026-03-14.md)
-- [../frontend/README.md](/Users/teradakousuke/Developer/engineer-cafe-navigator2025/frontend/README.md)
-- [../backend/README.md](/Users/teradakousuke/Developer/engineer-cafe-navigator2025/backend/README.md)
-- [archive/README.md](/Users/teradakousuke/Developer/engineer-cafe-navigator2025/docs/archive/README.md)
-
-### Legacy docs still needing explicit refresh or archive decisions
-
-- `docs/api/`
-- `docs/architecture/`
-- `docs/DEPLOYMENT.md`
-- `docs/SECURITY.md`
-- `docs/development/`
-- Some API and testing docs that still mention Mastra-era behavior
-
-### Removed duplication
-
-- Deleted duplicate file `docs/spaces/spaces/basement-spaces.md`
-
-## Recommended Next Workstream
-
-1. Close Issue `#197` or merge/finish PR `#132`
-2. Persist reception sessions through the repository layer
-3. Rewrite env and deployment docs from actual runtime contracts
-4. Refresh API, architecture, security, and deployment docs to remove deprecated agent descriptions and Vercel-era assumptions
-5. Add operator-facing production checklist and smoke test checklist
-6. Use umbrella Issue `#232` as the execution tracker for the next hardening session
+1. deploy-time authenticated smoke check を入れる (`#468`)
+2. live latency baseline と load test を整備する (`#140`)
+3. emotion -> expression -> animation の契約を一本化する (`#458`, `#190`)
+4. multilingual quality を評価基準込みで閉じる (`#138`, `#398`)
+5. reception の残作業を行動フロー中心に進める (`#117`)
+
+## 参照
+
+- [SECURITY.md](SECURITY.md)
+- [DEPLOYMENT.md](DEPLOYMENT.md)
+- [plans/production-readiness-followup-2026-04-19.md](plans/production-readiness-followup-2026-04-19.md)
+- [adr/008-operational-verification-and-deployment-guardrails.md](adr/008-operational-verification-and-deployment-guardrails.md)

--- a/docs/adr/008-operational-verification-and-deployment-guardrails.md
+++ b/docs/adr/008-operational-verification-and-deployment-guardrails.md
@@ -1,0 +1,84 @@
+# ADR-008: 運用検証とデプロイ・ガードレール
+
+## ステータス
+
+Accepted (2026-04-19)
+
+## 背景
+
+2026-04-19 時点で、3 月の hardening audit で挙がっていた項目の一部はすでにコード上で解消されていました。
+
+- frontend middleware があり、admin / cron / monitoring route を保護している
+- `API_SECRET_KEY` 未設定時の backend production startup は fail-closed
+- reception session state は repository layer 経由で永続化されている
+- voice / character の feature-discovery endpoint は実装済み
+
+しかし live audit では、コードレビューだけでは見えない production risk が残っていることも確認されました。
+
+1. 2026-04-16 から 2026-04-19 UTC の Cloud Run ログで `POST /api/character` の `403` が繰り返し出ていた
+2. 一方で、最新 production frontend route は後から `200` を返しており、恒常故障ではなく release drift を示唆していた
+3. Cloud Run ログでは `/api/voice` を中心に 60 秒超の slow request も出ていた
+4. いくつかの文書は、すでに解消した blocker を open のまま記述していた
+
+このため、「何を production truth とみなすか」「release をどう検証するか」を ADR として固定する必要があります。
+
+## 決定
+
+この repository では、以下を運用ルールとします。
+
+### 1. Production truth は code + live verification で決める
+
+architecture / security / operations に関する主張は、次の裏取りがない限り current とみなしません。
+
+- 現在の repository code
+- 現在の deployment configuration
+- runtime-sensitive な論点については live operational evidence
+
+### 2. Frontend-authenticated smoke check を release validation に含める
+
+production release では、direct backend health だけでなく、実際の Vercel -> Cloud Run 経路を検証する必要があります。
+
+最低限の確認項目:
+
+- production frontend 経由の `GET /api/voice?action=supported_languages` が `200`
+- production frontend 経由の `POST /api/character` が `200`
+
+### 3. `BACKEND_API_KEY` と `API_SECRET_KEY` は coupled contract とみなす
+
+frontend server runtime と backend runtime は、以下の 2 つで 1 つの運用上の認証境界を構成します。
+
+- Vercel `BACKEND_API_KEY`
+- Cloud Run `API_SECRET_KEY`
+
+片方だけ変更して release check を省略することは deployment risk として扱います。
+
+### 4. Live latency は test concern ではなく release concern とみなす
+
+local / CI の test があるだけでは load / latency work は完了とみなしません。production-ready と呼ぶには、
+live log review と documented baseline が必要です。
+
+### 5. 過去の plan document には superseded を明示する
+
+過去の運用文書を repo に残すこと自体は許容します。ただし、新しい plan や status が action list を置き換えた場合は、
+それを明示しなければなりません。
+
+## 影響
+
+### Positive
+
+- stale documentation が current blocker を誤って広げることを防げる
+- deploy validation が実際の frontend -> backend auth chain を通るようになる
+- runtime regression を早く見つけられる
+- 「実装済み」と「まだ runtime で残る課題」の切り分けがしやすくなる
+
+### Negative
+
+- release procedure は少し重くなる
+- operator は smoke script と log review を維持する必要がある
+- document 更新時に過去計画との supersession 管理が必要になる
+
+## フォローアップ
+
+- Issue `#468`: deploy smoke gate による auth drift 防止
+- Issue `#140`: latency / load baseline
+- `docs/STATUS.md`, `docs/SECURITY.md`, `docs/DEPLOYMENT.md` を 2026-04-19 時点に更新

--- a/docs/plans/alpha-trial-p1-remediation-2026-04-13.md
+++ b/docs/plans/alpha-trial-p1-remediation-2026-04-13.md
@@ -4,6 +4,9 @@ Date: 2026-04-13
 Scope: Start alpha user testing for the kiosk core flow while tracking the remaining P1 quality and implementation risks in a fixed execution order.
 Tracking issue: #460
 
+> 履歴注記: この文書は 2026-04-13 時点の alpha 開始判断を記録したものです。
+> 現在の follow-up plan は [production-readiness-followup-2026-04-19.md](production-readiness-followup-2026-04-19.md) を参照してください。
+
 ## Objective Status
 
 The current build is suitable for a controlled alpha trial of the kiosk core flow.

--- a/docs/plans/production-hardening-session-2026-03-14.md
+++ b/docs/plans/production-hardening-session-2026-03-14.md
@@ -2,6 +2,10 @@
 
 Last updated: 2026-03-14
 
+> 履歴注記: ここで挙げていた blocker の多くは 3 月の hardening 作業でコード上は解消済みです。
+> live runtime evidence を踏まえた現行計画は
+> [production-readiness-followup-2026-04-19.md](production-readiness-followup-2026-04-19.md) を参照してください。
+
 ## Goal
 
 次セッションで、現在確認できている production blocker をまとめて潰せるようにするための実行計画。

--- a/docs/plans/production-readiness-followup-2026-04-19.md
+++ b/docs/plans/production-readiness-followup-2026-04-19.md
@@ -1,0 +1,130 @@
+# Production Readiness Follow-up Plan
+
+Date: 2026-04-19
+
+## 目的
+
+2026-04-19 の live audit をもとに、現行コードと recent runtime evidence に基づく
+production follow-up plan を整理する。
+
+## 根拠
+
+この plan の根拠:
+
+- `develop` 上の repository state
+- 2026-04-16 から 2026-04-19 UTC の Cloud Run logs
+- 2026-04-19 UTC の recent Vercel production deploy
+- 現在 open の GitHub Issues
+
+Supabase CLI は linked project の確認まではできたが、同じ粒度の recent runtime log までは取得できなかった。
+data-layer observability は follow-up のままです。
+
+## すでに閉じている項目
+
+- admin / cron / monitoring route 用 frontend middleware
+- `API_SECRET_KEY` 未設定時の backend fail-closed startup
+- production 相当環境での `slowapi` 必須化
+- `ReceptionRepository` 経由の reception persistence
+- voice / character capability discovery route
+
+## 現在の優先順位
+
+### P0: frontend -> backend auth drift 用の release guardrail
+
+Issue:
+
+- `#468`
+
+理由:
+
+- recent Cloud Run logs で `POST /api/character` の `403` が繰り返し出た
+- その後の最新 production frontend validation は `200` で、恒常不具合というより deploy drift を示している
+
+完了条件:
+
+- production frontend route 用 authenticated smoke script がある
+- deploy / promotion 手順に smoke gate が組み込まれている
+- `BACKEND_API_KEY` と `API_SECRET_KEY` の ownership が文書化されている
+
+### P1: live latency baseline と load testing
+
+Issue:
+
+- `#140`
+
+理由:
+
+- `/api/voice` は recent Cloud Run logs で最大 `62.68s`
+- `/api/chat` と `/api/character` も slow threshold を繰り返し超過
+
+完了条件:
+
+- 再現可能な load script がある
+- text / STT / TTS の p50 / p95 / p99 が文書化されている
+- alpha / production の practical limit が書かれている
+
+### P1: emotion / expression / animation contract の一本化
+
+Issues:
+
+- `#458`
+- `#190`
+
+理由:
+
+- backend が partial emotion intensity を返している
+- frontend に独自正規化が残っている
+- live response verification でも mismatch が見えている
+
+完了条件:
+
+- shared emotion vocabulary が 1 つに定まっている
+- intensity handling が explicit かつ consistent
+- target-device validation で PASS / FAIL evidence が残る
+
+### P1: multilingual quality の残件を閉じる
+
+Issues:
+
+- `#138`
+- `#398`
+
+理由:
+
+- query 側の multilingual translation は改善済み
+- ただし response consistency は全言語で target bar に達していない
+
+完了条件:
+
+- 英語 / 韓国語 / 中国語の evaluation target が current behavior に合わせて更新されている
+- response-language correctness が可能な範囲で automated に確認されている
+- 残課題が retrieval / generation / prompt-quality に切り分けられている
+
+### P1: autonomous reception flow の継続実装
+
+Issue:
+
+- `#117`
+
+理由:
+
+- persistence base は強くなっているため、残作業は session durability ではなく behavior integration に寄せるべき
+
+完了条件:
+
+- 新規 / リピーター分岐が明示実装されている
+- slide handoff が統合フローで検証されている
+- autonomous flow 専用の verification path がある
+
+## 運用ルール
+
+1. runtime-sensitive な production readiness claim には live verification を添える
+2. 過去の plan と矛盾する場合は superseded を明示する
+3. frontend-authenticated smoke check が通るまで新 deploy を healthy とみなさない
+
+## 参照
+
+- [../STATUS.md](../STATUS.md)
+- [../SECURITY.md](../SECURITY.md)
+- [../DEPLOYMENT.md](../DEPLOYMENT.md)
+- [../adr/008-operational-verification-and-deployment-guardrails.md](../adr/008-operational-verification-and-deployment-guardrails.md)


### PR DESCRIPTION
## Summary
- 2026-04-19 の live audit に合わせて STATUS / SECURITY / DEPLOYMENT を更新
- ADR-008 と production follow-up plan を追加し、古い計画文書を superseded 扱いに整理
- GitHub Issue を同期し、新規 Issue #468 を追加、#460 をクローズ

## Details
- 実装用の現役ドキュメントは日本語で更新
- `BACKEND_API_KEY` -> `API_SECRET_KEY` の auth chain と deploy smoke gate を明文化
- live runtime evidence に基づく current priority を docs と issue tracker に反映

## Verification
- `git diff --check`

## Related
- Refs #468
- Refs #140
- Refs #458
- Refs #117
- Refs #138
- Refs #398