### PR TITLE
feat(knowledge): add content_en to top 10 KB entries for direct English RAG (#512)

### DIFF
--- a/backend/knowledge/data/community.yaml
+++ b/backend/knowledge/data/community.yaml
@@ -15,6 +15,14 @@ entries:
       「未経験からエンジニアになりたい社会人のためのスキルチェンジ相談会」も定期開催。
       コミュニティの構築・運営支援。エンジニア同士の交流促進・橋渡し。
       イベントの企画・運営サポート。技術的な相談にも対応可能です。
+    content_en: >
+      Multiple Community Managers (CMs) are stationed at Engineer Cafe.
+      They are present daily from around midday, supporting visitors through communication.
+      Consultation hours: 1:00 PM to 9:00 PM. No reservation needed; feel free to approach them.
+      Online consultations are also available.
+      Services: Maker and career advice, engineering career change support,
+      regular skill-change consultation events for working adults,
+      community building and networking facilitation, event planning support, and technical consultations.
     category: "consultation"
     tags: ["consultation", "career", "support", "engineer-cafe"]
     priority: 90

--- a/backend/knowledge/data/events.yaml
+++ b/backend/knowledge/data/events.yaml
@@ -30,6 +30,14 @@ entries:
       【参加方法】Connpassの場合はアカウント登録後、各イベントページから「参加する」ボタンで申し込みできます。
       参加費無料のイベントがほとんどです。定員がある場合は先着順が多いため、早めの申込をおすすめします。
       イベント当日は1階受付で利用登録（初回のみ）を行い、イベント参加者であることを伝えてください。
+    content_en: >
+      How to join events at Engineer Cafe.
+      Connpass: https://engineercafe.connpass.com/ (event list and registration).
+      Official events page: https://engineercafe.jp/ja/event (Engineer Cafe hosted/co-hosted events).
+      Official site: https://site.engineercafe.jp/ (facility-wide information and news).
+      Registration: Create a Connpass account, then click the "Join" button on each event page.
+      Most events are free. Capacity-limited events are first-come-first-served, so register early.
+      On the day: Complete first-time registration at the 1F reception and mention your event participation.
     category: "event"
     tags: ["event", "connpass", "registration", "engineer-cafe"]
     priority: 90

--- a/backend/knowledge/data/facilities.yaml
+++ b/backend/knowledge/data/facilities.yaml
@@ -14,6 +14,14 @@ entries:
       HHKBタッチ＆トライスポットも設置されており、自由に試用できます。
       これらの機材は通常イベントで使用しますが、コミュニティマネージャー同席のもと個別体験も可能です。
       電話、会話、オンラインミーティングが可能なオープンスペースです。
+    content_en: >
+      The 1F Main Hall serves as both an event space and a coworking area.
+      Events take priority; when no events are scheduled, it is open for coworking.
+      30 free seats with free Wi-Fi and power strips at every seat.
+      4K monitor rental and engineering book library available.
+      Latest tech: Apple Vision Pro, Meta Quest, mocopi motion capture, Tello drone, HHKB try station.
+      Equipment is typically used at events but individual demos may be possible with a Community Manager.
+      Phone calls, conversations, and online meetings are allowed in this open space.
     category: "facility-info"
     tags: ["main-hall", "coworking", "1f", "engineer-cafe"]
     priority: 90
@@ -37,6 +45,18 @@ entries:
       同一機材の予約は1人1件までです（利用前に別枠を予約すると先の予約がキャンセルされます。異なる機材の予約は重複可能）。
       【材料】材料は原則持ち込み制です。ただし3Dプリンターのフィラメントは持ち込み禁止で、使用分を買い取り方式で精算します。
       当日は1階受付で利用登録が必要です。予約時間を15分過ぎても来場がない場合は予約取り消しとなります。
+    content_en: >
+      The B1F MAKER's Space is a digital fabrication workshop.
+      8 seats, available 9:30 AM - 9:30 PM. Equipment use is free; 3D printer filament is paid.
+      Equipment: Laser cutter (trotec speedy100 C30), 3D printer (Bambu Lab P1S),
+      soldering iron, drill press, acrylic heater, oscilloscope, metal bender, band saw, and more.
+      First-time training (approx. 1 hour, free) is required for laser cutter and 3D printer.
+      Training requires advance booking via the official web page.
+      After training, equipment is free to use with reservation priority.
+      Bookings via: https://select-type.com/rsv/?id=K8t7W9WWRbc (up to the day before).
+      Materials: Bring your own. 3D printer filament must be purchased on-site (no outside filament).
+      Registration at 1F reception required on the day of use.
+      Reservations are cancelled if you are more than 15 minutes late.
     category: "facility-info"
     tags: ["makers-space", "fabrication", "b1f", "laser", "3d-printer", "engineer-cafe"]
     priority: 90
@@ -119,6 +139,15 @@ entries:
       【電源】各席に電源タップを設置しています（テラスを除く）。
       大規模イベントでも電源容量は十分に確保されています（50人規模のイベント実績あり）。
       cafe&bar sainoのカウンター席にもコンセントがあります。
+    content_en: >
+      Free Wi-Fi is available throughout Engineer Cafe.
+      SSID: engnecf-guest-2.4GHz or engnecf-guest-5GHz.
+      Password: akarenga-112years (also printed on the back of the reception card).
+      The 5GHz band provides high-speed connectivity. Coverage includes the terrace.
+      For large events (50+ people), simultaneous connections may cause instability.
+      A dedicated event Wi-Fi is available; ask staff when hosting events.
+      Power outlets are available at every seat (except the terrace).
+      cafe&bar saino counter seats also have power outlets.
     category: "facility-info"
     tags: ["wifi", "power", "internet", "engineer-cafe"]
     priority: 90

--- a/backend/knowledge/data/general.yaml
+++ b/backend/knowledge/data/general.yaml
@@ -27,6 +27,12 @@ entries:
       コミュニティマネージャーへの相談受付時間は13:00〜21:00です。
       休館日は毎月最終月曜日（祝休日のときは翌平日）と、12月29日〜1月3日です。
       ゴールデンウィーク・お盆期間は通常通り開館しますが、特別告知がある場合はX(@EngineerCafeJP)で案内されます。
+    content_en: >
+      Engineer Cafe is open from 9:00 AM to 10:00 PM.
+      Community Manager consultation hours are 1:00 PM to 9:00 PM.
+      Closed on the last Monday of each month (or the next weekday if it falls on a holiday),
+      and December 29 through January 3.
+      Open during Golden Week and Obon as usual, but check X(@EngineerCafeJP) for special announcements.
     category: "hours"
     tags: ["hours", "schedule", "engineer-cafe"]
     priority: 90
@@ -48,6 +54,17 @@ entries:
       【2回目以降】会員番号を伝え、利用スペースを申告し、受付カードを受け取ります。
       退館時に受付カードを受付に返却してください。
       【利用制限】イベント開催も無料ですが、企業広告やヘッドハンティング目的など公共性にそぐわない利用は不可です。
+    content_en: >
+      Engineer Cafe is a public-private project under Fukuoka's "Engineer Friendly City" initiative.
+      It is open to working engineers, aspiring engineers, and anyone in engineering-related fields.
+      Facility and equipment use is free. Only cafe&bar saino food/drinks and 3D printer filament are paid.
+      First-time registration: Complete a form at reception (5-10 min, free, no ID required).
+      You will receive a briefing on facility rules (food policy, quiet zones, 15-min seat policy).
+      Registration is in-person only; no online pre-registration available.
+      No age limit, but you must be able to use the facility safely on your own.
+      Returning visitors: Give your member number, declare your space, and take a reception card.
+      Return the card at reception when leaving.
+      Events are also free, but commercial advertising and headhunting activities are not permitted.
     category: "pricing"
     tags: ["pricing", "registration", "free", "engineer-cafe"]
     priority: 90
@@ -63,6 +80,13 @@ entries:
       地下鉄空港線「天神駅」から徒歩5分、西鉄バス「天神4丁目」下車すぐです。
       専用の駐車場・駐輪場はありません。近隣のコインパーキングや公共駐輪場をご利用ください。
       公共交通機関でのお越しをおすすめします。
+    content_en: >
+      Engineer Cafe is located at 1-15-30 Tenjin, Chuo-ku, Fukuoka,
+      inside the Fukuoka City Akarenga Bunka-kan (Red-Brick Culture Hall).
+      5-minute walk from Tenjin Station (Fukuoka City Subway Kuko Line).
+      Right outside Nishitetsu Bus "Tenjin 4-chome" stop.
+      No dedicated parking or bicycle parking. Please use nearby coin parking lots and public bicycle parking.
+      Public transportation is recommended.
     category: "access"
     tags: ["access", "location", "address", "engineer-cafe"]
     priority: 90
@@ -78,6 +102,12 @@ entries:
       公式サイト: https://engineercafe.jp/
       お問い合わせフォーム: https://engineercafe.jp/ja/contact
       イベント情報（connpass）: https://engineercafe.connpass.com/
+    content_en: >
+      Phone: 080-6742-7231 (consultation hours 1:00 PM - 9:00 PM).
+      2F Meeting Rooms (managed by Akarenga Bunka-kan): 092-722-4666.
+      Official website: https://engineercafe.jp/
+      Contact form: https://engineercafe.jp/ja/contact
+      Events (connpass): https://engineercafe.connpass.com/
     category: "contact"
     tags: ["contact", "phone", "website", "engineer-cafe"]
     priority: 60

--- a/backend/knowledge/data/policies.yaml
+++ b/backend/knowledge/data/policies.yaml
@@ -37,6 +37,9 @@ entries:
     content: >
       エンジニアカフェには専用駐車場はありません。
       近隣のコインパーキングをご利用ください。公共交通機関でのお越しをおすすめします。
+    content_en: >
+      Engineer Cafe does not have dedicated parking.
+      Please use nearby coin parking lots. Public transportation is recommended.
     category: "parking"
     tags: ["parking", "access", "engineer-cafe"]
     priority: 60

--- a/backend/knowledge/loader.py
+++ b/backend/knowledge/loader.py
@@ -208,13 +208,75 @@ def _apply_overlap(chunks: list[str], overlap_tokens: int) -> list[str]:
     return result
 
 
-def _build_metadata(entry: KnowledgeEntry) -> dict[str, Any]:
+def _build_metadata(entry: KnowledgeEntry, language: str = "ja") -> dict[str, Any]:
     """Build a *fresh* metadata dict for a chunk derived from *entry*."""
     return {
         "tags": list(entry.tags),
         "priority": entry.priority,
         "verified": entry.verified,
+        "language": language,
     }
+
+
+def _chunk_english_content(
+    entry: KnowledgeEntry,
+    strategy: ChunkingStrategy,
+) -> list[KnowledgeChunk]:
+    """Generate English-language chunks from content_en if present."""
+    if not entry.content_en:
+        return []
+
+    en_title = entry.title_en or f"{entry.title} (English)"
+    token_total = count_tokens(entry.content_en)
+
+    if token_total <= strategy.max_tokens:
+        return [
+            KnowledgeChunk(
+                entry_id=f"{entry.id}-en",
+                chunk_level="document",
+                chunk_index=0,
+                title=en_title,
+                content=entry.content_en,
+                token_count=token_total,
+                category=entry.category,
+                metadata=_build_metadata(entry, language="en"),
+            )
+        ]
+
+    summary = entry.content_en[:200].rstrip() + "..."
+    chunks: list[KnowledgeChunk] = [
+        KnowledgeChunk(
+            entry_id=f"{entry.id}-en",
+            chunk_level="document",
+            chunk_index=0,
+            title=en_title,
+            content=summary,
+            token_count=count_tokens(summary),
+            category=entry.category,
+            metadata=_build_metadata(entry, language="en"),
+        )
+    ]
+
+    merged = _split_and_merge(entry.content_en, strategy)
+    child_index = 1
+    for text in merged:
+        tc = count_tokens(text)
+        if tc < strategy.min_chunk_tokens:
+            continue
+        chunks.append(
+            KnowledgeChunk(
+                entry_id=f"{entry.id}-en",
+                chunk_level="chunk",
+                chunk_index=child_index,
+                title=en_title,
+                content=text,
+                token_count=tc,
+                category=entry.category,
+                metadata=_build_metadata(entry, language="en"),
+            )
+        )
+        child_index += 1
+    return chunks
 
 
 def _split_and_merge(content: str, strategy: ChunkingStrategy) -> list[str]:
@@ -324,7 +386,7 @@ def chunk_entry(
 
     # Small entry -> single document-level chunk
     if token_total <= strategy.max_tokens:
-        return [
+        chunks = [
             KnowledgeChunk(
                 entry_id=entry.id,
                 chunk_level="document",
@@ -336,11 +398,15 @@ def chunk_entry(
                 metadata=_build_metadata(entry),
             )
         ]
+        chunks.extend(_chunk_english_content(entry, strategy))
+        return chunks
 
     # Check for section headings in large entries
     sections = _split_into_sections(entry.content)
     if sections:
-        return _chunk_with_sections(entry, sections, strategy)
+        chunks = _chunk_with_sections(entry, sections, strategy)
+        chunks.extend(_chunk_english_content(entry, strategy))
+        return chunks
 
     # Large entry -> parent document + child chunks
     summary = entry.content[:200].rstrip() + "..."
@@ -362,7 +428,7 @@ def chunk_entry(
     for text in merged:
         tc = count_tokens(text)
         if tc < strategy.min_chunk_tokens:
-            continue  # Skip too-small standalone chunks
+            continue
         chunks.append(
             KnowledgeChunk(
                 entry_id=entry.id,
@@ -377,6 +443,7 @@ def chunk_entry(
         )
         child_index += 1
 
+    chunks.extend(_chunk_english_content(entry, strategy))
     return chunks
 
 

--- a/backend/tests/tools/test_enhanced_rag_i18n.py
+++ b/backend/tests/tools/test_enhanced_rag_i18n.py
@@ -1,0 +1,232 @@
+"""Tests for multilingual content_en support in knowledge loader and RAG.
+
+Validates:
+1. YAML entries with content_en load correctly via schema
+2. chunk_entry() produces separate English chunks
+3. English chunks have correct metadata (language='en')
+4. English and Japanese chunks have distinct entry_ids
+"""
+
+import pytest
+
+from backend.knowledge.loader import (
+    ChunkingStrategy,
+    _build_metadata,
+    _chunk_english_content,
+    chunk_entry,
+)
+from backend.knowledge.schema import KnowledgeEntry
+
+
+@pytest.fixture
+def ja_only_entry():
+    return KnowledgeEntry(
+        id="test-ja-only",
+        title="テストエントリ",
+        content="これは日本語のコンテンツです。テスト用のエントリです。",
+        category="general",
+        tags=["test"],
+        priority=50,
+        source="test",
+        verified=True,
+    )
+
+
+@pytest.fixture
+def bilingual_entry():
+    return KnowledgeEntry(
+        id="test-bilingual",
+        title="テストエントリ",
+        title_en="Test Entry",
+        content="これは日本語のコンテンツです。テスト用のエントリです。エンジニアカフェのテストです。",
+        content_en="This is English content for testing. Engineer Cafe test entry.",
+        category="general",
+        tags=["test"],
+        priority=50,
+        source="test",
+        verified=True,
+    )
+
+
+@pytest.fixture
+def large_bilingual_entry():
+    ja_content = "エンジニアカフェのテストです。" * 50
+    en_content = "Engineer Cafe test content for chunking. " * 80
+    return KnowledgeEntry(
+        id="test-large-bilingual",
+        title="大きなテストエントリ",
+        title_en="Large Test Entry",
+        content=ja_content,
+        content_en=en_content,
+        category="general",
+        tags=["test"],
+        priority=50,
+        source="test",
+        verified=True,
+    )
+
+
+class TestContentEnSchema:
+    def test_entry_without_content_en(self, ja_only_entry):
+        assert ja_only_entry.content_en is None
+
+    def test_entry_with_content_en(self, bilingual_entry):
+        assert bilingual_entry.content_en is not None
+        assert "English" in bilingual_entry.content_en
+
+    def test_content_en_none_by_default(self):
+        entry = KnowledgeEntry(
+            id="test-default", title="Test", content="Content", category="general"
+        )
+        assert entry.content_en is None
+
+
+class TestBuildMetadata:
+    def test_default_language_is_ja(self, ja_only_entry):
+        meta = _build_metadata(ja_only_entry)
+        assert meta["language"] == "ja"
+
+    def test_explicit_en_language(self, bilingual_entry):
+        meta = _build_metadata(bilingual_entry, language="en")
+        assert meta["language"] == "en"
+
+    def test_metadata_preserves_tags(self, bilingual_entry):
+        meta = _build_metadata(bilingual_entry, language="en")
+        assert meta["tags"] == ["test"]
+        assert meta["priority"] == 50
+        assert meta["verified"] is True
+
+
+class TestChunkEnglishContent:
+    def test_no_english_chunks_without_content_en(self, ja_only_entry):
+        chunks = _chunk_english_content(ja_only_entry, ChunkingStrategy())
+        assert len(chunks) == 0
+
+    def test_produces_english_chunks(self, bilingual_entry):
+        chunks = _chunk_english_content(bilingual_entry, ChunkingStrategy())
+        assert len(chunks) >= 1
+        assert all(c.metadata["language"] == "en" for c in chunks)
+
+    def test_english_chunk_entry_id_suffix(self, bilingual_entry):
+        chunks = _chunk_english_content(bilingual_entry, ChunkingStrategy())
+        assert all(c.entry_id.endswith("-en") for c in chunks)
+
+    def test_english_chunk_uses_title_en(self, bilingual_entry):
+        chunks = _chunk_english_content(bilingual_entry, ChunkingStrategy())
+        assert chunks[0].title == "Test Entry"
+
+    def test_english_chunk_fallback_title(self):
+        entry = KnowledgeEntry(
+            id="test-no-title-en",
+            title="テスト",
+            content="日本語コンテンツ",
+            content_en="English content here.",
+            category="general",
+        )
+        chunks = _chunk_english_content(entry, ChunkingStrategy())
+        assert chunks[0].title == "テスト (English)"
+
+    def test_large_english_content_produces_multiple_chunks(self, large_bilingual_entry):
+        chunks = _chunk_english_content(large_bilingual_entry, ChunkingStrategy())
+        assert len(chunks) >= 2
+        doc_chunks = [c for c in chunks if c.chunk_level == "document"]
+        assert len(doc_chunks) >= 1
+
+
+class TestChunkEntryBilingual:
+    def test_bilingual_produces_both_languages(self, bilingual_entry):
+        chunks = chunk_entry(bilingual_entry)
+        ja_chunks = [c for c in chunks if c.metadata.get("language") == "ja"]
+        en_chunks = [c for c in chunks if c.metadata.get("language") == "en"]
+        assert len(ja_chunks) >= 1
+        assert len(en_chunks) >= 1
+
+    def test_ja_only_produces_only_ja_chunks(self, ja_only_entry):
+        chunks = chunk_entry(ja_only_entry)
+        languages = {c.metadata.get("language") for c in chunks}
+        assert languages == {"ja"}
+
+    def test_ja_chunks_use_original_id(self, bilingual_entry):
+        chunks = chunk_entry(bilingual_entry)
+        ja_chunks = [c for c in chunks if c.metadata.get("language") == "ja"]
+        assert all(c.entry_id == "test-bilingual" for c in ja_chunks)
+
+    def test_en_chunks_use_suffixed_id(self, bilingual_entry):
+        chunks = chunk_entry(bilingual_entry)
+        en_chunks = [c for c in chunks if c.metadata.get("language") == "en"]
+        assert all(c.entry_id == "test-bilingual-en" for c in en_chunks)
+
+    def test_total_chunk_count_increases(self, bilingual_entry):
+        ja_only = KnowledgeEntry(
+            id="test-ja", title="テスト", content=bilingual_entry.content, category="general"
+        )
+        ja_chunks = chunk_entry(ja_only)
+        bi_chunks = chunk_entry(bilingual_entry)
+        assert len(bi_chunks) > len(ja_chunks)
+
+
+class TestYAMLLoadingWithContentEn:
+    def _load_all_entries(self):
+        from pathlib import Path
+
+        from backend.knowledge.loader import load_all_yaml_files
+
+        data_dir = Path(__file__).parent.parent.parent / "knowledge" / "data"
+        sections = load_all_yaml_files(data_dir)
+        entries = []
+        for section in sections:
+            entries.extend(section.entries)
+        return entries
+
+    def test_at_least_10_entries_have_content_en(self):
+        entries = self._load_all_entries()
+        entries_with_en = [e for e in entries if e.content_en is not None]
+        assert len(entries_with_en) >= 10
+
+    def test_general_hours_has_english(self):
+        for e in self._load_all_entries():
+            if e.id == "general-hours":
+                assert e.content_en is not None
+                assert "9:00" in e.content_en or "AM" in e.content_en
+                return
+        pytest.fail("general-hours not found")
+
+    def test_general_access_has_english(self):
+        for e in self._load_all_entries():
+            if e.id == "general-access":
+                assert e.content_en is not None
+                assert "Tenjin" in e.content_en
+                return
+        pytest.fail("general-access not found")
+
+    def test_facility_wifi_has_english(self):
+        for e in self._load_all_entries():
+            if e.id == "facility-wifi-power":
+                assert e.content_en is not None
+                assert "engnecf-guest" in e.content_en
+                return
+        pytest.fail("facility-wifi-power not found")
+
+    def test_community_manager_has_english(self):
+        for e in self._load_all_entries():
+            if e.id == "community-manager":
+                assert e.content_en is not None
+                assert "Community Manager" in e.content_en
+                return
+        pytest.fail("community-manager not found")
+
+    def test_policy_parking_has_english(self):
+        for e in self._load_all_entries():
+            if e.id == "policy-parking":
+                assert e.content_en is not None
+                assert "parking" in e.content_en.lower()
+                return
+        pytest.fail("policy-parking not found")
+
+    def test_event_connpass_has_english(self):
+        for e in self._load_all_entries():
+            if e.id == "event-connpass-howto":
+                assert e.content_en is not None
+                assert "connpass" in e.content_en.lower()
+                return
+        pytest.fail("event-connpass-howto not found")

--- a/backend/tools/enhanced_rag.py
+++ b/backend/tools/enhanced_rag.py
@@ -511,7 +511,11 @@ class EnhancedRAGSearch:
                 query_builder = query_builder.eq("category", category)
 
             # KB is Japanese-only; filter to ja for reliable results
-            query_builder = query_builder.eq("language", "ja")
+            # (English content_en chunks are stored with language='en')
+            if language == "en":
+                query_builder = query_builder.in_("language", ["en", "ja"])
+            else:
+                query_builder = query_builder.eq("language", "ja")
 
             result = query_builder.limit(max_results).execute()
 


### PR DESCRIPTION
## Summary

- Add `content_en` English translations to 10 priority knowledge base YAML entries so English queries hit English content directly via embedding similarity instead of relying on tRAG translation
- Modify `loader.py` to generate separate English chunks (with `language="en"` in metadata and `entry_id` suffixed `-en`) when `content_en` is present
- Modify `enhanced_rag.py` `_text_fallback_search()` to accept both `en` and `ja` language content for English queries
- Add 24 tests covering schema, metadata, bilingual chunking, and YAML integration

## 10 Target Entries

| File | Entry | Description |
|------|-------|-------------|
| general.yaml | general-hours | Opening hours 9:00-22:00 |
| general.yaml | general-pricing | Free usage, registration |
| general.yaml | general-access | Address, 5 min from Tenjin Station |
| general.yaml | general-contact | Phone/email/SNS |
| facilities.yaml | facility-wifi-power | SSID/password info |
| facilities.yaml | facility-main-hall | 1F coworking space |
| facilities.yaml | facility-makers-space | 3D printer, laser cutter |
| community.yaml | community-manager | 13:00-21:00, no reservation |
| policies.yaml | policy-parking | No dedicated parking |
| events.yaml | event-connpass-howto | Event registration method |

## Post-Merge Action Required

**Re-seed the knowledge base** to generate English embeddings:
```bash
python -m backend.scripts.seed_knowledge
```

## Test plan

- [x] `ruff check .` passes
- [x] `black --check .` passes  
- [x] 24 new tests pass (schema, metadata, chunking, YAML integration)
- [x] 202 total tests pass (knowledge + tools)
- [ ] CI pipeline green