### PR TITLE
perf(backend): return Qwen STT before Vosk fallback completes (#491)

### DIFF
--- a/backend/agents/stt_agent.py
+++ b/backend/agents/stt_agent.py
@@ -24,6 +24,7 @@ from __future__ import annotations
 
 import asyncio
 import concurrent.futures
+import contextlib
 import io
 import json
 import logging
@@ -1154,9 +1155,9 @@ class STTAgent:
     ) -> Dict[str, Any]:
         """Qwen primary + Vosk parallel fallback (ADR-007).
 
-        ``asyncio.gather`` で Qwen と Vosk を同時実行し、Qwen が
-        ``QWEN_STT_TIMEOUT`` 秒以内に成功すればその結果を返す。
-        タイムアウトまたはエラー時は Vosk の結果にフォールバックする。
+        Qwen と Vosk を同時実行し、Qwen が ``QWEN_STT_TIMEOUT`` 秒以内に
+        成功すれば Vosk の完了を待たずにその結果を返す。
+        タイムアウトまたはエラー時は、並走していた Vosk の結果にフォールバックする。
         """
 
         async def _run_qwen():
@@ -1170,44 +1171,72 @@ class STTAgent:
                 return await self._vosk_fallback_client.transcribe_auto_detect(audio_data)
             return await self._vosk_fallback_client.transcribe(audio_data, language)
 
-        qwen_result, vosk_result = await asyncio.gather(
-            _run_qwen(), _run_vosk(), return_exceptions=True
-        )
+        async def _discard_vosk_result(vosk_task: asyncio.Task[Any]) -> None:
+            if not vosk_task.done():
+                vosk_task.cancel()
+                with contextlib.suppress(asyncio.CancelledError):
+                    await vosk_task
+                return
 
-        # Qwen success
-        if isinstance(qwen_result, TranscriptionResult):
-            return {
-                "success": True,
-                "transcript": qwen_result.text,
-                "confidence": qwen_result.confidence,
-                "language": qwen_result.language,
-                "provider": "qwen-primary",
-            }
+            with contextlib.suppress(Exception):
+                vosk_task.result()
 
-        # Qwen failed -> Vosk fallback
-        logger.warning(
-            "Qwen STT failed, using Vosk fallback: %s",
-            qwen_result,
-        )
-        if isinstance(vosk_result, TranscriptionResult):
-            transcript = vosk_result.text
-            postprocessed = False
-            if os.getenv("STT_LLM_POSTPROCESS", "false").lower() == "true":
-                corrected = await self._llm_post_process(transcript, vosk_result.language)
-                if corrected != transcript:
-                    postprocessed = True
-                    transcript = corrected
-            return {
-                "success": True,
-                "transcript": transcript,
-                "confidence": vosk_result.confidence,
-                "language": vosk_result.language,
-                "provider": "vosk-fallback",
-                "postprocessed": postprocessed,
-            }
+        qwen_task = asyncio.create_task(_run_qwen())
+        vosk_task = asyncio.create_task(_run_vosk())
 
