### PR TITLE
fix(frontend): MarpViewer narration pipeline — race condition, silent swallow, contract mismatch (#475 #476 #477)

### DIFF
--- a/frontend/src/app/components/MarpViewer.tsx
+++ b/frontend/src/app/components/MarpViewer.tsx
@@ -24,7 +24,6 @@ interface SlidesApiResponse {
   error?: string;
   transitionMessage?: string;
   characterAction?: string;
-  audioResponse?: string | null;
 }
 
 interface VoiceApiResponse {
@@ -410,6 +409,7 @@ export default function MarpViewer({
     if (
       isPlaying &&
       totalSlides > 0 &&
+      narrationData !== null &&
       !isNarratingRef.current &&
       !isNarrationInProgressRef.current
     ) {
@@ -428,11 +428,11 @@ export default function MarpViewer({
     } else if (!isPlaying) {
       stopAutoPlayRef.current();
     } else {
-      // Auto-play skipped - already playing
+      // Auto-play skipped - already playing or narrationData not yet loaded
     }
 
     return () => clearPlaybackWorkRef.current();
-  }, [isPlaying, totalSlides]);
+  }, [isPlaying, totalSlides, narrationData]);
 
   // Save settings to localStorage whenever they change
   useEffect(() => {
@@ -844,6 +844,11 @@ export default function MarpViewer({
       // Skipping narration - already playing
       return;
     }
+
+    if (narrationData === null) {
+      console.warn('[MarpViewer] narrateCurrentSlide called before narrationData loaded — skipping');
+      return;
+    }
     
     setIsNarrationInProgress(true);
     setIsNarrating(true);
@@ -856,10 +861,11 @@ export default function MarpViewer({
       narrationAbortControllerRef.current = new AbortController();
 
       const slideNarration =
-        narrationData?.slides[slideNumberAtStart - 1]?.narration?.auto?.trim() ?? '';
+        narrationData.slides[slideNumberAtStart - 1]?.narration?.auto?.trim() ?? '';
 
       // If the current slide has no auto narration, proceed without audio.
       if (!slideNarration) {
+        console.warn(`[MarpViewer] slide ${slideNumberAtStart} has no narration text — auto-advancing`);
         if (isActivePlaybackSession(playbackSession)) {
           advancePresentation(500);
         }
@@ -923,11 +929,14 @@ export default function MarpViewer({
           error?.name === 'NotAllowedError' ||
           error?.message?.includes('interaction')
         ) {
+          console.warn('[MarpViewer] autoplay blocked — user interaction required');
           setShowAudioPermissionPrompt(true);
           setIsPlaying(false);
           onPresentationComplete?.('stopped');
           return;
         }
+
+        console.error('[MarpViewer] narration playback failed:', error);
 
         if (isActivePlaybackSession(playbackSession)) {
           advancePresentation(1000);
@@ -954,6 +963,7 @@ export default function MarpViewer({
       await AudioPlaybackService.playAudioFast(audioBase64, volume / 100);
     } catch (error) {
       console.error('[MarpViewer] Error playing fast audio:', error);
+      throw error;
     }
   };
 
@@ -983,6 +993,7 @@ export default function MarpViewer({
       });
     } catch (error) {
       console.error('[MarpViewer] Error playing audio with lip-sync:', error);
+      throw error;
     }
   };
 
@@ -1048,11 +1059,6 @@ export default function MarpViewer({
         // Only update if we got a valid slide number
         if (result.slideNumber !== currentSlideRef.current) {
           setSlideState(result.slideNumber);
-        }
-
-        // Play narration audio if available
-        if (result.audioResponse) {
-          playNarrationAudio(result.audioResponse);
         }
       } else if (result.transitionMessage) {
         // Handle end of presentation or other transition messages
@@ -1352,11 +1358,6 @@ export default function MarpViewer({
 
       if (result.success) {
         onQuestionAsked?.(questionText);
-        
-        // Play answer audio if available
-        if (result.audioResponse) {
-          playNarrationAudio(result.audioResponse);
-        }
 
         // Show answer in some way (could be passed to parent component)
       }


### PR DESCRIPTION
## Summary

2026-04-22 のアルファ実地テスト前調査で判明した MarpViewer ナレーション再生の3件の defect を1コミットで修正。すべて Epic #474 の P0 子issueに対応。

- **#475 (A-1)** Race condition: `setTotalSlides` が `setNarrationData` より先に state 反映され、`narrateCurrentSlide()` が `narrationData=null` のまま発火 → 空文字 narration で silent skip → スライド1のナレーションが無音のまま次へ進む
- **#476 (A-2)** Silent error swallow: `playAudioWithLipSync` / `playAudioFast` の catch で `console.error` だけで rethrow しないため、autoplay policy 拒否 / decode 失敗 / ネットワーク断が全て上位に届かず UI に表示されない
- **#477 (A-3)** Contract mismatch dead code: `SlidesApiResponse.audioResponse` と `/api/slides` 応答後の `if (result.audioResponse)` 2箇所（line 1054-1055, 1357-1358）。backend `SlidesResponse` は `audioResponse` を返さないので常に undefined、デッドコードとして削除

## Changes

`frontend/src/app/components/MarpViewer.tsx` のみ。`+15/-14` 行。

### A-1: Race condition 修正
- `useEffect` (line ~408) に `narrationData !== null` guard を追加、deps に `narrationData` 追加
- `narrateCurrentSlide()` 先頭に null guard 追加（load 前は console.warn して早期 return）
- narration 空文字時は `console.warn` で observable に（silent skip 廃止）

### A-2: Audio error の可視化
- `playAudioWithLipSync` / `playAudioFast` の catch で `throw error` 追加
- `narrateCurrentSlide()` catch で `NotAllowedError` の console.warn 追加（既存の `setShowAudioPermissionPrompt` UI は保持）

### A-3: デッドコード削除
- `SlidesApiResponse` から `audioResponse?: string | null` 削除
- line 1054-1055 と 1357-1358 の `if (result.audioResponse) { playNarrationAudio(...) }` ブロック削除
- `VoiceApiResponse.audioResponse` (`/api/voice` レスポンス) は保持

## Validation

- [x] `pnpm lint` — clean (既存の未修正 `exhaustive-deps` warnings は本PR外)
- [x] `pnpm typecheck` — pass
- [x] `pnpm build` — success
- [x] grep: SlidesApiResponse に `audioResponse` 参照 0件、VoiceApiResponse 経路は維持

## Test plan

- [ ] ローカルで `pnpm dev`、スライド auto-play → スライド1ナレーションが確実に再生されることを手動確認（10回連続で silent skip 0）
- [ ] DevTools で audio.play() を意図的に拒否 → console に `[MarpViewer] autoplay blocked — user interaction required` が出ること
- [ ] `/api/slides` ナビゲーション後に音声が二重再生されないこと（以前はデッドコードで常に false だったが念のため）
- [ ] 既存 Playwright E2E (`frontend-playwright-e2e`) が緑のまま

## Refs

- Epic #474 (音声パイプライン安定化)
- Closes #475 #476 #477

🤖 Generated with [Claude Code](https://claude.com/claude-code)
