### PR TITLE
fix(backend): fine-tune EN membership query expansion for RAG quality (#544)

### DIFF
--- a/backend/knowledge/data/general.yaml
+++ b/backend/knowledge/data/general.yaml
@@ -41,7 +41,7 @@ entries:
 
   - id: "general-pricing"
     title: "エンジニアカフェ 料金・利用登録"
-    title_en: "Engineer Cafe Pricing and Registration"
+    title_en: "Engineer Cafe Pricing, Registration, and Membership"
     content: >
       エンジニアカフェは「エンジニアフレンドリーシティ福岡」の実現を目的とした官民一体型プロジェクトで、
       現役エンジニア、エンジニアを目指す方、エンジニアリング分野に関連する業務や学習に取り組む方が対象です。
@@ -57,7 +57,8 @@ entries:
     content_en: >
       Engineer Cafe is a public-private project under Fukuoka's "Engineer Friendly City" initiative.
       It is open to working engineers, aspiring engineers, and anyone in engineering-related fields.
-      Facility and equipment use is free. Only cafe&bar saino food/drinks and 3D printer filament are paid.
+      Membership registration and facility use are free. Only cafe&bar saino food/drinks and
+      3D printer filament are paid.
       First-time registration: Complete a form at reception (5-10 min, free, no ID required).
       You will receive a briefing on facility rules (food policy, quiet zones, 15-min seat policy).
       Registration is in-person only; no online pre-registration available.
@@ -66,7 +67,7 @@ entries:
       Return the card at reception when leaving.
       Events are also free, but commercial advertising and headhunting activities are not permitted.
     category: "pricing"
-    tags: ["pricing", "registration", "free", "engineer-cafe"]
+    tags: ["pricing", "registration", "membership", "free", "engineer-cafe"]
     priority: 90
     source: "official"
     verified: true

--- a/backend/tests/tools/test_enhanced_rag.py
+++ b/backend/tests/tools/test_enhanced_rag.py
@@ -137,6 +137,51 @@ class TestQueryExpansion:
 
         assert "Where is the location?" in result
 
+    @pytest.mark.parametrize(
+        ("query", "expected_terms"),
+        [
+            ("Tell me about membership", ["会員", "利用登録", "無料"]),
+            ("What is the membership like?", ["会員", "利用登録", "受付"]),
+            ("Can I become a member?", ["会員", "利用登録", "初回"]),
+            ("Are there member benefits?", ["無料", "利用料", "会員"]),
+        ],
+    )
+    def test_expand_query_membership_english_matches_kb_terms(
+        self,
+        rag_search,
+        query,
+        expected_terms,
+    ):
+        """英語のmembership系クエリがKB由来の語彙へ拡張される"""
+        result = rag_search._expand_query(query, "general", "en")
+
+        assert result.startswith(query)
+        assert "(" in result
+        for term in expected_terms:
+            assert term in result
+
+    def test_expand_query_register_as_member_uses_corpus_terms(self, rag_search):
+        """member登録系クエリでKBにある語彙が優先される"""
+        result = rag_search._expand_query("How do I register as a member?", "general", "en")
+
+        assert "利用登録" in result
+        assert "会員" in result
+        assert "受付" in result
+        assert "サインアップ" not in result
+
+    def test_expand_query_parking_has_no_membership_noise(self, rag_search):
+        """関係ないクエリにmembership拡張が混ざらない"""
+        result = rag_search._expand_query("parking", "general", "en")
+
+        assert result == "parking"
+
+    def test_expand_query_business_hours_still_works_in_english(self, rag_search):
+        """既存の営業時間クエリ拡張が維持される"""
+        result = rag_search._expand_query("What are your business hours?", "hours", "en")
+
+        assert result.startswith("What are your business hours?")
+        assert "営業時間" in result or "開館時間" in result
+
     def test_expand_query_no_expansion_needed(self, rag_search):
         """拡張が不要なクエリ（generalカテゴリではアンカリングしない）"""
         result = rag_search._expand_query("こんにちは", "general", "ja")
@@ -644,6 +689,14 @@ class TestQueryExpansionMap:
         assert "営業時間" in QUERY_EXPANSION_MAP["opening hours"]
         assert "料金" in QUERY_EXPANSION_MAP["price"]
         assert "アクセス" in QUERY_EXPANSION_MAP["location"]
+
+    def test_membership_entries_use_kb_aligned_terms(self):
+        """membership系の英語キーがKB語彙に寄せられている"""
+        assert "サインアップ" not in QUERY_EXPANSION_MAP["register"]
+        assert "利用登録" in QUERY_EXPANSION_MAP["register"]
+        assert "無料" in QUERY_EXPANSION_MAP["membership"]
+        assert "無料" in QUERY_EXPANSION_MAP["member benefits"]
+        assert "会員番号" in QUERY_EXPANSION_MAP["member"]
 
 
 # ==============================================================================

--- a/backend/tools/enhanced_rag.py
+++ b/backend/tools/enhanced_rag.py
@@ -120,13 +120,15 @@ QUERY_EXPANSION_MAP: Dict[str, List[str]] = {
     "이벤트": ["イベント", "セミナー", "勉強会"],
     "회의실": ["会議室", "meeting room", "予約"],
     # English → Japanese keyword expansion (registration / membership)
-    "register": ["利用登録", "登録", "会員", "初回", "サインアップ"],
-    "membership": ["会員", "利用登録", "会員番号", "登録"],
+    "register": ["利用登録", "登録", "会員", "初回", "受付"],
+    "membership": ["会員", "利用登録", "無料", "受付", "会員番号"],
+    "member benefits": ["無料", "利用料", "会員", "利用登録", "受付"],
     "sign up": ["利用登録", "登録", "初回", "会員"],
     "signing up": ["利用登録", "登録", "初回"],
     "become a member": ["会員", "利用登録", "登録", "初回"],
     "how to join": ["利用方法", "利用登録", "参加", "登録"],
     "first time": ["初回", "初めて", "利用登録"],
+    "member": ["会員", "利用登録", "会員番号", "受付", "無料"],
     "member number": ["会員番号", "受付", "受付カード"],
     # Chinese → Japanese keyword expansion
     "营业时间": ["営業時間", "開館時間"],


### PR DESCRIPTION
## Summary
- align English membership query expansion with KB vocabulary already present in the corpus, including `利用登録`, `無料`, `受付`, and `会員番号`
- expand coverage for broader English membership phrasing such as `member` and `member benefits`, and remove the non-corpus `サインアップ` synonym
- add regression tests for membership-related English queries and update the general pricing knowledge entry to mention membership explicitly in English

Closes #544

## Acceptance checklist
- [x] `QUERY_EXPANSION_MAP` membership-related English keys now use KB-aligned terms
- [x] `register` no longer expands to `サインアップ`
- [x] Added broader English membership coverage for `member` and `member benefits`
- [x] Verified `Tell me about membership`, `What is the membership like?`, `Can I become a member?`, and `Are there member benefits?`
- [x] Preserved existing coverage for register / parking / business hours queries
- [x] Did not run DB seeding

## Test results
- [x] `python -m pytest tests/tools/test_enhanced_rag.py -m "not ragas and not slow and not e2e" -x -q` → 49 passed, 12 warnings
- [x] `python -m pytest tests/knowledge/test_yaml_files.py -q` → 110 passed, 12 warnings
- [x] `ruff check tools/enhanced_rag.py tests/tools/test_enhanced_rag.py && black --check tools/enhanced_rag.py tests/tools/test_enhanced_rag.py`

## Notes
- `backend/knowledge/data/general.yaml` was updated. 本番 seed は Claude/先輩に依頼が必要