### PR TITLE
chore(docs): add alpha smoke script + observability spec baseline

### DIFF
--- a/docs/adr/009-slow-403-cold-start-rca.md
+++ b/docs/adr/009-slow-403-cold-start-rca.md
@@ -1,10 +1,11 @@
 # ADR 009: Slow 403 responses during Cloud Run cold-start and model-load windows
 
-Date: 2026-04-22
+Date: 2026-04-22 (Proposed) / 2026-04-23 (Accepted)
 
 ## Status
 
-Proposed
+Accepted — #532 観測性 spec (docs/specs/rag-memory-observability.md) と連動して追跡する。
+実装の残タスクは #488 のコメント欄のチェックリストで管理する。
 
 ## Context
 

--- a/docs/specs/rag-memory-observability.md
+++ b/docs/specs/rag-memory-observability.md
@@ -1,0 +1,220 @@
+# RAG + Memory Observability Spec (draft)
+
+**Issue**: #513 E-6 — RAG/メモリ観測性強化
+**Status**: Draft
+**Date**: 2026-04-23
+**Author**: Claude Code（統括）
+**Related**: ADR 008 (operational guardrails), ADR 011 (LTM cross-session), ADR 012 (LTM connection pool, 予定), #532 (LTM regression incident), #508
+
+---
+
+## 背景
+
+2026-04-22 夜〜04-23 朝にかけて、LTM 跨セッション recall regression (#532) が発生した。
+Codex の live verify が**デプロイ直後の warm window で false positive**となり、本番で連続失敗していることが翌朝の smoke で初めて判明した。
+
+原因の核は「**本番で壊れていることを自動検知する仕組みがない**」こと。観測性の欠如が alpha 直前 blocker の遅れにつながった。
+
+本 spec は以下を同じパイプラインで仕組み化する:
+
+- RAG fallback の増減（言語別）
+- LTM 書込み/読出しの success rate
+- Supabase connection 健全性
+- Agent 応答 latency p50/p95/p99
+- Hallucination 検知（EventAgent の suspicious token）
+
+---
+
+## 目的
+
+1. 本番 regression を **自動で即検知**（deploy 後 10分以内、idle 15分以内）
+2. 監査で**言語別 RAG 品質**を継続計測（Epic E-4 #511 RAGAS と並行）
+3. Cloud Monitoring で**単一ダッシュボード**に集約
+4. アラートは**PagerDuty or email**で oncall に飛ぶ
+
+## 非目的
+
+- 外形 E2E 監視（別枠: `.github/workflows/voice-e2e-nightly.yml` で継続）
+- frontend 側 observability（Vercel Analytics で継続）
+- 課金系メトリクス（将来）
+
+---
+
+## SLI（Service Level Indicators）
+
+### 1. LTM Recall Success Rate
+
+> 同一 `visitor_id` で前セッションの明示記憶が次セッションで recall できる率
+
+- 測定: smoke script (`scripts/alpha-smoke.sh`) を 15分間隔で Cloud Scheduler から実行
+- 成功条件: `answer` に記憶対象の名前トークンが含まれる
+- 公開: `custom.googleapis.com/ecn/ltm_recall_success`
+
+### 2. LTM Store/Load Success Rate
+
+> アプリケーションからの Store/Load 呼び出しで、connection error なしに完了した率
+
+- 測定: log-based metric（後述）
+- 失敗シグナル: `the connection is closed`, `pool is closed`, `broken pipe`
+- 公開: `custom.googleapis.com/ecn/ltm_store_errors`, `ecn/ltm_load_errors`
+
+### 3. RAG Non-Fallback Rate（言語別）
+
+> 全 `/api/chat` request のうち `sources != ['fallback']` を返した率（言語別に分離）
+
+- 測定: `/api/chat` レスポンスで `metadata.sources` を構造化ログに記録
+- 公開: `custom.googleapis.com/ecn/rag_hit_rate{lang=ja|en|zh|ko}`
+
+### 4. Agent Response Latency（p50 / p95 / p99）
+
+> `/api/chat`, `/api/voice` の response time 分布
+
+- 測定: Cloud Run の request log は既に取得済 → Distribution metric 化
+- 公開: 既存 `run.googleapis.com/request_latencies` の分位数抽出
+
+### 5. EventAgent Hallucination Rate
+
+> EventAgent 応答のうち、suspicious token（`ビジー`, `ランチ交流会` 等）を含む率
+
+- 測定: 応答をログに記録 → keyword match で log-based metric 化
+- 公開: `custom.googleapis.com/ecn/event_hallucination_rate`
+
+---
+
+## SLO（Service Level Objectives）
+
+| SLI | 目標 | 測定期間 | アラート閾値 |
+|---|---|---|---|
+| LTM recall success | 95% | 24h rolling | 連続 3 回失敗で WARN、6 回で CRIT |
+| LTM store error rate | < 1% | 15min rolling | 5% 超で WARN、10% 超で CRIT |
+| LTM load error rate | < 1% | 15min rolling | 5% 超で WARN、10% 超で CRIT |
+| RAG non-fallback (ja) | ≥ 85% | 24h rolling | 80% 下回りで WARN |
+| RAG non-fallback (en) | ≥ 70% | 24h rolling | 60% 下回りで WARN |
+| RAG non-fallback (zh/ko) | ≥ 60% | 24h rolling | 50% 下回りで WARN |
+| Agent p95 latency | < 5s | 15min rolling | 7s 超で WARN |
+| Agent p99 latency | < 10s | 15min rolling | 15s 超で CRIT |
+| EventAgent hallucination | < 0.5% | 24h rolling | 1% 超で WARN |
+
+---
+
+## 実装プラン（段階導入）
+
+### Phase 1 — Foundation（今日〜2日）
+
+#### 1.1 構造化ログの正規化（backend/utils/logging_config.py 想定）
+- 既存 `jsonPayload` 形式は維持
+- 以下のフィールドを request 単位で必ず出力:
+  ```json
+  {
+    "request_id": "...",
+    "endpoint": "/api/chat",
+    "language": "ja|en|zh|ko",
+    "agent": "business_info|event|general_knowledge|...",
+    "sources": ["enhanced_rag|fallback|web_search"],
+    "latency_ms": 2841,
+    "visitor_id_hash": "sha1(vid)[:10]"
+  }
+  ```
+- 個人情報（visitor_id 生値）は出さず、ハッシュのみ。
+
+#### 1.2 Log-Based Metrics 定義（gcloud 経由）
+- `ecn_ltm_store_errors` = count of `jsonPayload.message =~ "long-term memory store failed"`
+- `ecn_ltm_load_errors` = count of `jsonPayload.message =~ "Long-term memory load failed"`
+- `ecn_rag_fallback` = count of `jsonPayload.sources[0] = "fallback"` labeled by `language`
+- `ecn_event_halluc` = count of suspicious tokens in EventAgent responses
+- `ecn_403_slow_count` = count of `httpRequest.status=403 AND httpRequest.latency>"1s"` （#488 連動）
+- `ecn_403_very_slow_count` = count of `httpRequest.status=403 AND httpRequest.latency>"10s"` （#488 連動）
+
+定義ファイル: `infra/monitoring/log-based-metrics.yaml` （新規）
+
+#### 1.3 Alerts（Cloud Monitoring Policy）
+- 各 metric に対して上記 SLO 閾値のアラートポリシーを Terraform で定義
+- 通知チャネル: email + Slack（既存 channel 流用）
+
+### Phase 2 — Dashboard（3日）
+
+#### 2.1 Cloud Monitoring Dashboard（JSON）
+- Panel 構成:
+  1. LTM Health（recall success, store/load error rate, connection closed count）
+  2. RAG by Language（hit rate ja/en/zh/ko の 4 グラフ重ね）
+  3. Agent Latency（p50/p95/p99 by endpoint）
+  4. Error Budget Remaining（SLO burn rate）
+- 配置: `infra/monitoring/dashboards/rag-memory.json`
+
+### Phase 3 — Active Probing（1週）
+
+#### 3.1 Cloud Scheduler で alpha-smoke を定期実行
+- 間隔: 15分
+- 環境: API_KEY は Secret Manager から引く
+- 失敗時: log-based metric `ecn_smoke_failures` を発火、アラート連動
+
+### Phase 4 — Audit ダッシュボード（2週）
+
+#### 4.1 週次 audit pipeline
+- RAGAS スコア（Epic E-4 #511 実装後に統合）
+- LTM promotion 統計（promoted candidates / day）
+- hallucination 検知内訳
+- Audit レポートは `docs/audit/YYYY-MM-DD-weekly.md` に書き出し
+
+---
+
+## Terraform / Infra 変更
+
+現状の `infra/` 配下を再利用:
+
+```
+infra/
+  monitoring/
+    log-based-metrics.tf    # Phase 1.2
+    alert-policies.tf        # Phase 1.3
+    dashboards/
+      rag-memory.json        # Phase 2.1
+  scheduler/
+    alpha-smoke-cron.tf      # Phase 3.1
+```
+
+権限:
+- Cloud Monitoring Admin to terraform service account
+- Cloud Scheduler にも既存 service account で invoke 可能にする
+
+---
+
+## 成功基準（Exit criteria）
+
+| 項目 | 達成基準 |
+|---|---|
+| Phase 1 | `ecn_ltm_store_errors` が Cloud Monitoring で見える / alert が test fire する |
+| Phase 2 | ダッシュボードで JA/EN の RAG hit rate が 1h 粒度で見える |
+| Phase 3 | 15分 cron 実行で failure が log-based metric に反映される |
+| Phase 4 | 週次 audit レポートが自動生成される |
+
+---
+
+## Open Questions
+
+1. **alpha-smoke を Cloud Scheduler から呼ぶか、Cloud Run Job にするか**
+   - Scheduler + HTTP invoke が一番軽い。Job 化は Phase 4 以降でも可。
+2. **log-based metric のカーディナリティ上限**
+   - `language` ラベルだけなら 4 値で問題なし。visitor_id_hash は metric label にしない（cardinality 爆発防止）。
+3. **既存 `/api/monitoring/dashboard` endpoint との棲み分け**
+   - 既存は backend 内部の debug 用。本 spec は GCP 外形観測。用途重複なし、両立可能。
+4. **Epic E-4 #511 RAGAS との統合タイミング**
+   - Phase 4 で統合。RAGAS は 127 件 batch 評価 → metric 化、本 spec は live probe 系。
+
+---
+
+## References
+
+- Issue #513（E-6 観測性 Epic）
+- Issue #532（LTM regression RCA）
+- Issue #488（`/api/character` 403 cold start、類似 observability ギャップ）
+- ADR 008 Operational Guardrails
+- ADR 011 LTM Cross-Session Design
+- `scripts/alpha-smoke.sh`（本日 Claude が追加）
+- Google SRE Book: "Service Level Objectives" 章
+
+---
+
+## Changelog
+
+- 2026-04-23: initial draft (Claude Code 統括), Phase 1–4 スケルトン、#513 spec draft 完了

--- a/scripts/alpha-smoke.sh
+++ b/scripts/alpha-smoke.sh
@@ -1,0 +1,265 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Alpha deployment smoke test — verifies the P0 scenarios that broke in rev 00093-gz5.
+#
+# Scenarios:
+#   1. Health check                            (fast)
+#   2. LTM cross-session recall                (15s wait default, 300s with --full)
+#   3. EventAgent hallucination check (JA/EN)  (fast)
+#   4. EN RAG registration / parking / hours   (fast)
+#
+# Usage:
+#   scripts/alpha-smoke.sh                                    # all scenarios, 15s LTM wait
+#   scripts/alpha-smoke.sh --full                             # +5min LTM idle acceptance
+#   scripts/alpha-smoke.sh --ltm-only                         # LTM only
+#   scripts/alpha-smoke.sh --host https://... --key $API_KEY  # override target
+#
+# Env:
+#   API_SECRET_KEY            Required unless --key provided or gcloud available
+#   ALPHA_SMOKE_BASE_URL      Overrides default Cloud Run URL
+#
+# Exit: 0 if every scenario passed, 1 otherwise.
+
+DEFAULT_URL="https://engineer-cafe-backend-639959525777.asia-northeast1.run.app"
+BASE_URL="${ALPHA_SMOKE_BASE_URL:-$DEFAULT_URL}"
+API_KEY="${API_SECRET_KEY:-}"
+MODE_FULL=0
+ONLY_LTM=0
+ONLY_EVENT=0
+ONLY_EN_RAG=0
+LTM_WAIT_DEFAULT=15
+LTM_WAIT_FULL=300
+
+PASS_COUNT=0
+FAIL_COUNT=0
+FAILED_CASES=()
+
+usage() {
+  sed -n '3,22p' "$0"
+  exit "${1:-0}"
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --full)       MODE_FULL=1; shift ;;
+    --ltm-only)   ONLY_LTM=1; shift ;;
+    --event-only) ONLY_EVENT=1; shift ;;
+    --en-only)    ONLY_EN_RAG=1; shift ;;
+    --host)       BASE_URL="$2"; shift 2 ;;
+    --key)        API_KEY="$2"; shift 2 ;;
+    -h|--help)    usage 0 ;;
+    *) echo "Unknown arg: $1" >&2; usage 1 ;;
+  esac
+done
+
+fetch_api_key_from_gcloud() {
+  if command -v gcloud >/dev/null 2>&1; then
+    gcloud secrets versions access latest \
+      --secret=API_SECRET_KEY --project=aipartner-426616 2>/dev/null || true
+  fi
+}
+
+if [ -z "$API_KEY" ]; then
+  API_KEY="$(fetch_api_key_from_gcloud)"
+fi
+
+if [ -z "$API_KEY" ]; then
+  echo "Error: API_SECRET_KEY is required (pass --key, set env, or gcloud login)" >&2
+  exit 2
+fi
+
+record_pass() {
+  PASS_COUNT=$((PASS_COUNT + 1))
+  echo "[PASS] $1"
+}
+
+record_fail() {
+  FAIL_COUNT=$((FAIL_COUNT + 1))
+  FAILED_CASES+=("$1")
+  echo "[FAIL] $1 — $2"
+}
+
+chat_post() {
+  local body="$1" tmp status
+  tmp=$(mktemp)
+  status=$(curl -sS -m 45 -o "$tmp" -w "%{http_code}" \
+    -X POST "$BASE_URL/api/chat" \
+    -H "Content-Type: application/json" \
+    -H "X-API-Key: $API_KEY" \
+    -d "$body" || true)
+  if [ "$status" != "200" ]; then
+    echo "HTTP_$status"
+    rm -f "$tmp"
+    return 1
+  fi
+  cat "$tmp"
+  rm -f "$tmp"
+}
+
+json_pick() {
+  python3 -c "
+import json, sys
+try:
+    data = json.loads(sys.stdin.read())
+except Exception as exc:
+    print(f'ERR:{exc}')
+    sys.exit(0)
+path = sys.argv[1].split('.')
+node = data
+for key in path:
+    if isinstance(node, dict):
+        node = node.get(key, '')
+    else:
+        node = ''
+        break
+print(node if isinstance(node, str) else json.dumps(node, ensure_ascii=False))
+" "$1"
+}
+
+contains_any() {
+  local haystack="$1"; shift
+  for needle in "$@"; do
+    [[ "$haystack" == *"$needle"* ]] && return 0
+  done
+  return 1
+}
+
+test_health() {
+  local code
+  code=$(curl -s -o /dev/null -w "%{http_code}" "$BASE_URL/health")
+  if [ "$code" = "200" ]; then
+    record_pass "health endpoint returns 200"
+  else
+    record_fail "health endpoint" "got $code"
+  fi
+}
+
+test_ltm_cross_session() {
+  local wait_seconds="$1"
+  local vid
+  vid="alpha-ltm-$(date +%s)-$$"
+  local write_body read_body write_out read_out answer
+  write_body=$(python3 -c "import json,sys;print(json.dumps({'query':'私の名前は山本太郎です。覚えてください。','language':'ja','session_id':'alpha-ltm-w','visitor_id':sys.argv[1]}))" "$vid")
+  write_out=$(chat_post "$write_body") || { record_fail "LTM write request" "$write_out"; return; }
+
+  echo "  ... sleeping ${wait_seconds}s to simulate idle before cross-session recall"
+  sleep "$wait_seconds"
+
+  read_body=$(python3 -c "import json,sys;print(json.dumps({'query':'私の名前を覚えていますか？','language':'ja','session_id':'alpha-ltm-r','visitor_id':sys.argv[1]}))" "$vid")
+  read_out=$(chat_post "$read_body") || { record_fail "LTM recall request" "$read_out"; return; }
+
+  answer=$(printf '%s' "$read_out" | json_pick answer)
+  if contains_any "$answer" "山本" "太郎"; then
+    record_pass "LTM cross-session recall (idle=${wait_seconds}s) vid=$vid"
+  else
+    record_fail "LTM cross-session recall (idle=${wait_seconds}s)" "answer='$answer' vid=$vid"
+  fi
+}
+
+test_event_agent_ja() {
+  local body out answer
+  body='{"query":"今日のイベントを教えて","language":"ja","session_id":"alpha-evt-ja"}'
+  out=$(chat_post "$body") || { record_fail "EventAgent JA request" "$out"; return; }
+  answer=$(printf '%s' "$out" | json_pick answer)
+  if contains_any "$answer" "ビジー" "your calendar" "ランチ交流会"; then
+    record_fail "EventAgent JA hallucination" "suspicious tokens in '$answer'"
+  else
+    record_pass "EventAgent JA responds without hallucination tokens"
+  fi
+}
+
+test_event_agent_en() {
+  local body out answer
+  body='{"query":"Any events today?","language":"en","session_id":"alpha-evt-en"}'
+  out=$(chat_post "$body") || { record_fail "EventAgent EN request" "$out"; return; }
+  answer=$(printf '%s' "$out" | json_pick answer)
+  if contains_any "$answer" "lunch exchange" "your calendar"; then
+    record_fail "EventAgent EN hallucination" "suspicious tokens in '$answer'"
+  else
+    record_pass "EventAgent EN responds without hallucination tokens"
+  fi
+}
+
+test_en_rag_query() {
+  local question="$1"
+  local expect_source="$2"
+  local body out sources ans
+  body=$(python3 -c "import json,sys;print(json.dumps({'query':sys.argv[1],'language':'en','session_id':'alpha-en-rag'}))" "$question")
+  out=$(chat_post "$body") || { record_fail "EN RAG request ($question)" "$out"; return; }
+  sources=$(printf '%s' "$out" | json_pick metadata.sources)
+  ans=$(printf '%s' "$out" | json_pick answer)
+  if [[ "$sources" == *"$expect_source"* ]]; then
+    record_pass "EN RAG '$question' -> sources contain $expect_source"
+  else
+    record_fail "EN RAG '$question'" "sources=$sources answer='${ans:0:80}'"
+  fi
+}
+
+run_ltm_scenarios() {
+  echo "--- LTM cross-session recall ---"
+  test_ltm_cross_session "$LTM_WAIT_DEFAULT"
+  if [ "$MODE_FULL" = "1" ]; then
+    test_ltm_cross_session "$LTM_WAIT_FULL"
+  fi
+  echo ""
+}
+
+run_event_scenarios() {
+  echo "--- EventAgent hallucination ---"
+  test_event_agent_ja
+  test_event_agent_en
+  echo ""
+}
+
+run_en_rag_scenarios() {
+  echo "--- EN RAG (membership / parking / hours) ---"
+  test_en_rag_query "How do I register as a member?" "enhanced_rag"
+  test_en_rag_query "Tell me about membership"        "enhanced_rag"
+  test_en_rag_query "Is there parking available?"     "enhanced_rag"
+  test_en_rag_query "What are the business hours?"    "enhanced_rag"
+  echo ""
+}
+
+print_header() {
+  echo "============================================"
+  echo "Alpha smoke test"
+  echo "URL : $BASE_URL"
+  echo "Mode: full=$MODE_FULL ltm_only=$ONLY_LTM event_only=$ONLY_EVENT en_only=$ONLY_EN_RAG"
+  echo "============================================"
+  echo ""
+}
+
+print_summary() {
+  local total=$((PASS_COUNT + FAIL_COUNT))
+  echo "============================================"
+  echo "Summary: $PASS_COUNT passed, $FAIL_COUNT failed (out of $total)"
+  if [ "$FAIL_COUNT" -gt 0 ]; then
+    echo "Failed cases:"
+    for c in "${FAILED_CASES[@]}"; do
+      echo "  - $c"
+    done
+  fi
+  echo "============================================"
+}
+
+main() {
+  print_header
+
+  if [ "$ONLY_LTM" = "0" ] && [ "$ONLY_EVENT" = "0" ] && [ "$ONLY_EN_RAG" = "0" ]; then
+    test_health
+    echo ""
+    run_ltm_scenarios
+    run_event_scenarios
+    run_en_rag_scenarios
+  else
+    [ "$ONLY_LTM" = "1" ]    && run_ltm_scenarios
+    [ "$ONLY_EVENT" = "1" ]  && run_event_scenarios
+    [ "$ONLY_EN_RAG" = "1" ] && run_en_rag_scenarios
+  fi
+
+  print_summary
+  [ "$FAIL_COUNT" -eq 0 ] || exit 1
+}
+
+main "$@"


