### PR TITLE
perf(backend): STT Phase 2 profiling + env guard (#557)

### DIFF
--- a/backend/agents/stt_agent.py
+++ b/backend/agents/stt_agent.py
@@ -28,13 +28,18 @@ import contextlib
 import io
 import json
 import logging
+import math
 import numpy as np
 import os
+import time
+import uuid
 import wave
 from dataclasses import dataclass, field
 from typing import Any, Dict, List, Optional
 
 import httpx as _stt_httpx
+
+from backend.observability.structured_logger import log_stt_event
 
 logger = logging.getLogger(__name__)
 
@@ -129,7 +134,7 @@ async def _qwen_llm_post_process(transcript: str, language: str) -> str:
     fix for Bug #439 (Qwen mangling proper nouns under noise) and adds
     OpenRouter latency to every Japanese STT request when enabled.
     """
-    if os.getenv("STT_QWEN_POSTPROCESS_ENABLED", "false").lower() != "true":
+    if not _qwen_postprocess_enabled():
         return transcript
     if language != "ja":
         return transcript
@@ -215,6 +220,33 @@ AUDIO_CONVERSION_ERROR_PREFIX = "Failed to convert WebM audio to WAV for STT tra
 PYDUB_IMPORT_ERROR = (
     "WebM audio conversion requires pydub. Install backend dependencies with pydub included."
 )
+
+
+def _duration_ms(started_at: float) -> int:
+    return int((time.perf_counter() - started_at) * 1000)
+
+
+def _parse_qwen_stt_timeout(raw_value: Optional[str], default: float = 10.0) -> float:
+    """Parse QWEN_STT_TIMEOUT defensively; production once had `true`."""
+
+    if raw_value is None or raw_value.strip() == "":
+        return default
+
+    try:
+        timeout = float(raw_value)
+    except (TypeError, ValueError):
+        logger.warning("Invalid QWEN_STT_TIMEOUT=%r; falling back to %.1fs", raw_value, default)
+        return default
+
+    if not math.isfinite(timeout) or timeout <= 0:
+        logger.warning("Invalid QWEN_STT_TIMEOUT=%r; falling back to %.1fs", raw_value, default)
+        return default
+
+    return timeout
+
+
+def _qwen_postprocess_enabled() -> bool:
+    return os.getenv("STT_QWEN_POSTPROCESS_ENABLED", "false").lower() == "true"
 
 
 def convert_audio_to_wav_bytes(audio_data: bytes) -> bytes:
@@ -803,12 +835,21 @@ class QwenSTTClient:
         self.device = resolved_device
 
         logger.info("Loading Qwen3-ASR model %s on %s", self.model_name, self.device)
+        load_started_at = time.perf_counter()
         self._model = Qwen3ASRModel.from_pretrained(
             self.model_name,
             torch_dtype=torch_dtype,
             device_map=self.device,
             low_cpu_mem_usage=True,
             max_new_tokens=256,
+        )
+        log_stt_event(
+            event="stt_model_load_complete",
+            stt_model_load_duration_ms=_duration_ms(load_started_at),
+            provider="qwen",
+            model_name=self.model_name,
+            model_variant=self.model_variant,
+            device=self.device,
         )
 
     def _sync_transcribe(
@@ -961,7 +1002,7 @@ class STTAgent:
                 default_language=os.getenv("QWEN_STT_LANGUAGE", "ja"),
             )
             self._vosk_fallback_client = LocalSTTClient()
-            self._qwen_timeout = float(os.getenv("QWEN_STT_TIMEOUT", "10"))
+            self._qwen_timeout = _parse_qwen_stt_timeout(os.getenv("QWEN_STT_TIMEOUT"))
         else:
             raise ValueError(f"Unknown STT provider: {self.stt_provider}")
 
@@ -1194,16 +1235,100 @@ class STTAgent:
         タイムアウトまたはエラー時は、並走していた Vosk の結果にフォールバックする。
         """
 
+        stt_trace_id = f"stt-{uuid.uuid4().hex[:12]}"
+        overall_started_at = time.perf_counter()
+        qwen_postprocess_enabled = _qwen_postprocess_enabled()
+
         async def _run_qwen():
-            return await asyncio.wait_for(
-                self.stt_client.transcribe(audio_data, language=language),
-                timeout=self._qwen_timeout,
+            qwen_started_at = time.perf_counter()
+            log_stt_event(
+                event="stt_qwen_start",
+                stt_trace_id=stt_trace_id,
+                provider="qwen-primary",
+                language=language,
+                timeout_s=self._qwen_timeout,
+                audio_bytes=len(audio_data),
+                qwen_postprocess_enabled=qwen_postprocess_enabled,
             )
+            try:
+                result = await asyncio.wait_for(
+                    self.stt_client.transcribe(audio_data, language=language),
+                    timeout=self._qwen_timeout,
+                )
+            except Exception as exc:
+                log_stt_event(
+                    event="stt_qwen_complete",
+                    stt_trace_id=stt_trace_id,
+                    provider="qwen-primary",
+                    language=language,
+                    success=False,
+                    error_type=type(exc).__name__,
+                    stt_qwen_duration_ms=_duration_ms(qwen_started_at),
+                    qwen_postprocess_enabled=qwen_postprocess_enabled,
+                )
+                raise
+
+            log_stt_event(
+                event="stt_qwen_complete",
+                stt_trace_id=stt_trace_id,
+                provider="qwen-primary",
+                language=result.language,
+                success=True,
+                transcript_chars=len(result.text),
+                confidence=result.confidence,
+                stt_qwen_duration_ms=_duration_ms(qwen_started_at),
+                qwen_postprocess_enabled=qwen_postprocess_enabled,
+            )
+            return result
 
         async def _run_vosk():
-            if language is None:
-                return await self._vosk_fallback_client.transcribe_auto_detect(audio_data)
-            return await self._vosk_fallback_client.transcribe(audio_data, language)
+            vosk_started_at = time.perf_counter()
+            log_stt_event(
+                event="stt_vosk_start",
+                stt_trace_id=stt_trace_id,
+                provider="vosk-fallback",
+                language=language,
+                audio_bytes=len(audio_data),
+            )
+            try:
+                if language is None:
+                    result = await self._vosk_fallback_client.transcribe_auto_detect(audio_data)
+                else:
+                    result = await self._vosk_fallback_client.transcribe(audio_data, language)
+            except asyncio.CancelledError:
+                log_stt_event(
+                    event="stt_vosk_complete",
+                    stt_trace_id=stt_trace_id,
+                    provider="vosk-fallback",
+                    language=language,
+                    success=False,
+                    cancelled=True,
+                    stt_vosk_duration_ms=_duration_ms(vosk_started_at),
+                )
+                raise
+            except Exception as exc:
+                log_stt_event(
+                    event="stt_vosk_complete",
+                    stt_trace_id=stt_trace_id,
+                    provider="vosk-fallback",
+                    language=language,
+                    success=False,
+                    error_type=type(exc).__name__,
+                    stt_vosk_duration_ms=_duration_ms(vosk_started_at),
+                )
+                raise
+
+            log_stt_event(
+                event="stt_vosk_complete",
+                stt_trace_id=stt_trace_id,
+                provider="vosk-fallback",
+                language=result.language,
+                success=True,
+                transcript_chars=len(result.text),
+                confidence=result.confidence,
+                stt_vosk_duration_ms=_duration_ms(vosk_started_at),
+            )
+            return result
 
         async def _discard_vosk_result(vosk_task: asyncio.Task[Any]) -> None:
             if not vosk_task.done():
@@ -1228,6 +1353,16 @@ class STTAgent:
             # Qwen success
             if isinstance(qwen_result, TranscriptionResult):
                 await _discard_vosk_result(vosk_task)
+                log_stt_event(
+                    event="stt_winner",
+                    stt_trace_id=stt_trace_id,
+                    stt_winner="qwen",
+                    provider="qwen-primary",
+                    language=qwen_result.language,
+                    success=True,
+                    stt_overall_duration_ms=_duration_ms(overall_started_at),
+                    qwen_postprocess_enabled=qwen_postprocess_enabled,
+                )
                 return {
                     "success": True,
                     "transcript": qwen_result.text,
@@ -1254,6 +1389,17 @@ class STTAgent:
                     if corrected != transcript:
                         postprocessed = True
                         transcript = corrected
+                log_stt_event(
+                    event="stt_winner",
+                    stt_trace_id=stt_trace_id,
+                    stt_winner="vosk",
+                    provider="vosk-fallback",
+                    language=vosk_result.language,
+                    success=True,
+                    stt_overall_duration_ms=_duration_ms(overall_started_at),
+                    vosk_postprocessed=postprocessed,
+                    qwen_error_type=type(qwen_result).__name__,
+                )
                 return {
                     "success": True,
                     "transcript": transcript,
@@ -1264,6 +1410,15 @@ class STTAgent:
                 }
 
             # Both failed
+            log_stt_event(
+                event="stt_winner",
+                stt_trace_id=stt_trace_id,
+                stt_winner="none",
+                success=False,
+                stt_overall_duration_ms=_duration_ms(overall_started_at),
+                qwen_error_type=type(qwen_result).__name__,
+                vosk_error_type=type(vosk_result).__name__,
+            )
             raise RuntimeError(
                 f"Both Qwen and Vosk STT failed: qwen={qwen_result}, vosk={vosk_result}"
             )

--- a/backend/observability/structured_logger.py
+++ b/backend/observability/structured_logger.py
@@ -5,14 +5,16 @@ from __future__ import annotations
 import json
 import logging
 import sys
-from typing import Any, Literal
+from typing import Any, Literal, cast
 
 CHAT_RESPONSE_EVENT = "chat_response"
 CHAT_RESPONSE_LOGGER_NAME = "backend.observability.chat_response"
+STT_LOGGER_NAME = "backend.observability.stt"
 
 LtmStoreWrite = Literal["success", "failed", "skipped"]
 
 _CHAT_LOG_HANDLER_MARKER = "_engineer_cafe_chat_response_json_handler"
+_STT_LOG_HANDLER_MARKER = "_engineer_cafe_stt_json_handler"
 
 
 class _ChatResponseJsonFormatter(logging.Formatter):
@@ -25,6 +27,16 @@ class _ChatResponseJsonFormatter(logging.Formatter):
         return json.dumps(payload, ensure_ascii=False, default=str)
 
 
+class _SttJsonFormatter(logging.Formatter):
+    """Emit STT observability payloads as top-level JSON objects."""
+
+    def format(self, record: logging.LogRecord) -> str:
+        payload = getattr(record, "observability_payload", None)
+        if not isinstance(payload, dict):
+            payload = {"event": getattr(record, "event", "stt_event")}
+        return json.dumps(payload, ensure_ascii=False, default=str)
+
+
 def _get_chat_response_logger() -> logging.Logger:
     logger = logging.getLogger(CHAT_RESPONSE_LOGGER_NAME)
     logger.setLevel(logging.INFO)
@@ -34,6 +46,20 @@ def _get_chat_response_logger() -> logging.Logger:
         handler = logging.StreamHandler(sys.stdout)
         handler.setFormatter(_ChatResponseJsonFormatter())
         setattr(handler, _CHAT_LOG_HANDLER_MARKER, True)
+        logger.addHandler(handler)
+
+    return logger
+
+
+def _get_stt_logger() -> logging.Logger:
+    logger = logging.getLogger(STT_LOGGER_NAME)
+    logger.setLevel(logging.INFO)
+    logger.propagate = True
+
+    if not any(getattr(handler, _STT_LOG_HANDLER_MARKER, False) for handler in logger.handlers):
+        handler = logging.StreamHandler(sys.stdout)
+        handler.setFormatter(_SttJsonFormatter())
+        setattr(handler, _STT_LOG_HANDLER_MARKER, True)
         logger.addHandler(handler)
 
     return logger
@@ -53,7 +79,7 @@ def _coerce_sources(raw_sources: Any) -> list[str]:
 
 def _coerce_ltm_store_write(value: Any) -> LtmStoreWrite:
     if value in ("success", "failed", "skipped"):
-        return value
+        return cast(LtmStoreWrite, value)
     if value is True:
         return "success"
     if value is False:
@@ -113,6 +139,30 @@ def log_chat_response(
     logger = _get_chat_response_logger()
     logger.info(
         CHAT_RESPONSE_EVENT,
+        extra={
+            **payload,
+            "observability_payload": payload,
+        },
+    )
+    return payload
+
+
+def build_stt_event_payload(*, event: str, **fields: Any) -> dict[str, Any]:
+    """Build the STT structured log payload used by profiling scripts."""
+
+    return {
+        "event": event,
+        **fields,
+    }
+
+
+def log_stt_event(*, event: str, **fields: Any) -> dict[str, Any]:
+    """Log an STT observability event and return the payload for tests."""
+
+    payload = build_stt_event_payload(event=event, **fields)
+    logger = _get_stt_logger()
+    logger.info(
+        event,
         extra={
             **payload,
             "observability_payload": payload,

--- a/backend/tests/agents/test_stt_agent.py
+++ b/backend/tests/agents/test_stt_agent.py
@@ -1,5 +1,6 @@
 """Tests for STTAgent - Speech-to-Text integration"""
 
+import logging
 import pytest
 import json
 import io
@@ -748,6 +749,30 @@ class TestSTTAgent:
 
         assert agent.stt_provider == "qwen0.6b-cpu"
         mock_qwen_client.assert_called_once_with(default_language="ja")
+
+    def test_init_qwen_primary_timeout_env_guard(self, monkeypatch):
+        """qwen-primary tolerates malformed QWEN_STT_TIMEOUT from prod env."""
+        monkeypatch.setenv("QWEN_STT_TIMEOUT", "true")
+
+        with (
+            patch("backend.agents.stt_agent.Qwen06BCpuSTTClient"),
+            patch("backend.agents.stt_agent.LocalSTTClient"),
+        ):
+            agent = STTAgent(stt_provider="qwen-primary")
+
+        assert agent._qwen_timeout == pytest.approx(10.0)
+
+    def test_init_qwen_primary_timeout_env_numeric(self, monkeypatch):
+        """qwen-primary accepts numeric QWEN_STT_TIMEOUT values."""
+        monkeypatch.setenv("QWEN_STT_TIMEOUT", "2.5")
+
+        with (
+            patch("backend.agents.stt_agent.Qwen06BCpuSTTClient"),
+            patch("backend.agents.stt_agent.LocalSTTClient"),
+        ):
+            agent = STTAgent(stt_provider="qwen-primary")
+
+        assert agent._qwen_timeout == pytest.approx(2.5)
 
     def test_init_invalid_provider_raises_error(self):
         """STTAgent raises ValueError for unknown provider"""
@@ -1699,8 +1724,9 @@ class TestQwenPrimaryParallel:
         return agent
 
     @pytest.mark.asyncio
-    async def test_qwen_primary_success(self):
+    async def test_qwen_primary_success(self, caplog):
         """Qwen succeeds -> provider='qwen-primary'"""
+        caplog.set_level(logging.INFO, logger="backend.observability.stt")
         mock_qwen = MagicMock()
         mock_qwen.transcribe = AsyncMock(
             return_value=TranscriptionResult(
@@ -1724,6 +1750,30 @@ class TestQwenPrimaryParallel:
         assert result["success"] is True
         assert result["provider"] == "qwen-primary"
         assert result["transcript"] == "こんにちは"
+        stt_records = [
+            record for record in caplog.records if record.name == "backend.observability.stt"
+        ]
+        events = [getattr(record, "event", None) for record in stt_records]
+        assert "stt_qwen_start" in events
+        assert "stt_qwen_complete" in events
+        assert "stt_winner" in events
+
+        winner = next(
+            record for record in stt_records if getattr(record, "event", None) == "stt_winner"
+        )
+        assert winner.stt_winner == "qwen"
+        assert winner.provider == "qwen-primary"
+        assert isinstance(winner.stt_overall_duration_ms, int)
+        assert winner.stt_trace_id.startswith("stt-")
+
+        qwen_complete = next(
+            record
+            for record in stt_records
+            if getattr(record, "event", None) == "stt_qwen_complete"
+        )
+        assert qwen_complete.success is True
+        assert isinstance(qwen_complete.stt_qwen_duration_ms, int)
+        assert qwen_complete.stt_trace_id == winner.stt_trace_id
 
     @pytest.mark.asyncio
     async def test_qwen_success_does_not_wait_for_slow_vosk(self):

--- a/docs/adr/016-qwen-stt-phase2-profiling.md
+++ b/docs/adr/016-qwen-stt-phase2-profiling.md
@@ -1,0 +1,105 @@
+# ADR 016: Qwen STT Phase 2 Profiling
+
+作成日: 2026-04-24
+
+## ステータス
+
+提案: Phase A profiling instrumentation を先に入れ、ONNX/INT4 には進まない。
+
+## 背景
+
+ADR 010 では Qwen3-ASR の ONNX/INT4 化を No-Go とした。理由は、Qwen3-ASR が
+`generate()` ベースの autoregressive model であり、Optimum の標準 export では扱えない
+ためである。ローカル PyTorch warm inference は約 0.3 秒で、Cloud Run の約 8 秒前後の
+STT latency は Qwen 推論本体以外にある可能性が高い。
+
+本番は `STT_PROVIDER=qwen-primary` で、Qwen と Vosk fallback の winner-race が既に実装
+されている。ただし本番でどちらが勝っているか、Vosk の cancel が latency にどう効いて
+いるか、cold model load がどの程度残っているかを structured log で継続的に確認できて
+いなかった。
+
+また本番環境には `QWEN_STT_TIMEOUT=true` という誤った値が入っていた。`qwen-primary`
+初期化時に数値変換するため、この値は起動時または agent 初期化時の失敗原因になる。
+
+## 決定
+
+Phase A では以下を実施する。
+
+- `QWEN_STT_TIMEOUT` は正の有限数だけを受け付け、不正値は 10 秒へ fallback する。
+- `backend.observability.structured_logger.log_stt_event()` で STT profiling 用 JSON log を
+  stdout に出す。
+- `qwen-primary` の各 request に `stt_trace_id` を付与し、以下のイベントを記録する。
+  - `stt_qwen_start`
+  - `stt_qwen_complete` with `stt_qwen_duration_ms`
+  - `stt_vosk_start`
+  - `stt_vosk_complete` with `stt_vosk_duration_ms`
+  - `stt_winner` with `stt_winner` and `stt_overall_duration_ms`
+  - `stt_model_load_complete` with `stt_model_load_duration_ms`
+- `scripts/profile_stt.sh` で Cloud Run live `/api/voice` を 20 回、4 秒間隔で叩き、
+  Cloud Logging の `jsonPayload.event=~"stt_.*"` を CSV と Markdown に保存する。
+
+## Profile 結果
+
+Codex のローカル作業環境では本番 Cloud Run への env 更新、deploy、live profiling は実行
+していない。`QWEN_STT_TIMEOUT` の本番値修正は、Phase A PR merge/deploy 前に terisuke /
+Claude の明示的承認後、以下で行う。
+
+```bash
+gcloud run services update engineer-cafe-backend \
+  --region=asia-northeast1 \
+  --project=aipartner-426616 \
+  --update-env-vars QWEN_STT_TIMEOUT=10
+```
+
+deploy 後、以下を実行して `backend/tests/reports/stt-profile-<timestamp>.md` と CSV を
+生成する。
+
+```bash
+scripts/profile_stt.sh --iterations 20 --sleep 4
+```
+
+この ADR の最終版では、生成された report から以下を転記する。
+
+| Metric | count | p50 ms | p90 ms | p95 ms | max ms |
+| --- | ---: | ---: | ---: | ---: | ---: |
+| request_total | TBD | TBD | TBD | TBD | TBD |
+| stt_overall | TBD | TBD | TBD | TBD | TBD |
+| qwen_inference | TBD | TBD | TBD | TBD | TBD |
+| vosk_inference | TBD | TBD | TBD | TBD | TBD |
+| model_load | TBD | TBD | TBD | TBD | TBD |
+
+## Phase B 判断基準
+
+Profile 結果に基づいて Phase B を 1 つだけ選ぶ。
+
+- Qwen が安定して速く、Vosk が CPU 競合または不要な待ちを生んでいる場合:
+  B-1 `Qwen-only path` を選ぶ。Vosk は Qwen failure / timeout 後に fallback-only とする。
+- model load や CPU 推論そのものが支配的で、alpha 期間のコスト承認が取れる場合:
+  B-2 `Cloud Run GPU Spike` を検討する。ただし GPU cost と region は事前承認必須。
+- Qwen 品質または runtime packaging がボトルネックで、Whisper の品質/速度が勝る場合:
+  B-3 `Whisper-large-v3-turbo` spike を検討する。
+
+現時点では Phase B の実装には進まない。Phase A の live profile report と Claude /
+terisuke の明示的 GO を待つ。
+
+## 互換性
+
+- API response schema は変更しない。
+- structured log は stdout への追加ログであり、既存 request behavior を変更しない。
+- `QWEN_STT_TIMEOUT` の不正値は 10 秒に fallback するため、誤設定時の起動失敗を避ける。
+- `STT_QWEN_POSTPROCESS_ENABLED` の状態は Qwen timing events と winner event に含める。
+
+## ロールバック
+
+問題が出た場合は、`backend/agents/stt_agent.py` の `log_stt_event()` 呼び出しと
+`backend/observability/structured_logger.py` の STT helper 追加分を revert する。timeout
+guard は安全側の変更であり、残しても既存挙動への影響は小さい。
+
+## 検証方針
+
+- Unit: `qwen-primary` が malformed `QWEN_STT_TIMEOUT=true` を 10 秒に fallback すること。
+- Unit: Qwen success path が `stt_qwen_start`、`stt_qwen_complete`、`stt_winner` を emit
+  すること。
+- Script: `scripts/profile_stt.sh --help` が通ること。
+- Production: deploy 後に `scripts/profile_stt.sh --iterations 20 --sleep 4` を実行し、
+  report の p50 / p90 / p95 / max と winner 分布を本 ADR に反映すること。

--- a/scripts/profile_stt.sh
+++ b/scripts/profile_stt.sh
@@ -1,0 +1,313 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Profile live Cloud Run STT via /api/voice and collect structured stt_* logs.
+#
+# Usage:
+#   scripts/profile_stt.sh --key "$API_SECRET_KEY"
+#   scripts/profile_stt.sh --host https://... --audio-file sample.wav --iterations 20 --sleep 4
+#
+# Env:
+#   API_SECRET_KEY              Required unless --key provided or gcloud secrets access works
+#   STT_PROFILE_BASE_URL        Overrides the default Cloud Run URL
+#   STT_PROFILE_PROJECT         Defaults to aipartner-426616
+#   STT_PROFILE_SERVICE         Defaults to engineer-cafe-backend
+#   STT_PROFILE_REGION          Defaults to asia-northeast1
+
+DEFAULT_URL="https://engineer-cafe-backend-639959525777.asia-northeast1.run.app"
+BASE_URL="${STT_PROFILE_BASE_URL:-$DEFAULT_URL}"
+PROJECT="${STT_PROFILE_PROJECT:-aipartner-426616}"
+SERVICE="${STT_PROFILE_SERVICE:-engineer-cafe-backend}"
+REGION="${STT_PROFILE_REGION:-asia-northeast1}"
+ITERATIONS=20
+SLEEP_SECONDS=4
+LANGUAGE="ja"
+PROFILE_TEXT="テストです"
+API_KEY="${API_SECRET_KEY:-}"
+AUDIO_FILE=""
+OUT_DIR="backend/tests/reports"
+
+usage() {
+  sed -n '3,16p' "$0"
+  exit "${1:-0}"
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --host) BASE_URL="$2"; shift 2 ;;
+    --project) PROJECT="$2"; shift 2 ;;
+    --service) SERVICE="$2"; shift 2 ;;
+    --region) REGION="$2"; shift 2 ;;
+    --iterations) ITERATIONS="$2"; shift 2 ;;
+    --sleep) SLEEP_SECONDS="$2"; shift 2 ;;
+    --language) LANGUAGE="$2"; shift 2 ;;
+    --text) PROFILE_TEXT="$2"; shift 2 ;;
+    --key) API_KEY="$2"; shift 2 ;;
+    --audio-file) AUDIO_FILE="$2"; shift 2 ;;
+    --out-dir) OUT_DIR="$2"; shift 2 ;;
+    -h|--help) usage 0 ;;
+    *) echo "Unknown arg: $1" >&2; usage 1 ;;
+  esac
+done
+
+fetch_api_key_from_gcloud() {
+  if command -v gcloud >/dev/null 2>&1; then
+    gcloud secrets versions access latest \
+      --secret=API_SECRET_KEY --project="$PROJECT" 2>/dev/null || true
+  fi
+}
+
+json_get() {
+  python3 -c '
+import json, sys
+data = json.load(sys.stdin)
+node = data
+for part in sys.argv[1].split("."):
+    if isinstance(node, dict):
+        node = node.get(part, "")
+    else:
+        node = ""
+        break
+print(node if node is not None else "")
+' "$1"
+}
+
+if [[ -z "$API_KEY" ]]; then
+  API_KEY="$(fetch_api_key_from_gcloud)"
+fi
+
+if [[ -z "$API_KEY" ]]; then
+  echo "Error: API_SECRET_KEY is required (pass --key, set env, or gcloud login)" >&2
+  exit 2
+fi
+
+if ! command -v gcloud >/dev/null 2>&1; then
+  echo "Error: gcloud is required to collect Cloud Logging events" >&2
+  exit 2
+fi
+
+mkdir -p "$OUT_DIR"
+STAMP="$(date -u +%Y%m%dT%H%M%SZ)"
+REQUEST_CSV="$OUT_DIR/stt-profile-$STAMP-requests.csv"
+EVENT_CSV="$OUT_DIR/stt-profile-$STAMP-events.csv"
+LOG_JSON="$OUT_DIR/stt-profile-$STAMP-logs.json"
+REPORT_MD="$OUT_DIR/stt-profile-$STAMP.md"
+
+if [[ -n "$AUDIO_FILE" ]]; then
+  AUDIO_B64="$(base64 < "$AUDIO_FILE" | tr -d '\n')"
+else
+  echo "Generating reusable TTS sample audio via /api/voice..."
+  TTS_BODY="$(PROFILE_TEXT="$PROFILE_TEXT" LANGUAGE="$LANGUAGE" python3 -c '
+import json, os
+print(json.dumps({
+    "action": "text_to_speech",
+    "text": os.environ["PROFILE_TEXT"],
+    "language": os.environ["LANGUAGE"],
+    "sessionId": "stt-profile-tts",
+}, ensure_ascii=False))
+')"
+  TTS_RESPONSE="$(curl -sS -m 60 \
+    -X POST "$BASE_URL/api/voice" \
+    -H "Content-Type: application/json" \
+    -H "X-API-Key: $API_KEY" \
+    -d "$TTS_BODY")"
+  AUDIO_B64="$(printf '%s' "$TTS_RESPONSE" | json_get audioResponse)"
+  if [[ -z "$AUDIO_B64" ]]; then
+    echo "Error: failed to generate TTS audio sample: $TTS_RESPONSE" >&2
+    exit 1
+  fi
+fi
+
+LOG_START="$(date -u +"%Y-%m-%dT%H:%M:%SZ")"
+echo "request_index,http_status,total_ms,transcript_chars,success" > "$REQUEST_CSV"
+
+for i in $(seq 1 "$ITERATIONS"); do
+  SESSION_ID="stt-profile-$STAMP-$i"
+  BODY="$(AUDIO_B64="$AUDIO_B64" SESSION_ID="$SESSION_ID" LANGUAGE="$LANGUAGE" python3 -c '
+import json, os
+print(json.dumps({
+    "action": "speech_to_text",
+    "audioData": os.environ["AUDIO_B64"],
+    "language": os.environ["LANGUAGE"],
+    "sessionId": os.environ["SESSION_ID"],
+}, ensure_ascii=False))
+')"
+  TMP_BODY="$(mktemp)"
+  TOTAL_SECONDS="$(curl -sS -m 90 -o "$TMP_BODY" -w "%{time_total}" \
+    -X POST "$BASE_URL/api/voice" \
+    -H "Content-Type: application/json" \
+    -H "X-API-Key: $API_KEY" \
+    -d "$BODY" || true)"
+  HTTP_STATUS="$(python3 - "$TMP_BODY" <<'PY'
+import json, sys
+try:
+    data = json.load(open(sys.argv[1], encoding="utf-8"))
+except Exception:
+    print("parse_error")
+else:
+    print("200" if data.get("success") is True else "error")
+PY
+)"
+  TRANSCRIPT_CHARS="$(python3 - "$TMP_BODY" <<'PY'
+import json, sys
+try:
+    data = json.load(open(sys.argv[1], encoding="utf-8"))
+    print(len(data.get("transcript") or ""))
+except Exception:
+    print(0)
+PY
+)"
+  SUCCESS="$(python3 - "$TMP_BODY" <<'PY'
+import json, sys
+try:
+    data = json.load(open(sys.argv[1], encoding="utf-8"))
+    print(str(data.get("success") is True).lower())
+except Exception:
+    print("false")
+PY
+)"
+  TOTAL_MS="$(TOTAL_SECONDS="$TOTAL_SECONDS" python3 -c 'import os; print(int(float(os.environ["TOTAL_SECONDS"]) * 1000))')"
+  echo "$i,$HTTP_STATUS,$TOTAL_MS,$TRANSCRIPT_CHARS,$SUCCESS" >> "$REQUEST_CSV"
+  rm -f "$TMP_BODY"
+  echo "[$i/$ITERATIONS] total=${TOTAL_MS}ms success=$SUCCESS"
+  if [[ "$i" != "$ITERATIONS" ]]; then
+    sleep "$SLEEP_SECONDS"
+  fi
+done
+
+LOG_END="$(date -u +"%Y-%m-%dT%H:%M:%SZ")"
+FILTER="resource.type=\"cloud_run_revision\" AND resource.labels.service_name=\"$SERVICE\" AND resource.labels.location=\"$REGION\" AND jsonPayload.event=~\"stt_.*\" AND timestamp>=\"$LOG_START\" AND timestamp<=\"$LOG_END\""
+
+gcloud logging read "$FILTER" \
+  --project="$PROJECT" \
+  --format=json \
+  --limit=1000 \
+  > "$LOG_JSON"
+
+python3 - "$REQUEST_CSV" "$LOG_JSON" "$EVENT_CSV" "$REPORT_MD" "$BASE_URL" "$SERVICE" "$REGION" "$LOG_START" "$LOG_END" <<'PY'
+import csv
+import json
+import math
+import statistics
+import sys
+from collections import defaultdict
+from pathlib import Path
+
+request_csv, log_json, event_csv, report_md, base_url, service, region, start, end = sys.argv[1:]
+
+requests = []
+with open(request_csv, newline="", encoding="utf-8") as fh:
+    requests = list(csv.DictReader(fh))
+
+logs = json.loads(Path(log_json).read_text(encoding="utf-8") or "[]")
+events = []
+for entry in logs:
+    payload = entry.get("jsonPayload") or {}
+    payload["timestamp"] = entry.get("timestamp")
+    if payload.get("event", "").startswith("stt_"):
+        events.append(payload)
+
+fieldnames = [
+    "timestamp",
+    "stt_trace_id",
+    "event",
+    "provider",
+    "stt_winner",
+    "success",
+    "stt_qwen_duration_ms",
+    "stt_vosk_duration_ms",
+    "stt_overall_duration_ms",
+    "stt_model_load_duration_ms",
+    "language",
+    "error_type",
+]
+with open(event_csv, "w", newline="", encoding="utf-8") as fh:
+    writer = csv.DictWriter(fh, fieldnames=fieldnames, extrasaction="ignore")
+    writer.writeheader()
+    writer.writerows(events)
+
+def percentile(values, ratio):
+    if not values:
+        return None
+    ordered = sorted(values)
+    if len(ordered) == 1:
+        return ordered[0]
+    pos = (len(ordered) - 1) * ratio
+    lower = math.floor(pos)
+    upper = math.ceil(pos)
+    if lower == upper:
+        return ordered[lower]
+    return ordered[lower] + (ordered[upper] - ordered[lower]) * (pos - lower)
+
+def stats(values):
+    nums = [float(v) for v in values if v not in (None, "")]
+    if not nums:
+        return {"count": 0, "p50": None, "p90": None, "p95": None, "max": None}
+    return {
+        "count": len(nums),
+        "p50": percentile(nums, 0.50),
+        "p90": percentile(nums, 0.90),
+        "p95": percentile(nums, 0.95),
+        "max": max(nums),
+    }
+
+winner_events = [event for event in events if event.get("event") == "stt_winner"]
+qwen_events = [event for event in events if event.get("event") == "stt_qwen_complete"]
+vosk_events = [event for event in events if event.get("event") == "stt_vosk_complete"]
+model_events = [event for event in events if event.get("event") == "stt_model_load_complete"]
+
+request_totals = [row["total_ms"] for row in requests]
+overall = stats(event.get("stt_overall_duration_ms") for event in winner_events)
+qwen = stats(event.get("stt_qwen_duration_ms") for event in qwen_events)
+vosk = stats(event.get("stt_vosk_duration_ms") for event in vosk_events)
+network = stats(request_totals)
+model = stats(event.get("stt_model_load_duration_ms") for event in model_events)
+
+winners = defaultdict(int)
+for event in winner_events:
+    winners[event.get("stt_winner") or "unknown"] += 1
+
+def fmt(value):
+    return "n/a" if value is None else f"{value:.0f}"
+
+lines = [
+    f"# STT Phase 2 Profile {Path(report_md).stem.removeprefix('stt-profile-')}",
+    "",
+    f"- Target: `{base_url}`",
+    f"- Cloud Run service: `{service}` / `{region}`",
+    f"- Window UTC: `{start}` to `{end}`",
+    f"- Requests: `{len(requests)}`",
+    f"- Structured STT events: `{len(events)}`",
+    f"- Event CSV: `{Path(event_csv).name}`",
+    f"- Request CSV: `{Path(request_csv).name}`",
+    "",
+    "## Summary",
+    "",
+    "| Metric | count | p50 ms | p90 ms | p95 ms | max ms |",
+    "| --- | ---: | ---: | ---: | ---: | ---: |",
+    f"| request_total | {network['count']} | {fmt(network['p50'])} | {fmt(network['p90'])} | {fmt(network['p95'])} | {fmt(network['max'])} |",
+    f"| stt_overall | {overall['count']} | {fmt(overall['p50'])} | {fmt(overall['p90'])} | {fmt(overall['p95'])} | {fmt(overall['max'])} |",
+    f"| qwen_inference | {qwen['count']} | {fmt(qwen['p50'])} | {fmt(qwen['p90'])} | {fmt(qwen['p95'])} | {fmt(qwen['max'])} |",
+    f"| vosk_inference | {vosk['count']} | {fmt(vosk['p50'])} | {fmt(vosk['p90'])} | {fmt(vosk['p95'])} | {fmt(vosk['max'])} |",
+    f"| model_load | {model['count']} | {fmt(model['p50'])} | {fmt(model['p90'])} | {fmt(model['p95'])} | {fmt(model['max'])} |",
+    "",
+    "## Winners",
+    "",
+]
+for winner, count in sorted(winners.items()):
+    lines.append(f"- `{winner}`: {count}")
+lines.extend([
+    "",
+    "## Notes",
+    "",
+    "- `request_total` includes network and JSON serialization overhead.",
+    "- `stt_overall` is emitted inside `STTAgent._transcribe_qwen_primary`.",
+    "- Event grouping uses `stt_trace_id`; request rows are ordered separately.",
+])
+
+Path(report_md).write_text("\n".join(lines) + "\n", encoding="utf-8")
+PY
+
+echo "Wrote $REPORT_MD"
+echo "Wrote $REQUEST_CSV"
+echo "Wrote $EVENT_CSV"


