### PR TITLE
perf(backend): STT Qwen-only fast-path with Vosk cancellation (#559)

### DIFF
--- a/.claude/analysis/codex-2026-04-24-complete-529-phase-b1.md
+++ b/.claude/analysis/codex-2026-04-24-complete-529-phase-b1.md
@@ -1,0 +1,52 @@
+# Codex Completion: Issue #559 STT Phase B-1
+
+Date: 2026-04-24
+Branch: `perf/qwen-only-fastpath-529-b1`
+Route: C
+
+## Summary
+
+- Implemented the Qwen-only fast path in `backend/agents/stt_agent.py`.
+- Qwen success now cancels the Vosk fallback task and returns immediately.
+- Qwen failure or timeout now releases the fallback gate and starts Vosk sequentially.
+- Preserved structured STT timing events using existing `log_stt_event()`.
+- Updated ADR 016 with the Phase B-1 adoption rationale from the Phase A profile.
+
+## Tests and Checks
+
+- `pytest backend/tests/agents/test_stt_agent.py -q`: passed, 97 tests.
+- `ruff check backend/`: passed.
+- `black --check backend/`: passed.
+- `git diff --check`: passed.
+- `mypy agents/stt_agent.py tests/agents/test_stt_agent.py` from `backend/`: failed on pre-existing backend typing/import issues, including missing stubs/imports and unrelated errors in `utils/context_priority.py`, `tools/enhanced_rag.py`, `utils/memory_helper.py`, and existing `agents/stt_agent.py` lines.
+
+## Coverage Added
+
+- Qwen success path verifies:
+  - Vosk fallback inference is not called.
+  - Vosk fallback task cancellation is emitted in caplog.
+  - `stt_overall_duration_ms - stt_qwen_duration_ms < 100`.
+- Qwen failure path verifies:
+  - Vosk starts after Qwen completion.
+  - Vosk transcript is returned as `vosk-fallback`.
+
+## Operational Readiness
+
+- Env vars/secrets: no changes.
+- CORS/domains: no changes.
+- MIME/assets: no changes.
+- Permissions/IAM/token scope: no changes.
+- Schedulers/cron: no changes.
+- Migrations/rollback: no migrations.
+- Terraform/infra/workflows: no changes.
+- Docker/runtime assumptions: no new dependency or runtime env change.
+- Post-merge validation: deploy and rerun `scripts/profile_stt.sh --iterations 20 --sleep 4`, then append Phase B-1 production measurements to ADR 016.
+
+## Scope Note
+
+This worktree already had a pre-existing commit on top of `origin/develop`:
+
+- `581e3f5 feat(backend): add content_en to general-what-is-ec and general-airport-hakata-access entries (#512)`
+- File: `backend/knowledge/data/general.yaml`
+
+I did not modify or revert that commit. It should be handled before opening the #559 PR if the PR must contain only the Phase B-1 STT change.

--- a/backend/agents/stt_agent.py
+++ b/backend/agents/stt_agent.py
@@ -24,7 +24,6 @@ from __future__ import annotations
 
 import asyncio
 import concurrent.futures
-import contextlib
 import io
 import json
 import logging
@@ -1242,11 +1241,11 @@ class STTAgent:
         audio_data: bytes,
         language: Optional[str] = None,
     ) -> Dict[str, Any]:
-        """Qwen primary + Vosk parallel fallback (ADR-007).
+        """Qwen primary + Vosk fallback-only path (ADR-007/016).
 
