### PR TITLE
fix(backend+frontend): upload unique violation error message improvement (#542)

### DIFF
--- a/backend/api/knowledge.py
+++ b/backend/api/knowledge.py
@@ -474,10 +474,15 @@ async def upload_knowledge(
             supabase.table("knowledge_base").select("title").in_("title", chunk_titles).execute()
         )
         if existing.data:
-            conflicting_title = existing.data[0]["title"]
+            existing_titles = {row["title"] for row in existing.data}
+            conflicts = [
+                {"chunk_index": i, "title": chunk_titles[i]}
+                for i in range(len(chunk_titles))
+                if chunk_titles[i] in existing_titles
+            ]
             raise HTTPException(
                 status_code=409,
-                detail=f"Knowledge with title '{conflicting_title}' already exists",
+                detail={"message": "duplicate titles", "conflicts": conflicts},
             )
 
         inserted_rows: List[Dict[str, Any]] = []
@@ -559,15 +564,21 @@ async def upload_knowledge(
         except APIError as exc:
             _rollback_uploaded_chunks(supabase, inserted_ids)
             if _is_unique_violation(exc):
-                conflict_title = effective_title
-                if exc.args:
-                    conflict_title = next(
-                        (chunk_title for chunk_title in chunk_titles if chunk_title in str(exc)),
-                        effective_title,
-                    )
+                exc_str = str(exc)
+                conflict_title = next(
+                    (ct for ct in chunk_titles if ct in exc_str),
+                    effective_title,
+                )
+                conflict_index = next(
+                    (i for i, ct in enumerate(chunk_titles) if ct == conflict_title),
+                    None,
+                )
                 raise HTTPException(
                     status_code=409,
-                    detail=f"Knowledge with title '{conflict_title}' already exists",
+                    detail={
+                        "message": "duplicate titles",
+                        "conflicts": [{"chunk_index": conflict_index, "title": conflict_title}],
+                    },
                 )
             logger.error(
                 "Supabase insert failed: table=knowledge_base title=%s filename=%s error=%s",
@@ -615,7 +626,10 @@ async def upload_knowledge(
         if _is_unique_violation(e):
             raise HTTPException(
                 status_code=409,
-                detail=f"Knowledge with title '{effective_title}' already exists",
+                detail={
+                    "message": "duplicate titles",
+                    "conflicts": [{"chunk_index": None, "title": effective_title}],
+                },
             )
         logger.error(
             "Failed to upload knowledge (%s): %s; filename=%s file_type=%s content_size=%s",

--- a/backend/tests/api/test_knowledge_api.py
+++ b/backend/tests/api/test_knowledge_api.py
@@ -555,14 +555,16 @@ def test_upload_markdown_splits_into_chunks(
 def test_upload_rejects_duplicate_chunk_title_from_batch_check(
     mock_get_sb, mock_parse_md, mock_chunk_text
 ):
-    """チャンクタイトル衝突時は単一INクエリで409を返す"""
+    """チャンクタイトル衝突時は全conflictを含む409を返す"""
     mock_parse_md.return_value = "Parsed markdown content"
-    mock_chunk_text.return_value = ["Chunk one", "Chunk two"]
+    mock_chunk_text.return_value = ["Chunk one", "Chunk two", "Chunk three"]
     mock_sb = _mock_supabase()
     mock_get_sb.return_value = mock_sb
 
     mock_sb.table.return_value.select.return_value.in_.return_value.execute.return_value = (
-        _mock_table_result([{"title": "duplicate_doc (part 2)"}])
+        _mock_table_result(
+            [{"title": "duplicate_doc (part 1)"}, {"title": "duplicate_doc (part 3)"}]
+        )
     )
 
     response = client.post(
@@ -572,12 +574,15 @@ def test_upload_rejects_duplicate_chunk_title_from_batch_check(
     )
 
     assert response.status_code == 409
-    assert (
-        response.json()["detail"] == "Knowledge with title 'duplicate_doc (part 2)' already exists"
-    )
+    detail = response.json()["detail"]
+    assert detail["message"] == "duplicate titles"
+    assert len(detail["conflicts"]) == 2
+    conflict_titles = {c["title"] for c in detail["conflicts"]}
+    assert "duplicate_doc (part 1)" in conflict_titles
+    assert "duplicate_doc (part 3)" in conflict_titles
     mock_sb.table.return_value.select.return_value.in_.assert_called_once_with(
         "title",
-        ["duplicate_doc (part 1)", "duplicate_doc (part 2)"],
+        ["duplicate_doc (part 1)", "duplicate_doc (part 2)", "duplicate_doc (part 3)"],
     )
     mock_sb.table.return_value.insert.assert_not_called()
 
@@ -690,7 +695,11 @@ def test_upload_rolls_back_inserted_chunks_on_unique_violation(
     )
 
     assert response.status_code == 409
-    assert response.json()["detail"] == "Knowledge with title 'race_doc (part 2)' already exists"
+    detail = response.json()["detail"]
+    assert detail["message"] == "duplicate titles"
+    assert len(detail["conflicts"]) == 1
+    assert detail["conflicts"][0]["title"] == "race_doc (part 2)"
+    assert detail["conflicts"][0]["chunk_index"] == 1
     assert mock_sb.table.return_value.delete.return_value.eq.call_args_list == [
         call("id", "first-chunk-id")
     ]

--- a/frontend/src/app/(admin)/admin/knowledge/upload/page.tsx
+++ b/frontend/src/app/(admin)/admin/knowledge/upload/page.tsx
@@ -4,7 +4,7 @@ import { useEffect, useState } from 'react';
 import Link from 'next/link';
 import { useRouter } from 'next/navigation';
 import { Toaster, toast } from 'react-hot-toast';
-import { downloadTemplate, getKnowledgeEditorConfig, uploadKnowledgeFile } from '@/lib/api/knowledge';
+import { downloadTemplate, getKnowledgeEditorConfig, uploadKnowledgeFile, KnowledgeUploadFileError } from '@/lib/api/knowledge';
 import type { KnowledgeEditorConfig } from '@/types/knowledge';
 import {
   transformKnowledgeUploadData,
@@ -119,7 +119,15 @@ export default function UploadKnowledgePage() {
       router.push('/admin/knowledge');
     } catch (error) {
       console.error('Upload error:', error);
-      toast.error(error instanceof Error ? error.message : 'アップロードに失敗しました');
+      if (error instanceof KnowledgeUploadFileError && error.conflicts?.length) {
+        const lines = error.conflicts.map(
+          (c) =>
+            `Chunk ${c.chunk_index !== null ? c.chunk_index + 1 : '?'}: 「${c.title}」は既存と重複`,
+        );
+        toast.error(lines.join('\n'), { duration: 8000 });
+      } else {
+        toast.error(error instanceof Error ? error.message : 'アップロードに失敗しました');
+      }
     } finally {
       setUploading(false);
     }

--- a/frontend/src/lib/api/knowledge.ts
+++ b/frontend/src/lib/api/knowledge.ts
@@ -4,6 +4,7 @@ import {
   type KnowledgeItem,
   type KnowledgeListResponse,
   type KnowledgeResponse,
+  type KnowledgeUploadConflict,
 } from '@/types/knowledge';
 
 export type {
@@ -13,6 +14,7 @@ export type {
   KnowledgeListResponse,
   KnowledgeResponse,
 };
+export type { KnowledgeUploadConflict } from '@/types/knowledge';
 
 interface KnowledgeTemplatesResponse {
   templates: Record<string, Record<string, unknown>>;
@@ -141,6 +143,15 @@ export async function deleteKnowledge(id: string): Promise<void> {
   }
 }
 
+export class KnowledgeUploadFileError extends Error {
+  conflicts?: KnowledgeUploadConflict[];
+  constructor(detail: { message: string; conflicts?: KnowledgeUploadConflict[] }) {
+    super(detail.message);
+    this.name = 'KnowledgeUploadFileError';
+    this.conflicts = detail.conflicts;
+  }
+}
+
 export async function uploadKnowledgeFile(params: {
   file: File;
   category: string;
@@ -161,7 +172,30 @@ export async function uploadKnowledgeFile(params: {
   });
 
   if (!response.ok) {
-    throw new Error(await getErrorMessage(response, 'Failed to upload knowledge file'));
+    const text = await response.text();
+    if (text) {
+      try {
+        const data = JSON.parse(text) as {
+          detail?: string | { message: string; conflicts?: KnowledgeUploadConflict[] };
+          error?: string;
+          message?: string;
+        };
+        if (typeof data.detail === 'object' && data.detail !== null) {
+          throw new KnowledgeUploadFileError(data.detail);
+        }
+        throw new Error(
+          data.error ||
+            (typeof data.detail === 'string' ? data.detail : '') ||
+            data.message ||
+            'Failed to upload knowledge file',
+        );
+      } catch (e) {
+        if (e instanceof KnowledgeUploadFileError) throw e;
+        if (e instanceof Error) throw e;
+        throw new Error(text);
+      }
+    }
+    throw new Error('Failed to upload knowledge file');
   }
 
   const json = (await response.json()) as KnowledgeResponse | KnowledgeItem;

--- a/frontend/src/types/knowledge.ts
+++ b/frontend/src/types/knowledge.ts
@@ -43,6 +43,16 @@ export interface KnowledgeEditorConfig extends KnowledgeCategoriesResponse {
   availableCategories: string[];
 }
 
+export interface KnowledgeUploadConflict {
+  chunk_index: number | null;
+  title: string;
+}
+
+export interface KnowledgeUploadError {
+  message: string;
+  conflicts?: KnowledgeUploadConflict[];
+}
+
 export interface MetadataFieldConfig {
   type: 'select' | 'date' | 'tags' | 'text';
   options?: string[];


### PR DESCRIPTION
## Summary
- Upload batch check now returns ALL conflicting `(chunk_index, title)` pairs instead of just the first
- Structured error detail format: `{"message": "duplicate titles", "conflicts": [...]}`
- Frontend shows per-chunk conflict messages via `KnowledgeUploadFileError` class

Closes #542

## Test plan
- [x] `backend/tests/api/test_knowledge_api.py` — 20/20 tests pass
- [x] `ruff check` + `black --check` clean
- [x] `pnpm lint` + `pnpm typecheck` clean
- [ ] Verify 409 response includes all conflicting chunks when uploading duplicate file