### PR TITLE
fix(backend): Supabase long-term memory reconnect + retry on connection errors (#486)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -138,6 +138,9 @@ docker-compose.override.yml
 # Reference implementation (external git repo)
 reference-implementation/
 
+# OpenCode CLI local state
+.opencode/
+
 # RAGAS evaluation reports (generated artifacts)
 backend/reports/
 backend/tests/reports/

--- a/backend/tests/utils/test_store_retry.py
+++ b/backend/tests/utils/test_store_retry.py
@@ -1,0 +1,221 @@
+"""Tests for store retry utilities: is_store_connection_error and store_with_retry."""
+
+import logging
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+import backend.utils.store as store_module
+from backend.utils.store import (
+    _CONNECTION_ERROR_INDICATORS,
+    close_store,
+    is_store_connection_error,
+    store_with_retry,
+)
+
+
+@pytest.fixture(autouse=True)
+def _reset_singleton():
+    store_module._store_instance = None
+    store_module._store_cm = None
+    yield
+    store_module._store_instance = None
+    store_module._store_cm = None
+
+
+class TestIsStoreConnectionError:
+    """Tests for is_store_connection_error()."""
+
+    @pytest.mark.parametrize(
+        "error_message",
+        list(_CONNECTION_ERROR_INDICATORS),
+        ids=[repr(m) for m in _CONNECTION_ERROR_INDICATORS],
+    )
+    def test_detects_known_connection_errors(self, error_message: str):
+        assert is_store_connection_error(RuntimeError(error_message)) is True
+
+    @pytest.mark.parametrize(
+        "error_message",
+        [
+            "something went wrong",
+            "timeout",
+            "permission denied",
+            "table not found",
+        ],
+    )
+    def test_rejects_unrelated_errors(self, error_message: str):
+        assert is_store_connection_error(RuntimeError(error_message)) is False
+
+    def test_detects_value_error_with_connection_closed(self):
+        assert is_store_connection_error(ValueError("connection is closed")) is True
+
+    def test_case_insensitive(self):
+        assert is_store_connection_error(RuntimeError("Connection Is Closed")) is True
+
+    def test_detects_generic_exception(self):
+        assert is_store_connection_error(Exception("broken pipe")) is True
+
+    def test_rejects_key_error(self):
+        assert is_store_connection_error(KeyError("missing key")) is False
+
+    def test_rejects_value_error_unrelated(self):
+        assert is_store_connection_error(ValueError("invalid argument")) is False
+
+
+def _async_return(value):
+    async def _f(*args, **kwargs):
+        return value
+
+    return _f
+
+
+def _async_call_counter():
+    calls = []
+
+    async def _f(store):
+        calls.append(1)
+        if len(calls) == 1:
+            raise RuntimeError("connection is closed")
+        return "recovered"
+
+    return _f, calls
+
+
+def _make_mock_cm(store_instance):
+    cm = MagicMock()
+    cm.__aenter__ = AsyncMock(return_value=store_instance)
+    cm.__aexit__ = AsyncMock(return_value=None)
+    return cm
+
+
+class TestStoreWithRetry:
+    """Tests for store_with_retry()."""
+
+    @pytest.mark.asyncio
+    async def test_returns_result_on_success(self):
+        mock_store = AsyncMock()
+        mock_store.setup = AsyncMock()
+        mock_cm = _make_mock_cm(mock_store)
+
+        with patch.dict("os.environ", {"SUPABASE_DB_URI": "postgresql://test@test/test"}):
+            with patch(
+                "backend.utils.store.AsyncPostgresStore.from_conn_string",
+                return_value=mock_cm,
+            ):
+                result = await store_with_retry(
+                    _async_return("ok"),
+                    operation_name="test op",
+                )
+                assert result == "ok"
+
+    @pytest.mark.asyncio
+    async def test_retries_on_connection_error_and_succeeds(self):
+        mock_store = AsyncMock()
+        mock_store.setup = AsyncMock()
+        mock_cm = _make_mock_cm(mock_store)
+
+        op, calls = _async_call_counter()
+
+        with patch.dict("os.environ", {"SUPABASE_DB_URI": "postgresql://test@test/test"}):
+            with patch(
+                "backend.utils.store.AsyncPostgresStore.from_conn_string",
+                return_value=mock_cm,
+            ):
+                result = await store_with_retry(op, operation_name="memory load")
+                assert result == "recovered"
+                assert len(calls) == 2
+
+    @pytest.mark.asyncio
+    async def test_raises_after_max_retries_exhausted(self):
+        mock_store = AsyncMock()
+        mock_store.setup = AsyncMock()
+        mock_cm = _make_mock_cm(mock_store)
+
+        async def _always_fail(store):
+            raise RuntimeError("connection is closed")
+
+        with patch.dict("os.environ", {"SUPABASE_DB_URI": "postgresql://test@test/test"}):
+            with patch(
+                "backend.utils.store.AsyncPostgresStore.from_conn_string",
+                return_value=mock_cm,
+            ):
+                with pytest.raises(RuntimeError, match="connection is closed"):
+                    await store_with_retry(
+                        _always_fail,
+                        max_retries=1,
+                        operation_name="memory load",
+                    )
+
+    @pytest.mark.asyncio
+    async def test_does_not_retry_non_connection_error(self):
+        async def _value_error(store):
+            raise ValueError("not a connection error")
+
+        mock_store = AsyncMock()
+        mock_store.setup = AsyncMock()
+        mock_cm = _make_mock_cm(mock_store)
+
+        with patch.dict("os.environ", {"SUPABASE_DB_URI": "postgresql://test@test/test"}):
+            with patch(
+                "backend.utils.store.AsyncPostgresStore.from_conn_string",
+                return_value=mock_cm,
+            ):
+                with pytest.raises(ValueError, match="not a connection error"):
+                    await store_with_retry(_value_error, operation_name="test")
+
+    @pytest.mark.asyncio
+    async def test_calls_close_store_on_connection_error(self):
+        mock_store = AsyncMock()
+        mock_store.setup = AsyncMock()
+        mock_cm = _make_mock_cm(mock_store)
+
+        op, calls = _async_call_counter()
+
+        with patch.dict("os.environ", {"SUPABASE_DB_URI": "postgresql://test@test/test"}):
+            with patch(
+                "backend.utils.store.AsyncPostgresStore.from_conn_string",
+                return_value=mock_cm,
+            ):
+                with patch("backend.utils.store.close_store", wraps=close_store) as mock_close:
+                    result = await store_with_retry(op, operation_name="memory load")
+                    assert result == "recovered"
+                    mock_close.assert_awaited()
+
+    @pytest.mark.asyncio
+    async def test_operation_name_in_retry_log(self, caplog):
+        mock_store = AsyncMock()
+        mock_store.setup = AsyncMock()
+        mock_cm = _make_mock_cm(mock_store)
+
+        op, calls = _async_call_counter()
+
+        with patch.dict("os.environ", {"SUPABASE_DB_URI": "postgresql://test@test/test"}):
+            with patch(
+                "backend.utils.store.AsyncPostgresStore.from_conn_string",
+                return_value=mock_cm,
+            ):
+                with caplog.at_level(logging.WARNING, logger="backend.utils.store"):
+                    result = await store_with_retry(op, operation_name="long-term memory load")
+                    assert result == "recovered"
+                    assert any("long-term memory load" in r.message for r in caplog.records)
+
+    @pytest.mark.asyncio
+    async def test_zero_max_retries_raises_immediately(self):
+        mock_store = AsyncMock()
+        mock_store.setup = AsyncMock()
+        mock_cm = _make_mock_cm(mock_store)
+
+        async def _conn_err(store):
+            raise RuntimeError("connection is closed")
+
+        with patch.dict("os.environ", {"SUPABASE_DB_URI": "postgresql://test@test/test"}):
+            with patch(
+                "backend.utils.store.AsyncPostgresStore.from_conn_string",
+                return_value=mock_cm,
+            ):
+                with pytest.raises(RuntimeError, match="connection is closed"):
+                    await store_with_retry(
+                        _conn_err,
+                        max_retries=0,
+                        operation_name="test",
+                    )

--- a/backend/tests/workflows/test_long_term_memory_retry.py
+++ b/backend/tests/workflows/test_long_term_memory_retry.py
@@ -1,0 +1,129 @@
+"""Tests for long-term memory retry integration in main_workflow."""
+
+import logging
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+import backend.utils.store as store_module
+from backend.utils.store import store_with_retry
+
+
+@pytest.fixture(autouse=True)
+def _reset_store_singleton():
+    store_module._store_instance = None
+    store_module._store_cm = None
+    yield
+    store_module._store_instance = None
+    store_module._store_cm = None
+
+
+def _setup_mock_store():
+    """Create a mock store and inject it as the singleton."""
+    mock_store = AsyncMock()
+    mock_store.asearch = AsyncMock(return_value=[])
+    mock_store.aput = AsyncMock(return_value=None)
+    mock_store.setup = AsyncMock()
+    store_module._store_instance = mock_store
+    return mock_store
+
+
+async def _noop_close_store():
+    """No-op close that preserves the mock singleton for retry tests."""
+    pass
+
+
+class TestLongTermMemoryLoadRetry:
+    """Test load path retry via store_with_retry."""
+
+    @pytest.mark.asyncio
+    async def test_load_retries_on_connection_error(self):
+        """When asearch raises a connection error, store_with_retry retries."""
+        mock_store = _setup_mock_store()
+        call_count = 0
+
+        async def _asearch_side_effect(*args, **kwargs):
+            nonlocal call_count
+            call_count += 1
+            if call_count == 1:
+                raise RuntimeError("connection is closed")
+            return []
+
+        mock_store.asearch.side_effect = _asearch_side_effect
+
+        with patch("backend.utils.store.close_store", side_effect=_noop_close_store):
+            result = await store_with_retry(
+                lambda s: s.asearch(("visitor_memories", "test-user"), query="test", limit=5),
+                operation_name="long-term memory load",
+            )
+        assert result == []
+        assert call_count == 2
+
+    @pytest.mark.asyncio
+    async def test_load_succeeds_without_retry(self):
+        """Normal load path has no retry overhead."""
+        mock_store = _setup_mock_store()
+        mock_store.asearch.return_value = []
+
+        result = await store_with_retry(
+            lambda s: s.asearch(("visitor_memories", "test-user"), query="test", limit=5),
+            operation_name="long-term memory load",
+        )
+        assert result == []
+        assert mock_store.asearch.call_count == 1
+
+
+class TestLongTermMemoryStoreRetry:
+    """Test store path retry via store_with_retry."""
+
+    @pytest.mark.asyncio
+    async def test_store_retries_on_connection_error(self):
+        """When aput raises a connection error, store_with_retry retries."""
+        mock_store = _setup_mock_store()
+        call_count = 0
+
+        async def _aput_side_effect(*args, **kwargs):
+            nonlocal call_count
+            call_count += 1
+            if call_count == 1:
+                raise RuntimeError("connection is closed")
+            return None
+
+        mock_store.aput.side_effect = _aput_side_effect
+
+        with patch("backend.utils.store.close_store", side_effect=_noop_close_store):
+            await store_with_retry(
+                lambda s: s.aput(("visitor_memories", "test-user"), "key", {"data": "test"}),
+                operation_name="long-term memory store",
+            )
+        assert call_count == 2
+
+    @pytest.mark.asyncio
+    async def test_store_succeeds_without_retry(self):
+        """Normal store path has no retry overhead."""
+        mock_store = _setup_mock_store()
+
+        await store_with_retry(
+            lambda s: s.aput(("visitor_memories", "test-user"), "key", {"data": "test"}),
+            operation_name="long-term memory store",
+        )
+        assert mock_store.aput.call_count == 1
+
+    @pytest.mark.asyncio
+    async def test_store_failed_log_only_on_final_failure(self, caplog):
+        """The 'long-term memory store' log only appears after all retries exhausted."""
+        mock_store = _setup_mock_store()
+
+        async def _always_fail(store):
+            raise RuntimeError("connection is closed")
+
+        with patch("backend.utils.store.close_store", side_effect=_noop_close_store):
+            with pytest.raises(RuntimeError, match="connection is closed"):
+                await store_with_retry(
+                    _always_fail,
+                    max_retries=1,
+                    operation_name="long-term memory store",
+                )
+
+        error_logs = [r for r in caplog.records if r.levelno >= logging.ERROR]
+        assert any("long-term memory store" in r.message for r in error_logs)

--- a/backend/tests/workflows/test_long_term_memory_retry.py
+++ b/backend/tests/workflows/test_long_term_memory_retry.py
@@ -112,7 +112,7 @@ class TestLongTermMemoryStoreRetry:
     @pytest.mark.asyncio
     async def test_store_failed_log_only_on_final_failure(self, caplog):
         """The 'long-term memory store' log only appears after all retries exhausted."""
-        mock_store = _setup_mock_store()
+        _setup_mock_store()  # side-effect only: registers mock store singleton
 
         async def _always_fail(store):
             raise RuntimeError("connection is closed")

--- a/backend/tests/workflows/test_main_workflow.py
+++ b/backend/tests/workflows/test_main_workflow.py
@@ -221,7 +221,14 @@ class TestMainWorkflowMemoryIntegration:
                     "language": "ja",
                 }
 
