### PR TITLE
fix(backend): acknowledge first-turn memory writes

### DIFF
--- a/backend/agents/general_knowledge_agent.py
+++ b/backend/agents/general_knowledge_agent.py
@@ -240,6 +240,8 @@ class GeneralKnowledgeAgent:
             )
 
             if not context.get("recent_messages") and not context.get("long_term_memory"):
+                if self._is_memory_write_query(query):
+                    return self._memory_write_ack_response(language)
                 return self._no_history_response(language)
 
             prompt = self._build_memory_prompt(query, context, query_type, language)
@@ -323,6 +325,37 @@ class GeneralKnowledgeAgent:
             return "other_option"
 
         return "general_memory"
+
+    @staticmethod
+    def _is_memory_write_query(query: str) -> bool:
+        """初回の記憶登録依頼を、履歴参照質問と区別する。"""
+        lower_query = query.lower()
+        remember_keywords = [
+            "覚えて",
+            "憶えて",
+            "記憶して",
+            "忘れないで",
+            "remember",
+            "memorize",
+            "keep in mind",
+        ]
+        self_disclosure_keywords = [
+            "私の名前",
+            "僕の名前",
+            "俺の名前",
+            "名前は",
+            "わたしは",
+            "私は",
+            "ぼくは",
+            "僕は",
+            "my name is",
+            "i am ",
+            "i'm ",
+            "call me",
+        ]
+        return any(kw in lower_query for kw in remember_keywords) and any(
+            kw in lower_query for kw in self_disclosure_keywords
+        )
 
     def _build_memory_prompt(
         self, query: str, context: Dict, query_type: str, language: str
@@ -427,6 +460,23 @@ class GeneralKnowledgeAgent:
             "answer": message,
             "emotion": "sad",
             "metadata": {"agent": self.name, "status": "no_history", "query_type": "memory"},
+        }
+
+    def _memory_write_ack_response(self, language: str) -> Dict[str, Any]:
+        """初回の記憶登録依頼に対する応答。"""
+        message = (
+            "承知しました。今後の会話で参照できるように覚えておきます。"
+            if language == "ja"
+            else "Got it. I'll remember that so I can refer to it in future conversations."
+        )
+        return {
+            "answer": message,
+            "emotion": "helpful",
+            "metadata": {
+                "agent": self.name,
+                "status": "success",
+                "query_type": "memory_write",
+            },
         }
 
     # =========================================================================

--- a/backend/tests/agents/test_gka_memory.py
+++ b/backend/tests/agents/test_gka_memory.py
@@ -149,6 +149,25 @@ class TestGKAHandleMemoryQuery:
         assert result["metadata"]["status"] == "no_history"
 
     @pytest.mark.asyncio
+    async def test_handle_memory_write_query_without_history_acknowledges(self):
+        """初回の記憶登録依頼は履歴なし応答にしない"""
+        mock_memory = MagicMock()
+        mock_memory.get_context = AsyncMock(return_value={"recent_messages": []})
+
+        agent = self._create_agent(memory_system=mock_memory)
+        result = await agent._handle_memory_query(
+            "私の名前は佐藤花子です。覚えてください。",
+            "session1",
+            "ja",
+        )
+
+        assert result["emotion"] == "helpful"
+        assert result["metadata"]["status"] == "success"
+        assert result["metadata"]["query_type"] == "memory_write"
+        assert "覚えて" in result["answer"]
+        agent.provider.generate.assert_not_called()
+
+    @pytest.mark.asyncio
     async def test_handle_memory_query_uses_long_term_memory_without_session_history(self):
         """別セッション由来の長期メモリを会話履歴プロンプトへ注入する"""
         mock_memory = MagicMock()


### PR DESCRIPTION
## Summary
- 初回の「覚えてください」系 self-disclosure を履歴参照質問と区別します
- 会話履歴が空でも memory-write acknowledgement を返し、no_history 応答に落とさないようにします
- GKA memory tests に初回記憶登録ケースを追加します

## Background
- #525 deploy 後の Cloud Run UUID session 実地検証で、cross-session recall 自体は成功しました
- ただし初回の「私の名前は佐藤花子です。覚えてください。」が `no_history` になるケースを確認しました
- Fast-path LTM store は成功しており session B では recall できましたが、初回応答 UX として不正です

## Validation
- `uv run pytest tests/agents/test_gka_memory.py -q` → 20 passed
- `uv run ruff check agents/general_knowledge_agent.py tests/agents/test_gka_memory.py` → passed
- `uv run black --check agents/general_knowledge_agent.py tests/agents/test_gka_memory.py` → passed

Refs #508, refs #507