### PR TITLE
fix(backend): resample non-16kHz audio to 16kHz for Vosk STT (#528)

### DIFF
--- a/backend/agents/stt_agent.py
+++ b/backend/agents/stt_agent.py
@@ -473,6 +473,38 @@ class LocalSTTClient:
         logger.info("Loaded Vosk %s model from %s", lang, model_path)
         return self._models[lang]
 
+    @staticmethod
+    def _resample_to_16khz(frames: bytes, orig_rate: int) -> tuple[bytes, int]:
+        """Resample PCM 16-bit mono audio to 16kHz using scipy.
+
+        Args:
+            frames: Raw PCM bytes (16-bit signed integers).
+            orig_rate: Original sample rate in Hz.
+
+        Returns:
+            Tuple of (resampled_frames_bytes, 16000).
+        """
+        if orig_rate == 16000:
+            return frames, 16000
+
+        from scipy.signal import resample_poly
+        from math import gcd
+
+        g = gcd(16000, orig_rate)
+        up = 16000 // g
+        down = orig_rate // g
+
+        audio = np.frombuffer(frames, dtype=np.int16).astype(np.float32)
+        resampled = resample_poly(audio, up, down)
+        resampled = np.clip(resampled, -32768, 32767).astype(np.int16)
+        logger.info(
+            "Resampled audio from %dHz to 16000Hz (%d -> %d samples)",
+            orig_rate,
+            len(audio),
+            len(resampled),
+        )
+        return resampled.tobytes(), 16000
+
     def _sync_transcribe(
         self,
         audio_data: bytes,
@@ -482,6 +514,7 @@ class LocalSTTClient:
         """Synchronous Vosk transcription (called via thread pool).
 
         注意: 入力は WAV (PCM) で、可能であれば 16kHz, 16bit, mono を推奨します。
+        非16kHz音声は自動的に16kHzにリサンプルされます。
         """
         import wave
 
@@ -499,10 +532,11 @@ class LocalSTTClient:
             frames = wf.readframes(wf.getnframes())
 
         if sample_rate != 16000:
-            logger.warning(
-                "Received sample rate %dHz — Vosk expects 16000Hz. Provide 16kHz for best results.",
+            logger.info(
+                "Received sample rate %dHz — resampling to 16000Hz for Vosk.",
                 sample_rate,
             )
+            frames, sample_rate = self._resample_to_16khz(frames, sample_rate)
 
         model = self._load_model(language)
 

--- a/backend/tests/agents/test_stt_agent.py
+++ b/backend/tests/agents/test_stt_agent.py
@@ -293,6 +293,61 @@ class TestLocalSTTClient:
 
 
 # ==============================================================================
+# Resample Tests
+# ==============================================================================
+
+
+class TestResampleTo16khz:
+    """Tests for _resample_to_16khz static method."""
+
+    def test_passthrough_16khz(self):
+        """16kHz audio is returned unchanged."""
+        samples = np.zeros(16000, dtype=np.int16)
+        result_frames, result_rate = LocalSTTClient._resample_to_16khz(samples.tobytes(), 16000)
+        assert result_rate == 16000
+        assert result_frames == samples.tobytes()
+
+    def test_resample_22050hz_to_16khz(self):
+        """22050Hz audio (Piper output) is resampled to 16kHz."""
+        orig_rate = 22050
+        duration = 0.5
+        num_samples = int(orig_rate * duration)
+        t = np.linspace(0, duration, num_samples, endpoint=False)
+        tone = (np.sin(2 * np.pi * 440 * t) * 16000).astype(np.int16)
+        orig_bytes = tone.tobytes()
+
+        result_frames, result_rate = LocalSTTClient._resample_to_16khz(orig_bytes, orig_rate)
+        assert result_rate == 16000
+
+        result_samples = np.frombuffer(result_frames, dtype=np.int16)
+        expected_len = int(num_samples * 16000 / orig_rate)
+        assert abs(len(result_samples) - expected_len) <= 2
+
+    def test_resample_8khz_to_16khz(self):
+        """8kHz audio is upsampled to 16kHz."""
+        orig_rate = 8000
+        samples = np.ones(8000, dtype=np.int16) * 1000
+        result_frames, result_rate = LocalSTTClient._resample_to_16khz(samples.tobytes(), orig_rate)
+        assert result_rate == 16000
+        result_samples = np.frombuffer(result_frames, dtype=np.int16)
+        assert len(result_samples) == 16000
+
+    def test_resample_preserves_dtype(self):
+        """Resampled output is int16 (matches WAV 16-bit PCM)."""
+        samples = np.ones(22050, dtype=np.int16) * 5000
+        result_frames, _ = LocalSTTClient._resample_to_16khz(samples.tobytes(), 22050)
+        result_samples = np.frombuffer(result_frames, dtype=np.int16)
+        assert result_samples.dtype == np.int16
+
+    def test_resample_silence(self):
+        """Resampling silence produces silence."""
+        silence = np.zeros(22050, dtype=np.int16)
+        result_frames, _ = LocalSTTClient._resample_to_16khz(silence.tobytes(), 22050)
+        result_samples = np.frombuffer(result_frames, dtype=np.int16)
+        np.testing.assert_array_equal(result_samples, np.zeros_like(result_samples))
+
+
+# ==============================================================================
 # Confidence Extraction Tests
 # ==============================================================================
 


### PR DESCRIPTION
## Summary

Piper TTS outputs 22050Hz WAV but Vosk only processes 16kHz correctly. Previously non-16kHz audio was passed to KaldiRecognizer at the wrong sample rate with just a warning, causing poor transcription accuracy.

## Changes

- Add `LocalSTTClient._resample_to_16khz()` using `scipy.signal.resample_poly` (GCD-based up/down factors for exact rate conversion)
- Replace warning-only path with actual resampling in `_sync_transcribe`
- Add 5 unit tests for resample edge cases (passthrough, 22050→16k, 8k→16k, dtype preservation, silence)

## Test evidence

```
pytest backend/tests/agents/test_stt_agent.py -q
91 passed
```

```bash
cd backend && ruff check . && black --check .
All checks passed
```

## Notes

- Multi-channel WAV downmix is tracked separately as **#534** (P2, nice-to-have, no real impact in alpha testing)
- scipy already in dependencies (`pyproject.toml: scipy>=1.10.0`)

Refs: #528