### PR TITLE
fix(backend): align fast-path actionable gate with MemoryPromoter (#522)

### DIFF
--- a/backend/tests/services/test_memory_promoter.py
+++ b/backend/tests/services/test_memory_promoter.py
@@ -221,3 +221,26 @@ class TestSingleton:
         reset_memory_promoter()
         b = get_memory_promoter()
         assert a is not b
+
+
+# --- Regression tests for #522 (fast-path actionable gate) -----------------
+# `_has_actionable_content` is shared between MemoryPromoter.promote_for_user
+# and _is_fast_path_memory in backend/workflows/main_workflow.py so that
+# empty / filler / single-character content — including the English "please"
+# extracted from remember-requests — never reaches LTM.
+@pytest.mark.parametrize(
+    "content, expected",
+    [
+        ("please", False),
+        ("ください", False),
+        ("お願いします", False),
+        ("a", False),  # len == 1
+        ("", False),
+        ("太郎", True),
+        ("田中太郎", True),
+        ("I love engineer cafe", True),
+    ],
+)
+def test_has_actionable_content_rejects_filler_strings(content, expected):
+    aggregate = {"content": content}
+    assert MemoryPromoter._has_actionable_content(aggregate) is expected

--- a/backend/workflows/main_workflow.py
+++ b/backend/workflows/main_workflow.py
@@ -37,6 +37,7 @@ from backend.agents.orchestrator_agent import (
 )
 from backend.agents.orchestrator_agent import OrchestratorAgent as RoutingLogicAgent
 from backend.config.routing_constants import GREETING_KEYWORDS, match_keywords
+from backend.services.memory_promoter import MemoryPromoter
 from backend.utils.store import store_with_retry
 
 logger = logging.getLogger(__name__)
@@ -1336,8 +1337,14 @@ class MainWorkflow:
                         "keep in mind",
                     )
 
+                    # Gate fast-path with the same actionable-content rule as
+                    # MemoryPromoter so that empty / filler strings (e.g. "please",
+                    # "ください", single characters) never reach LTM.
+                    if not MemoryPromoter._has_actionable_content(memory):
+                        return False
+
                     if memory_type == "explicit_remember":
-                        return confidence >= 0.5 and content not in {"ください", "お願いします"}
+                        return confidence >= 0.5
                     if any(keyword in explicit_text for keyword in explicit_keywords):
                         return confidence >= 0.8
                     return memory_type == "visitor_name" and confidence >= 0.9


### PR DESCRIPTION
## Summary

Align the fast-path LTM writer in `_is_fast_path_memory` with `MemoryPromoter._has_actionable_content()` so that empty / filler / single-character content (including the English `please` extracted from remember-requests) never reaches long-term memory via either pathway.

Closes #522
Refs #519 (review comment [2])

## Background

PR #519 review flagged an inconsistency between two LTM entry points:

- **Fast-path** (`backend/workflows/main_workflow.py:_is_fast_path_memory`) only excluded `{"ください", "お願いします"}`
- **Promoter** (`backend/services/memory_promoter.py:_has_actionable_content`) additionally excludes `"please"` and single-character strings

English remember-requests of the form "please remember that ..." would synthesize a candidate with `content="please"` which passed the fast-path filter but would have been rejected by the promoter — leaving filler strings in LTM only when the fast-path won the race.

## Changes

**`backend/workflows/main_workflow.py`**
- Import `MemoryPromoter` at module scope
- In `_is_fast_path_memory`, gate all branches with `MemoryPromoter._has_actionable_content(memory)` before type/confidence checks
- Removes the now-redundant `content not in {"ください", "お願いします"}` check on the `explicit_remember` branch since the gate already covers it

**`backend/tests/services/test_memory_promoter.py`**
- Parametrized regression test `test_has_actionable_content_rejects_filler_strings`
- Covers: `please`, `ください`, `お願いします`, 1-char (`"a"`), empty (`""`) → all rejected
- Positive cases: `太郎`, `田中太郎`, `I love engineer cafe` → accepted

## Note on PR #519 review [1] (store.py log wording)

The review suggested branching the log wording in `store_with_retry` based on whether `store` was injected. **This is already resolved by PR #533's pooled retry path**: the current implementation constructs a `retry_action` variable that conditionally reflects whether a reset actually happened. No additional change to `store.py` is needed.

## Test plan

- [x] `ruff check backend/` → All checks passed
- [x] `black --check backend/` → 327 files unchanged
- [x] `pytest backend/tests/services/test_memory_promoter.py -v` → 23 passed
- [x] `pytest backend/tests/workflows/test_long_term_memory_retry.py backend/tests/workflows/test_main_workflow.py -q` → 46 passed

## Out of scope / follow-up

- ADR 011 (review [3]) was already updated by #545 this morning
- store.py log wording (review [1]) already satisfied by #533

🤖 Generated with [Claude Code](https://claude.com/claude-code)