### PR TITLE
fix: harden field verification paths

### DIFF
--- a/.github/workflows/frontend-latency-probe.yml
+++ b/.github/workflows/frontend-latency-probe.yml
@@ -1,0 +1,39 @@
+name: Frontend Latency Probe
+
+on:
+  workflow_dispatch:
+    inputs:
+      base_url:
+        description: "Probe target base URL"
+        required: false
+        default: "https://frontend-delta-six-20.vercel.app"
+      iterations:
+        description: "Requests per endpoint"
+        required: false
+        default: "3"
+
+jobs:
+  probe:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Run latency probe
+        run: |
+          python scripts/latency_probe.py \
+            --base-url "${{ inputs.base_url }}" \
+            --iterations "${{ inputs.iterations }}" \
+            --json-out artifacts/latency-probe.json \
+            --markdown-out artifacts/latency-probe.md
+
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: frontend-latency-probe
+          path: artifacts/

--- a/backend/config/prompts/event_prompts.py
+++ b/backend/config/prompts/event_prompts.py
@@ -11,6 +11,7 @@ from backend.utils.language_types import LANGUAGE_INSTRUCTION
 # 時間範囲ラベル
 TIME_RANGE_LABELS: Dict[str, Dict[str, str]] = {
     "today": {"ja": "本日", "en": "today", "zh": "今天", "ko": "오늘"},
+    "tomorrow": {"ja": "明日", "en": "tomorrow", "zh": "明天", "ko": "내일"},
     "thisWeek": {"ja": "今週", "en": "this week", "zh": "本周", "ko": "이번 주"},
     "nextWeek": {"ja": "来週", "en": "next week", "zh": "下周", "ko": "다음 주"},
     "thisMonth": {"ja": "今月", "en": "this month", "zh": "本月", "ko": "이번 달"},

--- a/backend/main.py
+++ b/backend/main.py
@@ -702,7 +702,7 @@ async def voice_get_api(action: str = ""):
     }
 
 
-_CALENDAR_TIME_RANGES = {"today", "thisWeek", "nextWeek", "thisMonth"}
+_CALENDAR_TIME_RANGES = {"today", "tomorrow", "thisWeek", "nextWeek", "thisMonth"}
 
 
 @app.get("/api/calendar", dependencies=[Depends(verify_api_key)])

--- a/backend/tests/agents/test_event_agent.py
+++ b/backend/tests/agents/test_event_agent.py
@@ -80,7 +80,7 @@ class TestEventAgent:
 
     def test_get_no_events_response_various_time_ranges(self):
         """各時間範囲のイベントなし応答をテスト"""
-        for time_range in ["today", "thisWeek", "nextWeek", "thisMonth"]:
+        for time_range in ["today", "tomorrow", "thisWeek", "nextWeek", "thisMonth"]:
             response_ja = self.agent._get_no_events_response("ja", time_range)
             response_en = self.agent._get_no_events_response("en", time_range)
 

--- a/backend/tests/api/test_calendar_api.py
+++ b/backend/tests/api/test_calendar_api.py
@@ -61,6 +61,26 @@ def test_calendar_get_rejects_invalid_time_range(monkeypatch):
     assert response.json() == {"detail": "Invalid timeRange"}
 
 
+def test_calendar_get_accepts_tomorrow(monkeypatch):
+    monkeypatch.setattr(main_mod, "_API_SECRET_KEY", None)
+
+    with patch.object(
+        main_mod.CalendarService,
+        "search_events",
+        new_callable=AsyncMock,
+    ) as mock_search:
+        mock_search.return_value = {
+            "success": True,
+            "data": {"events": [], "timeRange": "tomorrow", "eventCount": 0},
+        }
+
+        response = client.get("/api/calendar?timeRange=tomorrow")
+
+    assert response.status_code == 200
+    assert response.json()["data"]["timeRange"] == "tomorrow"
+    mock_search.assert_awaited_once_with("tomorrow")
+
+
 def test_calendar_get_surfaces_backend_fetch_failures(monkeypatch):
     monkeypatch.setattr(main_mod, "_API_SECRET_KEY", None)
 

--- a/backend/tests/tools/test_calendar_service.py
+++ b/backend/tests/tools/test_calendar_service.py
@@ -116,7 +116,7 @@ class TestCalculateTimeRange:
         """Test 'today' returns same-day start (00:00:00) and end (23:59:59)"""
         monkeypatch.setattr(
             "backend.tools.calendar_service.datetime",
-            MagicMock(now=lambda: mock_now),
+            MagicMock(now=lambda *args, **kwargs: mock_now),
         )
 
         time_min, time_max = service._calculate_time_range("today")