-        # Both failed
-        raise RuntimeError(f"Both Qwen and Vosk STT failed: qwen={qwen_result}, vosk={vosk_result}")
+        try:
+            qwen_result: TranscriptionResult | Exception
+            try:
+                qwen_result = await qwen_task
+            except Exception as exc:
+                qwen_result = exc
+
+            # Qwen success
+            if isinstance(qwen_result, TranscriptionResult):
+                await _discard_vosk_result(vosk_task)
+                return {
+                    "success": True,
+                    "transcript": qwen_result.text,
+                    "confidence": qwen_result.confidence,
+                    "language": qwen_result.language,
+                    "provider": "qwen-primary",
+                }
+
+            # Qwen failed -> Vosk fallback
+            logger.warning(
+                "Qwen STT failed, using Vosk fallback: %s",
+                qwen_result,
+            )
+            try:
+                vosk_result: TranscriptionResult | Exception = await vosk_task
+            except Exception as exc:
+                vosk_result = exc
+
+            if isinstance(vosk_result, TranscriptionResult):
+                transcript = vosk_result.text
+                postprocessed = False
+                if os.getenv("STT_LLM_POSTPROCESS", "false").lower() == "true":
+                    corrected = await self._llm_post_process(transcript, vosk_result.language)
+                    if corrected != transcript:
+                        postprocessed = True
+                        transcript = corrected
+                return {
+                    "success": True,
+                    "transcript": transcript,
+                    "confidence": vosk_result.confidence,
+                    "language": vosk_result.language,
+                    "provider": "vosk-fallback",
+                    "postprocessed": postprocessed,
+                }
+
+            # Both failed
+            raise RuntimeError(
+                f"Both Qwen and Vosk STT failed: qwen={qwen_result}, vosk={vosk_result}"
+            )
+        finally:
+            for task in (qwen_task, vosk_task):
+                if not task.done():
+                    task.cancel()
 
     def _resolve_grammar(self, conversation_stage: Optional[str]) -> Optional[Dict[str, List[str]]]:
         """会話ステージに応じた Grammar 辞書を解決する。

--- a/backend/tests/agents/test_stt_agent.py
+++ b/backend/tests/agents/test_stt_agent.py
@@ -1671,6 +1671,51 @@ class TestQwenPrimaryParallel:
         assert result["transcript"] == "こんにちは"
 
     @pytest.mark.asyncio
+    async def test_qwen_success_does_not_wait_for_slow_vosk(self):
+        """Qwen succeeds -> returns immediately without waiting for Vosk fallback."""
+        import asyncio
+
+        vosk_started = asyncio.Event()
+        vosk_cancelled = asyncio.Event()
+
+        async def slow_vosk(*args, **kwargs):
+            vosk_started.set()
+            try:
+                await asyncio.sleep(20)
+            except asyncio.CancelledError:
+                vosk_cancelled.set()
+                raise
+            return TranscriptionResult(
+                text="slow fallback",
+                confidence=0.7,
+                language="ja",
+            )
+
+        mock_qwen = MagicMock()
+        mock_qwen.transcribe = AsyncMock(
+            return_value=TranscriptionResult(
+                text="qwen fast",
+                confidence=0.95,
+                language="ja",
+            )
+        )
+        mock_vosk = MagicMock(spec=LocalSTTClient)
+        mock_vosk.transcribe = AsyncMock(side_effect=slow_vosk)
+
+        agent = self._make_agent(mock_qwen, mock_vosk)
+        loop = asyncio.get_running_loop()
+        started_at = loop.time()
+        result = await agent.speech_to_text(b"audio", language="ja")
+        elapsed = loop.time() - started_at
+
+        assert result["success"] is True
+        assert result["provider"] == "qwen-primary"
+        assert result["transcript"] == "qwen fast"
+        assert vosk_started.is_set()
+        assert vosk_cancelled.is_set()
+        assert elapsed < 0.5
+
+    @pytest.mark.asyncio
     async def test_qwen_timeout_vosk_fallback(self):
         """Qwen times out -> Vosk fallback with provider='vosk-fallback'"""
         import asyncio

--- a/docs/adr/010-qwen-onnx-quantization.md
+++ b/docs/adr/010-qwen-onnx-quantization.md
@@ -1,35 +1,34 @@
-# ADR 010: Qwen3-ASR ONNX + INT4 quantization spike
+# ADR 010: Qwen3-ASR ONNX + INT4 量子化スパイク
 
-Date: 2026-04-22
+作成日: 2026-04-22
 
-## Status
+## ステータス
 
-Proposed: **No-Go for Phase 2 ONNX/INT4 implementation as currently scoped**
+提案: **現時点のスコープでは Phase 2 の ONNX/INT4 実装へ進まない（No-Go）**
 
-## Context
+## 背景
 
-Issue #491 proposed converting `Qwen/Qwen3-ASR-0.6B` from the current PyTorch CPU
-runtime to ONNX Runtime with INT4 quantization. The target was to reduce live STT
-latency from roughly p50 4.0s to p50 1.5s.
+Issue #491 では、現在 PyTorch CPU で動かしている `Qwen/Qwen3-ASR-0.6B` を ONNX Runtime + INT4 量子化に変換し、STT レイテンシを現状の p50 約 4.0 秒から p50 1.5 秒へ下げることを狙っていた。
 
-This ADR records Phase 1 spike results only. No runtime code was changed because:
+この ADR は Phase 1 スパイク結果だけを記録する。ランタイム実装はまだ変更していない。
 
-- OpenCode is working on #487 in `backend/utils/language_processor.py` and
-  `backend/workflows/main_workflow.py`.
-- session-1771 is working in `backend/api/*`.
-- The Phase 1 instruction explicitly required a Go/No-Go decision before Phase 2/3.
+理由:
 
-## Current implementation
+- OpenCode が #487 で `backend/utils/language_processor.py` と `backend/workflows/main_workflow.py` を作業中。
+- session-1771 が `backend/api/*` を作業中。
+- Phase 1 指示では、Phase 2/3 に進む前に Go / No-Go 判定を出すことになっている。
 
-The production STT path is `STT_PROVIDER=qwen-primary`.
+## 現在の STT 実装
 
-In `backend/agents/stt_agent.py`, `qwen-primary` creates:
+本番 Cloud Run は `STT_PROVIDER=qwen-primary` で動いている。
 
-- `Qwen06BCpuSTTClient` as the primary recognizer.
-- `LocalSTTClient` as a Vosk fallback.
-- `QWEN_STT_TIMEOUT` defaulting to 10s.
+`backend/agents/stt_agent.py` の `qwen-primary` は次を使う。
 
-Important behavior:
+- primary: `Qwen06BCpuSTTClient`
+- fallback: `LocalSTTClient`、つまり Vosk
+- timeout: `QWEN_STT_TIMEOUT`、現状は 10 秒
+
+重要な挙動:
 
 ```python
 qwen_result, vosk_result = await asyncio.gather(
@@ -37,23 +36,18 @@ qwen_result, vosk_result = await asyncio.gather(
 )
 ```
 
-This waits for both Qwen and Vosk to complete. It is not a "return the fastest valid
-winner" race. If Qwen finishes quickly but Vosk is slow because of model load or CPU
-contention, the request still waits for Vosk.
+これは「Qwen が先に成功したら即返す」実装ではない。Qwen と Vosk の両方が終わるまで待つ。つまり Qwen が速く終わっても、Vosk のモデルロードや CPU 競合が遅いと、リクエスト全体は Vosk を待って遅くなる。
 
-Also, Qwen success uses `QwenSTTClient.transcribe()`, whose Japanese LLM correction is
-controlled by `STT_QWEN_POSTPROCESS_ENABLED`, not by `STT_LLM_POSTPROCESS`.
-`STT_LLM_POSTPROCESS=true` currently applies to the Vosk fallback branch and the
-Vosk-only provider path, not to successful Qwen-primary results.
+もう1つ重要な点として、Qwen 成功時の補正は `STT_QWEN_POSTPROCESS_ENABLED` で制御されている。一方で Cloud Run に設定した `STT_LLM_POSTPROCESS=true` は、主に Vosk fallback 側または Vosk provider 側に効く。つまり Qwen が成功した場合、現状の `STT_LLM_POSTPROCESS=true` だけでは Qwen 出力の固有名詞補正が必ずしも有効にならない。
 
-## Phase 1 environment
+## Phase 1 実行環境
 
-Worktree:
+作業 worktree:
 
 - `/tmp/engineer-cafe-navigator2025-work5-491`
-- Base: `origin/develop` at `b5a5299c6`
+- base: `origin/develop` の `b5a5299c6`
 
-Spike dependencies installed into the local Work5 `.venv` only:
+スパイク用に Work5 のローカル `.venv` にだけ入れた依存:
 
 - `qwen-asr==0.0.6`
 - `torch==2.11.0`
@@ -63,11 +57,11 @@ Spike dependencies installed into the local Work5 `.venv` only:
 - `onnx==1.21.0`
 - `onnxruntime==1.24.4`
 
-These dependencies were not added to project files during Phase 1.
+これらは Phase 1 の検証用であり、プロジェクトの依存ファイルには追加していない。
 
-## ONNX export feasibility
+## ONNX export 可否
 
-Command:
+実行したコマンド:
 
 ```bash
 uv run optimum-cli export onnx \
@@ -76,26 +70,24 @@ uv run optimum-cli export onnx \
   /tmp/qwen-asr-onnx-spike-fp32
 ```
 
-Result: **failed**.
+結果: **失敗**。
 
-Error:
+エラー:
 
 ```text
 ValueError: The checkpoint you are trying to load has model type `qwen3_asr`
 but Transformers does not recognize this architecture.
 ```
 
-Root cause:
+原因:
 
-- `qwen_asr.inference.qwen3_asr` registers `qwen3_asr` with Transformers at import time:
+- `qwen_asr.inference.qwen3_asr` を import すると、以下の登録が行われる。
   - `AutoConfig.register("qwen3_asr", Qwen3ASRConfig)`
   - `AutoModel.register(Qwen3ASRConfig, Qwen3ASRForConditionalGeneration)`
   - `AutoProcessor.register(Qwen3ASRConfig, Qwen3ASRProcessor)`
-- The standalone `optimum-cli` path calls `AutoConfig.from_pretrained()` before importing
-  the `qwen_asr` package, so the architecture is unknown.
+- しかし `optimum-cli` は `qwen_asr` を import する前に `AutoConfig.from_pretrained()` を呼ぶため、`qwen3_asr` という architecture を知らずに失敗する。
 
-After importing `qwen_asr.inference.qwen3_asr`, local Python can resolve the config and
-model mapping:
+確認として、Python で先に `qwen_asr.inference.qwen3_asr` を import すれば Transformers は `qwen3_asr` を解決できる。
 
 ```text
 Qwen3ASRConfig
@@ -103,14 +95,13 @@ model_type=qwen3_asr
 AutoModel -> Qwen3ASRForConditionalGeneration
 ```
 
-However, this does not make standard Optimum export automatically usable.
+ただし、これだけでは Optimum の標準 export が使えるようにはならない。
 
-## Custom export feasibility
+## custom export の見込み
 
-`Qwen3ASRForConditionalGeneration.forward` is not implemented as a normal model forward;
-the class inherits the default `_forward_unimplemented`.
+`Qwen3ASRForConditionalGeneration.forward` は通常の forward として実装されておらず、デフォルトの `_forward_unimplemented` のままだった。
 
-The inference path is:
+実際の推論経路は次の形。
 
 ```python
 inputs = processor(text=sub_text, audio=sub_wavs, return_tensors="pt", padding=True)
@@ -118,24 +109,22 @@ text_ids = model.generate(**inputs, max_new_tokens=max_new_tokens)
 decoded = processor.batch_decode(text_ids.sequences[:, inputs["input_ids"].shape[1]:])
 ```
 
-This means Qwen3-ASR is a generation model, not a simple encoder-only ASR model. A
-production ONNX path would need to export and serve the autoregressive generation graph,
-including decoder cache handling. That is closer to building a custom Optimum ORT model
-integration than running a one-command export.
+つまり Qwen3-ASR は単純な encoder-only ASR モデルではなく、`generate()` を使う autoregressive generation モデルである。ONNX 化するには、decoder cache や生成ループを含む形で export / serving する必要がある。
 
-INT4 quantization also depends on having a valid ONNX graph first. Since FP32 ONNX export
-did not succeed, INT4 was not attempted.
+これは「コマンド1つで ONNX export して INT4 量子化する」作業ではなく、独自の Optimum ORT model integration に近い。
 
-## Local PyTorch baseline
+FP32 ONNX graph が作れなかったため、INT4 量子化は未実施。
 
-Sample:
+## ローカル PyTorch baseline
+
+使用 sample:
 
 - `frontend/e2e/fixtures/voice/sample.wav`
 - sample rate: 16kHz
-- duration: 1.811s
-- expected transcript: "Tell me about Engineer Cafe."
+- duration: 1.811 秒
+- 期待 transcript: `Tell me about Engineer Cafe.`
 
-Command shape:
+実行内容:
 
 ```python
 model = Qwen3ASRModel.from_pretrained(
@@ -148,31 +137,29 @@ model = Qwen3ASRModel.from_pretrained(
 model.transcribe(audio=(pcm, 16000), language="English")
 ```
 
-Result on local Apple Silicon environment:
+結果:
 
-| Metric | Result |
+| 指標 | 結果 |
 | --- | ---: |
-| Model load | 5.348s |
-| Iteration 1 | 0.601s |
-| Iteration 2 | 0.490s |
-| Iteration 3 | 0.293s |
-| Iteration 4 | 0.294s |
-| Iteration 5 | 0.293s |
-| Warm p50 | 0.294s |
-| Max | 0.601s |
-| Transcript | `Tell me about Engineer Cafe.` |
+| モデルロード | 5.348s |
+| 1回目 | 0.601s |
+| 2回目 | 0.490s |
+| 3回目 | 0.293s |
+| 4回目 | 0.294s |
+| 5回目 | 0.293s |
+| warm p50 | 0.294s |
+| max | 0.601s |
+| transcript | `Tell me about Engineer Cafe.` |
 
-Interpretation:
+解釈:
 
-- Qwen3-ASR 0.6B PyTorch itself can be fast once warm.
-- The observed Cloud Run STT p50 around 4s is unlikely to be explained by Qwen PyTorch
-  inference alone.
-- The current `qwen-primary` implementation waits for Vosk as well as Qwen, so Vosk model
-  load / CPU contention can dominate latency even when Qwen succeeds quickly.
+- Qwen3-ASR 0.6B の PyTorch 推論そのものは、warm 状態では十分速い可能性がある。
+- Cloud Run で観測している STT p50 約 4 秒は、Qwen PyTorch 単体の遅さだけでは説明しにくい。
+- 現在の `qwen-primary` は Qwen と Vosk の両方を待つため、Vosk のモデルロードや CPU 競合が全体 latency を支配している可能性が高い。
 
-## Live Piper Plus TTS -> STT accuracy check
+## Piper Plus 実音声テスト
 
-Command:
+実行コマンド:
 
 ```bash
 LIVE_BACKEND_URL=https://engineer-cafe-backend-639959525777.asia-northeast1.run.app \
@@ -181,12 +168,11 @@ LIVE_BACKEND_API_KEY="$(gcloud secrets versions access latest \
 uv run pytest --run-e2e tests/e2e/test_stt_japanese_accuracy.py -v -m e2e --no-header
 ```
 
-The test synthesizes Japanese audio through live `/api/voice` TTS, which uses Piper Plus
-in the current Cloud Run configuration, then sends that audio back through live STT.
+このテストは、Cloud Run の live `/api/voice` TTS で日本語音声を生成し、その音声を live STT に戻す。現行 Cloud Run 設定では TTS は Piper Plus 経路である。
 
-Per-sample result from the first parametrized pass:
+parametrize された最初の10サンプルの結果:
 
-| Sample | Result | Observed transcript |
+| サンプル | 結果 | transcript |
 | --- | --- | --- |
 | `proper_noun_cafe` | failed | `現地 に た` |
 | `coworking_katakana` | passed | n/a |
@@ -199,70 +185,64 @@ Per-sample result from the first parametrized pass:
 | `fukuoka_city` | passed | n/a |
 | `basement_space` | failed | `下の子は、エンジニアカフェ(Engineer Cafe)にいます。` |
 
-Effective first-pass accuracy: **4/10 = 40%**.
+実質的な初回 pass rate: **4/10 = 40%**。
 
-The aggregate test then hit the existing `/api/voice` rate limit:
+その後の aggregate test は `/api/voice` の rate limit に当たった。
 
 ```text
 429 {"error":"Rate limit exceeded: 20 per 1 minute"}
 ```
 
-Interpretation:
+解釈:
 
-- The live Piper Plus round-trip currently exposes accuracy regressions independent of
-  ONNX speed work.
-- The aggregate test duplicates the 10 TTS+STT calls after the parametrized test, causing
-  20+ requests/minute and triggering the `/api/voice` rate limit. This validates follow-up
-  #502 as a real test-design issue.
+- Piper Plus 音声を使った live STT では、速度以前に accuracy が足りていない。
+- 特に固有名詞、WiFi、受付、コミュニティマネージャー、ミーティングスペース、地下コワーキングが崩れている。
+- aggregate test は同じ10サンプルをもう一度 TTS+STT するため、1分以内に20回以上 `/api/voice` を叩いて rate limit にかかる。これは follow-up #502 の妥当性を確認する結果でもある。
 
-## Decision
+## 判断
 
-Do **not** proceed to Phase 2 ONNX/INT4 implementation yet.
+現時点では Phase 2 の ONNX/INT4 実装へ進まない。
 
-Reasons:
+理由:
 
-1. Standard Optimum ONNX export fails because `qwen3_asr` is not registered unless the
-   `qwen_asr` package is imported first.
-2. The model does not expose a normal `forward`; inference is through `generate()`.
-   Custom ONNX export would require a non-trivial autoregressive generation integration.
-3. Local PyTorch warm inference is already sub-second on the sample fixture. That suggests
-   the current Cloud Run p50 is dominated by orchestration/fallback/postprocess behavior,
-   not purely by PyTorch compute.
-4. Live Piper Plus TTS -> STT accuracy is currently only 4/10 on the first pass, so
-   optimizing inference speed alone will not make the user-facing STT path alpha-ready.
+1. Optimum 標準 ONNX export が `qwen3_asr` 未登録で失敗する。
+2. Qwen3-ASR は通常の `forward()` を持たず、`generate()` 経由の autoregressive model である。custom ONNX export はかなり重い。
+3. ローカル PyTorch warm inference は 0.3 秒前後で、Qwen PyTorch 単体は十分速い可能性がある。
+4. Cloud Run の 4 秒級 latency は、Qwen 単体ではなく `qwen-primary` が Vosk 完了まで待つ設計や、post-process flag の不整合に起因している可能性が高い。
+5. Piper Plus 実音声テストは 4/10 pass に留まり、速度改善だけでは alpha 品質に届かない。
 
-## Recommended next step
+## 推奨する次アクション
 
-Pivot #491 from "ONNX/INT4 first" to "remove avoidable qwen-primary latency and accuracy
-regression first":
+#491 をいきなり ONNX/INT4 に進めるのではなく、まず次の小さい最適化に pivot する。
 
-1. Change `qwen-primary` from `asyncio.gather()` to a safe winner-race:
-   - return Qwen immediately if it succeeds within timeout;
-   - keep Vosk only as fallback when Qwen fails or times out;
-   - do not wait for Vosk after Qwen success.
-2. Align post-processing flags:
-   - either set `STT_QWEN_POSTPROCESS_ENABLED=true` in Cloud Run, or make
-     `STT_LLM_POSTPROCESS=true` also enable Qwen success-path post-processing.
-3. Fix #502 before using the 10-sample live test as a release gate:
-   - avoid running the same 10 TTS+STT calls twice inside one minute;
-   - cache synthesized audio or make the aggregate test reuse per-sample results.
-4. Re-measure live STT p50/p95 after the race fix and post-process alignment.
-5. Revisit ONNX only if Qwen-only p50 remains above target.
+1. `qwen-primary` を `asyncio.gather()` から winner-race に変更する。
+   - Qwen が成功したら即返す。
+   - Vosk は Qwen failure / timeout 時だけ fallback として使う。
+   - Qwen 成功後に Vosk を待たない。
+2. post-process flag を揃える。
+   - Cloud Run に `STT_QWEN_POSTPROCESS_ENABLED=true` を追加する。
+   - もしくは `STT_LLM_POSTPROCESS=true` が Qwen 成功パスにも効くようにする。
+3. #502 を先に直す。
+   - 10サンプル live test が同じ TTS+STT を2回走らせないようにする。
+   - 生成済み audio を使い回す、または aggregate test が per-sample 結果を再利用する。
+4. その後に live STT p50/p95 と Piper Plus accuracy を再測定する。
+5. それでも Qwen-only p50 が目標未達なら、改めて ONNX custom export を検討する。
 
 ## Go / No-Go
 
-No-Go for ONNX/INT4 Phase 2 as scoped.
+ONNX/INT4 Phase 2 は **No-Go**。
 
-Go for a smaller backend optimization spike:
+代わりに次は次の Phase 2 を推奨する。
 
-- implement qwen-primary winner-race behind a feature flag;
-- verify Piper Plus TTS -> STT accuracy after Qwen post-process alignment;
-- only then decide whether ONNX export is still needed.
+- `qwen-primary` winner-race 実装
+- Qwen post-process flag 整合
+- #502 rate limit 回避
+- その後に Cloud Run + Piper Plus 実音声で再測定
 
-## Related
+## 関連
 
-- #491: Qwen3-ASR ONNX Runtime + INT4 quantization
-- #484: OSS release preparation
-- #502: STT test rate-limit follow-up
-- #480 / #499: STT post-process and live Japanese accuracy suite
+- #491: Qwen3-ASR ONNX Runtime + INT4 量子化
+- #484: OSSリリース準備
+- #502: STT test rate limit follow-up
+- #480 / #499: STT post-process と live Japanese accuracy suite
 - #478 / #498: MP3 encoding event-loop blocker removal

--- a/docs/adr/010-qwen-onnx-quantization.md
+++ b/docs/adr/010-qwen-onnx-quantization.md
@@ -1,0 +1,268 @@
+# ADR 010: Qwen3-ASR ONNX + INT4 quantization spike
+
+Date: 2026-04-22
+
+## Status
+
+Proposed: **No-Go for Phase 2 ONNX/INT4 implementation as currently scoped**
+
+## Context
+
+Issue #491 proposed converting `Qwen/Qwen3-ASR-0.6B` from the current PyTorch CPU
+runtime to ONNX Runtime with INT4 quantization. The target was to reduce live STT
+latency from roughly p50 4.0s to p50 1.5s.
+
+This ADR records Phase 1 spike results only. No runtime code was changed because:
+
+- OpenCode is working on #487 in `backend/utils/language_processor.py` and
+  `backend/workflows/main_workflow.py`.
+- session-1771 is working in `backend/api/*`.
+- The Phase 1 instruction explicitly required a Go/No-Go decision before Phase 2/3.
+
+## Current implementation
+
+The production STT path is `STT_PROVIDER=qwen-primary`.
+
+In `backend/agents/stt_agent.py`, `qwen-primary` creates:
+
+- `Qwen06BCpuSTTClient` as the primary recognizer.
+- `LocalSTTClient` as a Vosk fallback.
+- `QWEN_STT_TIMEOUT` defaulting to 10s.
+
+Important behavior:
+
+```python
+qwen_result, vosk_result = await asyncio.gather(
+    _run_qwen(), _run_vosk(), return_exceptions=True
+)
+```
+
+This waits for both Qwen and Vosk to complete. It is not a "return the fastest valid
+winner" race. If Qwen finishes quickly but Vosk is slow because of model load or CPU
+contention, the request still waits for Vosk.
+
+Also, Qwen success uses `QwenSTTClient.transcribe()`, whose Japanese LLM correction is
+controlled by `STT_QWEN_POSTPROCESS_ENABLED`, not by `STT_LLM_POSTPROCESS`.
+`STT_LLM_POSTPROCESS=true` currently applies to the Vosk fallback branch and the
+Vosk-only provider path, not to successful Qwen-primary results.
+
+## Phase 1 environment
+
+Worktree:
+
+- `/tmp/engineer-cafe-navigator2025-work5-491`
+- Base: `origin/develop` at `b5a5299c6`
+
+Spike dependencies installed into the local Work5 `.venv` only:
+
+- `qwen-asr==0.0.6`
+- `torch==2.11.0`
+- `transformers==4.57.6`
+- `optimum==2.1.0`
+- `optimum-onnx==0.1.0`
+- `onnx==1.21.0`
+- `onnxruntime==1.24.4`
+
+These dependencies were not added to project files during Phase 1.
+
+## ONNX export feasibility
+
+Command:
+
+```bash
+uv run optimum-cli export onnx \
+  --model Qwen/Qwen3-ASR-0.6B \
+  --task automatic-speech-recognition \
+  /tmp/qwen-asr-onnx-spike-fp32
+```
+
+Result: **failed**.
+
+Error:
+
+```text
+ValueError: The checkpoint you are trying to load has model type `qwen3_asr`
+but Transformers does not recognize this architecture.
+```
+
+Root cause:
+
+- `qwen_asr.inference.qwen3_asr` registers `qwen3_asr` with Transformers at import time:
+  - `AutoConfig.register("qwen3_asr", Qwen3ASRConfig)`
+  - `AutoModel.register(Qwen3ASRConfig, Qwen3ASRForConditionalGeneration)`
+  - `AutoProcessor.register(Qwen3ASRConfig, Qwen3ASRProcessor)`
+- The standalone `optimum-cli` path calls `AutoConfig.from_pretrained()` before importing
+  the `qwen_asr` package, so the architecture is unknown.
+
+After importing `qwen_asr.inference.qwen3_asr`, local Python can resolve the config and
+model mapping:
+
+```text
+Qwen3ASRConfig
+model_type=qwen3_asr
+AutoModel -> Qwen3ASRForConditionalGeneration
+```
+
+However, this does not make standard Optimum export automatically usable.
+
+## Custom export feasibility
+
+`Qwen3ASRForConditionalGeneration.forward` is not implemented as a normal model forward;
+the class inherits the default `_forward_unimplemented`.
+
+The inference path is:
+
+```python
+inputs = processor(text=sub_text, audio=sub_wavs, return_tensors="pt", padding=True)
+text_ids = model.generate(**inputs, max_new_tokens=max_new_tokens)
+decoded = processor.batch_decode(text_ids.sequences[:, inputs["input_ids"].shape[1]:])
+```
+
+This means Qwen3-ASR is a generation model, not a simple encoder-only ASR model. A
+production ONNX path would need to export and serve the autoregressive generation graph,
+including decoder cache handling. That is closer to building a custom Optimum ORT model
+integration than running a one-command export.
+
+INT4 quantization also depends on having a valid ONNX graph first. Since FP32 ONNX export
+did not succeed, INT4 was not attempted.
+
+## Local PyTorch baseline
+
+Sample:
+
+- `frontend/e2e/fixtures/voice/sample.wav`
+- sample rate: 16kHz
+- duration: 1.811s
+- expected transcript: "Tell me about Engineer Cafe."
+
+Command shape:
+
+```python
+model = Qwen3ASRModel.from_pretrained(
+    "Qwen/Qwen3-ASR-0.6B",
+    torch_dtype=torch.float32,
+    device_map="cpu",
+    low_cpu_mem_usage=True,
+    max_new_tokens=256,
+)
+model.transcribe(audio=(pcm, 16000), language="English")
+```
+
+Result on local Apple Silicon environment:
+
+| Metric | Result |
+| --- | ---: |
+| Model load | 5.348s |
+| Iteration 1 | 0.601s |
+| Iteration 2 | 0.490s |
+| Iteration 3 | 0.293s |
+| Iteration 4 | 0.294s |
+| Iteration 5 | 0.293s |
+| Warm p50 | 0.294s |
+| Max | 0.601s |
+| Transcript | `Tell me about Engineer Cafe.` |
+
+Interpretation:
+
+- Qwen3-ASR 0.6B PyTorch itself can be fast once warm.
+- The observed Cloud Run STT p50 around 4s is unlikely to be explained by Qwen PyTorch
+  inference alone.
+- The current `qwen-primary` implementation waits for Vosk as well as Qwen, so Vosk model
+  load / CPU contention can dominate latency even when Qwen succeeds quickly.
+
+## Live Piper Plus TTS -> STT accuracy check
+
+Command:
+
+```bash
+LIVE_BACKEND_URL=https://engineer-cafe-backend-639959525777.asia-northeast1.run.app \
+LIVE_BACKEND_API_KEY="$(gcloud secrets versions access latest \
+  --secret=API_SECRET_KEY --project=aipartner-426616)" \
+uv run pytest --run-e2e tests/e2e/test_stt_japanese_accuracy.py -v -m e2e --no-header
+```
+
+The test synthesizes Japanese audio through live `/api/voice` TTS, which uses Piper Plus
+in the current Cloud Run configuration, then sends that audio back through live STT.
+
+Per-sample result from the first parametrized pass:
+
+| Sample | Result | Observed transcript |
+| --- | --- | --- |
+| `proper_noun_cafe` | failed | `現地 に た` |
+| `coworking_katakana` | passed | n/a |
+| `business_hours` | passed | n/a |
+| `event_info` | passed | n/a |
+| `wifi_alphanumeric` | failed | `はい 日 の パスワード は あり ます か` |
+| `reception_procedure` | failed | `駆けつけました。ご確認ください。` |
+| `community_manager` | failed | `今年 に か な 姉 じゃあ に 澤田 し たい` |
+| `meeting_reserve` | failed | `エンジニアカフェは予約できますか？` |
+| `fukuoka_city` | passed | n/a |
+| `basement_space` | failed | `下の子は、エンジニアカフェ(Engineer Cafe)にいます。` |
+
+Effective first-pass accuracy: **4/10 = 40%**.
+
+The aggregate test then hit the existing `/api/voice` rate limit:
+
+```text
+429 {"error":"Rate limit exceeded: 20 per 1 minute"}
+```
+
+Interpretation:
+
+- The live Piper Plus round-trip currently exposes accuracy regressions independent of
+  ONNX speed work.
+- The aggregate test duplicates the 10 TTS+STT calls after the parametrized test, causing
+  20+ requests/minute and triggering the `/api/voice` rate limit. This validates follow-up
+  #502 as a real test-design issue.
+
+## Decision
+
+Do **not** proceed to Phase 2 ONNX/INT4 implementation yet.
+
+Reasons:
+
+1. Standard Optimum ONNX export fails because `qwen3_asr` is not registered unless the
+   `qwen_asr` package is imported first.
+2. The model does not expose a normal `forward`; inference is through `generate()`.
+   Custom ONNX export would require a non-trivial autoregressive generation integration.
+3. Local PyTorch warm inference is already sub-second on the sample fixture. That suggests
+   the current Cloud Run p50 is dominated by orchestration/fallback/postprocess behavior,
+   not purely by PyTorch compute.
+4. Live Piper Plus TTS -> STT accuracy is currently only 4/10 on the first pass, so
+   optimizing inference speed alone will not make the user-facing STT path alpha-ready.
+
+## Recommended next step
+
+Pivot #491 from "ONNX/INT4 first" to "remove avoidable qwen-primary latency and accuracy
+regression first":
+
+1. Change `qwen-primary` from `asyncio.gather()` to a safe winner-race:
+   - return Qwen immediately if it succeeds within timeout;
+   - keep Vosk only as fallback when Qwen fails or times out;
+   - do not wait for Vosk after Qwen success.
+2. Align post-processing flags:
+   - either set `STT_QWEN_POSTPROCESS_ENABLED=true` in Cloud Run, or make
+     `STT_LLM_POSTPROCESS=true` also enable Qwen success-path post-processing.
+3. Fix #502 before using the 10-sample live test as a release gate:
+   - avoid running the same 10 TTS+STT calls twice inside one minute;
+   - cache synthesized audio or make the aggregate test reuse per-sample results.
+4. Re-measure live STT p50/p95 after the race fix and post-process alignment.
+5. Revisit ONNX only if Qwen-only p50 remains above target.
+
+## Go / No-Go
+
+No-Go for ONNX/INT4 Phase 2 as scoped.
+
+Go for a smaller backend optimization spike:
+
+- implement qwen-primary winner-race behind a feature flag;
+- verify Piper Plus TTS -> STT accuracy after Qwen post-process alignment;
+- only then decide whether ONNX export is still needed.
+
+## Related
+
+- #491: Qwen3-ASR ONNX Runtime + INT4 quantization
+- #484: OSS release preparation
+- #502: STT test rate-limit follow-up
+- #480 / #499: STT post-process and live Japanese accuracy suite
+- #478 / #498: MP3 encoding event-loop blocker removal


### PR DESCRIPTION
## Summary
- Qwen3-ASR ONNX + INT4 量子化の Phase 1 spike 結果を ADR 010 として記録
- ONNX/INT4 は短期 No-Go と判定し、Cloud Run で効果が出る可能性が高い STT orchestration 改善へ pivot
- `qwen-primary` の Qwen/Vosk 並走処理を winner-race 化し、Qwen 成功時は Vosk fallback の完了を待たずに即返却
- Qwen timeout/error 時は、従来通り並走していた Vosk fallback に切り替え

## Background
Epic C-2 #491 の目標は STT p50 を 4.0s から 1.5s へ下げることです。Phase 1 では Qwen3-ASR-0.6B の ONNX/INT4 化を検証しましたが、`qwen3_asr` の Optimum export 非対応と `generate()` 前提モデル構造により、短期の ONNX/INT4 実装は現実的ではありませんでした。

一方、ローカル PyTorch warm 推論は p50 約 0.294s と十分速く、現行 Cloud Run の 4s 級遅延はモデル本体ではなく、Qwen 成功時にも Vosk fallback 完了を待つ `asyncio.gather()` 構造が主因候補です。

## Changes
- `docs/adr/010-qwen-onnx-quantization.md`
  - ONNX/INT4 spike 結果を日本語 ADR として追加
- `backend/agents/stt_agent.py`
  - Qwen と Vosk fallback を同時開始
  - Qwen 成功時は Vosk task を cancel/discard して即返却
  - Qwen timeout/error 時のみ Vosk fallback result を await
- `backend/tests/agents/test_stt_agent.py`
  - Qwen 成功時に slow Vosk を待たない regression test を追加

## Validation
- `uv run optimum-cli export onnx --model Qwen/Qwen3-ASR-0.6B --task automatic-speech-recognition /tmp/qwen-asr-onnx-spike-fp32`
  - 期待通り失敗。ADR に根拠を記録
- ローカル Qwen PyTorch 推論 5 回計測
  - warm p50 約 0.294s
- Piper Plus 実音声 E2E against deployed backend
  - 10 サンプル中 4 件合格
  - aggregate は 429 rate limit 到達
- `uv run pytest tests/agents/test_stt_agent.py::TestQwenPrimaryParallel -q`
  - 8 passed
- `uv run ruff check agents/stt_agent.py tests/agents/test_stt_agent.py`
  - All checks passed

## Expected production impact
Cloud Run 上で Qwen が正常成功するケースでは、Vosk fallback の完了待ち時間がレスポンスから外れます。モデル本体の warm 推論が十分速いことから、p50 STT latency の大幅改善が期待できます。

## Post-merge validation plan
1. PR merge 後、GitHub Actions の develop deploy 完了を確認
2. Cloud Run revision が更新されたことを確認
3. 内部 STT API で同一音声を 3-5 回測定
4. Piper Plus 実音声 E2E を再実行
5. p50/p95、transcript、429 発生有無を PR/Issue に記録

Refs #491
Refs #484
