### PR TITLE
fix(backend): tRAG translation retry/backoff for en/ko/zh (#487)

### DIFF
--- a/backend/services/translation_service.py
+++ b/backend/services/translation_service.py
@@ -167,23 +167,30 @@ class TranslationService:
     # Public async API
     # ------------------------------------------------------------------
 
+    _MAX_TRANSLATION_RETRIES = 3
+    _RETRY_BACKOFF_BASE = 0.5  # seconds
+
     async def translate(
         self,
         text: str,
         direction: TranslationDirection,
+        *,
+        max_retries: int = 3,
     ) -> str:
         """
         Translate text between English and Japanese.
 
         Skips translation when text is already in the target language.
+        Retries up to *max_retries* times with exponential backoff on failure.
 
         Args:
             text: Source text.
             direction: ``"en_to_ja"`` or ``"ja_to_en"``.
+            max_retries: Maximum number of retries (default 3).
 
         Returns:
             Translated text, or the original if already in the target language
-            or if translation fails.
+            or if translation fails after all retries.
         """
         if not text or not text.strip():
             return text
@@ -196,23 +203,42 @@ class TranslationService:
             logger.debug("Skip JA->EN: text is already Latin-only")
             return text
 
-        try:
-            loop = asyncio.get_running_loop()
-            translated = await loop.run_in_executor(None, self._translate_sync, text, direction)
-            logger.debug(
-                "Translated [%s]: '%s' -> '%s'",
-                direction,
-                text[:60],
-                translated[:60],
-            )
-            return translated
-        except Exception:
-            logger.warning(
-                "Translation failed [%s], returning original text.",
-                direction,
-                exc_info=True,
-            )
-            return text
+        loop = asyncio.get_running_loop()
+        for attempt in range(max_retries + 1):
+            try:
+                translated = await loop.run_in_executor(
+                    None,
+                    self._translate_sync,
+                    text,
+                    direction,
+                )
+                logger.debug(
+                    "Translated [%s]: '%s' -> '%s'",
+                    direction,
+                    text[:60],
+                    translated[:60],
+                )
+                return translated
+            except Exception as exc:
+                if attempt < max_retries:
+                    delay = self._RETRY_BACKOFF_BASE * (2**attempt)
+                    logger.warning(
+                        "Translation [%s] attempt %d/%d failed: %s — retrying in %.1fs",
+                        direction,
+                        attempt + 1,
+                        max_retries + 1,
+                        exc,
+                        delay,
+                    )
+                    await asyncio.sleep(delay)
+                else:
+                    logger.error(
+                        "Translation [%s] failed after %d attempts: %s",
+                        direction,
+                        max_retries + 1,
+                        exc,
+                    )
+        return text
 
     async def translate_batch(
         self,

--- a/backend/tests/utils/test_translation_retry.py
+++ b/backend/tests/utils/test_translation_retry.py
@@ -1,0 +1,260 @@
+"""Tests for tRAG translation retry/backoff (Issue #487)."""
+
+import asyncio
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+# =============================================================================
+# TranslationService.translate() retry tests
+# =============================================================================
+
+
+class TestTranslationServiceRetry:
+    """Tests for retry logic in TranslationService.translate()."""
+
+    @pytest.mark.asyncio
+    async def test_translate_succeeds_on_first_attempt(self):
+        from backend.services.translation_service import TranslationService
+
+        svc = TranslationService.__new__(TranslationService)
+        svc._model_dir = "/dummy"
+        svc._translators = {}
+        svc._source_sps = {}
+        svc._target_sps = {}
+
+        async def _fake_executor(executor, fn, *args):
+            return "翻訳されたテキスト"
+
+        with patch.object(
+            asyncio.get_running_loop(),
+            "run_in_executor",
+            side_effect=_fake_executor,
+        ):
+            result = await svc.translate("hello", "en_to_ja")
+            assert result == "翻訳されたテキスト"
+
+    @pytest.mark.asyncio
+    async def test_translate_retries_on_failure_then_succeeds(self):
+        from backend.services.translation_service import TranslationService
+
+        svc = TranslationService.__new__(TranslationService)
+        svc._model_dir = "/dummy"
+        svc._translators = {}
+        svc._source_sps = {}
+        svc._target_sps = {}
+
+        call_count = 0
+
+        async def _fake_executor(executor, fn, *args):
+            nonlocal call_count
+            call_count += 1
+            if call_count == 1:
+                raise RuntimeError("model load failed")
+            return "翻訳結果"
+
+        with patch("asyncio.sleep", new_callable=AsyncMock):
+            with patch.object(
+                asyncio.get_running_loop(),
+                "run_in_executor",
+                side_effect=_fake_executor,
+            ):
+                result = await svc.translate("hello", "en_to_ja")
+                assert result == "翻訳結果"
+                assert call_count == 2
+
+    @pytest.mark.asyncio
+    async def test_translate_returns_original_after_all_retries_exhausted(self):
+        from backend.services.translation_service import TranslationService
+
+        svc = TranslationService.__new__(TranslationService)
+        svc._model_dir = "/dummy"
+        svc._translators = {}
+        svc._source_sps = {}
+        svc._target_sps = {}
+
+        async def _always_fail(executor, fn, *args):
+            raise RuntimeError("persistent failure")
+
+        with patch("asyncio.sleep", new_callable=AsyncMock):
+            with patch.object(
+                asyncio.get_running_loop(),
+                "run_in_executor",
+                side_effect=_always_fail,
+            ):
+                result = await svc.translate("hello", "en_to_ja")
+                assert result == "hello"
+
+    @pytest.mark.asyncio
+    async def test_translate_skip_when_already_japanese(self):
+        from backend.services.translation_service import TranslationService
+
+        svc = TranslationService.__new__(TranslationService)
+        svc._model_dir = "/dummy"
+        svc._translators = {}
+        svc._source_sps = {}
+        svc._target_sps = {}
+
+        result = await svc.translate("こんにちは", "en_to_ja")
+        assert result == "こんにちは"
+
+
+# =============================================================================
+# _translate_llm_with_retry tests
+# =============================================================================
+
+
+class TestTranslateLlmWithRetry:
+    """Tests for KO/ZH LLM translation retry via _translate_llm_with_retry."""
+
+    @pytest.mark.asyncio
+    async def test_llm_translate_succeeds_on_first_try(self):
+        from backend.workflows.main_workflow import _translate_llm_with_retry
+
+        mock_resp = MagicMock()
+        mock_resp.status_code = 200
+        mock_resp.json.return_value = {
+            "choices": [{"message": {"content": "営業時間は何時ですか"}}]
+        }
+
+        mock_client = AsyncMock()
+        mock_client.post = AsyncMock(return_value=mock_resp)
+
+        with patch.dict("os.environ", {"OPENROUTER_API_KEY": "test-key"}):
+            with patch(
+                "backend.workflows.main_workflow._get_trag_client",
+                return_value=mock_client,
+            ):
+                result = await _translate_llm_with_retry("영업시간", "ko")
+                assert result == "営業時間は何時ですか"
+                mock_client.post.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_llm_translate_retries_on_500_then_succeeds(self):
+        from backend.workflows.main_workflow import _translate_llm_with_retry
+
+        mock_resp_500 = MagicMock()
+        mock_resp_500.status_code = 500
+        mock_resp_500.text = "Internal Server Error"
+
+        mock_resp_200 = MagicMock()
+        mock_resp_200.status_code = 200
+        mock_resp_200.json.return_value = {"choices": [{"message": {"content": "営業時間"}}]}
+
+        mock_client = AsyncMock()
+        mock_client.post = AsyncMock(side_effect=[mock_resp_500, mock_resp_200])
+
+        with patch.dict("os.environ", {"OPENROUTER_API_KEY": "test-key"}):
+            with patch("asyncio.sleep", new_callable=AsyncMock):
+                with patch(
+                    "backend.workflows.main_workflow._get_trag_client",
+                    return_value=mock_client,
+                ):
+                    result = await _translate_llm_with_retry("营业时间", "zh")
+                    assert result == "営業時間"
+                    assert mock_client.post.call_count == 2
+
+    @pytest.mark.asyncio
+    async def test_llm_translate_returns_empty_after_max_retries(self):
+        from backend.workflows.main_workflow import _translate_llm_with_retry
+
+        mock_resp_500 = MagicMock()
+        mock_resp_500.status_code = 500
+        mock_resp_500.text = "Error"
+
+        mock_client = AsyncMock()
+        mock_client.post = AsyncMock(return_value=mock_resp_500)
+
+        with patch.dict("os.environ", {"OPENROUTER_API_KEY": "test-key"}):
+            with patch("asyncio.sleep", new_callable=AsyncMock):
+                with patch(
+                    "backend.workflows.main_workflow._get_trag_client",
+                    return_value=mock_client,
+                ):
+                    result = await _translate_llm_with_retry(
+                        "test",
+                        "ko",
+                        max_retries=2,
+                    )
+                    assert result == ""
+                    assert mock_client.post.call_count == 3
+
+    @pytest.mark.asyncio
+    async def test_llm_translate_no_api_key_returns_empty(self):
+        from backend.workflows.main_workflow import _translate_llm_with_retry
+
+        with patch.dict("os.environ", {"OPENROUTER_API_KEY": ""}):
+            result = await _translate_llm_with_retry("test", "zh")
+            assert result == ""
+
+    @pytest.mark.asyncio
+    async def test_llm_translate_strips_preamble(self):
+        from backend.workflows.main_workflow import _translate_llm_with_retry
+
+        mock_resp = MagicMock()
+        mock_resp.status_code = 200
+        mock_resp.json.return_value = {
+            "choices": [{"message": {"content": "Translation: 営業時間は9時から22時です"}}]
+        }
+
+        mock_client = AsyncMock()
+        mock_client.post = AsyncMock(return_value=mock_resp)
+
+        with patch.dict("os.environ", {"OPENROUTER_API_KEY": "test-key"}):
+            with patch(
+                "backend.workflows.main_workflow._get_trag_client",
+                return_value=mock_client,
+            ):
+                result = await _translate_llm_with_retry("hours", "ko")
+                assert result == "営業時間は9時から22時です"
+                assert not result.startswith("Translation")
+
+    @pytest.mark.asyncio
+    async def test_llm_translate_returns_empty_for_english_only_output(self):
+        from backend.workflows.main_workflow import _translate_llm_with_retry
+
+        mock_resp = MagicMock()
+        mock_resp.status_code = 200
+        mock_resp.json.return_value = {
+            "choices": [{"message": {"content": "Business hours are from 9am"}}]
+        }
+
+        mock_client = AsyncMock()
+        mock_client.post = AsyncMock(return_value=mock_resp)
+
+        with patch.dict("os.environ", {"OPENROUTER_API_KEY": "test-key"}):
+            with patch(
+                "backend.workflows.main_workflow._get_trag_client",
+                return_value=mock_client,
+            ):
+                result = await _translate_llm_with_retry("hours", "zh")
+                assert result == ""
+
+    @pytest.mark.asyncio
+    async def test_llm_translate_retries_on_connection_error(self):
+        from backend.workflows.main_workflow import _translate_llm_with_retry
+
+        call_count = 0
+
+        async def _post_side_effect(*args, **kwargs):
+            nonlocal call_count
+            call_count += 1
+            if call_count == 1:
+                raise ConnectionError("Connection reset")
+            mock_resp = MagicMock()
+            mock_resp.status_code = 200
+            mock_resp.json.return_value = {"choices": [{"message": {"content": "営業時間"}}]}
+            return mock_resp
+
+        mock_client = AsyncMock()
+        mock_client.post = AsyncMock(side_effect=_post_side_effect)
+
+        with patch.dict("os.environ", {"OPENROUTER_API_KEY": "test-key"}):
+            with patch("asyncio.sleep", new_callable=AsyncMock):
+                with patch(
+                    "backend.workflows.main_workflow._get_trag_client",
+                    return_value=mock_client,
+                ):
+                    result = await _translate_llm_with_retry("test", "ko")
+                    assert result == "営業時間"
+                    assert call_count == 2

--- a/backend/workflows/main_workflow.py
+++ b/backend/workflows/main_workflow.py
@@ -68,8 +68,89 @@ def _get_trag_client() -> "_httpx.AsyncClient":
     """Return a shared httpx client for tRAG translation."""
     global _trag_http_client
     if _trag_http_client is None or _trag_http_client.is_closed:
-        _trag_http_client = _httpx.AsyncClient(timeout=10.0)
+        _trag_http_client = _httpx.AsyncClient(
+            timeout=_httpx.Timeout(connect=5.0, read=15.0, write=5.0, pool=5.0),
+        )
     return _trag_http_client
+
+
+async def _translate_llm_with_retry(
+    query: str,
+    language: str,
+    *,
+    max_retries: int = 3,
+    backoff_base: float = 0.5,
+) -> str:
+    """Translate KO/ZH query to JA via OpenRouter with exponential backoff."""
+    _TRAG_MODEL = os.getenv("TRAG_TRANSLATION_MODEL", "google/gemini-2.0-flash-001")
+    api_key = os.getenv("OPENROUTER_API_KEY", "")
+    if not api_key:
+        logger.warning("OPENROUTER_API_KEY not set, skipping %s->ja", language)
+        return ""
+
+    client = _get_trag_client()
+    payload = {
+        "model": _TRAG_MODEL,
+        "messages": [
+            {
+                "role": "system",
+                "content": (
+                    "You are a translation "
+                    "engine. Translate the "
+                    "user's text to Japanese."
+                    " Return ONLY the "
+                    "Japanese translation."
+                ),
+            },
+            {"role": "user", "content": query},
+        ],
+        "max_tokens": 200,
+    }
+    headers = {
+        "Authorization": f"Bearer {api_key}",
+        "Content-Type": "application/json",
+    }
+
+    for attempt in range(max_retries + 1):
+        try:
+            resp = await client.post(
+                "https://openrouter.ai/api/v1/chat/completions",
+                headers=headers,
+                json=payload,
+            )
+            if resp.status_code == 200:
+                data = resp.json()
+                translated = (
+                    data.get("choices", [{}])[0].get("message", {}).get("content", "").strip()
+                )
+                translated = _TRAG_PREAMBLE_RE.sub("", translated).strip()
+                if re.search(r"^[A-Za-z]{5,}", translated):
+                    logger.warning("tRAG preamble: '%s'", translated[:60])
+                    translated = ""
+                return translated
+            logger.warning(
+                "OpenRouter %d (attempt %d/%d): %s",
+                resp.status_code,
+                attempt + 1,
+                max_retries + 1,
+                resp.text[:200],
+            )
+        except Exception as exc:
+            logger.warning(
+                "LLM translation %s->ja request error (attempt %d/%d): %s",
+                language,
+                attempt + 1,
+                max_retries + 1,
+                exc,
+            )
+        if attempt < max_retries:
+            await asyncio.sleep(backoff_base * (2**attempt))
+    logger.error(
+        "LLM translation %s->ja failed after %d attempts",
+        language,
+        max_retries + 1,
+    )
+    return ""
 
 
 class WorkflowStateDict(TypedDict):
@@ -550,80 +631,20 @@ class MainWorkflow:
                         )
                 elif language in ("ko", "zh"):
                     try:
-                        _TRAG_MODEL = os.getenv(
-                            "TRAG_TRANSLATION_MODEL",
-                            "google/gemini-2.0-flash-001",
-                        )
-                        api_key = os.getenv("OPENROUTER_API_KEY", "")
-                        if not api_key:
-                            logger.warning(
-                                "OPENROUTER_API_KEY not set, skipping %s->ja",
+                        translated = await _translate_llm_with_retry(query, language)
+                        if translated and _JA_RE.search(translated):
+                            rag_query = translated
+                            logger.info(
+                                "tRAG %s->ja: '%s' -> '%s'",
                                 language,
+                                query[:40],
+                                rag_query[:40],
                             )
-                        else:
-                            client = _get_trag_client()
-                            resp = await client.post(
-                                "https://openrouter.ai/api/v1/chat/completions",
-                                headers={
-                                    "Authorization": f"Bearer {api_key}",
-                                    "Content-Type": "application/json",
-                                },
-                                json={
-                                    "model": _TRAG_MODEL,
-                                    "messages": [
-                                        {
-                                            "role": "system",
-                                            "content": (
-                                                "You are a translation "
-                                                "engine. Translate the "
-                                                "user's text to Japanese."
-                                                " Return ONLY the "
-                                                "Japanese translation."
-                                            ),
-                                        },
-                                        {
-                                            "role": "user",
-                                            "content": query,
-                                        },
-                                    ],
-                                    "max_tokens": 200,
-                                },
+                        elif translated:
+                            logger.warning(
+                                "tRAG not Japanese: '%s'",
+                                translated[:60],
                             )
-                            if resp.status_code == 200:
-                                data = resp.json()
-                                translated = (
-                                    data.get("choices", [{}])[0]
-                                    .get("message", {})
-                                    .get("content", "")
-                                    .strip()
-                                )
-                                # Sanitize LLM preamble
-                                translated = _TRAG_PREAMBLE_RE.sub("", translated).strip()
-                                if re.search(r"^[A-Za-z]{5,}", translated):
-                                    logger.warning(
-                                        "tRAG preamble: '%s'",
-                                        translated[:60],
-                                    )
-                                    translated = ""
-                                if translated and _JA_RE.search(translated):
-                                    rag_query = translated
-                                    logger.info(
-                                        "tRAG %s->ja: '%s' -> '%s'",
-                                        language,
-                                        query[:40],
-                                        rag_query[:40],
-                                    )
-                                elif translated:
-                                    logger.warning(
-                                        "tRAG not Japanese: '%s'",
-                                        translated[:60],
-                                    )
-                            else:
-                                logger.warning(
-                                    "OpenRouter %d: %s",
-                                    resp.status_code,
-                                    resp.text[:200],
-                                )
                     except Exception as trans_err:
                         logger.warning(
                             "LLM translation (%s->ja) failed: %s",


### PR DESCRIPTION
## Summary

Cloud Run ログ (2026-04-21 19:37) で観測された `Translation failed [en_to_ja], returning original text.` エラーを自動リトライ + 指数バックオフで吸収する。

### 変更点

1. **`backend/services/translation_service.py`** — `translate()` に 3回リトライ + 0.5s base exponential backoff を追加
2. **`backend/workflows/main_workflow.py`**:
   - `_get_trag_client()` の httpx タイムアウトを tiered (connect=5s, read=15s) に変更
   - `_translate_llm_with_retry()` ヘルパーを追加（3回リトライ + exponential backoff）
   - KO/ZH elif ブロックをヘルパー呼び出しに簡略化
3. **`backend/tests/utils/test_translation_retry.py`** — 新規テスト 11件

### 検証

- [x] `ruff check .` 緑
- [x] `black --check .` 緑
- [x] `pytest -m "not ragas and not slow and not e2e"` 緑 (2851 テスト通過)

Closes #487
Refs: Epic #483

🤖 Generated with OpenCode