@@ -124,11 +124,23 @@ class TestCalculateTimeRange:
         assert time_min == datetime(2026, 2, 16, 0, 0, 0, 0)
         assert time_max == datetime(2026, 2, 16, 23, 59, 59, 999999)
 
+    def test_calculate_tomorrow(self, service, mock_now, monkeypatch):
+        """Test 'tomorrow' returns next-day start (00:00:00) and end (23:59:59)"""
+        monkeypatch.setattr(
+            "backend.tools.calendar_service.datetime",
+            MagicMock(now=lambda *args, **kwargs: mock_now),
+        )
+
+        time_min, time_max = service._calculate_time_range("tomorrow")
+
+        assert time_min == datetime(2026, 2, 17, 0, 0, 0, 0)
+        assert time_max == datetime(2026, 2, 17, 23, 59, 59, 999999)
+
     def test_calculate_this_week(self, service, mock_now, monkeypatch):
         """Test 'thisWeek' returns Monday to Sunday of current week"""
         monkeypatch.setattr(
             "backend.tools.calendar_service.datetime",
-            MagicMock(now=lambda: mock_now),
+            MagicMock(now=lambda *args, **kwargs: mock_now),
         )
 
         time_min, time_max = service._calculate_time_range("thisWeek")
@@ -142,7 +154,7 @@ class TestCalculateTimeRange:
         """Test 'nextWeek' returns Monday to Sunday of next week"""
         monkeypatch.setattr(
             "backend.tools.calendar_service.datetime",
-            MagicMock(now=lambda: mock_now),
+            MagicMock(now=lambda *args, **kwargs: mock_now),
         )
 
         time_min, time_max = service._calculate_time_range("nextWeek")
@@ -156,7 +168,7 @@ class TestCalculateTimeRange:
         """Test 'thisMonth' returns first day to last day of current month"""
         monkeypatch.setattr(
             "backend.tools.calendar_service.datetime",
-            MagicMock(now=lambda: mock_now),
+            MagicMock(now=lambda *args, **kwargs: mock_now),
         )
 
         time_min, time_max = service._calculate_time_range("thisMonth")
@@ -300,6 +312,10 @@ class TestExtractTimeRange:
         """Test Japanese query for 'thisWeek'"""
         assert service.extract_time_range_from_query("今週のイベント") == "thisWeek"
 
+    def test_extract_japanese_tomorrow(self, service):
+        """Test Japanese query for 'tomorrow'"""
+        assert service.extract_time_range_from_query("明日のイベント") == "tomorrow"
+
     def test_extract_japanese_next_week(self, service):
         """Test Japanese query for 'nextWeek'"""
         assert service.extract_time_range_from_query("来週は?") == "nextWeek"
@@ -318,6 +334,11 @@ class TestExtractTimeRange:
         """Test English query for 'thisWeek'"""
         assert service.extract_time_range_from_query("this week") == "thisWeek"
         assert service.extract_time_range_from_query("This Week events") == "thisWeek"
+
+    def test_extract_english_tomorrow(self, service):
+        """Test English query for 'tomorrow'"""
+        assert service.extract_time_range_from_query("tomorrow") == "tomorrow"
+        assert service.extract_time_range_from_query("Tomorrow events") == "tomorrow"
 
     def test_extract_english_next_week(self, service):
         """Test English query for 'nextWeek'"""

--- a/backend/tests/tools/test_connpass_service.py
+++ b/backend/tests/tools/test_connpass_service.py
@@ -184,6 +184,15 @@ class TestGetYmdList:
         today = datetime.now().date().strftime("%Y%m%d")
         assert result[0] == today
 
+    def test_get_ymd_list_tomorrow(self):
+        """Test 'tomorrow' returns next day's single date"""
+        service = ConnpassService()
+        result = service._get_ymd_list("tomorrow")
+
+        assert len(result) == 1
+        tomorrow = (datetime.now().date() + timedelta(days=1)).strftime("%Y%m%d")
+        assert result[0] == tomorrow
+
     def test_get_ymd_list_this_week(self):
         """Test 'thisWeek' returns 7 dates"""
         service = ConnpassService()
@@ -406,6 +415,13 @@ class TestExtractTimeRange:
 
         assert service.extract_time_range_from_query("今週のイベント") == "thisWeek"
         assert service.extract_time_range_from_query("this week events") == "thisWeek"
+
+    def test_extract_time_range_tomorrow(self):
+        """Test extracting 'tomorrow' from query"""
+        service = ConnpassService()
+
+        assert service.extract_time_range_from_query("明日のイベント") == "tomorrow"
+        assert service.extract_time_range_from_query("tomorrow events") == "tomorrow"
 
     def test_extract_time_range_next_week(self):
         """Test extracting 'nextWeek' from query"""

