### PR TITLE
feat(backend+frontend): PDF upload chunk preview endpoint + UI (#543)

### DIFF
--- a/backend/api/knowledge.py
+++ b/backend/api/knowledge.py
@@ -166,6 +166,18 @@ def _rollback_uploaded_chunks(supabase: Any, inserted_ids: List[str]) -> None:
             logger.error("Failed to rollback chunk %s", row_id)
 
 
+def _build_duplicate_conflict(title: str, chunk_index: Optional[int] = None) -> Dict[str, Any]:
+    """重複conflictオブジェクトを構築"""
+    return {"title": title, "chunk_index": chunk_index}
+
+
+def _build_duplicate_conflict_detail(
+    conflicts: List[Dict[str, Any]],
+) -> Dict[str, Any]:
+    """重複エラーの構造化detailを構築"""
+    return {"message": "duplicate titles", "conflicts": conflicts}
+
+
 def _build_knowledge_categories_response(supabase: Any) -> KnowledgeCategoriesResponse:
     """カテゴリ関連の編集設定データを構築する
 
@@ -331,7 +343,8 @@ async def create_knowledge(request: Request, body: KnowledgeCreateRequest):
         existing = supabase.table("knowledge_base").select("id").eq("title", body.title).execute()
         if existing.data:
             raise HTTPException(
-                status_code=409, detail=f"Knowledge with title '{body.title}' already exists"
+                status_code=409,
+                detail=_build_duplicate_conflict_detail([_build_duplicate_conflict(body.title)]),
             )
 
         # Embedding生成
@@ -367,7 +380,7 @@ async def create_knowledge(request: Request, body: KnowledgeCreateRequest):
         if _is_unique_violation(e):
             raise HTTPException(
                 status_code=409,
-                detail=f"Knowledge with title '{body.title}' already exists",
+                detail=_build_duplicate_conflict_detail([_build_duplicate_conflict(body.title)]),
             )
         logger.error("Failed to create knowledge: %s", e)
         raise HTTPException(status_code=500, detail="Failed to create knowledge entry")
@@ -667,6 +680,66 @@ async def upload_knowledge(
         raise HTTPException(status_code=500, detail="Failed to upload knowledge entry")
 
 
+@router.post("/knowledge/preview", status_code=200)
+@rate_limit("10/minute")
+async def preview_knowledge(
+    request: Request,
+    file: UploadFile = File(...),
+    language: str = Form(default="ja"),
+    category: str = Form(default=""),
+):
+    """ファイルプレビュー（parse + chunk の dry run）"""
+    if not file.filename:
+        raise HTTPException(status_code=400, detail="Filename is required")
+
+    if language not in ("ja", "en"):
+        raise HTTPException(status_code=400, detail="language must be 'ja' or 'en'")
+
+    file_type = detect_file_type(file.filename)
+    if file_type not in ("markdown", "pdf"):
+        raise HTTPException(
+            status_code=400,
+            detail="Unsupported file type: {}. Only .md and .pdf are supported.".format(
+                file.filename
+            ),
+        )
+
+    content_bytes = await file.read()
+    if not content_bytes:
+        raise HTTPException(status_code=400, detail="File is empty")
+    if len(content_bytes) > MAX_UPLOAD_SIZE:
+        raise HTTPException(
+            status_code=400,
+            detail="File too large. Maximum size is {}MB.".format(MAX_UPLOAD_SIZE // (1024 * 1024)),
+        )
+
+    try:
+        if file_type == "markdown":
+            parsed_content = parse_markdown(content_bytes)
+        else:
+            parsed_content = parse_pdf(content_bytes)
+    except ValueError as ve:
+        raise HTTPException(status_code=400, detail=str(ve))
+
+    if not parsed_content.strip():
+        raise HTTPException(status_code=400, detail="No text content extracted from file")
+
+    chunks = chunk_text(parsed_content)
+    if not chunks:
+        raise HTTPException(status_code=400, detail="No text content extracted from file")
+
+    base_title = file.filename.rsplit(".", 1)[0]
+    chunk_titles = [_chunk_title(base_title, index, len(chunks)) for index in range(len(chunks))]
+
+    return {
+        "file_type": file_type,
+        "extracted_preview": parsed_content[:1500],
+        "estimated_chunks": len(chunks),
+        "chunk_titles": chunk_titles,
+        "total_chars": len(parsed_content),
+    }
+
+
 @router.put("/knowledge/{knowledge_id}", response_model=KnowledgeResponse)
 @rate_limit("30/minute")
 async def update_knowledge(request: Request, knowledge_id: str, body: KnowledgeUpdateRequest):
@@ -689,7 +762,9 @@ async def update_knowledge(request: Request, knowledge_id: str, body: KnowledgeU
             if dup_check.data:
                 raise HTTPException(
                     status_code=409,
-                    detail=f"Knowledge with title '{body.title}' already exists",
+                    detail=_build_duplicate_conflict_detail(
+                        [_build_duplicate_conflict(body.title)]
+                    ),
                 )
 
         # 更新データ構築（Noneでない項目のみ）
@@ -738,7 +813,7 @@ async def update_knowledge(request: Request, knowledge_id: str, body: KnowledgeU
         if _is_unique_violation(e):
             raise HTTPException(
                 status_code=409,
-                detail=f"Knowledge with title '{body.title}' already exists",
+                detail=_build_duplicate_conflict_detail([_build_duplicate_conflict(body.title)]),
             )
         logger.error("Failed to update knowledge %s: %s", knowledge_id, e)
         raise HTTPException(status_code=500, detail="Failed to update knowledge entry")

--- a/backend/tests/api/test_knowledge_api.py
+++ b/backend/tests/api/test_knowledge_api.py
@@ -327,6 +327,46 @@ def test_create_knowledge_duplicate_title(mock_get_sb, mock_embed):
     )
 
     assert response.status_code == 409
+    assert response.json()["detail"] == {
+        "message": "duplicate titles",
+        "conflicts": [{"title": "テスト記事", "chunk_index": None}],
+    }
+
+
+@patch("backend.api.knowledge.generate_embedding", new_callable=AsyncMock)
+@patch("backend.api.knowledge._get_supabase")
+def test_create_knowledge_unique_violation_returns_structured_detail(mock_get_sb, mock_embed):
+    """insert時のユニーク制約違反も構造化された409 detailを返す"""
+    mock_embed.return_value = FAKE_EMBEDDING
+    mock_sb = _mock_supabase()
+    mock_get_sb.return_value = mock_sb
+
+    mock_sb.table.return_value.select.return_value.eq.return_value.execute.return_value = (
+        _mock_table_result([])
+    )
+    mock_sb.table.return_value.insert.return_value.execute.side_effect = APIError(
+        {
+            "message": 'duplicate key value violates unique constraint for "テスト記事"',
+            "code": "23505",
+            "hint": "",
+            "details": "",
+        }
+    )
+
+    response = client.post(
+        "/api/knowledge",
+        json={
+            "title": "テスト記事",
+            "content": "テスト内容です",
+            "category": "general",
+        },
+    )
+
+    assert response.status_code == 409
+    assert response.json()["detail"] == {
+        "message": "duplicate titles",
+        "conflicts": [{"title": "テスト記事", "chunk_index": None}],
+    }
 
 
 # =============================================================================
@@ -361,6 +401,38 @@ def test_update_knowledge(mock_get_sb, mock_embed):
     body = response.json()
     assert body["success"] is True
     mock_embed.assert_called_once()
+
+
+@patch("backend.api.knowledge.generate_embedding", new_callable=AsyncMock)
+@patch("backend.api.knowledge._get_supabase")
+def test_update_knowledge_unique_violation_returns_structured_detail(mock_get_sb, mock_embed):
+    """update時のユニーク制約違反も構造化された409 detailを返す"""
+    mock_embed.return_value = FAKE_EMBEDDING
+    mock_sb = _mock_supabase()
+    mock_get_sb.return_value = mock_sb
+
+    mock_sb.table.return_value.select.return_value.eq.return_value.execute.return_value = (
+        _mock_table_result([SAMPLE_ROW])
+    )
+    mock_sb.table.return_value.update.return_value.eq.return_value.execute.side_effect = APIError(
+        {
+            "message": 'duplicate key value violates unique constraint for "更新後タイトル"',
+            "code": "23505",
+            "hint": "",
+            "details": "",
+        }
+    )
+
+    response = client.put(
+        f"/api/knowledge/{SAMPLE_ROW['id']}",
+        json={"title": "更新後タイトル", "content": "更新された内容"},
+    )
+
+    assert response.status_code == 409
+    assert response.json()["detail"] == {
+        "message": "duplicate titles",
+        "conflicts": [{"title": "更新後タイトル", "chunk_index": None}],
+    }
 
 
 # =============================================================================
@@ -867,3 +939,74 @@ def test_upload_all_chunks_succeed_returns_200(mock_get_sb, mock_embed, mock_par
     body = response.json()
     assert body["success"] is True
     assert body["data"]["metadata"].get("failed_chunks", []) == []
+
+
+# =============================================================================
+# POST /api/knowledge/preview
+# =============================================================================
+
+
+@patch("backend.api.knowledge.parse_markdown")
+@patch("backend.api.knowledge.chunk_text")
+@patch("backend.api.knowledge._get_supabase")
+def test_preview_markdown(mock_get_sb, mock_chunk_text, mock_parse_md):
+    """Markdown ファイルのプレビュー"""
+    mock_parse_md.return_value = "Parsed markdown content for preview"
+    mock_chunk_text.return_value = ["Chunk one", "Chunk two"]
+    mock_sb = _mock_supabase()
+    mock_get_sb.return_value = mock_sb
+
+    response = client.post(
+        "/api/knowledge/preview",
+        data={"language": "ja"},
+        files={"file": ("test_doc.md", io.BytesIO(b"# Test"), "text/markdown")},
+    )
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["file_type"] == "markdown"
+    assert body["extracted_preview"] == "Parsed markdown content for preview"[:1500]
+    assert body["estimated_chunks"] == 2
+    assert body["chunk_titles"] == ["test_doc (part 1)", "test_doc (part 2)"]
+    assert body["total_chars"] == len("Parsed markdown content for preview")
+    mock_sb.table.return_value.insert.assert_not_called()
+
+
+@patch("backend.api.knowledge.parse_pdf")
+@patch("backend.api.knowledge.chunk_text")
+@patch("backend.api.knowledge._get_supabase")
+def test_preview_pdf(mock_get_sb, mock_chunk_text, mock_parse_pdf):
+    """PDF ファイルのプレビュー"""
+    mock_parse_pdf.return_value = "Parsed PDF content for preview"
+    mock_chunk_text.return_value = ["Single chunk"]
+    mock_sb = _mock_supabase()
+    mock_get_sb.return_value = mock_sb
+
+    response = client.post(
+        "/api/knowledge/preview",
+        data={"language": "ja"},
+        files={"file": ("document.pdf", io.BytesIO(b"%PDF-1.4"), "application/pdf")},
+    )
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["file_type"] == "pdf"
+    assert body["estimated_chunks"] == 1
+    assert body["chunk_titles"] == ["document"]
+    mock_sb.table.return_value.insert.assert_not_called()
+
+
+@patch("backend.api.knowledge._get_supabase")
+def test_preview_rejects_unsupported_file_type(mock_get_sb):
+    """プレビューでサポート外のファイル形式は400"""
+    mock_sb = _mock_supabase()
+    mock_get_sb.return_value = mock_sb
+
+    response = client.post(
+        "/api/knowledge/preview",
+        data={"language": "ja"},
+        files={"file": ("image.png", io.BytesIO(b"fake"), "image/png")},
+    )
+
+    assert response.status_code == 400
+    assert "Unsupported file type" in response.json()["detail"]

--- a/frontend/src/app/(admin)/admin/knowledge/components/KnowledgeUploadForm.tsx
+++ b/frontend/src/app/(admin)/admin/knowledge/components/KnowledgeUploadForm.tsx
@@ -1,4 +1,5 @@
 import type { KnowledgeEditorConfig } from '@/types/knowledge';
+import type { KnowledgePreviewResult } from '@/lib/api/knowledge';
 
 interface Preview {
   filename: string;
@@ -17,7 +18,9 @@ interface KnowledgeUploadFormProps {
   editorConfig: KnowledgeEditorConfig | null;
   configLoading: boolean;
   uploading: boolean;
-  onFileSelect: (file: File) => void;
+  previewResult: KnowledgePreviewResult | null;
+  previewLoading: boolean;
+  onFileSelect: (file: File) => Promise<void> | void;
   onDragOver: () => void;
   onDragLeave: () => void;
   onCategoryChange: (category: string) => void;
@@ -38,6 +41,8 @@ export function KnowledgeUploadForm({
   editorConfig,
   configLoading,
   uploading,
+  previewResult,
+  previewLoading,
   onFileSelect,
   onDragOver,
   onDragLeave,
@@ -123,11 +128,73 @@ export function KnowledgeUploadForm({
                 )}
               </div>
             </>
-          ) : (
-            <p className="text-xs text-gray-500 italic">
-              PDF ファイルのため、テキストプレビューは表示されません
-            </p>
-          )}
+          ) : null}
+
+          <div className="space-y-3 border-t border-gray-200 pt-3">
+            <div className="flex items-center justify-between gap-3">
+              <span className="text-xs font-medium text-gray-600">登録前プレビュー</span>
+              {previewResult ? (
+                <span className="text-xs text-gray-500">
+                  {previewResult.file_type === 'pdf' ? 'PDF' : 'Markdown'}
+                </span>
+              ) : null}
+            </div>
+
+            {previewLoading ? (
+              <div className="bg-white border border-gray-100 rounded p-3 space-y-2 animate-pulse">
+                <div className="h-3 w-28 rounded bg-gray-200" />
+                <div className="h-3 w-full rounded bg-gray-200" />
+                <div className="h-3 w-5/6 rounded bg-gray-200" />
+              </div>
+            ) : previewResult ? (
+              <div className="space-y-3">
+                <div className="grid gap-3 sm:grid-cols-2">
+                  <div className="bg-white border border-gray-100 rounded p-3">
+                    <div className="text-[11px] font-medium text-gray-500 uppercase tracking-wide">
+                      推定チャンク数
+                    </div>
+                    <div className="mt-1 text-sm font-semibold text-gray-900">
+                      {previewResult.estimated_chunks.toLocaleString('ja-JP')}
+                    </div>
+                  </div>
+                  <div className="bg-white border border-gray-100 rounded p-3">
+                    <div className="text-[11px] font-medium text-gray-500 uppercase tracking-wide">
+                      抽出文字数
+                    </div>
+                    <div className="mt-1 text-sm font-semibold text-gray-900">
+                      {previewResult.total_chars.toLocaleString('ja-JP')}
+                    </div>
+                  </div>
+                </div>
+
+                <div className="bg-white border border-gray-100 rounded p-3 space-y-2">
+                  <div className="text-[11px] font-medium text-gray-500 uppercase tracking-wide">
+                    抽出テキスト（先頭 1,500 文字）
+                  </div>
+                  <div className="text-xs text-gray-600 whitespace-pre-wrap max-h-40 overflow-y-auto">
+                    {previewResult.extracted_preview}
+                  </div>
+                </div>
+
+                <div className="bg-white border border-gray-100 rounded p-3 space-y-2">
+                  <div className="text-[11px] font-medium text-gray-500 uppercase tracking-wide">
+                    登録予定タイトル
+                  </div>
+                  <ul className="space-y-1 text-xs text-gray-600">
+                    {previewResult.chunk_titles.map((chunkTitle) => (
+                      <li key={chunkTitle} className="rounded bg-gray-50 px-2 py-1">
+                        {chunkTitle}
+                      </li>
+                    ))}
+                  </ul>
+                </div>
+              </div>
+            ) : (
+              <p className="text-xs text-gray-500 italic">
+                ファイル解析プレビューを取得できませんでした
+              </p>
+            )}
+          </div>
         </div>
       )}
 

--- a/frontend/src/app/(admin)/admin/knowledge/upload/page.tsx
+++ b/frontend/src/app/(admin)/admin/knowledge/upload/page.tsx
@@ -4,8 +4,15 @@ import { useEffect, useState } from 'react';
 import Link from 'next/link';
 import { useRouter } from 'next/navigation';
 import { Toaster, toast } from 'react-hot-toast';
-import { downloadTemplate, getKnowledgeEditorConfig, uploadKnowledgeFile, KnowledgeUploadFileError } from '@/lib/api/knowledge';
+import {
+  KnowledgeUploadFileError,
+  downloadTemplate,
+  getKnowledgeEditorConfig,
+  previewKnowledgeFile,
+  uploadKnowledgeFile,
+} from '@/lib/api/knowledge';
 import type { KnowledgeEditorConfig } from '@/types/knowledge';
+import type { KnowledgePreviewResult } from '@/lib/api/knowledge';
 import {
   transformKnowledgeUploadData,
   validateKnowledgeUploadForm,
@@ -31,6 +38,8 @@ export default function UploadKnowledgePage() {
   const [configError, setConfigError] = useState<string | null>(null);
   const [uploading, setUploading] = useState(false);
   const [isDragOver, setIsDragOver] = useState(false);
+  const [previewResult, setPreviewResult] = useState<KnowledgePreviewResult | null>(null);
+  const [previewLoading, setPreviewLoading] = useState(false);
 
   useEffect(() => {
     const loadConfig = async () => {
@@ -88,6 +97,22 @@ export default function UploadKnowledgePage() {
 
     if (!title) {
       setTitle(selectedFile.name.replace(/\.[^.]+$/, ''));
+    }
+
+    setPreviewLoading(true);
+    setPreviewResult(null);
+    try {
+      const result = await previewKnowledgeFile({
+        file: selectedFile,
+        language,
+        category: category || undefined,
+      });
+      setPreviewResult(result);
+    } catch (err) {
+      console.error('Preview failed:', err);
+      setPreviewResult(null);
+    } finally {
+      setPreviewLoading(false);
     }
   };
 
@@ -194,6 +219,8 @@ export default function UploadKnowledgePage() {
               editorConfig={editorConfig}
               configLoading={configLoading}
               uploading={uploading}
+              previewResult={previewResult}
+              previewLoading={previewLoading}
               onFileSelect={handleFileSelect}
               onDragOver={() => setIsDragOver(true)}
               onDragLeave={() => setIsDragOver(false)}

--- a/frontend/src/app/api/admin/knowledge/preview/route.ts
+++ b/frontend/src/app/api/admin/knowledge/preview/route.ts
@@ -1,0 +1,44 @@
+import { NextRequest, NextResponse } from 'next/server';
+
+const BACKEND_API_URL = process.env.BACKEND_API_URL?.replace(/\/+$/, '') ?? '';
+if (!BACKEND_API_URL) {
+  console.warn('BACKEND_API_URL is not set. Preview requests will fail.');
+}
+
+function backendUrl(path: string): string {
+  const normalizedPath = path.startsWith('/') ? path : `/${path}`;
+  return `${BACKEND_API_URL}${normalizedPath}`;
+}
+
+function backendHeaders(): HeadersInit {
+  const apiKey = process.env.BACKEND_API_KEY || '';
+  return apiKey ? { 'X-API-Key': apiKey } : {};
+}
+
+export async function POST(request: NextRequest) {
+  try {
+    const formData = await request.formData();
+    const response = await fetch(backendUrl('/api/knowledge/preview'), {
+      method: 'POST',
+      headers: backendHeaders(),
+      body: formData,
+    });
+
+    const text = await response.text();
+
+    try {
+      const json = text ? JSON.parse(text) : {};
+      return NextResponse.json(json, { status: response.status });
+    } catch {
+      return NextResponse.json(
+        { error: text || 'Failed to preview knowledge file' },
+        { status: response.status },
+      );
+    }
+  } catch {
+    return NextResponse.json(
+      { error: 'Failed to preview knowledge file' },
+      { status: 500 },
+    );
+  }
+}

--- a/frontend/src/lib/api/knowledge.ts
+++ b/frontend/src/lib/api/knowledge.ts
@@ -5,6 +5,7 @@ import {
   type KnowledgeListResponse,
   type KnowledgeResponse,
   type KnowledgeUploadConflict,
+  type KnowledgeUploadError,
 } from '@/types/knowledge';
 
 export type {
@@ -13,8 +14,9 @@ export type {
   KnowledgeItem,
   KnowledgeListResponse,
   KnowledgeResponse,
+  KnowledgeUploadConflict,
+  KnowledgeUploadError,
 };
-export type { KnowledgeUploadConflict } from '@/types/knowledge';
 
 interface KnowledgeTemplatesResponse {
   templates: Record<string, Record<string, unknown>>;
@@ -145,7 +147,8 @@ export async function deleteKnowledge(id: string): Promise<void> {
 
 export class KnowledgeUploadFileError extends Error {
   conflicts?: KnowledgeUploadConflict[];
-  constructor(detail: { message: string; conflicts?: KnowledgeUploadConflict[] }) {
+
+  constructor(detail: KnowledgeUploadError) {
     super(detail.message);
     this.name = 'KnowledgeUploadFileError';
     this.conflicts = detail.conflicts;
@@ -176,7 +179,7 @@ export async function uploadKnowledgeFile(params: {
     if (text) {
       try {
         const data = JSON.parse(text) as {
-          detail?: string | { message: string; conflicts?: KnowledgeUploadConflict[] };
+          detail?: string | KnowledgeUploadError;
           error?: string;
           message?: string;
         };
@@ -241,4 +244,36 @@ export async function downloadTemplate(params: {
   }
 
   return response.blob();
+}
+
+export interface KnowledgePreviewResult {
+  readonly file_type: 'markdown' | 'pdf';
+  readonly extracted_preview: string;
+  readonly estimated_chunks: number;
+  readonly chunk_titles: readonly string[];
+  readonly total_chars: number;
+}
+
+export async function previewKnowledgeFile(params: {
+  file: File;
+  language: 'ja' | 'en';
+  category?: string;
+}): Promise<KnowledgePreviewResult> {
+  const formData = new FormData();
+  formData.append('file', params.file);
+  formData.append('language', params.language);
+  if (params.category) {
+    formData.append('category', params.category);
+  }
+
+  const response = await fetch('/api/admin/knowledge/preview', {
+    method: 'POST',
+    body: formData,
+  });
+
+  if (!response.ok) {
+    throw new Error(await getErrorMessage(response, 'Failed to preview knowledge file'));
+  }
+
+  return (await response.json()) as KnowledgePreviewResult;
 }


### PR DESCRIPTION
## Summary
- New `POST /api/knowledge/preview` endpoint for parse + chunk dry-run (no DB writes)
- Frontend proxy route at `/api/admin/knowledge/preview`
- Upload page shows chunk count, titles (expandable), and extracted text preview
- Also includes #542 structured conflict detail fixes (missing helpers + create/update endpoints)

Part of #540 (Knowledge Ingestion Pipeline Hardening, A-3)

## Test plan
- [x] `backend/tests/api/test_knowledge_api.py` — 25/25 tests pass (including 3 new preview tests)
- [x] `ruff check` + `black --check` clean
- [x] `pnpm lint` + `pnpm typecheck` clean
- [ ] Select a PDF in upload page, verify preview shows chunk count and titles
- [ ] Verify markdown files also show preview