-        Qwen と Vosk を同時実行し、Qwen が ``QWEN_STT_TIMEOUT`` 秒以内に
-        成功すれば Vosk の完了を待たずにその結果を返す。
-        タイムアウトまたはエラー時は、並走していた Vosk の結果にフォールバックする。
+        Qwen が ``QWEN_STT_TIMEOUT`` 秒以内に成功すれば Vosk の fallback task を
+        cancel して即座に返す。タイムアウトまたはエラー時だけ Vosk inference を
+        sequential に起動してフォールバックする。
         """
 
         stt_trace_id = f"stt-{uuid.uuid4().hex[:12]}"
@@ -1317,6 +1316,7 @@ class STTAgent:
                     language=language,
                     success=False,
                     cancelled=True,
+                    vosk_fallback_started=True,
                     stt_vosk_duration_ms=_duration_ms(vosk_started_at),
                 )
                 raise
@@ -1344,18 +1344,28 @@ class STTAgent:
             )
             return result
 
-        async def _discard_vosk_result(vosk_task: asyncio.Task[Any]) -> None:
-            if not vosk_task.done():
-                vosk_task.cancel()
-                with contextlib.suppress(asyncio.CancelledError):
-                    await vosk_task
-                return
+        vosk_fallback_allowed = asyncio.Event()
 
-            with contextlib.suppress(Exception):
-                vosk_task.result()
+        async def _run_vosk_after_qwen_failure():
+            vosk_task_started_at = time.perf_counter()
+            try:
+                await vosk_fallback_allowed.wait()
+            except asyncio.CancelledError:
+                log_stt_event(
+                    event="stt_vosk_complete",
+                    stt_trace_id=stt_trace_id,
+                    provider="vosk-fallback",
+                    language=language,
+                    success=False,
+                    cancelled=True,
+                    vosk_fallback_started=False,
+                    stt_vosk_duration_ms=_duration_ms(vosk_task_started_at),
+                )
+                raise
+            return await _run_vosk()
 
         qwen_task = asyncio.create_task(_run_qwen())
-        vosk_task = asyncio.create_task(_run_vosk())
+        vosk_task = asyncio.create_task(_run_vosk_after_qwen_failure())
 
         try:
             qwen_result: TranscriptionResult | Exception
@@ -1366,7 +1376,9 @@ class STTAgent:
 
             # Qwen success
             if isinstance(qwen_result, TranscriptionResult):
-                await _discard_vosk_result(vosk_task)
+                if not vosk_task.done():
+                    vosk_task.cancel()
+                    await asyncio.gather(vosk_task, return_exceptions=True)
                 log_stt_event(
                     event="stt_winner",
                     stt_trace_id=stt_trace_id,
@@ -1390,6 +1402,7 @@ class STTAgent:
                 "Qwen STT failed, using Vosk fallback: %s",
                 qwen_result,
             )
+            vosk_fallback_allowed.set()
             try:
                 vosk_result: TranscriptionResult | Exception = await vosk_task
             except Exception as exc:
@@ -1437,9 +1450,11 @@ class STTAgent:
                 f"Both Qwen and Vosk STT failed: qwen={qwen_result}, vosk={vosk_result}"
             )
         finally:
-            for task in (qwen_task, vosk_task):
-                if not task.done():
-                    task.cancel()
+            pending_tasks = [task for task in (qwen_task, vosk_task) if not task.done()]
+            for task in pending_tasks:
+                task.cancel()
+            if pending_tasks:
+                await asyncio.gather(*pending_tasks, return_exceptions=True)
 
     def _resolve_grammar(self, conversation_stage: Optional[str]) -> Optional[Dict[str, List[str]]]:
         """会話ステージに応じた Grammar 辞書を解決する。

--- a/backend/tests/agents/test_stt_agent.py
+++ b/backend/tests/agents/test_stt_agent.py
@@ -1806,12 +1806,12 @@ class TestSTTLLMPostProcess:
 
 
 # ==============================================================================
-# Qwen Primary + Vosk Parallel Fallback (ADR-007)
+# Qwen Primary + Vosk Fallback (ADR-007/016)
 # ==============================================================================
 
 
-class TestQwenPrimaryParallel:
-    """Tests for qwen-primary provider with Vosk parallel fallback."""
+class TestQwenPrimaryFallback:
+    """Tests for qwen-primary provider with Vosk fallback."""
 
     def _make_agent(self, mock_qwen, mock_vosk):
         """Create STTAgent wired for qwen-primary with mock clients."""