--- a/backend/tools/calendar_service.py
+++ b/backend/tools/calendar_service.py
@@ -12,11 +12,13 @@ import re
 import hashlib
 from datetime import datetime, timedelta
 from typing import List, Dict, Literal, Optional
+from zoneinfo import ZoneInfo
 import httpx
 
 logger = logging.getLogger(__name__)
 
-TimeRange = Literal["today", "thisWeek", "nextWeek", "thisMonth"]
+TimeRange = Literal["today", "tomorrow", "thisWeek", "nextWeek", "thisMonth"]
+_JST = ZoneInfo("Asia/Tokyo")
 
 
 class CalendarService:
@@ -31,7 +33,7 @@ class CalendarService:
         指定期間のイベントを検索
 
         Args:
-            time_range: 検索期間（today, thisWeek, nextWeek, thisMonth）
+            time_range: 検索期間（today, tomorrow, thisWeek, nextWeek, thisMonth）
 
         Returns:
             イベント情報辞書 {success, data: {events, timeRange, eventCount}}
@@ -65,12 +67,17 @@ class CalendarService:
         Returns:
             (time_min, time_max)のタプル
         """
-        now = datetime.now()
+        now = datetime.now(_JST).replace(tzinfo=None)
         today_start = now.replace(hour=0, minute=0, second=0, microsecond=0)
         today_end = now.replace(hour=23, minute=59, second=59, microsecond=999999)
 
         if time_range == "today":
             return (today_start, today_end)
+
+        elif time_range == "tomorrow":
+            tomorrow_start = today_start + timedelta(days=1)
+            tomorrow_end = today_end + timedelta(days=1)
+            return (tomorrow_start, tomorrow_end)
 
         elif time_range == "thisWeek":
             # 今週の月曜日から日曜日
@@ -324,13 +331,17 @@ class CalendarService:
             query: ユーザークエリ
 
         Returns:
-            時間範囲（today, thisWeek, nextWeek, thisMonth）
+            時間範囲（today, tomorrow, thisWeek, nextWeek, thisMonth）
         """
         query_lower = query.lower()
 
         # 今日
         if "今日" in query_lower or "today" in query_lower or "本日" in query_lower:
             return "today"
+
+        # 明日
+        if "明日" in query_lower or "tomorrow" in query_lower:
+            return "tomorrow"
 
         # 今週
         if "今週" in query_lower or "this week" in query_lower:

--- a/backend/tools/connpass_service.py
+++ b/backend/tools/connpass_service.py
@@ -7,11 +7,13 @@ import logging
 import os
 from datetime import datetime, timedelta
 from typing import Any, List, Dict, Optional, Literal
+from zoneinfo import ZoneInfo
 import httpx
 
 logger = logging.getLogger(__name__)
 
-TimeRange = Literal["today", "thisWeek", "nextWeek", "thisMonth"]
+TimeRange = Literal["today", "tomorrow", "thisWeek", "nextWeek", "thisMonth"]
+_JST = ZoneInfo("Asia/Tokyo")
 
 
 class ConnpassService:
@@ -62,7 +64,7 @@ class ConnpassService:
         Connpassからイベントを検索
 
         Args:
-            time_range: 検索期間（today, thisWeek, nextWeek, thisMonth）
+            time_range: 検索期間（today, tomorrow, thisWeek, nextWeek, thisMonth）
             keyword: 検索キーワード（オプション）
             prefecture: 都道府県コード（オプション、デフォルトは福岡）
             count: 取得件数（最大100）
@@ -148,11 +150,14 @@ class ConnpassService:
             >>> print(dates)
             ["20260125"]
         """
-        now = datetime.now()
+        now = datetime.now(_JST)
         today = now.date()
 
         if time_range == "today":
             return [today.strftime("%Y%m%d")]
+
+        elif time_range == "tomorrow":
+            return [(today + timedelta(days=1)).strftime("%Y%m%d")]
 
         elif time_range == "thisWeek":
             # 今週の月曜日から日曜日
@@ -292,13 +297,17 @@ class ConnpassService:
             query: ユーザークエリ
 
         Returns:
-            時間範囲（today, thisWeek, nextWeek, thisMonth）
+            時間範囲（today, tomorrow, thisWeek, nextWeek, thisMonth）
         """
         query_lower = query.lower()
 
         # 今日
         if "今日" in query_lower or "today" in query_lower or "本日" in query_lower:
             return "today"
+
+        # 明日
+        if "明日" in query_lower or "tomorrow" in query_lower:
+            return "tomorrow"
 
         # 今週
         if "今週" in query_lower or "this week" in query_lower:

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -6,17 +6,22 @@
 - 運用検証と deploy guardrail を定義する ADR-008
 - 現在の follow-up plan として `docs/plans/production-readiness-followup-2026-04-19.md`
 - frontend -> backend auth drift 対策用の Issue `#468`
