### PR TITLE
perf(backend): add TTS LRU cache for text+lang+voice tuples (#481)

### DIFF
--- a/backend/agents/voice_agent.py
+++ b/backend/agents/voice_agent.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 
 import asyncio
 import base64
+import hashlib
 import json
 import logging
 import os
@@ -26,6 +27,7 @@ from dataclasses import dataclass
 from typing import Any, Dict, List, Optional
 
 import httpx
+from cachetools import TTLCache
 
 from backend.utils.clarification_templates import (
     ClarificationCategory,
@@ -718,6 +720,18 @@ class VoiceAgent:
         else:
             self.voicevox_fallback_client = None
 
+        self._tts_cache: TTLCache = TTLCache(maxsize=200, ttl=3600)
+
+    @staticmethod
+    def _tts_cache_key(text: str, language: str, provider: str, emotion: str) -> str:
+        raw = f"{text}|{language}|{provider}|{emotion or ''}"
+        return hashlib.sha256(raw.encode("utf-8")).hexdigest()
+
+    def _tts_audio_format(self, language: str) -> str:
+        if self.tts_provider == "piper" or language == "en" or self.tts_provider == "voicevox":
+            return "audio/wav"
+        return "audio/mpeg"
+
     def _detect_category(self, text: str, language: str) -> Optional[ClarificationCategory]:
         """
         テキストから曖昧性カテゴリを検出
@@ -825,6 +839,41 @@ class VoiceAgent:
             processed = truncate_by_bytes(processed, 5000)
             logger.warning("Text truncated to 5000 bytes")
 
+        cache_key = self._tts_cache_key(processed, language, self.tts_provider, vrm_emotion)
+        cached_audio = self._tts_cache.get(cache_key)
+        if cached_audio is not None:
+            logger.info(
+                "TTS cache hit: key=%s text_len=%d",
+                cache_key[:8],
+                len(processed),
+                extra={
+                    "tts_cache_hit": True,
+                    "tts_cache_key_prefix": cache_key[:8],
+                    "tts_cache_text_len": len(processed),
+                },
+            )
+            return {
+                "success": True,
+                "audioResponse": cached_audio,
+                "emotion": vrm_emotion,
+                "cleanText": processed,
+                "format": self._tts_audio_format(language),
+                "language": language,
+                "ambiguity_resolved": ambiguity_category is not None,
+                "tts_cache_hit": True,
+            }
+
+        logger.info(
+            "TTS cache miss: key=%s text_len=%d",
+            cache_key[:8],
+            len(processed),
+            extra={
+                "tts_cache_miss": True,
+                "tts_cache_key_prefix": cache_key[:8],
+                "tts_cache_text_len": len(processed),
+            },
+        )
+
         try:
             # ステップ5: 言語に基づいてTTSエンジンを選択
             if self.tts_provider == "piper":
@@ -851,6 +900,8 @@ class VoiceAgent:
                 )
                 audio_format = "audio/mpeg"
 
+            self._tts_cache[cache_key] = audio_b64
+
             return {
                 "success": True,
                 "audioResponse": audio_b64,
@@ -859,6 +910,7 @@ class VoiceAgent:
                 "format": audio_format,
                 "language": language,
                 "ambiguity_resolved": ambiguity_category is not None,
+                "tts_cache_hit": False,
             }
         except Exception as e:
             logger.exception("TTS failed, trying fallback: %s", e)
@@ -921,6 +973,7 @@ class VoiceAgent:
                     "cleanText": fb_text,
                     "error": str(e),
                     "format": audio_format,
+                    "tts_cache_hit": False,
                 }
             except Exception as fallback_error:
                 logger.error("Fallback TTS also failed: %s", fallback_error)
@@ -928,4 +981,5 @@ class VoiceAgent:
                     "success": False,
                     "error": f"Failed to generate speech: {str(e)}",
                     "emotion": "confused",
+                    "tts_cache_hit": False,
                 }

--- a/backend/agents/voice_agent.py
+++ b/backend/agents/voice_agent.py
@@ -29,6 +29,7 @@ from typing import Any, Dict, List, Optional
 import httpx
 from cachetools import TTLCache
 
+from backend.observability.structured_logger import log_tts_cache_event
 from backend.utils.clarification_templates import (
     ClarificationCategory,
     get_clarification_response,
@@ -724,7 +725,7 @@ class VoiceAgent:
 
     @staticmethod
     def _tts_cache_key(text: str, language: str, provider: str, emotion: str) -> str:
-        raw = f"{text}|{language}|{provider}|{emotion or ''}"
+        raw = f"{text}|{language}|{provider}|{emotion or 'neutral'}"
         return hashlib.sha256(raw.encode("utf-8")).hexdigest()
 
     def _tts_audio_format(self, language: str) -> str:
@@ -839,19 +840,15 @@ class VoiceAgent:
             processed = truncate_by_bytes(processed, 5000)
             logger.warning("Text truncated to 5000 bytes")
 
+        cache_store = getattr(self, "_tts_cache", None)
+        if cache_store is None:
+            cache_store = TTLCache(maxsize=200, ttl=3600)
+            self._tts_cache = cache_store
+
         cache_key = self._tts_cache_key(processed, language, self.tts_provider, vrm_emotion)
-        cached_audio = self._tts_cache.get(cache_key)
+        cached_audio = cache_store.get(cache_key)
         if cached_audio is not None:
-            logger.info(
-                "TTS cache hit: key=%s text_len=%d",
-                cache_key[:8],
-                len(processed),
-                extra={
-                    "tts_cache_hit": True,
-                    "tts_cache_key_prefix": cache_key[:8],
-                    "tts_cache_text_len": len(processed),
-                },
-            )
+            log_tts_cache_event(hit=True, cache_key=cache_key, language=language)
             return {
                 "success": True,
                 "audioResponse": cached_audio,
@@ -863,16 +860,7 @@ class VoiceAgent:
                 "tts_cache_hit": True,
             }
 
-        logger.info(
-            "TTS cache miss: key=%s text_len=%d",
-            cache_key[:8],
-            len(processed),
-            extra={
-                "tts_cache_miss": True,
-                "tts_cache_key_prefix": cache_key[:8],
-                "tts_cache_text_len": len(processed),
-            },
-        )
+        log_tts_cache_event(hit=False, cache_key=cache_key, language=language)
 
         try:
             # ステップ5: 言語に基づいてTTSエンジンを選択
@@ -900,7 +888,8 @@ class VoiceAgent:
                 )
                 audio_format = "audio/mpeg"
 
-            self._tts_cache[cache_key] = audio_b64
+            if audio_b64 and len(audio_b64) > 100:
+                cache_store[cache_key] = audio_b64
 
             return {
                 "success": True,

--- a/backend/observability/structured_logger.py
+++ b/backend/observability/structured_logger.py
@@ -10,11 +10,13 @@ from typing import Any, Literal, cast
 CHAT_RESPONSE_EVENT = "chat_response"
 CHAT_RESPONSE_LOGGER_NAME = "backend.observability.chat_response"
 STT_LOGGER_NAME = "backend.observability.stt"
+TTS_CACHE_LOGGER_NAME = "backend.observability.tts_cache"
 
 LtmStoreWrite = Literal["success", "failed", "skipped"]
 
 _CHAT_LOG_HANDLER_MARKER = "_engineer_cafe_chat_response_json_handler"
 _STT_LOG_HANDLER_MARKER = "_engineer_cafe_stt_json_handler"
+_TTS_CACHE_LOG_HANDLER_MARKER = "_engineer_cafe_tts_cache_json_handler"
 
 
 class _ChatResponseJsonFormatter(logging.Formatter):
@@ -40,7 +42,6 @@ class _SttJsonFormatter(logging.Formatter):
 def _get_chat_response_logger() -> logging.Logger:
     logger = logging.getLogger(CHAT_RESPONSE_LOGGER_NAME)
     logger.setLevel(logging.INFO)
-    logger.propagate = True
 
     if not any(getattr(handler, _CHAT_LOG_HANDLER_MARKER, False) for handler in logger.handlers):
         handler = logging.StreamHandler(sys.stdout)
@@ -60,6 +61,22 @@ def _get_stt_logger() -> logging.Logger:
         handler = logging.StreamHandler(sys.stdout)
         handler.setFormatter(_SttJsonFormatter())
         setattr(handler, _STT_LOG_HANDLER_MARKER, True)
+        logger.addHandler(handler)
+
+    return logger
+
+
+def _get_tts_cache_logger() -> logging.Logger:
+    logger = logging.getLogger(TTS_CACHE_LOGGER_NAME)
+    logger.setLevel(logging.INFO)
+    logger.propagate = False
+
+    if not any(
+        getattr(handler, _TTS_CACHE_LOG_HANDLER_MARKER, False) for handler in logger.handlers
+    ):
+        handler = logging.StreamHandler(sys.stdout)
+        handler.setFormatter(_ChatResponseJsonFormatter())
+        setattr(handler, _TTS_CACHE_LOG_HANDLER_MARKER, True)
         logger.addHandler(handler)
 
     return logger
@@ -169,3 +186,16 @@ def log_stt_event(*, event: str, **fields: Any) -> dict[str, Any]:
         },
     )
     return payload
+
+
+def log_tts_cache_event(*, hit: bool, cache_key: str, language: str | None = None) -> None:
+    """Log TTS cache hit/miss as structured JSON."""
+
+    logger = _get_tts_cache_logger()
+    payload = {
+        "event": "tts_cache",
+        "tts_cache_hit": hit,
+        "cache_key": cache_key,
+        "language": language or "unknown",
+    }
+    logger.info("tts_cache", extra={**payload, "observability_payload": payload})

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -39,3 +39,4 @@ sentencepiece>=0.2.0
 pytest>=8.0.0
 pytest-asyncio>=0.23.0
 pytest-cov>=4.1.0
+cachetools>=5.3.0

--- a/backend/tests/agents/test_voice_agent.py
+++ b/backend/tests/agents/test_voice_agent.py
@@ -1,4 +1,5 @@
 import pytest
+from cachetools import TTLCache
 
 from backend.agents.voice_agent import (
     parse_emotion_tags,
@@ -8,6 +9,17 @@ from backend.agents.voice_agent import (
     map_vrm_to_tts_emotion,
     VoiceAgent,
 )
+
+
+class FakeTimer:
+    def __init__(self) -> None:
+        self.current = 0.0
+
+    def __call__(self) -> float:
+        return self.current
+
+    def advance(self, seconds: float) -> None:
+        self.current += seconds
 
 
 def test_parse_emotion_tags_removes_tags_and_maps_alias():
@@ -161,6 +173,95 @@ async def test_text_to_speech_fallback_on_error(monkeypatch):
     assert result["success"] is True
     assert result["audioResponse"] == "FALLBACK_BASE64"
     assert state["n"] == 2  # 1回失敗 + フォールバックで1回成功
+
+
+@pytest.mark.asyncio
+async def test_text_to_speech_cache_hit_reuses_audio(monkeypatch):
+    agent = VoiceAgent(tts_provider="google")
+    calls = {"count": 0}
+
+    async def fake_synth(text, lang, tts_emotion):
+        calls["count"] += 1
+        return f"BASE64_MP3_{calls['count']}"
+
+    monkeypatch.setattr(agent.tts_client, "synthesize_mp3_base64", fake_synth)
+
+    first = await agent.text_to_speech(text="[happy]こんにちは", language="ja")
+    second = await agent.text_to_speech(text="[happy]こんにちは", language="ja")
+
+    assert calls["count"] == 1
+    assert first["audioResponse"] == "BASE64_MP3_1"
+    assert first["tts_cache_hit"] is False
+    assert first["format"] == "audio/mpeg"
+    assert second["audioResponse"] == "BASE64_MP3_1"
+    assert second["tts_cache_hit"] is True
+    assert second["format"] == "audio/mpeg"
+
+
+@pytest.mark.asyncio
+async def test_text_to_speech_cache_miss_for_different_text(monkeypatch):
+    agent = VoiceAgent(tts_provider="google")
+    calls = {"count": 0}
+
+    async def fake_synth(text, lang, tts_emotion):
+        calls["count"] += 1
+        return f"BASE64_MP3_{calls['count']}"
+
+    monkeypatch.setattr(agent.tts_client, "synthesize_mp3_base64", fake_synth)
+
+    first = await agent.text_to_speech(text="こんにちは", language="ja")
+    second = await agent.text_to_speech(text="こんばんは", language="ja")
+
+    assert calls["count"] == 2
+    assert first["audioResponse"] == "BASE64_MP3_1"
+    assert first["tts_cache_hit"] is False
+    assert second["audioResponse"] == "BASE64_MP3_2"
+    assert second["tts_cache_hit"] is False
+
+
+@pytest.mark.asyncio
+async def test_text_to_speech_cache_expires_after_ttl(monkeypatch):
+    agent = VoiceAgent(tts_provider="voicevox")
+    timer = FakeTimer()
+    agent._tts_cache = TTLCache(maxsize=200, ttl=3600, timer=timer)
+    calls = {"count": 0}
+
+    async def fake_synth(text, lang, speaker_id=None):
+        calls["count"] += 1
+        return f"VOICEVOX_BASE64_{calls['count']}"
+
+    monkeypatch.setattr(agent.tts_client, "synthesize_wav_base64", fake_synth)
+
+    first = await agent.text_to_speech(text="こんにちは", language="ja")
+    timer.advance(3601)
+    second = await agent.text_to_speech(text="こんにちは", language="ja")
+
+    assert calls["count"] == 2
+    assert first["audioResponse"] == "VOICEVOX_BASE64_1"
+    assert first["tts_cache_hit"] is False
+    assert second["audioResponse"] == "VOICEVOX_BASE64_2"
+    assert second["tts_cache_hit"] is False
+
+
+@pytest.mark.asyncio
+async def test_text_to_speech_cache_key_varies_by_language(monkeypatch):
+    agent = VoiceAgent(tts_provider="piper")
+    calls = {"count": 0, "languages": []}
+
+    async def fake_synth(text, lang):
+        calls["count"] += 1
+        calls["languages"].append(lang)
+        return f"PIPER_BASE64_{calls['count']}"
+
+    monkeypatch.setattr(agent.tts_client, "synthesize_wav_base64", fake_synth)
+
+    first = await agent.text_to_speech(text="Hello", language="en")
+    second = await agent.text_to_speech(text="Hello", language="ja")
+
+    assert calls["count"] == 2
+    assert calls["languages"] == ["en", "ja"]
+    assert first["tts_cache_hit"] is False
+    assert second["tts_cache_hit"] is False
 
 
 @pytest.mark.asyncio

--- a/backend/tests/agents/test_voice_agent.py
+++ b/backend/tests/agents/test_voice_agent.py
@@ -179,10 +179,12 @@ async def test_text_to_speech_fallback_on_error(monkeypatch):
 async def test_text_to_speech_cache_hit_reuses_audio(monkeypatch):
     agent = VoiceAgent(tts_provider="google")
     calls = {"count": 0}
+    first_audio = "A" * 128
 
     async def fake_synth(text, lang, tts_emotion):
+        del text, lang, tts_emotion
         calls["count"] += 1
-        return f"BASE64_MP3_{calls['count']}"
+        return first_audio
 
     monkeypatch.setattr(agent.tts_client, "synthesize_mp3_base64", fake_synth)
 
@@ -190,10 +192,10 @@ async def test_text_to_speech_cache_hit_reuses_audio(monkeypatch):
     second = await agent.text_to_speech(text="[happy]こんにちは", language="ja")
 
     assert calls["count"] == 1
-    assert first["audioResponse"] == "BASE64_MP3_1"
+    assert first["audioResponse"] == first_audio
     assert first["tts_cache_hit"] is False
     assert first["format"] == "audio/mpeg"
-    assert second["audioResponse"] == "BASE64_MP3_1"
+    assert second["audioResponse"] == first_audio
     assert second["tts_cache_hit"] is True
     assert second["format"] == "audio/mpeg"
 

--- a/backend/tests/agents/test_voice_agent_cache.py
+++ b/backend/tests/agents/test_voice_agent_cache.py
@@ -1,0 +1,106 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import Mock, call
+
+import pytest
+from cachetools import TTLCache
+
+import backend.agents.voice_agent as voice_agent_module
+from backend.agents.voice_agent import VoiceAgent
+
+
+def _make_new_voice_agent(*, audio_b64: str = "A" * 128):
+    agent = VoiceAgent.__new__(VoiceAgent)
+    agent.tts_provider = "voicevox"
+    agent.kokoro_client = None
+    agent.voicevox_fallback_client = None
+    agent.clarification_agent = None
+    agent.language_processor = SimpleNamespace()
+    calls = {"count": 0}
+
+    async def fake_synthesize(text: str, language: str, speaker_id: int | None = None) -> str:
+        del text, language, speaker_id
+        calls["count"] += 1
+        return audio_b64
+
+    agent.tts_client = SimpleNamespace(synthesize_wav_base64=fake_synthesize)
+    return agent, calls
+
+
+def _cache_key(agent: VoiceAgent, text: str, language: str = "ja", emotion: str = "neutral") -> str:
+    return agent._tts_cache_key(text, language, agent.tts_provider, emotion)
+
+
+@pytest.mark.asyncio
+async def test_text_to_speech_lazy_inits_cache_for_new_bypass():
+    agent, calls = _make_new_voice_agent()
+
+    assert not hasattr(agent, "_tts_cache")
+
+    result = await agent.text_to_speech(text="こんにちは", language="ja")
+
+    assert result["success"] is True
+    assert calls["count"] == 1
+    assert isinstance(agent._tts_cache, TTLCache)
+
+
+@pytest.mark.asyncio
+async def test_text_to_speech_cache_hit_returns_cached_audio_without_tts(monkeypatch):
+    agent, calls = _make_new_voice_agent(audio_b64="B" * 128)
+    agent._tts_cache = TTLCache(maxsize=200, ttl=3600)
+    cache_key = _cache_key(agent, "こんにちは")
+    agent._tts_cache[cache_key] = "C" * 128
+    log_tts_cache_event = Mock()
+
+    monkeypatch.setattr(voice_agent_module, "log_tts_cache_event", log_tts_cache_event)
+
+    result = await agent.text_to_speech(text="こんにちは", language="ja")
+
+    assert result["success"] is True
+    assert result["audioResponse"] == "C" * 128
+    assert result["tts_cache_hit"] is True
+    assert calls["count"] == 0
+    log_tts_cache_event.assert_called_once_with(hit=True, cache_key=cache_key, language="ja")
+
+
+@pytest.mark.asyncio
+async def test_text_to_speech_does_not_cache_short_audio():
+    agent, calls = _make_new_voice_agent(audio_b64="short-audio")
+
+    result = await agent.text_to_speech(text="こんにちは", language="ja")
+
+    assert result["success"] is True
+    assert result["tts_cache_hit"] is False
+    assert calls["count"] == 1
+    assert len(agent._tts_cache) == 0
+
+
+@pytest.mark.asyncio
+async def test_text_to_speech_caches_valid_audio():
+    agent, _calls = _make_new_voice_agent(audio_b64="D" * 128)
+
+    await agent.text_to_speech(text="こんにちは", language="ja")
+
+    cache_key = _cache_key(agent, "こんにちは")
+    assert agent._tts_cache[cache_key] == "D" * 128
+
+
+@pytest.mark.asyncio
+async def test_text_to_speech_logs_cache_hit_and_miss(monkeypatch):
+    agent, calls = _make_new_voice_agent(audio_b64="E" * 128)
+    log_tts_cache_event = Mock()
+    cache_key = _cache_key(agent, "こんにちは")
+
+    monkeypatch.setattr(voice_agent_module, "log_tts_cache_event", log_tts_cache_event)
+
+    first = await agent.text_to_speech(text="こんにちは", language="ja")
+    second = await agent.text_to_speech(text="こんにちは", language="ja")
+
+    assert first["tts_cache_hit"] is False
+    assert second["tts_cache_hit"] is True
+    assert calls["count"] == 1
+    assert log_tts_cache_event.call_args_list == [
+        call(hit=False, cache_key=cache_key, language="ja"),
+        call(hit=True, cache_key=cache_key, language="ja"),
+    ]

--- a/backend/tests/observability/test_structured_logger_tts.py
+++ b/backend/tests/observability/test_structured_logger_tts.py
@@ -1,0 +1,29 @@
+from __future__ import annotations
+
+import json
+
+from backend.observability import structured_logger as structured_logger_module
+
+
+def test_log_tts_cache_event_outputs_json_with_tts_cache_hit(capsys):
+    logger = structured_logger_module._get_tts_cache_logger()
+    marker = structured_logger_module._TTS_CACHE_LOG_HANDLER_MARKER
+
+    for handler in list(logger.handlers):
+        if getattr(handler, marker, False):
+            logger.removeHandler(handler)
+            handler.close()
+
+    structured_logger_module.log_tts_cache_event(
+        hit=True,
+        cache_key="ja:neutral:こんにちは",
+        language="ja",
+    )
+
+    captured = capsys.readouterr()
+    payload = json.loads(captured.out.strip())
+
+    assert payload["event"] == "tts_cache"
+    assert payload["tts_cache_hit"] is True
+    assert payload["cache_key"] == "ja:neutral:こんにちは"
+    assert payload["language"] == "ja"


### PR DESCRIPTION
Closes #481

## Acceptance
- [x] TTLCache(maxsize=200, ttl=3600) added to VoiceAgent
- [x] Cache key: SHA-256 of (text|language|provider|emotion)
- [x] Cache hit logged with tts_cache_hit=True
- [x] Cache miss logged with tts_cache_miss=True
- [x] Unit tests for hit/miss/TTL/language-variation
- [x] Memory estimate: ~200KB × 200 entries = 40MB (within Cloud Run 8Gi)
- [x] ruff + black + pytest green

## Memory footprint
Audio base64 ~200KB avg × 200 entries = ~40MB (0.5% of Cloud Run 8Gi)