-                await workflow._format_response_node(state, runtime)
+                async def _passthrough(op, **kw):
+                    return await op(runtime.store)
+
+                with patch(
+                    "backend.workflows.main_workflow.store_with_retry",
+                    side_effect=_passthrough,
+                ):
+                    await workflow._format_response_node(state, runtime)
 
                 runtime.store.aput.assert_called_once()
                 args = runtime.store.aput.await_args.args
@@ -279,7 +286,14 @@ class TestMainWorkflowMemoryIntegration:
                     "language": "ja",
                 }
 
-                await workflow._format_response_node(state, runtime)
+                async def _passthrough(op, **kw):
+                    return await op(runtime.store)
+
+                with patch(
+                    "backend.workflows.main_workflow.store_with_retry",
+                    side_effect=_passthrough,
+                ):
+                    await workflow._format_response_node(state, runtime)
                 runtime.store.aput.assert_not_called()
 
     @pytest.mark.asyncio
@@ -331,7 +345,14 @@ class TestMainWorkflowMemoryIntegration:
                     "language": "ja",
                 }
 
-                result = await workflow._format_response_node(state, runtime)
+                async def _passthrough(op, **kw):
+                    return await op(runtime.store)
+
+                with patch(
+                    "backend.workflows.main_workflow.store_with_retry",
+                    side_effect=_passthrough,
+                ):
+                    result = await workflow._format_response_node(state, runtime)
                 assert "messages" in result
                 assert len(result["messages"]) == 2
 