@@ -1879,20 +1879,14 @@ class TestQwenPrimaryParallel:
         assert qwen_complete.stt_trace_id == winner.stt_trace_id
 
     @pytest.mark.asyncio
-    async def test_qwen_success_does_not_wait_for_slow_vosk(self):
-        """Qwen succeeds -> returns immediately without waiting for Vosk fallback."""
+    async def test_qwen_success_cancels_vosk_and_logs_cancellation(self, caplog):
+        """Qwen succeeds -> cancels Vosk fallback task and returns immediately."""
         import asyncio
 
-        vosk_started = asyncio.Event()
-        vosk_cancelled = asyncio.Event()
+        caplog.set_level(logging.INFO, logger="backend.observability.stt")
 
         async def slow_vosk(*args, **kwargs):
-            vosk_started.set()
-            try:
-                await asyncio.sleep(20)
-            except asyncio.CancelledError:
-                vosk_cancelled.set()
-                raise
+            await asyncio.sleep(20)
             return TranscriptionResult(
                 text="slow fallback",
                 confidence=0.7,
@@ -1919,9 +1913,32 @@ class TestQwenPrimaryParallel:
         assert result["success"] is True
         assert result["provider"] == "qwen-primary"
         assert result["transcript"] == "qwen fast"
-        assert vosk_started.is_set()
-        assert vosk_cancelled.is_set()
+        mock_vosk.transcribe.assert_not_called()
         assert elapsed < 0.5
+
+        stt_records = [
+            record for record in caplog.records if record.name == "backend.observability.stt"
+        ]
+        vosk_cancel = next(
+            record
+            for record in stt_records
+            if getattr(record, "event", None) == "stt_vosk_complete"
+            and getattr(record, "cancelled", False) is True
+        )
+        winner = next(
+            record for record in stt_records if getattr(record, "event", None) == "stt_winner"
+        )
+        qwen_complete = next(
+            record
+            for record in stt_records
+            if getattr(record, "event", None) == "stt_qwen_complete"
+        )
+        assert vosk_cancel.success is False
+        assert vosk_cancel.provider == "vosk-fallback"
+        assert vosk_cancel.vosk_fallback_started is False
+        assert isinstance(vosk_cancel.stt_vosk_duration_ms, int)
+        assert winner.stt_winner == "qwen"
+        assert winner.stt_overall_duration_ms - qwen_complete.stt_qwen_duration_ms < 100
 
     @pytest.mark.asyncio
     async def test_qwen_timeout_vosk_fallback(self):
@@ -1971,6 +1988,45 @@ class TestQwenPrimaryParallel:
         assert result["success"] is True
         assert result["provider"] == "vosk-fallback"
         assert result["transcript"] == "fallback ok"
+
+    @pytest.mark.asyncio
+    async def test_qwen_failure_starts_vosk_after_qwen_and_returns_vosk(self, caplog):
+        """Qwen failure -> Vosk starts sequentially and returns fallback transcript."""
+        caplog.set_level(logging.INFO, logger="backend.observability.stt")
+        calls = []
+
+        async def fail_qwen(*args, **kwargs):
+            calls.append("qwen")
+            raise RuntimeError("Model OOM")
+
+        async def run_vosk(*args, **kwargs):
+            calls.append("vosk")
+            return TranscriptionResult(
+                text="fallback ok",
+                confidence=0.75,
+                language="en",
+            )
+
+        mock_qwen = MagicMock()
+        mock_qwen.transcribe = AsyncMock(side_effect=fail_qwen)
+        mock_vosk = MagicMock(spec=LocalSTTClient)
+        mock_vosk.transcribe = AsyncMock(side_effect=run_vosk)
+
+        agent = self._make_agent(mock_qwen, mock_vosk)
+        result = await agent.speech_to_text(b"audio", language="en")
+
+        assert calls == ["qwen", "vosk"]
+        assert result["success"] is True
+        assert result["provider"] == "vosk-fallback"
+        assert result["transcript"] == "fallback ok"
+        mock_qwen.transcribe.assert_called_once_with(b"audio", language="en")
+        mock_vosk.transcribe.assert_called_once_with(b"audio", "en")
+
+        stt_records = [
+            record for record in caplog.records if record.name == "backend.observability.stt"
+        ]
+        events = [getattr(record, "event", None) for record in stt_records]
+        assert events.index("stt_qwen_complete") < events.index("stt_vosk_start")
 
     @pytest.mark.asyncio
     async def test_both_fail_raises(self):
@@ -2040,7 +2096,7 @@ class TestQwenPrimaryParallel:
         assert result["provider"] == "qwen-primary"
         assert result["language"] == "en"
         mock_qwen.transcribe.assert_called_once_with(b"audio", language=None)
-        mock_vosk.transcribe_auto_detect.assert_called_once_with(b"audio")
+        mock_vosk.transcribe_auto_detect.assert_not_called()
 
     @pytest.mark.asyncio
     async def test_vosk_fallback_with_llm_postprocess(self, monkeypatch):

--- a/docs/adr/016-qwen-stt-phase2-profiling.md
+++ b/docs/adr/016-qwen-stt-phase2-profiling.md
@@ -4,7 +4,7 @@
 
 ## ステータス
 
-提案: Phase A profiling instrumentation を先に入れ、ONNX/INT4 には進まない。
+採用: Phase A profiling instrumentation 後、Phase B-1 `Qwen-only path` を実装する。
 
 ## 背景
 
@@ -79,8 +79,24 @@ Profile 結果に基づいて Phase B を 1 つだけ選ぶ。
 - Qwen 品質または runtime packaging がボトルネックで、Whisper の品質/速度が勝る場合:
   B-3 `Whisper-large-v3-turbo` spike を検討する。
 
-現時点では Phase B の実装には進まない。Phase A の live profile report と Claude /
-terisuke の明示的 GO を待つ。
+Phase A profile (`backend/tests/reports/stt-profile-20260424T115017Z.md`) では、STT latency は
+以下だった。
+
+| Metric | p50 ms |
+| --- | ---: |
+| stt_overall | 4318 |
+| qwen_inference | 3098 |
+| vosk_inference | 4317 |
+
+winner 分布は qwen=18、vosk=1 で、Qwen が多くの request で勝っていた。一方で
+`stt_overall` は `vosk_inference` に近く、Qwen 勝利後も Vosk 側の完了待ちまたは CPU 競合
+が残っていた。したがって Phase B-1 を採用し、Qwen success path では Vosk fallback task を
+cancel して即 return する。Qwen failure / timeout の場合だけ Vosk を sequential に起動する。
+
+期待値は `stt_overall` p50 が `qwen_inference` p50 に近い約 3.1 秒となること、つまり Phase A
+の約 4.3 秒から約 1.2 秒短縮すること。merge / deploy 後に
+`scripts/profile_stt.sh --iterations 20 --sleep 4` を再実行し、この ADR に Phase B-1 実測値を
+追記する。
 
 ## 互換性
 


### PR DESCRIPTION
## Summary

Issue #529 Phase B-1. Phase A profile (rev 00099-rx2, stt-profile-20260424T115017Z.md) で stt_overall p50=4318ms が vosk_inference p50=4317ms 完了待ちで律速していることが判明。Qwen 勝利 18/19 だが Vosk 完了を待つ実装だった。

## Changes

- backend/agents/stt_agent.py: Qwen success → Vosk cancel 即 return、Qwen fail → Vosk sequential fallback
- backend/tests/agents/test_stt_agent.py: 97 passed (新 assert: cancelled caplog, overall-qwen diff <100ms)
- docs/adr/016: Phase B-1 採用理由追記

## Expected

p50 4318ms → ~3098ms (Vosk wait 1220ms 削減)

## Validation

- ruff / black: pass
- pytest: 97 passed
- code-reviewer agent: Approve, no CRITICAL/HIGH
- codex exec review: no introduced issues

## Post-merge

deploy + scripts/profile_stt.sh 再測 → ADR 016 に production 結果追記

Closes #559
Refs #529, #474

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Codex <noreply@openai.com>
Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>