+- frontend 実経路の p50 / p95 / p99 を採る `scripts/latency_probe.py`
+- `workflow_dispatch` で走らせる `Frontend Latency Probe` workflow
 
 ### Changed
 - `docs/STATUS.md` を 2026-04-19 の codebase / live audit に同期
 - `docs/SECURITY.md` に `BACKEND_API_KEY` -> `API_SECRET_KEY` の auth chain を明記
 - `docs/DEPLOYMENT.md` を current Vercel + Cloud Run 運用と frontend-authenticated smoke check 前提に更新
 - `docs/README.md` で current docs と historical plan を明確に分離
+- イベント照会で `明日` / `tomorrow` を専用 time range として扱い、JST 基準で日付計算するよう修正
+- iPad / iOS では `HTMLAudioElement` fallback を優先し、再生開始 watchdog を追加
 
 ### Noted
 - 直近 3 日の Cloud Run logs で `POST /api/character` の `403` が繰り返し発生
 - 直近 3 日の Cloud Run logs で `/api/voice` に 60 秒超の latency spike を確認
 - Supabase CLI だけでは同等の runtime log inspection ができなかった
+- 2026-04-19 18:20-18:30 JST の Cloud Run / Vercel logs では `/api/qa` `/api/voice` は 200 応答で、iPad 音声停止は frontend playback path 側と判断
 
 ---
 

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -185,6 +185,7 @@ curl -sf "$(gcloud run services describe engineer-cafe-backend --region asia-nor
 - voice path の smoke test が通る
 - production frontend 経由の `GET /api/voice?action=supported_languages` が `200`
 - production frontend 経由の `POST /api/character` が `200`
+- `frontend-latency-probe` workflow で `/api/qa` `/api/voice` `/api/character` の p50 / p95 / p99 を採取する
 - Cloud Run logs に immediate な `403` / `5xx` spike がない
 
 ## Release Guardrails
@@ -203,6 +204,34 @@ frontend は `BACKEND_API_KEY` が missing / stale でも startup 自体は止�
 2. その deployment に対して frontend-authenticated smoke check を実行する
 3. 同じ時間帯の Cloud Run logs を確認する
 4. ここまで通って初めて healthy deploy とみなす
+
+## Latency Baseline
+
+live 検証の前に、frontend 実経路の遅延を最低 1 回は採取する。
+
+### GitHub Actions
+
+- workflow: `Frontend Latency Probe`
+- trigger: `workflow_dispatch`
+- artifact:
+  - `artifacts/latency-probe.json`
+  - `artifacts/latency-probe.md`
+
+### Local execution
+
+```bash
+python scripts/latency_probe.py \
+  --base-url https://frontend-delta-six-20.vercel.app \
+  --iterations 3
+```
+
+この probe は以下を対象にする。
+
+- `POST /api/qa`
+- `POST /api/voice` (`text_to_speech`)
+- `POST /api/character`
+
+field verification で iPad 系の音声停止が出たため、数値だけでなく実機再生も合わせて確認する。
 
 ## ロールバック
 