@@ -391,7 +412,14 @@ class TestMainWorkflowMemoryIntegration:
                     "language": "ja",
                 }
 
-                await workflow._format_response_node(state, runtime)
+                async def _passthrough(op, **kw):
+                    return await op(runtime.store)
+
+                with patch(
+                    "backend.workflows.main_workflow.store_with_retry",
+                    side_effect=_passthrough,
+                ):
+                    await workflow._format_response_node(state, runtime)
 
                 mock_promoter.promote_for_user.assert_called_once()
 
@@ -454,7 +482,14 @@ class TestMainWorkflowMemoryIntegration:
                     "language": "ja",
                 }
 
-                await workflow._format_response_node(state, runtime)
+                async def _passthrough(op, **kw):
+                    return await op(runtime.store)
+
+                with patch(
+                    "backend.workflows.main_workflow.store_with_retry",
+                    side_effect=_passthrough,
+                ):
+                    await workflow._format_response_node(state, runtime)
 
                 # extract_memories should NOT be called when candidates enabled
                 extract_memories_mock.assert_not_called()
@@ -511,7 +546,14 @@ class TestMainWorkflowMemoryIntegration:
                     "language": "ja",
                 }
 
-                await workflow._format_response_node(state, runtime)
+                async def _passthrough(op, **kw):
+                    return await op(runtime.store)
+
+                with patch(
+                    "backend.workflows.main_workflow.store_with_retry",
+                    side_effect=_passthrough,
+                ):
+                    await workflow._format_response_node(state, runtime)
 
                 # Direct write to visitor_memories namespace
                 runtime.store.aput.assert_called_once()