### PR DESCRIPTION
## Summary

Phase A of #529 STT optimization. Per ADR-010 No-Go on ONNX custom export, pivoted to profiling-first approach. See ADR 016.

## Changes

- backend/agents/stt_agent.py (+171-11): guarded malformed QWEN_STT_TIMEOUT env, added Qwen/Vosk/winner/model-load structured timing logs
- backend/observability/structured_logger.py (+54): STT structured log helper
- backend/tests/agents/test_stt_agent.py (+52): env guard + log emission tests
- scripts/profile_stt.sh (+313 new): 20-run live Cloud Run profiler, rate-limit aware
- docs/adr/016-qwen-stt-phase2-profiling.md (+105 new): ADR pending metrics

## Held (explicit approval required)

- Production QWEN_STT_TIMEOUT=10 env update (currently literal string "true")
- 20-run live Cloud Run profile execution

## Validation

- black --check / ruff check: pass
- pytest backend/tests/agents/test_stt_agent.py -q: 93 passed
- bash -n scripts/profile_stt.sh / scripts/profile_stt.sh --help: pass
- code-reviewer agent: Approve, no blockers, conflict risk vs #534 = zero (disjoint regions)

## Next

Phase B decision pending live profile results. Phase B tracked in parent #529.

Closes #557
Refs #529, #474

Co-Authored-By: Codex <noreply@openai.com>
Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>