--- a/frontend/src/lib/audio/mobile-audio-service.ts
+++ b/frontend/src/lib/audio/mobile-audio-service.ts
@@ -23,10 +23,14 @@ export interface MobileAudioOptions extends MobileAudioPlayerOptions {
 export type AudioPlaybackResult = AudioOperationResult;
 
 export class MobileAudioService {
+  private static readonly PLAYBACK_START_TIMEOUT_MS = 8000;
   private webAudioPlayer: WebAudioPlayer | null = null;
+  private htmlAudioElement: HTMLAudioElement | null = null;
+  private htmlAudioUrl: string | null = null;
+  private detachHtmlAudioListeners: (() => void) | null = null;
   private interactionManager: AudioInteractionManager;
   private options: MobileAudioOptions;
-  private currentMethod: 'web-audio' | null = null;
+  private currentMethod: 'web-audio' | 'html-audio' | null = null;
 
   constructor(options: MobileAudioOptions = {}) {
     this.options = {
@@ -49,20 +53,31 @@ export class MobileAudioService {
    */
   public async playAudio(audioData: AudioDataInput): Promise<AudioOperationResult> {
     try {
-      const result = await this.tryWebAudio(audioData);
+      const result = await this.withPlaybackStartTimeout(async () => {
+        if (DeviceDetector.isIOS()) {
+          const htmlAudioResult = await this.tryHtmlAudio(audioData);
+          if (htmlAudioResult.success) {
+            return htmlAudioResult;
+          }
+
+          console.warn('[MOBILE-AUDIO] HTML audio fallback failed, retrying Web Audio:', htmlAudioResult.error);
+        }
+
+        return this.tryWebAudio(audioData);
+      });
       if (result.success) {
-        this.currentMethod = 'web-audio';
-        return { ...result, method: 'web-audio' };
+        this.currentMethod = (result.method as 'web-audio' | null) ?? 'web-audio';
+        return result;
       }
       
       const error = result.error || new AudioError(
         AudioErrorType.PLAYBACK_FAILED, 
-        'Web Audio API playback failed'
+        'Audio playback failed'
       );
 
       return {
         success: false,
-        method: 'web-audio',
+        method: result.method ?? 'web-audio',
         error
       };
     } catch (error) {
@@ -144,6 +159,148 @@ export class MobileAudioService {
     }
   }
 
+  private async tryHtmlAudio(audioData: AudioDataInput): Promise<AudioOperationResult> {
+    try {
+      const audioBlob = await this.toAudioBlob(audioData);
+      this.cleanupHtmlAudio();
+
+      const audioUrl = URL.createObjectURL(audioBlob);
+      const audio = new Audio(audioUrl);
+      audio.preload = 'auto';
+      audio.volume = this.options.volume ?? 0.8;
+      audio.setAttribute('playsinline', 'true');
+      audio.setAttribute('webkit-playsinline', 'true');
+
+      let didEmitPlay = false;
+      const emitPlay = () => {
+        if (didEmitPlay) {
+          return;
+        }
+        didEmitPlay = true;
+        this.options.onPlay?.();
+      };
+
+      const onPlay = () => emitPlay();
+      const onPause = () => {
+        if (!audio.ended) {
+          this.options.onPause?.();
+        }
+      };
+      const onEnded = () => {
+        this.options.onEnded?.();
+        this.cleanupHtmlAudio();
+      };
+      const onError = () => {
+        const audioError = new AudioError(
+          AudioErrorType.PLAYBACK_FAILED,
+          'HTML audio playback failed on iOS',
+        );
+        this.options.onError?.(audioError);
+        this.cleanupHtmlAudio();
+      };
+
+      audio.addEventListener('play', onPlay);
+      audio.addEventListener('pause', onPause);
+      audio.addEventListener('ended', onEnded);
+      audio.addEventListener('error', onError);
+
+      this.detachHtmlAudioListeners = () => {
+        audio.removeEventListener('play', onPlay);
+        audio.removeEventListener('pause', onPause);
+        audio.removeEventListener('ended', onEnded);
+        audio.removeEventListener('error', onError);
+      };
+
+      this.htmlAudioElement = audio;
+      this.htmlAudioUrl = audioUrl;
+
+      await audio.play();
+      emitPlay();
+
+      return {
+        success: true,
+        method: 'html-audio',
+      };
+    } catch (error) {
+      this.cleanupHtmlAudio();
+      console.warn('[MOBILE-AUDIO] HTML audio playback failed:', error);
+      const audioError = AudioError.fromError(error as Error, AudioErrorType.PLAYBACK_FAILED);
+      return {
+        success: false,
+        method: 'html-audio',
+        error: audioError,
+      };
+    }
+  }
+
+  private async toAudioBlob(audioData: AudioDataInput): Promise<Blob> {
+    if (audioData instanceof Blob) {
+      return audioData;
+    }
+
+    if (audioData instanceof ArrayBuffer) {
+      const mimeType = AudioDataProcessor.detectAudioFormat(audioData);
+      return new Blob([audioData], { type: mimeType });
+    }
+
+    const blobResult = await AudioDataProcessor.base64ToBlob(audioData);
+    if (!blobResult.success || !blobResult.data) {
+      throw new AudioError(
+        AudioErrorType.INVALID_DATA,
+        blobResult.error || 'Failed to convert base64 audio to Blob',
+      );
+    }
+
+    return blobResult.data;
+  }
+
+  private async withPlaybackStartTimeout(
+    runner: () => Promise<AudioOperationResult>
+  ): Promise<AudioOperationResult> {
+    let timeoutId: number | null = null;
+
+    const timeoutPromise = new Promise<AudioOperationResult>((resolve) => {
+      timeoutId = window.setTimeout(() => {
+        this.stop();
+        resolve({
+          success: false,
+          method: this.currentMethod ?? 'web-audio',
+          error: new AudioError(
+            AudioErrorType.PLAYBACK_FAILED,
+            `Audio playback did not start within ${MobileAudioService.PLAYBACK_START_TIMEOUT_MS}ms`,
+          ),
+        });
+      }, MobileAudioService.PLAYBACK_START_TIMEOUT_MS);
+    });
+
+    try {
+      return await Promise.race([runner(), timeoutPromise]);
+    } finally {
+      if (timeoutId) {
+        clearTimeout(timeoutId);
+      }
+    }
+  }
+
+  private cleanupHtmlAudio(revokeUrl: boolean = true): void {
+    if (this.detachHtmlAudioListeners) {
+      this.detachHtmlAudioListeners();
+      this.detachHtmlAudioListeners = null;
+    }
+
+    if (this.htmlAudioElement) {
+      this.htmlAudioElement.pause();
+      this.htmlAudioElement.removeAttribute('src');
+      this.htmlAudioElement.load();
+      this.htmlAudioElement = null;
+    }
+
+    if (revokeUrl && this.htmlAudioUrl) {
+      URL.revokeObjectURL(this.htmlAudioUrl);
+      this.htmlAudioUrl = null;
+    }
+  }
+
 
 
   // Removed helper methods - now using shared utilities from AudioDataProcessor and AudioError
@@ -152,6 +309,9 @@ export class MobileAudioService {
    * Pause current playback
    */
   public pause(): void {
+    if (this.htmlAudioElement) {
+      this.htmlAudioElement.pause();
+    }
     if (this.webAudioPlayer) {
       this.webAudioPlayer.pause();
     }
@@ -161,6 +321,8 @@ export class MobileAudioService {
    * Stop current playback
    */
   public stop(): void {
+    this.cleanupHtmlAudio();
+
     if (this.webAudioPlayer) {
       this.webAudioPlayer.stop();
       
@@ -176,6 +338,10 @@ export class MobileAudioService {
    * Set volume
    */
   public setVolume(volume: number): void {
+    this.options.volume = volume;
+    if (this.htmlAudioElement) {
+      this.htmlAudioElement.volume = volume;
+    }
     if (this.webAudioPlayer) {
       this.webAudioPlayer.setVolume(volume);
     }
@@ -185,6 +351,9 @@ export class MobileAudioService {
    * Get current playback time
    */
   public getCurrentTime(): number {
+    if (this.htmlAudioElement) {
+      return this.htmlAudioElement.currentTime;
+    }
     if (this.webAudioPlayer) {
       return this.webAudioPlayer.getCurrentTime();
     }
@@ -195,6 +364,9 @@ export class MobileAudioService {
    * Get duration
    */
   public getDuration(): number {
+    if (this.htmlAudioElement) {
+      return Number.isFinite(this.htmlAudioElement.duration) ? this.htmlAudioElement.duration : 0;
+    }
     if (this.webAudioPlayer) {
       return this.webAudioPlayer.getDuration();
     }
@@ -205,6 +377,9 @@ export class MobileAudioService {
    * Check if playing
    */
   public isPlaying(): boolean {
+    if (this.htmlAudioElement) {
+      return !this.htmlAudioElement.paused && !this.htmlAudioElement.ended;
+    }
     if (this.webAudioPlayer) {
       return this.webAudioPlayer.getIsPlaying();
     }
@@ -214,7 +389,7 @@ export class MobileAudioService {
   /**
    * Get current playback method
    */
-  public getCurrentMethod(): 'web-audio' | null {
+  public getCurrentMethod(): 'web-audio' | 'html-audio' | null {
     return this.currentMethod;
   }
 
@@ -229,6 +404,8 @@ export class MobileAudioService {
    * Cleanup resources
    */
   public dispose(): void {
+    this.cleanupHtmlAudio();
+
     if (this.webAudioPlayer) {
       this.webAudioPlayer.dispose();
       this.webAudioPlayer = null;

--- a/frontend/src/lib/audio/web-audio-player.ts
+++ b/frontend/src/lib/audio/web-audio-player.ts
@@ -378,7 +378,11 @@ export class WebAudioPlayer {
   }
 
   private async resumeContextIfNeeded(): Promise<void> {
-    if (!this.audioContext || this.audioContext.state !== 'suspended') {
+    const state = this.audioContext?.state as string | undefined;
+    if (
+      !this.audioContext ||
+      (state !== 'suspended' && state !== 'interrupted')
+    ) {
       return;
     }
 
@@ -386,7 +390,7 @@ export class WebAudioPlayer {
       await waitForAudioUserInteraction();
     }
 
-    if (this.audioContext.state === 'suspended') {
+    if (this.audioContext.state !== 'running' && this.audioContext.state !== 'closed') {
       await this.audioContext.resume();
     }
   }
@@ -434,7 +438,11 @@ export class GlobalAudioManager {
   }
 
   public async ensureResumed(): Promise<void> {
-    if (!this.audioContext || this.audioContext.state !== 'suspended') {
+    const state = this.audioContext?.state as string | undefined;
+    if (
+      !this.audioContext ||
+      (state !== 'suspended' && state !== 'interrupted')
+    ) {
       return;
     }
 
@@ -442,7 +450,7 @@ export class GlobalAudioManager {
       await waitForAudioUserInteraction();
     }
 
-    if (this.audioContext.state === 'suspended') {
+    if (this.audioContext.state !== 'running' && this.audioContext.state !== 'closed') {
       await this.audioContext.resume();
     }
   }

--- a/scripts/latency_probe.py
+++ b/scripts/latency_probe.py
@@ -1,0 +1,246 @@
+#!/usr/bin/env python3
+"""Frontend latency probe for pre-field verification.
+
+Measures user-path latency on the deployed frontend and writes both JSON and
+Markdown summaries so they can be attached to a workflow run.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import math
+import statistics
+import sys
+import time
+import urllib.error
+import urllib.request
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+
+DEFAULT_BASE_URL = "https://frontend-delta-six-20.vercel.app"
+
+
+@dataclass(frozen=True)
+class ProbeSpec:
+    name: str
+    method: str
+    path: str
+    payload: dict[str, Any] | None
+
+
+PROBES: tuple[ProbeSpec, ...] = (
+    ProbeSpec(
+        name="qa_answer",
+        method="POST",
+        path="/api/qa",
+        payload={
+            "action": "ask",
+            "question": "営業時間を教えてください",
+            "text": "営業時間を教えてください",
+            "language": "ja",
+            "sessionId": "latency-probe",
+            "visitorId": "latency-probe",
+        },
+    ),
+    ProbeSpec(
+        name="tts_roundtrip",
+        method="POST",
+        path="/api/voice",
+        payload={
+            "action": "text_to_speech",
+            "text": "テストです",
+            "language": "ja",
+            "includeVrmControl": True,
+            "sessionId": "latency-probe",
+        },
+    ),
+    ProbeSpec(
+        name="character_status",
+        method="POST",
+        path="/api/character",
+        payload={"action": "get_status"},
+    ),
+)
+
+
+def percentile(values: list[float], ratio: float) -> float:
+    if not values:
+        raise ValueError("values must not be empty")
+
+    ordered = sorted(values)
+    if len(ordered) == 1:
+        return ordered[0]
+
+    position = (len(ordered) - 1) * ratio
+    lower = math.floor(position)
+    upper = math.ceil(position)
+    if lower == upper:
+        return ordered[lower]
+
+    weight = position - lower
+    return ordered[lower] + (ordered[upper] - ordered[lower]) * weight
+
+
+def request_json(base_url: str, spec: ProbeSpec, timeout: float) -> tuple[float, int, Any]:
+    body_bytes = None
+    headers = {"Content-Type": "application/json"}
+    if spec.payload is not None:
+        body_bytes = json.dumps(spec.payload).encode("utf-8")
+
+    request = urllib.request.Request(
+        url=f"{base_url.rstrip('/')}{spec.path}",
+        data=body_bytes,
+        headers=headers,
+        method=spec.method,
+    )
+
+    started = time.perf_counter()
+    with urllib.request.urlopen(request, timeout=timeout) as response:
+        response_body = response.read()
+        elapsed_ms = (time.perf_counter() - started) * 1000
+        payload = json.loads(response_body.decode("utf-8"))
+        return elapsed_ms, response.status, payload
+
+
+def validate_response(spec: ProbeSpec, status_code: int, payload: Any) -> None:
+    if status_code != 200:
+        raise RuntimeError(f"{spec.name}: unexpected status {status_code}")
+
+    if not isinstance(payload, dict):
+        raise RuntimeError(f"{spec.name}: response is not an object")
+
+    if payload.get("success") is False:
+        raise RuntimeError(f"{spec.name}: success=false response: {payload}")
+
+    if spec.name == "tts_roundtrip" and not payload.get("audioResponse"):
+        raise RuntimeError(f"{spec.name}: audioResponse missing")
+
+
+def run_probe(
+    base_url: str,
+    iterations: int,
+    timeout: float,
+) -> dict[str, Any]:
+    started_at = time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime())
+    results: list[dict[str, Any]] = []
+
+    for spec in PROBES:
+        samples: list[float] = []
+        failures: list[str] = []
+
+        for _ in range(iterations):
+            try:
+                elapsed_ms, status_code, payload = request_json(base_url, spec, timeout)
+                validate_response(spec, status_code, payload)
+                samples.append(round(elapsed_ms, 2))
+            except (urllib.error.URLError, urllib.error.HTTPError, RuntimeError, json.JSONDecodeError) as exc:
+                failures.append(str(exc))
+
+        if samples:
+            summary = {
+                "samples_ms": samples,
+                "count": len(samples),
+                "failures": failures,
+                "p50_ms": round(percentile(samples, 0.50), 2),
+                "p95_ms": round(percentile(samples, 0.95), 2),
+                "p99_ms": round(percentile(samples, 0.99), 2),
+                "mean_ms": round(statistics.mean(samples), 2),
+                "max_ms": round(max(samples), 2),
+            }
+        else:
+            summary = {
+                "samples_ms": [],
+                "count": 0,
+                "failures": failures,
+            }
+
+        results.append(
+            {
+                "name": spec.name,
+                "method": spec.method,
+                "path": spec.path,
+                **summary,
+            }
+        )
+
+    return {
+        "base_url": base_url,
+        "iterations": iterations,
+        "timeout_seconds": timeout,
+        "started_at": started_at,
+        "results": results,
+    }
+
+
+def format_markdown(report: dict[str, Any]) -> str:
+    lines = [
+        "# Frontend Latency Probe",
+        "",
+        f"- Base URL: `{report['base_url']}`",
+        f"- Iterations: `{report['iterations']}`",
+        f"- Timeout: `{report['timeout_seconds']}` seconds",
+        f"- Started At (UTC): `{report['started_at']}`",
+        "",
+        "| Probe | p50 (ms) | p95 (ms) | p99 (ms) | mean (ms) | max (ms) | failures |",
+        "| --- | ---: | ---: | ---: | ---: | ---: | ---: |",
+    ]
+
+    for result in report["results"]:
+        lines.append(
+            "| {name} | {p50} | {p95} | {p99} | {mean} | {max_} | {failures} |".format(
+                name=result["name"],
+                p50=result.get("p50_ms", "-"),
+                p95=result.get("p95_ms", "-"),
+                p99=result.get("p99_ms", "-"),
+                mean=result.get("mean_ms", "-"),
+                max_=result.get("max_ms", "-"),
+                failures=len(result.get("failures", [])),
+            )
+        )
+
+    lines.append("")
+    for result in report["results"]:
+        failures = result.get("failures", [])
+        if failures:
+            lines.append(f"## {result['name']} failures")
+            lines.extend(f"- {failure}" for failure in failures)
+            lines.append("")
+
+    return "\n".join(lines).rstrip() + "\n"
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Measure deployed frontend latency.")
+    parser.add_argument("--base-url", default=DEFAULT_BASE_URL)
+    parser.add_argument("--iterations", type=int, default=3)
+    parser.add_argument("--timeout", type=float, default=30.0)
+    parser.add_argument("--json-out", type=Path, default=Path("artifacts/latency-probe.json"))
+    parser.add_argument("--markdown-out", type=Path, default=Path("artifacts/latency-probe.md"))
+    return parser.parse_args()
+
+
+def write_output(path: Path, content: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(content, encoding="utf-8")
+
+
+def main() -> int:
+    args = parse_args()
+    report = run_probe(args.base_url, args.iterations, args.timeout)
+    markdown = format_markdown(report)
+    json_text = json.dumps(report, ensure_ascii=False, indent=2) + "\n"
+
+    write_output(args.json_out, json_text)
+    write_output(args.markdown_out, markdown)
+
+    print(markdown)
+
+    has_failure = any(result.get("failures") for result in report["results"])
+    return 1 if has_failure else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary
- iPad / iOS で Web Audio だけに依存していた再生経路に `HTMLAudioElement` fallback と playback start watchdog を追加
- イベント照会に `tomorrow` time range を追加し、Calendar / Connpass の日付計算を JST 基準に修正
- 現地検証前の latency baseline 用に `scripts/latency_probe.py` と workflow を追加
- deployment docs / changelog を今回の field verification 反映に更新

## Root Cause
- 2026-04-19 18:20-18:30 JST の Cloud Run / Vercel logs では `/api/qa` と `/api/voice` が 200 で返っており、iPad 事象は backend 生成失敗ではなく frontend playback path 側だった
- `CalendarService` / `ConnpassService` は `明日` / `tomorrow` を解釈しておらず、未認識時に `thisWeek` へフォールバックしていた
- `CalendarService` の日付境界は `datetime.now()` 依存で、JST 固定ではなかった

## Validation
- `cd backend && pytest tests/tools/test_calendar_service.py tests/tools/test_connpass_service.py tests/api/test_calendar_api.py tests/agents/test_event_agent.py -q`
- `cd frontend && pnpm typecheck`
- `python scripts/latency_probe.py --base-url https://frontend-delta-six-20.vercel.app --iterations 1 --json-out /tmp/latency-probe.json --markdown-out /tmp/latency-probe.md`

## Issues
- Closes #471
- Closes #472
- Progress on #140
