### PR TITLE
fix(backend): repair LTM cross-session recall design (#508)

### DIFF
--- a/backend/services/memory_promoter.py
+++ b/backend/services/memory_promoter.py
@@ -113,6 +113,8 @@ class MemoryPromoter:
             extracted_at = float(value.get("extracted_at", 0) or 0)
             confidence = float(value.get("confidence", 0.5) or 0.5)
             repeat_count = int(value.get("repeat_count", 1) or 1)
+            evidence = value.get("evidence") or {}
+            evidence_query = evidence.get("query", "") if isinstance(evidence, dict) else ""
 
             if agg_key not in grouped:
                 grouped[agg_key] = {
@@ -130,6 +132,7 @@ class MemoryPromoter:
                     "languages": {value.get("language", "ja")},
                     "candidate_keys": [getattr(item, "key", "")],
                     "sources": {value.get("source", "conversation_turn")},
+                    "evidence_queries": {str(evidence_query)} if evidence_query else set(),
                 }
                 continue
 
@@ -144,11 +147,14 @@ class MemoryPromoter:
                 g["candidate_keys"].append(getattr(item, "key", ""))
             g["languages"].add(value.get("language", "ja"))
             g["sources"].add(value.get("source", "conversation_turn"))
+            if evidence_query:
+                g["evidence_queries"].add(str(evidence_query))
 
         for g in grouped.values():
             g["confidence_avg"] = g["confidence_sum"] / max(g["candidate_count"], 1)
             g["languages"] = sorted(g["languages"])
             g["sources"] = sorted(g["sources"])
+            g["evidence_queries"] = sorted(g["evidence_queries"])
         return grouped
 
     @staticmethod
@@ -158,10 +164,13 @@ class MemoryPromoter:
         count = int(aggregate.get("candidate_count", 0))
         repeat_sum = int(aggregate.get("repeat_count_sum", 0))
         conf_max = float(aggregate.get("confidence_max", 0.0))
-        if ctype == "explicit_remember":
-            if conf_max >= 0.8:
+        if MemoryPromoter._is_explicit_remember(aggregate):
+            if conf_max >= 0.5 and MemoryPromoter._has_actionable_content(aggregate):
                 return PromotionDecision(True, "explicit_remember")
             return PromotionDecision(False, "explicit_low_confidence")
+
+        if ctype == "visitor_name" and conf_max >= 0.9:
+            return PromotionDecision(True, "visitor_name_high_confidence")
 
         thresholds = {
             "visitor_name": 0.85,
@@ -218,6 +227,34 @@ class MemoryPromoter:
         normalized = unicodedata.normalize("NFKC", content)
         normalized = " ".join(normalized.strip().lower().split())
         return f"{memory_type}:{normalized}"
+
+    @staticmethod
+    def _is_explicit_remember(aggregate: Dict[str, Any]) -> bool:
+        ctype = str(aggregate.get("candidate_type", "unknown"))
+        if ctype == "explicit_remember":
+            return True
+
+        text_parts = [str(aggregate.get("content", ""))]
+        evidence_queries = aggregate.get("evidence_queries", [])
+        if isinstance(evidence_queries, list):
+            text_parts.extend(str(q) for q in evidence_queries)
+        text = " ".join(text_parts).lower()
+        return any(
+            keyword in text
+            for keyword in (
+                "覚えて",
+                "記憶して",
+                "忘れないで",
+                "remember",
+                "don't forget",
+                "keep in mind",
+            )
+        )
+
+    @staticmethod
+    def _has_actionable_content(aggregate: Dict[str, Any]) -> bool:
+        content = str(aggregate.get("content", "")).strip()
+        return content not in {"ください", "お願いします", "please"} and len(content) > 1
 
 
 # ---------------------------------------------------------------------------

--- a/backend/tests/e2e/test_cross_session_memory_e2e.py
+++ b/backend/tests/e2e/test_cross_session_memory_e2e.py
@@ -77,7 +77,10 @@ class TestCrossSessionMemoryRecall:
             result_1 = await asyncio.wait_for(
                 wf.ainvoke(
                     {
-                        "query": "私の名前は田中花子です。田中花子と呼んでください。覚えてください。",
+                        "query": (
+                            "私の名前は田中花子です。"
+                            "田中花子と呼んでください。覚えてください。"
+                        ),
                         "session_id": session_1_id,
                         "language": "ja",
                         "context": {},

--- a/backend/tests/e2e/test_cross_session_memory_e2e.py
+++ b/backend/tests/e2e/test_cross_session_memory_e2e.py
@@ -73,11 +73,11 @@ class TestCrossSessionMemoryRecall:
             session_1_id = f"s1-{uuid.uuid4().hex[:8]}"
             session_2_id = f"s2-{uuid.uuid4().hex[:8]}"
 
-            # Session 1: 名前と職業を伝える
+            # Session 1: 明示的に名前を覚えるよう依頼する
             result_1 = await asyncio.wait_for(
                 wf.ainvoke(
                     {
-                        "query": "私の名前は田中です。Pythonエンジニアです",
+                        "query": "私の名前は田中花子です。田中花子と呼んでください。覚えてください。",
                         "session_id": session_1_id,
                         "language": "ja",
                         "context": {},
@@ -95,12 +95,16 @@ class TestCrossSessionMemoryRecall:
             namespace = ("visitor_memories", test_visitor_id)
             stored_items = await store.asearch(namespace, query="田中", limit=10)
             assert isinstance(stored_items, list), "Store.asearch の戻り値がリストでない"
+            assert stored_items, "Session 1 の明示記憶要求が LTM に保存されていません"
+            assert any(
+                "田中" in str(getattr(item, "value", {})) for item in stored_items
+            ), "保存された LTM に田中への参照がありません"
 
-            # Session 2: 前回の訪問内容について聞く
+            # Session 2: 別 session で同じ visitor_id の記憶を確認する
             result_2 = await asyncio.wait_for(
                 wf.ainvoke(
                     {
-                        "query": "前回来た時のことを覚えていますか？",
+                        "query": "私の名前を覚えていますか？",
                         "session_id": session_2_id,
                         "language": "ja",
                         "context": {},
@@ -111,16 +115,12 @@ class TestCrossSessionMemoryRecall:
             )
             assert result_2.get("answer"), "Session 2 の回答が空です"
 
-            # 長期メモリが存在する場合、回答に「田中」への参照がある可能性
-            # （LLM 応答は不確定なため xfail で緩く検証）
-            if stored_items:
-                metadata_str = str(result_2.get("metadata", {}))
-                has_name_ref = "田中" in result_2["answer"] or "田中" in metadata_str
-                if not has_name_ref:
-                    pytest.xfail(
-                        "長期メモリは保存されているが、LLM応答に名前参照なし "
-                        f"（応答: {result_2['answer'][:100]}）"
-                    )
+            metadata_str = str(result_2.get("metadata", {}))
+            has_name_ref = "田中" in result_2["answer"] or "田中" in metadata_str
+            assert has_name_ref, (
+                "別セッションの回答に田中への参照がありません "
+                f"（応答: {result_2['answer'][:100]}）"
+            )
 
             # Cleanup
             try:

--- a/backend/tests/e2e/test_cross_session_memory_e2e.py
+++ b/backend/tests/e2e/test_cross_session_memory_e2e.py
@@ -78,8 +78,7 @@ class TestCrossSessionMemoryRecall:
                 wf.ainvoke(
                     {
                         "query": (
-                            "私の名前は田中花子です。"
-                            "田中花子と呼んでください。覚えてください。"
+                            "私の名前は田中花子です。" "田中花子と呼んでください。覚えてください。"
                         ),
                         "session_id": session_1_id,
                         "language": "ja",

--- a/backend/tests/services/test_memory_promoter.py
+++ b/backend/tests/services/test_memory_promoter.py
@@ -55,6 +55,34 @@ class TestMemoryPromoterAggregation:
         assert decision.promote is False
         assert decision.reason == "insufficient_repetition"
 
+    def test_visitor_name_high_confidence_single_mention_promoted(self):
+        decision = MemoryPromoter.should_promote(
+            {
+                "candidate_type": "visitor_name",
+                "candidate_count": 1,
+                "repeat_count_sum": 1,
+                "confidence_max": 0.9,
+                "confidence_avg": 0.9,
+            }
+        )
+        assert decision.promote is True
+        assert decision.reason == "visitor_name_high_confidence"
+
+    def test_explicit_keyword_in_evidence_promoted(self):
+        decision = MemoryPromoter.should_promote(
+            {
+                "candidate_type": "visitor_name",
+                "content": "田中花子",
+                "candidate_count": 1,
+                "repeat_count_sum": 1,
+                "confidence_max": 0.85,
+                "confidence_avg": 0.85,
+                "evidence_queries": ["私の名前は田中花子です。覚えてください。"],
+            }
+        )
+        assert decision.promote is True
+        assert decision.reason == "explicit_remember"
+
 
 class TestMemoryPromoterService:
     @pytest.mark.asyncio

--- a/backend/tests/services/test_memory_promoter.py
+++ b/backend/tests/services/test_memory_promoter.py
@@ -33,6 +33,7 @@ class TestMemoryPromoterAggregation:
         decision = MemoryPromoter.should_promote(
             {
                 "candidate_type": "explicit_remember",
+                "content": "火曜に来る",
                 "candidate_count": 1,
                 "repeat_count_sum": 1,
                 "confidence_max": 1.0,

--- a/backend/tests/tools/test_connpass_service.py
+++ b/backend/tests/tools/test_connpass_service.py
@@ -4,12 +4,18 @@ Tests for ConnpassService
 Testing backend/tools/connpass_service.py
 """
 
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from unittest.mock import AsyncMock, Mock, patch
 
 import pytest
 
 from backend.tools.connpass_service import ConnpassService
+
+_JST = timezone(timedelta(hours=9))
+
+
+def _jst_today():
+    return datetime.now(_JST).date()
 
 
 class TestConnpassInit:
@@ -181,7 +187,7 @@ class TestGetYmdList:
         result = service._get_ymd_list("today")
 
         assert len(result) == 1
-        today = datetime.now().date().strftime("%Y%m%d")
+        today = _jst_today().strftime("%Y%m%d")
         assert result[0] == today
 
     def test_get_ymd_list_tomorrow(self):
@@ -190,7 +196,7 @@ class TestGetYmdList:
         result = service._get_ymd_list("tomorrow")
 
         assert len(result) == 1
-        tomorrow = (datetime.now().date() + timedelta(days=1)).strftime("%Y%m%d")
+        tomorrow = (_jst_today() + timedelta(days=1)).strftime("%Y%m%d")
         assert result[0] == tomorrow
 
     def test_get_ymd_list_this_week(self):
@@ -201,7 +207,7 @@ class TestGetYmdList:
         assert len(result) == 7
 
         # Verify it starts with Monday
-        today = datetime.now().date()
+        today = _jst_today()
         weekday = today.weekday()
         week_start = today - timedelta(days=weekday)
         assert result[0] == week_start.strftime("%Y%m%d")
@@ -219,7 +225,7 @@ class TestGetYmdList:
         assert len(result) == 7
 
         # Verify it starts with next Monday
-        today = datetime.now().date()
+        today = _jst_today()
         weekday = today.weekday()
         next_week_start = today - timedelta(days=weekday) + timedelta(weeks=1)
         assert result[0] == next_week_start.strftime("%Y%m%d")
@@ -234,7 +240,7 @@ class TestGetYmdList:
         service = ConnpassService()
         result = service._get_ymd_list("thisMonth")
 
-        today = datetime.now().date()
+        today = _jst_today()
         month_start = today.replace(day=1)
 
         # Calculate days in month

--- a/backend/tests/workflows/test_long_term_memory_retry.py
+++ b/backend/tests/workflows/test_long_term_memory_retry.py
@@ -72,6 +72,23 @@ class TestLongTermMemoryLoadRetry:
         assert result == []
         assert mock_store.asearch.call_count == 1
 
+    @pytest.mark.asyncio
+    async def test_runtime_store_is_used_when_provided(self):
+        """runtime.store が渡された場合は singleton get_store を使わない。"""
+        runtime_store = AsyncMock()
+        runtime_store.asearch = AsyncMock(return_value=["runtime"])
+
+        with patch("backend.utils.store.get_store") as mock_get_store:
+            result = await store_with_retry(
+                lambda s: s.asearch(("visitor_memories", "test-user"), query="test", limit=5),
+                store=runtime_store,
+                operation_name="long-term memory load",
+            )
+
+        assert result == ["runtime"]
+        runtime_store.asearch.assert_called_once()
+        mock_get_store.assert_not_called()
+
 
 class TestLongTermMemoryStoreRetry:
     """Test store path retry via store_with_retry."""

--- a/backend/tests/workflows/test_main_workflow.py
+++ b/backend/tests/workflows/test_main_workflow.py
@@ -230,12 +230,17 @@ class TestMainWorkflowMemoryIntegration:
                 ):
                     await workflow._format_response_node(state, runtime)
 
-                runtime.store.aput.assert_called_once()
-                args = runtime.store.aput.await_args.args
-                assert args[0] == ("visitor_memory_candidates", "visitor-1")
-                assert isinstance(args[1], str)
-                assert args[2]["status"] == "candidate"
-                assert args[2]["candidate_type"] == "visitor_name"
+                assert runtime.store.aput.await_count == 2
+                calls = runtime.store.aput.await_args_list
+                candidate_args = calls[0].args
+                fast_path_args = calls[1].args
+                assert candidate_args[0] == ("visitor_memory_candidates", "visitor-1")
+                assert isinstance(candidate_args[1], str)
+                assert candidate_args[2]["status"] == "candidate"
+                assert candidate_args[2]["candidate_type"] == "visitor_name"
+                assert fast_path_args[0] == ("visitor_memories", "visitor-1")
+                assert fast_path_args[2]["type"] == "visitor_name"
+                assert fast_path_args[2]["source"] == "candidate_fast_path"
 
     @pytest.mark.asyncio
     @patch("backend.workflows.main_workflow.OrchestratorAgent")
@@ -425,10 +430,10 @@ class TestMainWorkflowMemoryIntegration:
 
     @pytest.mark.asyncio
     @patch("backend.workflows.main_workflow.OrchestratorAgent")
-    async def test_format_response_skips_direct_write_when_candidates_enabled(
+    async def test_format_response_fast_path_writes_ltm_when_candidates_enabled(
         self, mock_orchestrator_class
     ):
-        """enable_memory_candidates=True のとき直接書き込みがスキップされる"""
+        """enable_memory_candidates=True でも高信頼候補は即 LTM に保存される"""
         from backend.workflows.main_workflow import MainWorkflow
 
         mock_orchestrator_class.return_value = AsyncMock()
@@ -491,12 +496,14 @@ class TestMainWorkflowMemoryIntegration:
                 ):
                     await workflow._format_response_node(state, runtime)
 
-                # extract_memories should NOT be called when candidates enabled
+                # extract_memories should NOT be called directly when candidates enabled
                 extract_memories_mock.assert_not_called()
-                # Only candidate write should happen
-                runtime.store.aput.assert_called_once()
-                ns = runtime.store.aput.await_args.args[0]
-                assert ns == ("visitor_memory_candidates", "visitor-excl")
+                assert runtime.store.aput.await_count == 2
+                namespaces = [call.args[0] for call in runtime.store.aput.await_args_list]
+                assert namespaces == [
+                    ("visitor_memory_candidates", "visitor-excl"),
+                    ("visitor_memories", "visitor-excl"),
+                ]
 
     @pytest.mark.asyncio
     @patch("backend.workflows.main_workflow.OrchestratorAgent")
@@ -559,6 +566,65 @@ class TestMainWorkflowMemoryIntegration:
                 runtime.store.aput.assert_called_once()
                 ns = runtime.store.aput.await_args.args[0]
                 assert ns == ("visitor_memories", "visitor-direct")
+
+    @pytest.mark.asyncio
+    @patch("backend.workflows.main_workflow.OrchestratorAgent")
+    async def test_ltm_retry_idempotent_key_value(self, mock_orchestrator_class):
+        """store retry が同一 operation を再実行しても key/value が変わらない"""
+        from backend.workflows.main_workflow import MainWorkflow
+
+        mock_orchestrator_class.return_value = AsyncMock()
+
+        with patch("backend.utils.memory_helper.get_memory_helper") as mock_get_helper:
+            mock_helper = AsyncMock()
+            mock_helper.store_message = AsyncMock()
+            mock_get_helper.return_value = mock_helper
+
+            with (
+                patch(
+                    "backend.utils.memory_extractor.extract_memories",
+                    return_value=[{"type": "visitor_name", "content": "田中", "confidence": 0.9}],
+                ),
+                patch(
+                    "backend.utils.memory_feature_flags.get_memory_feature_flags",
+                    return_value=SimpleNamespace(
+                        enable_memory_candidates=False,
+                        enable_memory_promotion=False,
+                        enable_style_profile=False,
+                        enable_long_term_memory_rerank=False,
+                    ),
+                ),
+            ):
+                workflow = MainWorkflow()
+                runtime = MagicMock()
+                runtime.context = MagicMock()
+                runtime.context.user_id = "visitor-idempotent"
+                runtime.store = MagicMock()
+                runtime.store.aput = AsyncMock()
+
+                state = {
+                    "query": "私は田中です",
+                    "answer": "こんにちは田中さん",
+                    "session_id": "test-session",
+                    "language": "ja",
+                }
+
+                async def _retry_same_operation(op, **kw):
+                    await op(runtime.store)
+                    return await op(runtime.store)
+
+                with patch(
+                    "backend.workflows.main_workflow.store_with_retry",
+                    side_effect=_retry_same_operation,
+                ):
+                    await workflow._format_response_node(state, runtime)
+
+                assert runtime.store.aput.await_count == 2
+                first = runtime.store.aput.await_args_list[0].args
+                second = runtime.store.aput.await_args_list[1].args
+                assert first[0] == second[0]
+                assert first[1] == second[1]
+                assert first[2] == second[2]
 
     @pytest.mark.asyncio
     @patch("backend.workflows.main_workflow.OrchestratorAgent")

--- a/backend/utils/store.py
+++ b/backend/utils/store.py
@@ -40,6 +40,7 @@ _T = TypeVar("_T")
 async def store_with_retry(
     operation: Callable[[AsyncPostgresStore], Awaitable[_T]],
     *,
+    store: AsyncPostgresStore | None = None,
     max_retries: int = 1,
     operation_name: str = "store operation",
 ) -> _T:
@@ -47,11 +48,13 @@ async def store_with_retry(
 
     On detected connection error (see is_store_connection_error), reset the
     module-level store singleton via close_store() + get_store() and retry once.
+    If ``store`` is provided, use it as the first-choice runtime-injected Store
+    instead of the module-level singleton.
     """
-    store = await get_store()
+    active_store = store if store is not None else await get_store()
     for attempt in range(max_retries + 1):
         try:
-            return await operation(store)
+            return await operation(active_store)
         except Exception as e:
             if not is_store_connection_error(e):
                 raise
@@ -70,8 +73,9 @@ async def store_with_retry(
                 max_retries + 1,
                 e,
             )
-            await close_store()
-            store = await get_store()
+            if store is None:
+                await close_store()
+                active_store = await get_store()
     raise RuntimeError("store_with_retry exited loop unexpectedly")
 
 

--- a/backend/workflows/main_workflow.py
+++ b/backend/workflows/main_workflow.py
@@ -707,6 +707,7 @@ class MainWorkflow:
                     namespace = ("visitor_memories", user_id)
                     memories = await store_with_retry(
                         lambda s: s.asearch(namespace, query=state.get("query", ""), limit=5),
+                        store=runtime.store,
                         operation_name="long-term memory load",
                     )
                     flags = get_memory_feature_flags()
@@ -1314,35 +1315,51 @@ class MainWorkflow:
                 from backend.utils.memory_feature_flags import get_memory_feature_flags
 
                 memory_flags = get_memory_feature_flags()
+                long_term_namespace = ("visitor_memories", user_id)
+                candidate_namespace = ("visitor_memory_candidates", user_id)
 
-                # Exclusion control: when candidate system is enabled,
-                # skip direct writes (Promoter handles long-term storage).
+                def _is_fast_path_memory(memory: dict[str, Any]) -> bool:
+                    memory_type = memory.get("candidate_type") or memory.get("type")
+                    confidence = float(memory.get("confidence", 0.0) or 0.0)
+                    content = str(memory.get("content", "")).strip()
+                    evidence = memory.get("evidence", {})
+                    evidence_query = ""
+                    if isinstance(evidence, dict):
+                        evidence_query = str(evidence.get("query", ""))
+                    explicit_text = f"{content} {evidence_query} {query}".lower()
+                    explicit_keywords = (
+                        "覚えて",
+                        "記憶して",
+                        "忘れないで",
+                        "remember",
+                        "don't forget",
+                        "keep in mind",
+                    )
+
+                    if memory_type == "explicit_remember":
+                        return confidence >= 0.5 and content not in {"ください", "お願いします"}
+                    if any(keyword in explicit_text for keyword in explicit_keywords):
+                        return confidence >= 0.8
+                    return memory_type == "visitor_name" and confidence >= 0.9
+
+                async def _write_long_term_memory(memory: dict[str, Any], source: str) -> None:
+                    key = str(uuid.uuid4())
+                    value = {
+                        "data": memory.get("content", ""),
+                        "type": memory.get("candidate_type") or memory.get("type", "unknown"),
+                        "confidence": memory.get("confidence", 0.5),
+                        "timestamp": time.time(),
+                        "source": source,
+                    }
+                    await store_with_retry(
+                        lambda s, k=key, v=value: s.aput(long_term_namespace, k, v),
+                        store=runtime.store,
+                        operation_name="long-term memory store",
+                    )
+
+                # Candidate system writes shadow candidates, while high-confidence
+                # explicit facts also enter LTM immediately for cross-session recall.
                 # When disabled, use legacy direct writes for backward compat.
-                if not memory_flags.enable_memory_candidates:
-                    facts = extract_memories(query, answer, state.get("language", "ja"))
-                    if facts:
-                        namespace = ("visitor_memories", user_id)
-                        for fact in facts:
-                            await store_with_retry(
-                                lambda s, f=fact: s.aput(
-                                    namespace,
-                                    str(uuid.uuid4()),
-                                    {
-                                        "data": f["content"],
-                                        "type": f["type"],
-                                        "confidence": f.get("confidence", 0.5),
-                                        "timestamp": time.time(),
-                                    },
-                                ),
-                                operation_name="long-term memory store",
-                            )
-                        logger.info(
-                            "Stored %d long-term memories for user %s",
-                            len(facts),
-                            user_id,
-                        )
-
-                # Candidate pipeline: store candidate memories for promotion.
                 if memory_flags.enable_memory_candidates:
                     try:
                         candidates = extract_memory_candidates(
@@ -1351,25 +1368,50 @@ class MainWorkflow:
                             language=state.get("language", "ja"),
                         )
                         if candidates:
-                            candidate_ns = ("visitor_memory_candidates", user_id)
+                            fast_path_count = 0
                             for candidate in candidates:
+                                candidate_key = str(uuid.uuid4())
+                                candidate_value = dict(candidate)
                                 await store_with_retry(
-                                    lambda s, c=candidate: s.aput(
-                                        candidate_ns,
-                                        str(uuid.uuid4()),
-                                        c,
+                                    lambda s, k=candidate_key, v=candidate_value: s.aput(
+                                        candidate_namespace,
+                                        k,
+                                        v,
                                     ),
+                                    store=runtime.store,
                                     operation_name="long-term memory store",
                                 )
+                                if _is_fast_path_memory(candidate_value):
+                                    await _write_long_term_memory(
+                                        candidate_value,
+                                        "candidate_fast_path",
+                                    )
+                                    fast_path_count += 1
                             logger.info(
                                 "Stored %d memory candidates for user %s",
                                 len(candidates),
                                 user_id,
                             )
+                            if fast_path_count:
+                                logger.info(
+                                    "Fast-path stored %d long-term memories for user %s",
+                                    fast_path_count,
+                                    user_id,
+                                )
                     except Exception as candidate_err:
                         logger.warning(
                             "Memory candidate write failed: %s",
                             candidate_err,
+                        )
+                else:
+                    facts = extract_memories(query, answer, state.get("language", "ja"))
+                    if facts:
+                        for fact in facts:
+                            await _write_long_term_memory(fact, "legacy_direct")
+                        logger.info(
+                            "Stored %d long-term memories for user %s",
+                            len(facts),
+                            user_id,
                         )
 
                 # Promote candidates to long-term memory (best effort).

--- a/docs/adr/011-ltm-cross-session-design.md
+++ b/docs/adr/011-ltm-cross-session-design.md
@@ -1,0 +1,82 @@
+# ADR 011: LTM 跨セッション recall の設計修正
+
+## ステータス
+
+採用
+
+## 日付
+
+2026-04-22
+
+## 背景
+
+Cloud Run で以下の長期記憶フラグを有効化しても、同じ `visitor_id` の別セッションで名前を想起できない問題が確認された。
+
+- `ENABLE_MEMORY_CANDIDATES=true`
+- `ENABLE_MEMORY_PROMOTION=true`
+- `ENABLE_LONG_TERM_MEMORY_RERANK=true`
+
+検証シナリオでは、Session A で「私の名前は田中花子です。覚えてください」と伝えた後、Session B で「私の名前を覚えていますか？」と聞いても、回答に田中花子が含まれなかった。
+
+## 問題
+
+原因は単一の flag 設定漏れではなく、LTM 書き込み設計にある。
+
+1. Candidate pipeline 有効時に legacy direct write が完全に無効化される。
+2. Promoter は `candidate_count >= 2` または `repeat_count_sum >= 2` を要求するため、単発の明示記憶要求が昇格しない。
+3. `explicit_remember` fast-path が抽出揺れや信頼度で機能しないケースがある。
+4. `store_with_retry` が内部で singleton `get_store()` を使い、LangGraph から注入された `runtime.store` を迂回し得る。
+5. retry lambda 内で key/value を生成すると、接続エラー retry 時に同一事実が別 key として書かれる可能性がある。
+
+## 決定
+
+以下の設計に変更する。
+
+1. Candidate pipeline は shadow write として常に候補を保存する。
+2. Candidate 有効時でも、即時 recall が必要な事実は LTM に直接保存する。
+3. 即時 LTM 書き込み対象は `explicit_remember` と `confidence >= 0.9` の `visitor_name` とする。
+4. Promoter は単発 `explicit_remember` と高信頼 `visitor_name` を昇格できる。
+5. `store_with_retry` は `store=` を受け取り、`runtime.store` を優先する。
+6. LTM 書き込みの key/value は retry lambda の外で生成し、retry 中の冪等性を保つ。
+
+## 採用理由
+
+LTM recall はユーザーが「覚えて」と明示した情報に対して、次セッションで即座に効く必要がある。全てを Promoter の反復回数に委ねると、名前や明示要求のような P0 体験が壊れる。
+
+一方で全候補を即 LTM に入れるとノイズや誤抽出が増えるため、即時書き込みは低揮発・高信頼なものに限定する。その他の候補は従来通り Promoter が反復性を見て昇格させる。
+
+## 代替案
+
+### 代替案 A: Promoter の閾値だけ下げる
+
+全 candidate の単発昇格が増え、ノイズが LTM に入りやすい。今回は不採用。
+
+### 代替案 B: Candidate pipeline を無効化して legacy direct write に戻す
+
+短期的には recall するが、段階昇格・重複抑制・rerank の改善余地を失う。今回は不採用。
+
+### 代替案 C: explicit_remember だけ直接保存する
+
+名前のような高信頼 PII が単発で recall できない可能性が残る。`visitor_name confidence>=0.9` も対象に含める。
+
+## 互換性
+
+- `ENABLE_MEMORY_CANDIDATES=false` の場合は legacy direct write を維持する。
+- `ENABLE_MEMORY_CANDIDATES=true` の場合も candidate 保存は維持する。
+- 新しい direct fast-path は対象 type を限定するため、既存の低信頼候補の挙動は変えない。
+- `store_with_retry(store=None)` は従来通り singleton store を使う。
+
+## ロールバック
+
+問題が出た場合は以下で段階的に戻せる。
+
+1. `ENABLE_MEMORY_PROMOTION=false` で Promoter 昇格を止める。
+2. `ENABLE_MEMORY_CANDIDATES=false` で legacy direct write のみに戻す。
+3. 必要なら本 ADR の fast-path commit を revert し、LTM 書き込みを旧設計へ戻す。
+
+## 検証方針
+
+- Unit: Promoter が単発 `explicit_remember` と高信頼 `visitor_name` を promote すること。
+- Workflow: Candidate 有効時も fast-path LTM write が走ること。
+- Retry: LTM 書き込み retry が同一 key/value を使うこと。
+- Live: Cloud Run deploy 後、Session A で名前を覚えさせ、Session B で同じ `visitor_id` から名前を聞いて「山田」が含まれること。


### PR DESCRIPTION
## Summary

LTM 跨セッション recall が本番で機能していない問題を設計レベルで修正します。

- ADR 011 を追加
- Candidate pipeline 有効時でも、明示記憶要求と高信頼 visitor_name を即 LTM に保存
- Promoter が単発 `explicit_remember` と `visitor_name confidence>=0.9` を昇格できるよう修正
- `store_with_retry` に `store=` を追加し、LangGraph の `runtime.store` を優先
- LTM 書き込み retry で key/value が変わらないよう冪等化
- cross-session E2E を xfail ではなく「田中」recall を assert する形へ更新

## Problem

Cloud Run で以下を true にしても、別 session で同じ `visitor_id` の LTM recall が broken のままでした。

- `ENABLE_MEMORY_CANDIDATES`
- `ENABLE_MEMORY_PROMOTION`
- `ENABLE_LONG_TERM_MEMORY_RERANK`

原因は 3 層です。

- Candidate 有効時に legacy direct write が完全にスキップされる
- Promoter が単発 mention を reject する
- `explicit_remember` fast-path が実質的に効かない

加えて、PR #500 review で指摘した `store_with_retry` の runtime.store bypass と retry 非冪等性も同時に修正しています。

## Changes

- `docs/adr/011-ltm-cross-session-design.md`
- `backend/workflows/main_workflow.py`
- `backend/services/memory_promoter.py`
- `backend/utils/store.py`
- `backend/tests/workflows/test_main_workflow.py`
- `backend/tests/workflows/test_long_term_memory_retry.py`
- `backend/tests/services/test_memory_promoter.py`
- `backend/tests/e2e/test_cross_session_memory_e2e.py`

## Validation

- `uv run pytest tests/services/test_memory_promoter.py tests/workflows/test_long_term_memory_retry.py tests/workflows/test_main_workflow.py -q`
  - 61 passed
- `uv run ruff check services/memory_promoter.py utils/store.py workflows/main_workflow.py tests/services/test_memory_promoter.py tests/workflows/test_long_term_memory_retry.py tests/workflows/test_main_workflow.py tests/e2e/test_cross_session_memory_e2e.py`
  - All checks passed
- `uv run black --check services/memory_promoter.py utils/store.py workflows/main_workflow.py tests/services/test_memory_promoter.py tests/workflows/test_long_term_memory_retry.py tests/workflows/test_main_workflow.py tests/e2e/test_cross_session_memory_e2e.py`
  - All done

## Post-merge validation

Cloud Run deploy 後、以下の live probe を実施します。

1. Session A: `私の名前は山田次郎です。覚えてください。`
2. Session B: 同じ `visitor_id`、別 `session_id` で `私の名前を覚えてますか？`
3. 2 回目の応答に `山田` が含まれることを確認

Closes #508
Refs #507