@@ -587,7 +629,14 @@ class TestMainWorkflowMemoryIntegration:
                     "context": {},
                 }
 
-                result = await workflow._memory_loader_node(state, runtime)
+                async def _passthrough(op, **kw):
+                    return await op(runtime.store)
+
+                with patch(
+                    "backend.workflows.main_workflow.store_with_retry",
+                    side_effect=_passthrough,
+                ):
+                    result = await workflow._memory_loader_node(state, runtime)
                 lt = result["context"]["long_term_memory"]
                 assert lt
                 assert lt[0]["type"] == "explicit_remember"

--- a/backend/utils/store.py
+++ b/backend/utils/store.py
@@ -10,11 +10,70 @@ Supabase PostgreSQLを使用して訪問者の長期記憶を永続化する。
 import asyncio
 import logging
 import os
-from typing import Optional
+from typing import Awaitable, Callable, Optional, TypeVar
 
 from langgraph.store.postgres.aio import AsyncPostgresStore
 
 logger = logging.getLogger(__name__)
+
+_CONNECTION_ERROR_INDICATORS = (
+    "connection is closed",
+    "connection closed",
+    "pool is closed",
+    "server closed the connection unexpectedly",
+    "terminating connection",
+    "broken pipe",
+    "ssl connection has been closed unexpectedly",
+    "consuming input failed",
+)
+
+
+def is_store_connection_error(error: Exception) -> bool:
+    """Return True when the exception indicates a dead/closed Store connection."""
+    error_message = str(error).lower()
+    return any(indicator in error_message for indicator in _CONNECTION_ERROR_INDICATORS)
+
+
+_T = TypeVar("_T")
+
+
+async def store_with_retry(
+    operation: Callable[[AsyncPostgresStore], Awaitable[_T]],
+    *,
+    max_retries: int = 1,
+    operation_name: str = "store operation",
+) -> _T:
+    """Execute a store operation with automatic reconnect on connection errors.
+
+    On detected connection error (see is_store_connection_error), reset the
+    module-level store singleton via close_store() + get_store() and retry once.
+    """
+    store = await get_store()
+    for attempt in range(max_retries + 1):
+        try:
+            return await operation(store)
+        except Exception as e:
+            if not is_store_connection_error(e):
+                raise
+            if attempt >= max_retries:
+                logger.error(
+                    "%s failed after %d retries: %s",
+                    operation_name,
+                    max_retries,
+                    e,
+                )
+                raise
+            logger.warning(
+                "%s hit connection error (attempt %d/%d), resetting store: %s",
+                operation_name,
+                attempt + 1,
+                max_retries + 1,
+                e,
+            )
+            await close_store()
+            store = await get_store()
+    raise RuntimeError("store_with_retry exited loop unexpectedly")
+
 
 # 非同期シングルトン用ロック
 _store_lock = asyncio.Lock()

