### PR TITLE
fix(backend): add EN registration query expansion and content_en for RAG (#531)

### DIFF
--- a/backend/knowledge/data/general.yaml
+++ b/backend/knowledge/data/general.yaml
@@ -275,6 +275,23 @@ entries:
       【開館時間】9:00〜22:00（休館: 毎月最終月曜日、年末年始）
       【対象者】現役エンジニア、エンジニアを目指す学生、フリーランス、海外エンジニアなど
       エンジニアリングに関わるすべての方がご利用いただけます。
+    content_en: >
+      Welcome to Engineer Cafe! Here is a guide for first-time visitors.
+      What you can do: Free coworking with Wi-Fi and power outlets, join events
+      (hackathons, study groups), use 3D printers and laser cutters (first-time
+      training required, equipment is free), career and tech consultation with
+      Community Managers (1:00 PM - 9:00 PM), food and drinks at cafe&bar saino,
+      networking with fellow engineers.
+      First-time registration steps:
+      1. Visit the 1F reception desk.
+      2. Fill out the registration form (5-10 min, free, no ID required).
+      3. Receive a briefing on facility rules.
+      4. Get your member number and start using the space!
+      Returning visitors: Just give your member number at reception.
+      Hours: 9:00 AM - 10:00 PM. Closed on the last Monday of each month and
+      Dec 29 - Jan 3.
+      Open to all engineers: working engineers, students, freelancers,
+      and international engineers.
     category: "general"
     tags: ["welcome", "first-time", "reception", "guide", "overview", "engineer-cafe"]
     priority: 90

--- a/backend/tools/enhanced_rag.py
+++ b/backend/tools/enhanced_rag.py
@@ -119,6 +119,15 @@ QUERY_EXPANSION_MAP: Dict[str, List[str]] = {
     "와이파이": ["Wi-Fi", "WiFi", "ネットワーク"],
     "이벤트": ["イベント", "セミナー", "勉強会"],
     "회의실": ["会議室", "meeting room", "予約"],
+    # English → Japanese keyword expansion (registration / membership)
+    "register": ["利用登録", "登録", "会員", "初回", "サインアップ"],
+    "membership": ["会員", "利用登録", "会員番号", "登録"],
+    "sign up": ["利用登録", "登録", "初回", "会員"],
+    "signing up": ["利用登録", "登録", "初回"],
+    "become a member": ["会員", "利用登録", "登録", "初回"],
+    "how to join": ["利用方法", "利用登録", "参加", "登録"],
+    "first time": ["初回", "初めて", "利用登録"],
+    "member number": ["会員番号", "受付", "受付カード"],
     # Chinese → Japanese keyword expansion
     "营业时间": ["営業時間", "開館時間"],
     "费用": ["料金", "値段", "無料"],


### PR DESCRIPTION
## Summary

EN registration/membership queries ("How do I register as a member?", "How to become a member?") fell back to LLM instead of using enhanced_rag. Root cause: `QUERY_EXPANSION_MAP` lacked English registration terms, and the translated Japanese queries ("メンバー登録") did not match KB terminology ("利用登録"/"会員番号").

## Changes

1. **`backend/tools/enhanced_rag.py`**: Add 8 EN→JA registration expansions to `QUERY_EXPANSION_MAP`
   - `register` → [利用登録, 登録, 会員, 初回, サインアップ]
   - `membership` → [会員, 利用登録, 会員番号, 登録]
   - `sign up` → [利用登録, 登録, 初回, 会員]
   - `signing up`, `become a member`, `how to join`, `first time`, `member number`

2. **`backend/knowledge/data/general.yaml`**: Add `content_en` to `general-first-time-welcome` entry for direct EN embedding matching

## Test evidence

```
pytest backend/tests/tools/test_enhanced_rag.py -q   # 41 passed
pytest backend/tests/knowledge/ -q                     # 178 passed
```

```bash
cd backend && ruff check backend/tools/enhanced_rag.py backend/knowledge/ && black --check backend/tools/enhanced_rag.py
All checks passed
```

## Post-merge action required

Run `seed_knowledge.py` against production DB to generate EN embedding chunks for the new `content_en` field:
```bash
cd backend && uv run python -m scripts.seed_knowledge
```

Refs: #531