### PR TITLE
fix(backend): inject LTM into memory prompts (#508 follow-up)

### DIFF
--- a/backend/agents/general_knowledge_agent.py
+++ b/backend/agents/general_knowledge_agent.py
@@ -84,9 +84,19 @@ class GeneralKnowledgeAgent:
     ) -> Dict[str, Any]:
         """統合クエリハンドラ: query_typeに応じて処理を分岐"""
         if query_type == "memory":
-            return await self._handle_memory_query(query, session_id or "", language)
+            return await self._handle_memory_query(
+                query,
+                session_id or "",
+                language,
+                long_term_memory=long_term_memory,
+            )
         return await self.answer_general_query(
-            query, language, session_id, state_context, context_signals
+            query,
+            language,
+            session_id,
+            state_context,
+            context_signals,
+            long_term_memory=long_term_memory,
         )
 
     async def answer_general_query(
@@ -96,6 +106,7 @@ class GeneralKnowledgeAgent:
         session_id: Optional[str] = None,
         state_context: Optional[Dict] = None,
         context_signals=None,
+        long_term_memory: Optional[list] = None,
     ) -> Dict[str, Any]:
         """
         一般的な質問に回答
@@ -159,6 +170,11 @@ class GeneralKnowledgeAgent:
                             "Web検索成功: %d chars, %d sources", len(web_text), len(web_sources)
                         )
 
+            long_term_text = self._format_long_term_memory_context(long_term_memory, language)
+            if long_term_text:
+                context = f"{context}\n\n{long_term_text}".strip()
+                sources.append("long_term_memory")
+
             # 4. コンテキストがない場合はフォールバック
             if not context:
                 logger.warning("コンテキストが取得できませんでした")
@@ -202,7 +218,11 @@ class GeneralKnowledgeAgent:
     # =========================================================================
 
     async def _handle_memory_query(
-        self, query: str, session_id: str, language: str = "ja"
+        self,
+        query: str,
+        session_id: str,
+        language: str = "ja",
+        long_term_memory: Optional[list] = None,
     ) -> Dict[str, Any]:
         """メモリ関連クエリを処理"""
         if not self.memory_system:
@@ -213,8 +233,13 @@ class GeneralKnowledgeAgent:
             context = await self.memory_system.get_context(
                 query, session_id, {"language": language, "inherit_context": True}
             )
+            context = self._merge_long_term_memory_context(
+                context,
+                long_term_memory,
+                language,
+            )
 
-            if not context.get("recent_messages"):
+            if not context.get("recent_messages") and not context.get("long_term_memory"):
                 return self._no_history_response(language)
 
             prompt = self._build_memory_prompt(query, context, query_type, language)
@@ -235,6 +260,7 @@ class GeneralKnowledgeAgent:
                     "query_type": query_type,
                     "message_count": len(context.get("recent_messages", [])),
                     "inherited_request_type": context.get("inherited_request_type"),
+                    "long_term_memory_count": len(context.get("long_term_memory", [])),
                 },
             }
         except Exception as e:
@@ -303,6 +329,65 @@ class GeneralKnowledgeAgent:
     ) -> str:
         """メモリプロンプト構築（memory_prompts.pyに委譲）"""
         return build_memory_prompt(query, context, query_type, language)
+
+    def _merge_long_term_memory_context(
+        self,
+        context: Dict[str, Any],
+        long_term_memory: Optional[list],
+        language: str,
+    ) -> Dict[str, Any]:
+        """セッション履歴コンテキストへ長期メモリを追記する。"""
+        if not long_term_memory:
+            return context
+
+        merged = dict(context or {})
+        long_term_text = self._format_long_term_memory_context(long_term_memory, language)
+        if not long_term_text:
+            return merged
+
+        existing_context = str(merged.get("context_string") or "").strip()
+        merged["context_string"] = f"{existing_context}\n\n{long_term_text}".strip()
+        merged["long_term_memory"] = long_term_memory
+        return merged
+
+    @staticmethod
+    def _format_long_term_memory_context(
+        long_term_memory: Optional[list],
+        language: str,
+    ) -> str:
+        """長期メモリをプロンプトへ渡せる短い箇条書きに整形する。"""
+        if not long_term_memory:
+            return ""
+
+        lines: list[str] = []
+        for memory in long_term_memory:
+            if isinstance(memory, dict):
+                content = str(
+                    memory.get("data")
+                    or memory.get("content")
+                    or memory.get("summary")
+                    or memory.get("text")
+                    or ""
+                ).strip()
+                memory_type = str(memory.get("type") or memory.get("candidate_type") or "").strip()
+                if content and memory_type:
+                    lines.append(f"- [{memory_type}] {content}")
+                elif content:
+                    lines.append(f"- {content}")
+            else:
+                content = str(memory).strip()
+                if content:
+                    lines.append(f"- {content}")
+
+        if not lines:
+            return ""
+
+        title = (
+            "長期メモリ（過去セッションから保持された利用者情報）"
+            if language == "ja"
+            else ("Long-term memory (visitor facts retained across sessions)")
+        )
+        return f"{title}:\n" + "\n".join(lines)
 
     def _determine_memory_emotion(self, context: Dict, query_type: str) -> str:
         """メモリクエリの感情タグ決定"""

--- a/backend/tests/agents/test_gka_memory.py
+++ b/backend/tests/agents/test_gka_memory.py
@@ -54,9 +54,19 @@ class TestGKAAnswerQueryDispatch:
         agent._handle_memory_query = AsyncMock(
             return_value={"answer": "メモリ回答", "emotion": "relaxed", "metadata": {}}
         )
+        long_term_memory = [{"data": "ユーザーの名前は山田次郎です", "type": "visitor_name"}]
 
-        result = await agent.answer_query("さっき何を聞いた？", query_type="memory")
-        agent._handle_memory_query.assert_called_once()
+        result = await agent.answer_query(
+            "さっき何を聞いた？",
+            query_type="memory",
+            long_term_memory=long_term_memory,
+        )
+        agent._handle_memory_query.assert_called_once_with(
+            "さっき何を聞いた？",
+            "",
+            "ja",
+            long_term_memory=long_term_memory,
+        )
         assert result["answer"] == "メモリ回答"
 
     @pytest.mark.asyncio
@@ -67,8 +77,20 @@ class TestGKAAnswerQueryDispatch:
             return_value={"answer": "一般回答", "emotion": "neutral", "metadata": {}}
         )
 
-        result = await agent.answer_query("エンジニアカフェとは？", query_type="general")
-        agent.answer_general_query.assert_called_once()
+        long_term_memory = [{"data": "ユーザーは展示に興味があります", "type": "interest"}]
+        result = await agent.answer_query(
+            "エンジニアカフェとは？",
+            query_type="general",
+            long_term_memory=long_term_memory,
+        )
+        agent.answer_general_query.assert_called_once_with(
+            "エンジニアカフェとは？",
+            "ja",
+            None,
+            None,
+            None,
+            long_term_memory=long_term_memory,
+        )
         assert result["answer"] == "一般回答"
 
 
@@ -125,6 +147,38 @@ class TestGKAHandleMemoryQuery:
 
         assert result["emotion"] == "sad"
         assert result["metadata"]["status"] == "no_history"
+
+    @pytest.mark.asyncio
+    async def test_handle_memory_query_uses_long_term_memory_without_session_history(self):
+        """別セッション由来の長期メモリを会話履歴プロンプトへ注入する"""
+        mock_memory = MagicMock()
+        mock_memory.get_context = AsyncMock(
+            return_value={
+                "recent_messages": [],
+                "context_string": "",
+            }
+        )
+
+        agent = self._create_agent(memory_system=mock_memory)
+        result = await agent._handle_memory_query(
+            "私の名前を覚えてますか？",
+            "session2",
+            "ja",
+            long_term_memory=[
+                {
+                    "data": "ユーザーの名前は山田次郎です",
+                    "type": "visitor_name",
+                    "confidence": 0.95,
+                }
+            ],
+        )
+
+        assert result["metadata"]["status"] == "success"
+        assert result["metadata"]["long_term_memory_count"] == 1
+        call_kwargs = agent.provider.generate.call_args.kwargs
+        prompt = call_kwargs["messages"][0].content
+        assert "長期メモリ" in prompt
+        assert "山田次郎" in prompt
 
     @pytest.mark.asyncio
     async def test_handle_memory_query_error(self):


### PR DESCRIPTION
## Summary
- Pass retrieved long-term memory through GeneralKnowledgeAgent memory-query path instead of dropping it.
- Merge long-term memory facts into the memory prompt context so cross-session recall can answer from LTM.
- Add regression coverage for memory queries with no same-session history but existing long-term memory.

## Background
Production validation of #519 on revision engineer-cafe-backend-00090-dkk showed LTM load/store was working, but Session B still answered that the name was unknown. Cloud Run logs showed `Loaded 1 long-term memories` before answer generation, so the remaining gap was prompt/context injection.

## Validation
- `uv run pytest tests/agents/test_gka_memory.py -q` -> 19 passed
- `uv run ruff check agents/general_knowledge_agent.py tests/agents/test_gka_memory.py` -> passed
- `uv run black --check agents/general_knowledge_agent.py tests/agents/test_gka_memory.py` -> passed

Refs #508, refs #507