--- a/backend/workflows/main_workflow.py
+++ b/backend/workflows/main_workflow.py
@@ -37,6 +37,7 @@ from backend.agents.orchestrator_agent import (
 )
 from backend.agents.orchestrator_agent import OrchestratorAgent as RoutingLogicAgent
 from backend.config.routing_constants import GREETING_KEYWORDS, match_keywords
+from backend.utils.store import store_with_retry
 
 logger = logging.getLogger(__name__)
 
@@ -683,8 +684,9 @@ class MainWorkflow:
                     from backend.utils.memory_feature_flags import get_memory_feature_flags
 
                     namespace = ("visitor_memories", user_id)
-                    memories = await runtime.store.asearch(
-                        namespace, query=state.get("query", ""), limit=5
+                    memories = await store_with_retry(
+                        lambda s: s.asearch(namespace, query=state.get("query", ""), limit=5),
+                        operation_name="long-term memory load",
                     )
                     flags = get_memory_feature_flags()
                     if flags.enable_long_term_memory_rerank and memories:
@@ -1300,15 +1302,18 @@ class MainWorkflow:
                     if facts:
                         namespace = ("visitor_memories", user_id)
                         for fact in facts:
-                            await runtime.store.aput(
-                                namespace,
-                                str(uuid.uuid4()),
-                                {
-                                    "data": fact["content"],
-                                    "type": fact["type"],
-                                    "confidence": fact.get("confidence", 0.5),
-                                    "timestamp": time.time(),
-                                },
+                            await store_with_retry(
+                                lambda s, f=fact: s.aput(
+                                    namespace,
+                                    str(uuid.uuid4()),
+                                    {
+                                        "data": f["content"],
+                                        "type": f["type"],
+                                        "confidence": f.get("confidence", 0.5),
+                                        "timestamp": time.time(),
+                                    },
+                                ),
+                                operation_name="long-term memory store",
                             )
                         logger.info(
                             "Stored %d long-term memories for user %s",
@@ -1327,10 +1332,13 @@ class MainWorkflow:
                         if candidates:
                             candidate_ns = ("visitor_memory_candidates", user_id)
                             for candidate in candidates:
-                                await runtime.store.aput(
-                                    candidate_ns,
-                                    str(uuid.uuid4()),
-                                    candidate,
+                                await store_with_retry(
+                                    lambda s, c=candidate: s.aput(
+                                        candidate_ns,
+                                        str(uuid.uuid4()),
+                                        c,
+                                    ),
+                                    operation_name="long-term memory store",
                                 )
                             logger.info(
                                 "Stored %d memory candidates for user %s",


### PR DESCRIPTION
## Summary

Supabase Pooler の idle timeout 起因で発生する `Long-term memory store/load failed: connection is closed` エラーを自動リトライで吸収する。既存 `backend/utils/checkpointer.py` の `ResilientAsyncPostgresSaver` パターンを `backend/utils/store.py` 側にも横展開。

### 変更点

1. `backend/utils/store.py` に `is_store_connection_error()` と `store_with_retry()` を追加
2. `backend/workflows/main_workflow.py` の long-term memory load (line ~687) と store (line ~1307, ~1337) の3箇所を retry wrapper 経由に変更
3. 既存テストに `store_with_retry` パススルーモックを追加

### 検証

- [x] `ruff check .` 緑
- [x] `black --check .` 緑
- [x] `pytest -m "not ragas and not slow and not e2e"` 緑 (2839 テスト通過、新規29件含む)
- [x] Mutation test: `CONNECTION_ERROR_INDICATORS` から "connection is closed" を削除すると `test_detects_known_connection_errors['connection is closed']` が FAIL することを確認

## Test plan

- [ ] staging 環境デプロイ後、意図的に Supabase 接続をアイドル放置 (15分以上) してから /api/chat を叩き、Cloud Run logs で "resetting store" ログが出ることを確認
- [ ] 1週間 Cloud Run logs を監視し、`Long-term memory .* failed` エラーが 0 件になることを確認

Closes #486
Refs: Epic #483

🤖 Generated with OpenCode