### PR DESCRIPTION
## Summary

Baseline for Epic B (#483) Phase 0 + E-6 (#513) Phase 0: commit the live-verify tooling and observability spec that Issue #532 showed were missing.

**Closes #538**

## Context

Today's Issue #532 LTM regression slipped past Codex's live verify (warm-window false positive) and was only caught by the morning smoke. This PR codifies the morning-smoke tooling and the SLI/SLO spec so the next regression is caught automatically.

## Changes

### `scripts/alpha-smoke.sh` (new)
Reusable live smoke covering the four scenarios from the #532 post-mortem:
- LTM cross-session recall — 15s default or 300s with `--full` (used as #533 acceptance)
- EventAgent hallucination (JA / EN)
- EN RAG membership / parking / hours
- `/health` check

Flags: `--full` / `--ltm-only` / `--event-only` / `--en-only` / `--host` / `--key`. Fetches `API_SECRET_KEY` from Secret Manager when `--key` is absent.

### `docs/specs/rag-memory-observability.md` (new)
Draft spec for #513:
- SLI: LTM recall rate, store/load error rate, RAG hit rate per language, agent latency p50/p95/p99, hallucination rate
- SLO tied to alert thresholds
- Phase 1–4 roadmap (log-based metrics → dashboards → active probing → weekly audit)
- Log-based metric names reserved: `ecn_ltm_store_errors`, `ecn_ltm_load_errors`, `ecn_rag_fallback{language=...}`, `ecn_event_halluc`, `ecn_403_slow_count` (for #488), `ecn_403_very_slow_count`

### `docs/adr/009-slow-403-cold-start-rca.md` (modified)
Promoted Proposed → Accepted. Linked to the new spec and the #488 follow-up checklist.

## Validation

- `bash -n scripts/alpha-smoke.sh` — ok
- `shellcheck scripts/alpha-smoke.sh` — clean
- `scripts/alpha-smoke.sh --help` renders
- Spec reviewed internally against Google SRE SLO chapter and existing log patterns

## Test plan

- [ ] CI green (docs-only / path-filter skips backend test)
- [ ] code-reviewer LGTM
- [ ] merge → reference from #533 deploy smoke + #513 implementation PR

## Related

- #488 slow 403 RCA (spec picks up the metric names)
- #513 RAG/memory observability (本丸実装、本 PR はその前提条件)
- #532 LTM regression (本事案の発端)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
