### PR TITLE
fix(backend): MP3 encoding run_in_executor + verify-deployment.sh contract fix (#478)

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -767,9 +767,9 @@ async def voice_api(request: Request, body: VoiceRequest):
                 and audio_b64
             ):
                 try:
-                    from backend.utils.audio_encode import wav_base64_to_mp3_base64
+                    from backend.utils.audio_encode import wav_base64_to_mp3_base64_async
 
-                    audio_b64 = wav_base64_to_mp3_base64(audio_b64)
+                    audio_b64 = await wav_base64_to_mp3_base64_async(audio_b64)
                     audio_format = "audio/mpeg"
                 except Exception as e:
                     logger.exception("WAV to MP3 conversion failed: %s", e)

--- a/backend/tests/api/test_voice_api.py
+++ b/backend/tests/api/test_voice_api.py
@@ -119,9 +119,9 @@ async def voice_api(request: VoiceRequest):
                 and audio_b64
             ):
                 try:
-                    from backend.utils.audio_encode import wav_base64_to_mp3_base64
+                    from backend.utils.audio_encode import wav_base64_to_mp3_base64_async
 
-                    audio_b64 = wav_base64_to_mp3_base64(audio_b64)
+                    audio_b64 = await wav_base64_to_mp3_base64_async(audio_b64)
                     audio_format = "audio/mpeg"
                 except Exception:
                     raise HTTPException(
@@ -305,6 +305,28 @@ class TestTextToSpeech:
 
 class TestOutputEncodingMp3:
     """outputEncoding=mp3 で WAV を MP3 に変換する経路"""
+
+    @pytest.mark.asyncio
+    async def test_wav_to_mp3_async_uses_executor(self, monkeypatch):
+        call_count = 0
+
+        def fake_wav_to_mp3(wav_b64: str) -> str:
+            nonlocal call_count
+            call_count += 1
+            assert wav_b64 == "input_b64"
+            return "mp3_result"
+
+        monkeypatch.setattr(
+            "backend.utils.audio_encode.wav_base64_to_mp3_base64",
+            fake_wav_to_mp3,
+        )
+
+        from backend.utils.audio_encode import wav_base64_to_mp3_base64_async
+
+        result = await wav_base64_to_mp3_base64_async("input_b64")
+
+        assert result == "mp3_result"
+        assert call_count == 1
 
     def test_tts_output_mp3_converts_wav(self, monkeypatch):
         def fake_wav_to_mp3(wav_b64: str) -> str:

--- a/backend/utils/audio_encode.py
+++ b/backend/utils/audio_encode.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 import base64
 from io import BytesIO
 
@@ -15,3 +16,9 @@ def wav_base64_to_mp3_base64(wav_b64: str) -> str:
     out = BytesIO()
     segment.export(out, format="mp3")
     return base64.b64encode(out.getvalue()).decode("utf-8")
+
+
+async def wav_base64_to_mp3_base64_async(wav_b64: str) -> str:
+    """Run WAV to MP3 encoding in a thread pool to avoid blocking the event loop."""
+    loop = asyncio.get_running_loop()
+    return await loop.run_in_executor(None, wav_base64_to_mp3_base64, wav_b64)

--- a/scripts/verify-deployment.sh
+++ b/scripts/verify-deployment.sh
@@ -79,7 +79,7 @@ code=$(curl -s -o /dev/null -w "%{http_code}" \
   -X POST "$BASE_URL/api/slides" \
   -H "Content-Type: application/json" \
   -H "X-API-Key: $API_KEY" \
-  -d '{"action":"get_current","session_id":"test"}')
+  -d '{"action":"narrate","session_id":"smoke-test"}')
 check "POST /api/slides (with key)" 200 "$code"
 
 code=$(curl -s -o /dev/null -w "%{http_code}" \
@@ -113,7 +113,7 @@ code=$(curl -s -o /dev/null -w "%{http_code}" \
   -X POST "$BASE_URL/api/reception/start" \
   -H "Content-Type: application/json" \
   -H "X-API-Key: $API_KEY" \
-  -d '{"language":"ja"}')
+  -d "{\"session_id\":\"smoke-$(date +%s)\",\"language\":\"ja\"}")
 check "POST /api/reception/start (with key)" 200 "$code"
 
 code=$(curl -s -o /dev/null -w "%{http_code}" \


### PR DESCRIPTION
## Summary

- #478: run WAV to MP3 encoding through the asyncio default thread pool
- Fix verify-deployment.sh contract drift for /api/slides and /api/reception/start

## Background

#480 live validation found that scripts/verify-deployment.sh had stale payloads for two backend endpoints. Separately, /api/voice outputEncoding=mp3 still called the pydub/ffmpeg encoder synchronously inside an async request handler.

## Changes

- Added wav_base64_to_mp3_base64_async() in backend/utils/audio_encode.py
- Updated backend/main.py to await the async encoder wrapper
- Updated backend/tests/api/test_voice_api.py mirror and added async wrapper coverage
- Updated scripts/verify-deployment.sh to use action=narrate for /api/slides and include session_id for /api/reception/start

## Validation

- uv run pytest backend/tests/api/test_voice_api.py --tb=short -q: 23 passed
- cd backend && uv run ruff check .: passed
- cd backend && uv run black --check .: passed
- cd backend && uv run pytest -m "not ragas and not slow and not e2e" --tb=short -q: 2807 passed, 53 skipped, 223 deselected
- API_SECRET_KEY=... bash scripts/verify-deployment.sh: 14 passed, 0 failed

## Test plan

- After merge, confirm develop CI/CD deploys Cloud Run
- Re-run deployment smoke against the deployed revision
- Measure /api/voice text_to_speech outputEncoding=mp3 warm latency and confirm no degradation

Closes #478
Refs #474