### PR TITLE
feat(infra): observability Phase 1b — dashboard + SLO alerts (#513)

### DIFF
--- a/.claude/analysis/codex-2026-04-25-complete-513-phase-1b.md
+++ b/.claude/analysis/codex-2026-04-25-complete-513-phase-1b.md
@@ -1,0 +1,167 @@
+# Codex Completion: Issue #513 Observability Phase 1b
+
+Date: 2026-04-25
+Branch: `feat/observability-phase1b-513`
+Base: `develop`
+Origin: PR #550 / Phase 1a structured logs
+
+## PR
+
+PR URL: not created locally. `git add` / commit / push are blocked by this Codex sandbox because the Git worktree index is outside the writable roots:
+
+```text
+fatal: Unable to create '/Users/teradakousuke/Developer/engineer-cafe-navigator2025/.git/worktrees/engineer-cafe-navigator2025-feat-observability-phase1b-513/index.lock': Operation not permitted
+```
+
+Required PR title:
+
+```text
+feat(infra): observability Phase 1b - dashboard + SLO alerts (#513 Phase 1b)
+```
+
+Required PR body references:
+
+```text
+Closes #513
+Refs #550
+```
+
+## Implemented
+
+- Terraform root module under `infra/terraform/`.
+- Log-based metrics for:
+  - `chat_response` count and latency distribution.
+  - `chat_response` fallback count.
+  - `stt_winner` count with `qwen` / `vosk` / `none` labels.
+  - `stt_overall_duration_ms` latency distribution.
+  - `backend.utils.memory_helper` ERROR logs.
+- Alert policies for:
+  - chat fallback SLO burn rate, 1h + 6h multi-window.
+  - STT `winner=none` SLO burn rate, 1h + 6h multi-window.
+  - chat p95 latency.
+  - STT p95 latency.
+  - memory helper errors.
+- Terraform-managed Cloud Monitoring dashboard with four required sections:
+  - `STT latency`
+  - `Chat response`
+  - `Memory errors`
+  - `Fallback rate`
+- GitHub Actions `Terraform Plan` PR validation workflow.
+- ADR 017 and observability runbook.
+
+## Structured Log Alignment
+
+Verified against current `origin/develop`:
+
+- `backend.observability.structured_logger.log_chat_response()` emits top-level `jsonPayload.event="chat_response"` with `language`, `route`, `sources`, `rag_fallback`, `hallucination_flag`, `ltm_store_write`, and `latency_ms`.
+- STT emits top-level `jsonPayload.event="stt_winner"` with `stt_winner` and `stt_overall_duration_ms`.
+- There is no structured `memory_*` event in current backend code and `backend/**` is out of scope for this task. Phase 1b therefore monitors existing root structured logs where `jsonPayload.logger="backend.utils.memory_helper"` and `jsonPayload.level="ERROR"`.
+
+## Local Terraform Output
+
+`terraform fmt -recursive -check -diff infra/terraform`:
+
+```text
+passed
+```
+
+`terraform -chdir=infra/terraform init -backend=false -no-color`:
+
+```text
+Initializing provider plugins...
+- Finding hashicorp/google versions matching "~> 6.0"...
+
+Error: Failed to query available provider packages
+
+Could not retrieve the list of available versions for provider
+hashicorp/google: could not connect to registry.terraform.io: failed to
+request discovery document: Get
+"https://registry.terraform.io/.well-known/terraform.json": dial tcp: lookup
+registry.terraform.io: no such host
+```
+
+`terraform -chdir=infra/terraform validate -no-color`:
+
+```text
+Error: Missing required provider
+
+This configuration requires provider registry.terraform.io/hashicorp/google,
+but that provider isn't available. You may be able to install it
+automatically by running:
+  terraform init
+```
+
+`terraform -chdir=infra/terraform plan -no-color -input=false`:
+
+```text
+Error: Inconsistent dependency lock file
+
+The following dependency selections recorded in the lock file are
+inconsistent with the current configuration:
+  - provider registry.terraform.io/hashicorp/google: required by this configuration but no version is selected
+
+To make the initial dependency selections that will initialize the dependency
+lock file, run:
+  terraform init
+```
+
+Local plan could not proceed because this sandbox has no DNS/network access to `registry.terraform.io` and no cached Google provider. The GitHub workflow runs `terraform init -backend=false`, `terraform validate`, and `terraform plan` when Workload Identity secrets are configured.
+
+## Other Local Checks
+
+```text
+ruby -e 'require "yaml"; YAML.load_file(".github/workflows/terraform-plan.yml"); puts "yaml ok"'
+yaml ok
+
+git diff --check
+passed
+
+terraform providers
+Providers required by configuration:
+.
+└── provider[registry.terraform.io/hashicorp/google] ~> 6.0
+```
+
+## Commit / PR Command
+
+Run from a shell with normal write access to the parent repository `.git` directory:
+
+```bash
+git add .claude/analysis/codex-2026-04-25-complete-513-phase-1b.md \
+  .github/workflows/terraform-plan.yml \
+  docs/adr/017-observability-phase1b.md \
+  docs/observability-runbook.md \
+  infra/terraform
+git commit -m "feat(infra): add observability phase 1b monitoring"
+git push -u origin feat/observability-phase1b-513
+gh pr create \
+  --base develop \
+  --title "feat(infra): observability Phase 1b - dashboard + SLO alerts (#513 Phase 1b)" \
+  --body $'Closes #513\nRefs #550'
+```
+
+## Manual Apply Example
+
+After PR merge and CI review, operator applies manually:
+
+```bash
+terraform -chdir=infra/terraform init
+terraform -chdir=infra/terraform plan \
+  -var='project_id=aipartner-426616' \
+  -var='cloud_run_service_name=engineer-cafe-backend' \
+  -var='region=asia-northeast1' \
+  -var='notification_channel_ids=["projects/aipartner-426616/notificationChannels/CHANNEL_ID"]'
+terraform -chdir=infra/terraform apply \
+  -var='project_id=aipartner-426616' \
+  -var='cloud_run_service_name=engineer-cafe-backend' \
+  -var='region=asia-northeast1' \
+  -var='notification_channel_ids=["projects/aipartner-426616/notificationChannels/CHANNEL_ID"]'
+```
+
+## Operationally Ready Notes
+
+- Required GCP IAM for CI/manual operator: Logging metric admin and Monitoring dashboard/alert policy editor, plus Workload Identity token permissions for CI.
+- Required GitHub secrets for CI plan: `GCP_WORKLOAD_IDENTITY_PROVIDER`, `GCP_SERVICE_ACCOUNT`; optional project override via `GCP_PROJECT_ID`.
+- `notification_channel_ids` defaults to `[]`; set before production apply if paging/notification is required.
+- No backend/frontend runtime behavior changes.
+- No migrations, Docker changes, CORS/domain changes, schedulers, or auto-apply workflow changes.

--- a/.github/workflows/terraform-plan.yml
+++ b/.github/workflows/terraform-plan.yml
@@ -1,0 +1,108 @@
+name: Terraform Plan
+
+on:
+  pull_request:
+    branches: [develop, main]
+    paths:
+      - 'infra/terraform/**'
+      - '.github/workflows/terraform-plan.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  id-token: write
+
+concurrency:
+  group: terraform-plan-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+env:
+  TERRAFORM_WORKING_DIRECTORY: infra/terraform
+  TF_IN_AUTOMATION: 'true'
+  TF_INPUT: 'false'
+
+jobs:
+  terraform-plan:
+    name: Terraform PR validation
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Detect Terraform directory
+        id: terraform_directory
+        shell: bash
+        run: |
+          if [[ -d "$TERRAFORM_WORKING_DIRECTORY" ]]; then
+            echo "exists=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "exists=false" >> "$GITHUB_OUTPUT"
+            echo "::notice::Skipping Terraform checks because $TERRAFORM_WORKING_DIRECTORY does not exist in this checkout."
+          fi
+
+      - name: Setup Terraform
+        if: steps.terraform_directory.outputs.exists == 'true'
+        uses: hashicorp/setup-terraform@v3
+
+      - name: Check Terraform formatting
+        if: steps.terraform_directory.outputs.exists == 'true'
+        working-directory: ${{ env.TERRAFORM_WORKING_DIRECTORY }}
+        run: terraform fmt -check -recursive
+
+      - name: Initialize Terraform without backend
+        if: steps.terraform_directory.outputs.exists == 'true'
+        working-directory: ${{ env.TERRAFORM_WORKING_DIRECTORY }}
+        run: terraform init -backend=false
+
+      - name: Validate Terraform configuration
+        if: steps.terraform_directory.outputs.exists == 'true'
+        working-directory: ${{ env.TERRAFORM_WORKING_DIRECTORY }}
+        run: terraform validate
+
+      - name: Check GCP plan credentials
+        id: gcp_credentials
+        if: steps.terraform_directory.outputs.exists == 'true'
+        shell: bash
+        env:
+          GCP_PROJECT_ID: ${{ vars.GCP_PROJECT_ID || secrets.GCP_PROJECT_ID || 'aipartner-426616' }}
+          GCP_WORKLOAD_IDENTITY_PROVIDER: ${{ secrets.GCP_WORKLOAD_IDENTITY_PROVIDER }}
+          GCP_SERVICE_ACCOUNT: ${{ secrets.GCP_SERVICE_ACCOUNT }}
+        run: |
+          missing=()
+
+          if [[ -z "${GCP_PROJECT_ID:-}" ]]; then
+            missing+=("GCP_PROJECT_ID repository variable or secret")
+          fi
+
+          if [[ -z "${GCP_WORKLOAD_IDENTITY_PROVIDER:-}" ]]; then
+            missing+=("GCP_WORKLOAD_IDENTITY_PROVIDER secret")
+          fi
+
+          if [[ -z "${GCP_SERVICE_ACCOUNT:-}" ]]; then
+            missing+=("GCP_SERVICE_ACCOUNT secret")
+          fi
+
+          if (( ${#missing[@]} > 0 )); then
+            printf 'Missing optional inputs for terraform plan:\n' >&2
+            printf ' - %s\n' "${missing[@]}" >&2
+            echo "::notice::Skipping terraform plan because optional GCP Workload Identity inputs are not configured for this run."
+            echo "can_plan=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "can_plan=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Authenticate to Google Cloud
+        if: steps.terraform_directory.outputs.exists == 'true' && steps.gcp_credentials.outputs.can_plan == 'true'
+        uses: google-github-actions/auth@v2
+        with:
+          project_id: ${{ vars.GCP_PROJECT_ID || secrets.GCP_PROJECT_ID || 'aipartner-426616' }}
+          workload_identity_provider: ${{ secrets.GCP_WORKLOAD_IDENTITY_PROVIDER }}
+          service_account: ${{ secrets.GCP_SERVICE_ACCOUNT }}
+
+      - name: Create Terraform plan
+        if: steps.terraform_directory.outputs.exists == 'true' && steps.gcp_credentials.outputs.can_plan == 'true'
+        working-directory: ${{ env.TERRAFORM_WORKING_DIRECTORY }}
+        env:
+          GOOGLE_CLOUD_PROJECT: ${{ vars.GCP_PROJECT_ID || secrets.GCP_PROJECT_ID || 'aipartner-426616' }}
+          GOOGLE_PROJECT: ${{ vars.GCP_PROJECT_ID || secrets.GCP_PROJECT_ID || 'aipartner-426616' }}
+          TF_VAR_project_id: ${{ vars.GCP_PROJECT_ID || secrets.GCP_PROJECT_ID || 'aipartner-426616' }}
+        run: terraform plan -no-color -input=false

--- a/docs/adr/017-observability-phase1b.md
+++ b/docs/adr/017-observability-phase1b.md
@@ -1,0 +1,115 @@
+# ADR 017: Observability Phase 1b — Terraform Metrics, Dashboard, and Alerts
+
+## ステータス
+
+採用
+
+## 日付
+
+2026-04-25
+
+## 背景
+
+ADR 014 で `/api/chat` の `chat_response` structured log を追加し、ADR 016 で
+`stt_*` structured log を追加した。Phase 1b では、この runtime log schema を Cloud
+Monitoring の log-based metric、dashboard、alert policy に固定する。
+
+Issue #513 の目的は、alpha 運用中に STT latency、chat response latency、RAG fallback、
+memory helper error を早く検知できる状態にすることである。backend behavior の追加変更は
+Phase 1b の対象外とし、既存ログから観測できる範囲を Terraform 管理する。
+
+## 決定
+
+Phase 1b の observability resource は Terraform で管理する。
+
+- Log-based metrics: `chat_response`, `stt_*`, memory helper error, fallback count/rate
+- Dashboard: STT latency、chat response latency、memory errors、fallback rate を 1 画面で確認
+- Alert policies: latency threshold、memory error count、fallback rate、SLO burn-rate
+
+Terraform は review 可能な IaC として repository に入れるが、`terraform apply` は merge 後に
+operator が手動実行する。PR merge と同時に本番 Monitoring resource を変更しないことで、
+notification channel、project ID、state、IAM の誤設定を人間が最終確認できるようにする。
+
+## 現在のログ前提
+
+Phase 1b は次の既存ログだけを信頼する。
+
+- STT: `jsonPayload.event` が `stt_*` の structured log
+- Chat: `jsonPayload.event="chat_response"` の structured log
+- Memory: 現時点で `memory_*` structured event は存在しない
+
+`backend/**` は本 issue の範囲外であるため、memory 専用 event は追加しない。memory helper の
+error は、既存の root structured log から `logger="backend.utils.memory_helper"` かつ
+`level="ERROR"` で監視する。
+
+## Alert Thresholds
+
+Latency alert は user-facing degradation を早く拾うが、一時的な cold start や少数 request で
+noise になりやすい。このため、単発 request ではなく rolling window の p95 / rate で判定する。
+
+| Signal | Warning | Critical | 理由 |
+| --- | ---: | ---: | --- |
+| STT p95 latency | dashboard watch | > 6s over 15m | ADR 016 の Phase B-1 期待値は約 3.1s。6s は baseline の約 2 倍で、Qwen timeout / Vosk fallback / cold path を疑う。 |
+| Chat p95 latency | dashboard watch | > 10s over 15m | alpha kiosk で対話が途切れる上限として 10s を採用し、short spike は 15m 継続で抑制する。 |
+| Memory helper errors | dashboard watch | > 0 over 15m | memory write/load は volume が低くても recall regression に直結するため、絶対数で検知する。 |
+| Fallback burn rate | 1h > 14.4x only | 1h > 14.4x and 6h > 6x | 98% SLO の 2% error budget に対して 28.8% / 12% bad-event ratio。急激な悪化と sustained degradation を分ける。 |
+| STT failure burn rate | 1h > 14.4x only | 1h > 14.4x and 6h > 6x | `stt_winner="none"` を bad event とし、98% STT availability SLO の error budget 消費として扱う。 |
+
+SLO burn-rate alert は multi-window で定義する。1h window は急激な regression を早く検知し、
+6h window は短い spike や deploy 直後の warm-up noise を抑制する。両方の window が同時に
+閾値を超えた場合に page / high severity とし、1h のみ超過は warning とする。
+
+推奨する初期値:
+
+- Chat quality SLO: chat requests の 98% が non-fallback
+- STT availability SLO: STT winner events の 98% が `none` 以外
+- Latency guardrail: STT p95 6s、chat p95 10s
+- Memory guardrail: memory helper ERROR log が 15m で 0 件
+- Burn-rate: 1h が 14.4x 以上、かつ 6h が 6x 以上で critical
+
+## 採用理由
+
+Terraform 管理により、Console で手作業作成した metric や alert が drift することを避けられる。
+dashboard と alert policy を同じ review 単位にすることで、operator は「どの metric がどの
+panel と alert に使われるか」を PR 上で確認できる。
+
+一方で apply は manual after merge とする。Monitoring resource は即時に通知や incident を
+発生させるため、merge gate だけで本番へ反映するより、merge 後に `terraform plan` を確認して
+から operator が apply する方が alpha 運用では安全である。
+
+## 代替案
+
+### Console で手動管理する
+
+早いが、query、threshold、notification channel が属人化し、Phase 1a の後続として残すには
+drift risk が高い。Issue #513 では不採用。
+
+### Backend に memory structured event を追加する
+
+`memory_store_failed` などの event があれば metric は作りやすい。ただし Phase 1b の ownership
+は observability IaC と docs であり、`backend/**` は out of scope。今回は既存 root structured
+log の `logger=backend.utils.memory_helper` と `level=ERROR` を使う。
+
+### SLO burn-rate を 1 window のみにする
+
+実装は単純だが、short spike で false positive になりやすい。1h + 6h の multi-window により、
+早い検知と noise 抑制を両立する。
+
+## 互換性
+
+- Backend API schema と runtime behavior は変更しない。
+- 既存 structured log schema を前提にする。
+- Terraform apply までは GCP Monitoring resource は変更されない。
+
+## ロールバック
+
+問題が出た場合は、該当 alert policy の notification を停止するか、Terraform で対象 resource
+を戻して手動 apply する。backend deploy の rollback は不要。
+
+## 検証方針
+
+- `terraform fmt -check`
+- `terraform validate`
+- `terraform plan` で log metric、dashboard、alert policy の差分を確認
+- Merge 後、operator が手動で `terraform apply` を実行
+- Apply 後、Cloud Logging query と Cloud Monitoring dashboard で metric ingestion を確認

--- a/docs/observability-runbook.md
+++ b/docs/observability-runbook.md
@@ -1,0 +1,147 @@
+# Observability Runbook
+
+Issue #513 Phase 1b monitors Cloud Run logs through Terraform-managed log metrics,
+dashboard panels, and alert policies. Terraform changes are applied manually after merge.
+
+## Terraform Apply
+
+Run from the Terraform observability directory used by the infra PR. Example:
+
+```bash
+terraform -chdir=infra/terraform init
+terraform -chdir=infra/terraform plan
+terraform -chdir=infra/terraform apply
+```
+
+Before apply, confirm `project_id`, local or remote state handling, `notification_channel_ids`,
+and IAM permissions. Apply is manual after PR merge; the GitHub workflow never runs apply.
+
+## STT Latency
+
+Primary signal: `jsonPayload.event="stt_winner"` with `stt_overall_duration_ms`.
+
+Useful Cloud Logging query:
+
+```text
+resource.type="cloud_run_revision"
+resource.labels.service_name="engineer-cafe-backend"
+jsonPayload.event="stt_winner"
+```
+
+High-latency query:
+
+```text
+resource.type="cloud_run_revision"
+resource.labels.service_name="engineer-cafe-backend"
+jsonPayload.event="stt_winner"
+jsonPayload.stt_overall_duration_ms>=6000
+```
+
+Triage:
+
+1. Compare `stt_overall_duration_ms`, `stt_qwen_duration_ms`, and `stt_vosk_duration_ms`.
+2. Check whether `stt_winner` shifted from `qwen` to `vosk`.
+3. Look for `stt_model_load_complete` spikes that indicate cold model load.
+4. Confirm Cloud Run revision, CPU/memory, and `STT_PROVIDER` / `QWEN_STT_TIMEOUT`.
+
+## Chat Response
+
+Primary signal: `jsonPayload.event="chat_response"` with `latency_ms`, `route`, `language`,
+`sources`, `rag_fallback`, and `hallucination_flag`.
+
+Useful Cloud Logging query:
+
+```text
+resource.type="cloud_run_revision"
+resource.labels.service_name="engineer-cafe-backend"
+jsonPayload.event="chat_response"
+```
+
+High-latency query:
+
+```text
+resource.type="cloud_run_revision"
+resource.labels.service_name="engineer-cafe-backend"
+jsonPayload.event="chat_response"
+jsonPayload.latency_ms>=10000
+```
+
+Triage:
+
+1. Group by `route` and `language` to identify whether one agent path regressed.
+2. Check `sources` and `rag_fallback` for RAG degradation.
+3. Check Cloud Run request latency and 5xx logs for platform-level issues.
+4. Compare the current revision against the previous healthy revision.
+
+## Memory Errors
+
+There is no structured `memory_*` event today. Phase 1b monitors existing root structured
+logs from `backend.utils.memory_helper` at error level.
+
+Useful Cloud Logging query:
+
+```text
+resource.type="cloud_run_revision"
+resource.labels.service_name="engineer-cafe-backend"
+jsonPayload.logger="backend.utils.memory_helper"
+jsonPayload.level="ERROR"
+```
+
+Connection-related query:
+
+```text
+resource.type="cloud_run_revision"
+resource.labels.service_name="engineer-cafe-backend"
+jsonPayload.logger="backend.utils.memory_helper"
+jsonPayload.level="ERROR"
+jsonPayload.message=~"connection is closed|pool is closed|broken pipe|Supabase"
+```
+
+Triage:
+
+1. Check whether errors started after a deploy or Supabase incident.
+2. Inspect messages for connection pool exhaustion, closed connections, or timeout.
+3. Validate Supabase availability and connection limits.
+4. Run the alpha memory smoke if available, then keep the alert open until successful recall is verified.
+
+## Fallback Rate
+
+Primary signal: `chat_response` logs where `rag_fallback=true` or `sources` indicates fallback.
+
+Useful Cloud Logging query:
+
+```text
+resource.type="cloud_run_revision"
+resource.labels.service_name="engineer-cafe-backend"
+jsonPayload.event="chat_response"
+jsonPayload.rag_fallback=true
+```
+
+Language-specific query:
+
+```text
+resource.type="cloud_run_revision"
+resource.labels.service_name="engineer-cafe-backend"
+jsonPayload.event="chat_response"
+jsonPayload.rag_fallback=true
+jsonPayload.language="ja"
+```
+
+Triage:
+
+1. Compare fallback rate by `language`.
+2. Check whether fallback is isolated to one `route`.
+3. Confirm RAG/Supabase availability and recent knowledge base changes.
+4. Review hallucination flags and answer quality before lowering thresholds.
+
+## SLO Burn-Rate Alerts
+
+Burn-rate alerts use 1h and 6h windows. Treat a 1h-only alert as early warning and a
+1h+6h alert as sustained degradation.
+
+Triage:
+
+1. Open the dashboard and confirm which panel is burning budget.
+2. Use the matching log query above to find example requests.
+3. Identify deploy, config, dependency, or data-change correlation.
+4. Mitigate first, then tune thresholds only after the incident is understood.

--- a/infra/terraform/alerts.tf
+++ b/infra/terraform/alerts.tf
@@ -1,0 +1,252 @@
+resource "google_monitoring_alert_policy" "chat_fallback_burn_rate" {
+  display_name = "Engineer Cafe chat fallback burn rate"
+  combiner     = "AND"
+  enabled      = var.alert_enabled
+
+  notification_channels = var.notification_channel_ids
+
+  documentation {
+    content   = "Chat fallback ratio is consuming the 98% chat quality SLO error budget in both the 1h and 6h windows. See docs/observability-runbook.md."
+    mime_type = "text/markdown"
+  }
+
+  conditions {
+    display_name = "1h fallback burn rate > 14.4x budget"
+
+    condition_threshold {
+      filter                  = "metric.type=\"${local.metric_type.chat_rag_fallback_count}\" ${local.cloud_run_metric_scope}"
+      denominator_filter      = "metric.type=\"${local.metric_type.chat_response_count}\" ${local.cloud_run_metric_scope}"
+      comparison              = "COMPARISON_GT"
+      threshold_value         = local.slo.fast_burn_threshold
+      duration                = "0s"
+      evaluation_missing_data = "EVALUATION_MISSING_DATA_INACTIVE"
+
+      aggregations {
+        alignment_period     = "3600s"
+        per_series_aligner   = "ALIGN_DELTA"
+        cross_series_reducer = "REDUCE_SUM"
+      }
+
+      denominator_aggregations {
+        alignment_period     = "3600s"
+        per_series_aligner   = "ALIGN_DELTA"
+        cross_series_reducer = "REDUCE_SUM"
+      }
+
+      trigger {
+        count = 1
+      }
+    }
+  }
+
+  conditions {
+    display_name = "6h fallback burn rate > 6x budget"
+
+    condition_threshold {
+      filter                  = "metric.type=\"${local.metric_type.chat_rag_fallback_count}\" ${local.cloud_run_metric_scope}"
+      denominator_filter      = "metric.type=\"${local.metric_type.chat_response_count}\" ${local.cloud_run_metric_scope}"
+      comparison              = "COMPARISON_GT"
+      threshold_value         = local.slo.slow_burn_threshold
+      duration                = "0s"
+      evaluation_missing_data = "EVALUATION_MISSING_DATA_INACTIVE"
+
+      aggregations {
+        alignment_period     = "21600s"
+        per_series_aligner   = "ALIGN_DELTA"
+        cross_series_reducer = "REDUCE_SUM"
+      }
+
+      denominator_aggregations {
+        alignment_period     = "21600s"
+        per_series_aligner   = "ALIGN_DELTA"
+        cross_series_reducer = "REDUCE_SUM"
+      }
+
+      trigger {
+        count = 1
+      }
+    }
+  }
+}
+
+resource "google_monitoring_alert_policy" "stt_failure_burn_rate" {
+  display_name = "Engineer Cafe STT failure burn rate"
+  combiner     = "AND"
+  enabled      = var.alert_enabled
+
+  notification_channels = var.notification_channel_ids
+
+  documentation {
+    content   = "STT winner=none ratio is consuming the 98% STT availability SLO error budget in both the 1h and 6h windows. See docs/observability-runbook.md."
+    mime_type = "text/markdown"
+  }
+
+  conditions {
+    display_name = "1h STT none burn rate > 14.4x budget"
+
+    condition_threshold {
+      filter                  = "metric.type=\"${local.metric_type.stt_none_count}\" ${local.cloud_run_metric_scope}"
+      denominator_filter      = "metric.type=\"${local.metric_type.stt_winner_count}\" ${local.cloud_run_metric_scope}"
+      comparison              = "COMPARISON_GT"
+      threshold_value         = local.slo.fast_burn_threshold
+      duration                = "0s"
+      evaluation_missing_data = "EVALUATION_MISSING_DATA_INACTIVE"
+
+      aggregations {
+        alignment_period     = "3600s"
+        per_series_aligner   = "ALIGN_DELTA"
+        cross_series_reducer = "REDUCE_SUM"
+      }
+
+      denominator_aggregations {
+        alignment_period     = "3600s"
+        per_series_aligner   = "ALIGN_DELTA"
+        cross_series_reducer = "REDUCE_SUM"
+      }
+
+      trigger {
+        count = 1
+      }
+    }
+  }
+
+  conditions {
+    display_name = "6h STT none burn rate > 6x budget"
+
+    condition_threshold {
+      filter                  = "metric.type=\"${local.metric_type.stt_none_count}\" ${local.cloud_run_metric_scope}"
+      denominator_filter      = "metric.type=\"${local.metric_type.stt_winner_count}\" ${local.cloud_run_metric_scope}"
+      comparison              = "COMPARISON_GT"
+      threshold_value         = local.slo.slow_burn_threshold
+      duration                = "0s"
+      evaluation_missing_data = "EVALUATION_MISSING_DATA_INACTIVE"
+
+      aggregations {
+        alignment_period     = "21600s"
+        per_series_aligner   = "ALIGN_DELTA"
+        cross_series_reducer = "REDUCE_SUM"
+      }
+
+      denominator_aggregations {
+        alignment_period     = "21600s"
+        per_series_aligner   = "ALIGN_DELTA"
+        cross_series_reducer = "REDUCE_SUM"
+      }
+
+      trigger {
+        count = 1
+      }
+    }
+  }
+}
+
+resource "google_monitoring_alert_policy" "chat_latency_p95" {
+  display_name = "Engineer Cafe chat response p95 latency"
+  combiner     = "OR"
+  enabled      = var.alert_enabled
+
+  notification_channels = var.notification_channel_ids
+
+  documentation {
+    content   = "Chat response p95 latency exceeded 10s for 15 minutes. See docs/observability-runbook.md."
+    mime_type = "text/markdown"
+  }
+
+  conditions {
+    display_name = "chat_response p95 > 10000 ms"
+
+    condition_threshold {
+      filter                  = "metric.type=\"${local.metric_type.chat_response_latency_ms}\" ${local.cloud_run_metric_scope}"
+      comparison              = "COMPARISON_GT"
+      threshold_value         = local.slo.chat_latency_p95_ms
+      duration                = "900s"
+      evaluation_missing_data = "EVALUATION_MISSING_DATA_INACTIVE"
+
+      aggregations {
+        alignment_period     = "300s"
+        per_series_aligner   = "ALIGN_PERCENTILE_95"
+        cross_series_reducer = "REDUCE_MAX"
+        group_by_fields = [
+          "resource.label.service_name",
+        ]
+      }
+
+      trigger {
+        count = 1
+      }
+    }
+  }
+}
+
+resource "google_monitoring_alert_policy" "stt_latency_p95" {
+  display_name = "Engineer Cafe STT p95 latency"
+  combiner     = "OR"
+  enabled      = var.alert_enabled
+
+  notification_channels = var.notification_channel_ids
+
+  documentation {
+    content   = "STT p95 latency exceeded 6s for 15 minutes. See docs/observability-runbook.md."
+    mime_type = "text/markdown"
+  }
+
+  conditions {
+    display_name = "stt_overall p95 > 6000 ms"
+
+    condition_threshold {
+      filter                  = "metric.type=\"${local.metric_type.stt_overall_duration_ms}\" ${local.cloud_run_metric_scope}"
+      comparison              = "COMPARISON_GT"
+      threshold_value         = local.slo.stt_latency_p95_ms
+      duration                = "900s"
+      evaluation_missing_data = "EVALUATION_MISSING_DATA_INACTIVE"
+
+      aggregations {
+        alignment_period     = "300s"
+        per_series_aligner   = "ALIGN_PERCENTILE_95"
+        cross_series_reducer = "REDUCE_MAX"
+        group_by_fields = [
+          "resource.label.service_name",
+        ]
+      }
+
+      trigger {
+        count = 1
+      }
+    }
+  }
+}
+
+resource "google_monitoring_alert_policy" "memory_helper_errors" {
+  display_name = "Engineer Cafe memory helper errors"
+  combiner     = "OR"
+  enabled      = var.alert_enabled
+
+  notification_channels = var.notification_channel_ids
+
+  documentation {
+    content   = "backend.utils.memory_helper emitted ERROR logs. See docs/observability-runbook.md."
+    mime_type = "text/markdown"
+  }
+
+  conditions {
+    display_name = "memory_helper ERROR count > 0"
+
+    condition_threshold {
+      filter                  = "metric.type=\"${local.metric_type.memory_helper_error_count}\" ${local.cloud_run_metric_scope}"
+      comparison              = "COMPARISON_GT"
+      threshold_value         = local.slo.memory_error_count_15
+      duration                = "0s"
+      evaluation_missing_data = "EVALUATION_MISSING_DATA_INACTIVE"
+
+      aggregations {
+        alignment_period     = "900s"
+        per_series_aligner   = "ALIGN_DELTA"
+        cross_series_reducer = "REDUCE_SUM"
+      }
+
+      trigger {
+        count = 1
+      }
+    }
+  }
+}

--- a/infra/terraform/dashboard.tf
+++ b/infra/terraform/dashboard.tf
@@ -1,0 +1,147 @@
+resource "google_monitoring_dashboard" "observability_phase1b" {
+  dashboard_json = jsonencode({
+    displayName = "Engineer Cafe Observability Phase 1b"
+    mosaicLayout = {
+      columns = 12
+      tiles = [
+        {
+          xPos   = 0
+          yPos   = 0
+          width  = 6
+          height = 4
+          widget = {
+            title = "STT latency"
+            xyChart = {
+              dataSets = [
+                {
+                  plotType   = "LINE"
+                  targetAxis = "Y1"
+                  timeSeriesQuery = {
+                    timeSeriesFilter = {
+                      filter = "metric.type=\"${local.metric_type.stt_overall_duration_ms}\" ${local.cloud_run_metric_scope}"
+                      aggregation = {
+                        alignmentPeriod    = "300s"
+                        perSeriesAligner   = "ALIGN_PERCENTILE_95"
+                        crossSeriesReducer = "REDUCE_MAX"
+                        groupByFields      = ["metric.label.stt_winner"]
+                      }
+                    }
+                  }
+                }
+              ]
+              yAxis = {
+                label = "p95 ms"
+                scale = "LINEAR"
+              }
+            }
+          }
+        },
+        {
+          xPos   = 6
+          yPos   = 0
+          width  = 6
+          height = 4
+          widget = {
+            title = "Chat response"
+            xyChart = {
+              dataSets = [
+                {
+                  plotType   = "LINE"
+                  targetAxis = "Y1"
+                  timeSeriesQuery = {
+                    timeSeriesFilter = {
+                      filter = "metric.type=\"${local.metric_type.chat_response_latency_ms}\" ${local.cloud_run_metric_scope}"
+                      aggregation = {
+                        alignmentPeriod    = "300s"
+                        perSeriesAligner   = "ALIGN_PERCENTILE_95"
+                        crossSeriesReducer = "REDUCE_MAX"
+                        groupByFields      = ["metric.label.route"]
+                      }
+                    }
+                  }
+                }
+              ]
+              yAxis = {
+                label = "p95 ms"
+                scale = "LINEAR"
+              }
+            }
+          }
+        },
+        {
+          xPos   = 0
+          yPos   = 4
+          width  = 6
+          height = 4
+          widget = {
+            title = "Memory errors"
+            xyChart = {
+              dataSets = [
+                {
+                  plotType   = "STACKED_BAR"
+                  targetAxis = "Y1"
+                  timeSeriesQuery = {
+                    timeSeriesFilter = {
+                      filter = "metric.type=\"${local.metric_type.memory_helper_error_count}\" ${local.cloud_run_metric_scope}"
+                      aggregation = {
+                        alignmentPeriod    = "900s"
+                        perSeriesAligner   = "ALIGN_DELTA"
+                        crossSeriesReducer = "REDUCE_SUM"
+                        groupByFields      = ["metric.label.message"]
+                      }
+                    }
+                  }
+                }
+              ]
+              yAxis = {
+                label = "errors / 15m"
+                scale = "LINEAR"
+              }
+            }
+          }
+        },
+        {
+          xPos   = 6
+          yPos   = 4
+          width  = 6
+          height = 4
+          widget = {
+            title = "Fallback rate"
+            xyChart = {
+              dataSets = [
+                {
+                  plotType   = "LINE"
+                  targetAxis = "Y1"
+                  timeSeriesQuery = {
+                    timeSeriesFilterRatio = {
+                      numerator = {
+                        filter = "metric.type=\"${local.metric_type.chat_rag_fallback_count}\" ${local.cloud_run_metric_scope}"
+                        aggregation = {
+                          alignmentPeriod    = "300s"
+                          perSeriesAligner   = "ALIGN_DELTA"
+                          crossSeriesReducer = "REDUCE_SUM"
+                        }
+                      }
+                      denominator = {
+                        filter = "metric.type=\"${local.metric_type.chat_response_count}\" ${local.cloud_run_metric_scope}"
+                        aggregation = {
+                          alignmentPeriod    = "300s"
+                          perSeriesAligner   = "ALIGN_DELTA"
+                          crossSeriesReducer = "REDUCE_SUM"
+                        }
+                      }
+                    }
+                  }
+                }
+              ]
+              yAxis = {
+                label = "ratio"
+                scale = "LINEAR"
+              }
+            }
+          }
+        }
+      ]
+    }
+  })
+}

--- a/infra/terraform/locals.tf
+++ b/infra/terraform/locals.tf
@@ -1,0 +1,26 @@
+locals {
+  cloud_run_filter       = "resource.type=\"cloud_run_revision\" resource.labels.service_name=\"${var.cloud_run_service_name}\" resource.labels.location=\"${var.region}\""
+  cloud_run_metric_scope = "resource.type=\"cloud_run_revision\" resource.label.service_name=\"${var.cloud_run_service_name}\" resource.label.location=\"${var.region}\""
+
+  metric_type = {
+    chat_response_count       = "logging.googleapis.com/user/engineer_cafe_chat_response_count"
+    chat_rag_fallback_count   = "logging.googleapis.com/user/engineer_cafe_chat_rag_fallback_count"
+    chat_response_latency_ms  = "logging.googleapis.com/user/engineer_cafe_chat_response_latency_ms"
+    stt_winner_count          = "logging.googleapis.com/user/engineer_cafe_stt_winner_count"
+    stt_none_count            = "logging.googleapis.com/user/engineer_cafe_stt_none_count"
+    stt_overall_duration_ms   = "logging.googleapis.com/user/engineer_cafe_stt_overall_duration_ms"
+    memory_helper_error_count = "logging.googleapis.com/user/engineer_cafe_memory_helper_error_count"
+  }
+
+  slo = {
+    objective             = 0.98
+    error_budget          = 0.02
+    fast_burn_rate        = 14.4
+    slow_burn_rate        = 6
+    fast_burn_threshold   = 0.288
+    slow_burn_threshold   = 0.12
+    chat_latency_p95_ms   = 10000
+    stt_latency_p95_ms    = 6000
+    memory_error_count_15 = 0
+  }
+}

--- a/infra/terraform/log_metrics.tf
+++ b/infra/terraform/log_metrics.tf
@@ -1,0 +1,208 @@
+resource "google_logging_metric" "chat_response_count" {
+  name        = "engineer_cafe_chat_response_count"
+  description = "Count of Phase 1a /api/chat structured response events."
+  filter      = "${local.cloud_run_filter} jsonPayload.event=\"chat_response\""
+
+  label_extractors = {
+    language        = "EXTRACT(jsonPayload.language)"
+    route           = "EXTRACT(jsonPayload.route)"
+    rag_fallback    = "EXTRACT(jsonPayload.rag_fallback)"
+    ltm_store_write = "EXTRACT(jsonPayload.ltm_store_write)"
+  }
+
+  metric_descriptor {
+    metric_kind = "DELTA"
+    value_type  = "INT64"
+    unit        = "1"
+
+    labels {
+      key         = "language"
+      value_type  = "STRING"
+      description = "Language requested by the client."
+    }
+    labels {
+      key         = "route"
+      value_type  = "STRING"
+      description = "Resolved route/category/agent from chat metadata."
+    }
+    labels {
+      key         = "rag_fallback"
+      value_type  = "STRING"
+      description = "Whether the chat response used a fallback source."
+    }
+    labels {
+      key         = "ltm_store_write"
+      value_type  = "STRING"
+      description = "Long-term memory write result: success, failed, or skipped."
+    }
+  }
+}
+
+resource "google_logging_metric" "chat_response_latency_ms" {
+  name        = "engineer_cafe_chat_response_latency_ms"
+  description = "Distribution of /api/chat response latency in milliseconds."
+  filter      = "${local.cloud_run_filter} jsonPayload.event=\"chat_response\" jsonPayload.latency_ms:*"
+
+  value_extractor = "EXTRACT(jsonPayload.latency_ms)"
+
+  label_extractors = {
+    language = "EXTRACT(jsonPayload.language)"
+    route    = "EXTRACT(jsonPayload.route)"
+  }
+
+  bucket_options {
+    explicit_buckets {
+      bounds = [250, 500, 1000, 2000, 3000, 5000, 7500, 10000, 15000, 30000]
+    }
+  }
+
+  metric_descriptor {
+    metric_kind = "DELTA"
+    value_type  = "DISTRIBUTION"
+    unit        = "ms"
+
+    labels {
+      key         = "language"
+      value_type  = "STRING"
+      description = "Language requested by the client."
+    }
+    labels {
+      key         = "route"
+      value_type  = "STRING"
+      description = "Resolved route/category/agent from chat metadata."
+    }
+  }
+}
+
+resource "google_logging_metric" "chat_rag_fallback_count" {
+  name        = "engineer_cafe_chat_rag_fallback_count"
+  description = "Count of chat responses where rag_fallback is true."
+  filter      = "${local.cloud_run_filter} jsonPayload.event=\"chat_response\" jsonPayload.rag_fallback=true"
+
+  label_extractors = {
+    language = "EXTRACT(jsonPayload.language)"
+    route    = "EXTRACT(jsonPayload.route)"
+  }
+
+  metric_descriptor {
+    metric_kind = "DELTA"
+    value_type  = "INT64"
+    unit        = "1"
+
+    labels {
+      key         = "language"
+      value_type  = "STRING"
+      description = "Language requested by the client."
+    }
+    labels {
+      key         = "route"
+      value_type  = "STRING"
+      description = "Resolved route/category/agent from chat metadata."
+    }
+  }
+}
+
+resource "google_logging_metric" "stt_winner_count" {
+  name        = "engineer_cafe_stt_winner_count"
+  description = "Count of STT winner events by qwen, vosk, or none."
+  filter      = "${local.cloud_run_filter} jsonPayload.event=\"stt_winner\""
+
+  label_extractors = {
+    stt_winner = "EXTRACT(jsonPayload.stt_winner)"
+    language   = "EXTRACT(jsonPayload.language)"
+    provider   = "EXTRACT(jsonPayload.provider)"
+  }
+
+  metric_descriptor {
+    metric_kind = "DELTA"
+    value_type  = "INT64"
+    unit        = "1"
+
+    labels {
+      key         = "stt_winner"
+      value_type  = "STRING"
+      description = "Winning STT provider: qwen, vosk, or none."
+    }
+    labels {
+      key         = "language"
+      value_type  = "STRING"
+      description = "Detected/requested STT language."
+    }
+    labels {
+      key         = "provider"
+      value_type  = "STRING"
+      description = "Provider name emitted by the STT event."
+    }
+  }
+}
+
+resource "google_logging_metric" "stt_none_count" {
+  name        = "engineer_cafe_stt_none_count"
+  description = "Count of STT requests where neither Qwen nor Vosk succeeded."
+  filter      = "${local.cloud_run_filter} jsonPayload.event=\"stt_winner\" jsonPayload.stt_winner=\"none\""
+
+  metric_descriptor {
+    metric_kind = "DELTA"
+    value_type  = "INT64"
+    unit        = "1"
+  }
+}
+
+resource "google_logging_metric" "stt_overall_duration_ms" {
+  name        = "engineer_cafe_stt_overall_duration_ms"
+  description = "Distribution of end-to-end STT winner latency in milliseconds."
+  filter      = "${local.cloud_run_filter} jsonPayload.event=\"stt_winner\" jsonPayload.stt_overall_duration_ms:*"
+
+  value_extractor = "EXTRACT(jsonPayload.stt_overall_duration_ms)"
+
+  label_extractors = {
+    stt_winner = "EXTRACT(jsonPayload.stt_winner)"
+    language   = "EXTRACT(jsonPayload.language)"
+  }
+
+  bucket_options {
+    explicit_buckets {
+      bounds = [500, 1000, 2000, 3000, 4000, 6000, 8000, 10000, 15000, 30000]
+    }
+  }
+
+  metric_descriptor {
+    metric_kind = "DELTA"
+    value_type  = "DISTRIBUTION"
+    unit        = "ms"
+
+    labels {
+      key         = "stt_winner"
+      value_type  = "STRING"
+      description = "Winning STT provider: qwen, vosk, or none."
+    }
+    labels {
+      key         = "language"
+      value_type  = "STRING"
+      description = "Detected/requested STT language."
+    }
+  }
+}
+
+resource "google_logging_metric" "memory_helper_error_count" {
+  name        = "engineer_cafe_memory_helper_error_count"
+  description = "Count of existing structured root logs from backend.utils.memory_helper at ERROR level."
+  filter      = "${local.cloud_run_filter} jsonPayload.logger=\"backend.utils.memory_helper\" jsonPayload.level=\"ERROR\""
+
+  label_extractors = {
+    message = "EXTRACT(jsonPayload.message)"
+  }
+
+  metric_descriptor {
+    metric_kind = "DELTA"
+    value_type  = "INT64"
+    unit        = "1"
+
+    labels {
+      key         = "message"
+      value_type  = "STRING"
+      description = "Memory helper error message template."
+    }
+  }
+}
+

--- a/infra/terraform/outputs.tf
+++ b/infra/terraform/outputs.tf
@@ -1,0 +1,16 @@
+output "dashboard_id" {
+  description = "Terraform-managed Cloud Monitoring dashboard ID."
+  value       = google_monitoring_dashboard.observability_phase1b.id
+}
+
+output "alert_policy_ids" {
+  description = "Terraform-managed alert policy IDs."
+  value = {
+    chat_fallback_burn_rate = google_monitoring_alert_policy.chat_fallback_burn_rate.id
+    stt_failure_burn_rate   = google_monitoring_alert_policy.stt_failure_burn_rate.id
+    chat_latency_p95        = google_monitoring_alert_policy.chat_latency_p95.id
+    stt_latency_p95         = google_monitoring_alert_policy.stt_latency_p95.id
+    memory_helper_errors    = google_monitoring_alert_policy.memory_helper_errors.id
+  }
+}
+

--- a/infra/terraform/providers.tf
+++ b/infra/terraform/providers.tf
@@ -1,0 +1,5 @@
+provider "google" {
+  project = var.project_id
+  region  = var.region
+}
+

--- a/infra/terraform/variables.tf
+++ b/infra/terraform/variables.tf
@@ -1,0 +1,30 @@
+variable "project_id" {
+  description = "GCP project that hosts Cloud Run and Cloud Monitoring."
+  type        = string
+  default     = "aipartner-426616"
+}
+
+variable "region" {
+  description = "Default GCP region for provider operations."
+  type        = string
+  default     = "asia-northeast1"
+}
+
+variable "cloud_run_service_name" {
+  description = "Cloud Run service name that emits Phase 1a structured logs."
+  type        = string
+  default     = "engineer-cafe-backend"
+}
+
+variable "notification_channel_ids" {
+  description = "Monitoring notification channel resource IDs. Leave empty for PR validation; set before manual apply."
+  type        = list(string)
+  default     = []
+}
+
+variable "alert_enabled" {
+  description = "Whether Terraform-managed alert policies are enabled."
+  type        = bool
+  default     = true
+}
+

--- a/infra/terraform/versions.tf
+++ b/infra/terraform/versions.tf
@@ -1,0 +1,11 @@
+terraform {
+  required_version = ">= 1.6.0"
+
+  required_providers {
+    google = {
+      source  = "hashicorp/google"
+      version = "~> 6.0"
+    }
+  }
+}
+


### PR DESCRIPTION
## Summary

Issue #513 Observability Phase 1b 実装。Phase 1a (PR #550) の structured logging を Grafana-equivalent な GCP Monitoring dashboard + SLO burn-rate alerts に接続。

## Changes

### infra/terraform/ (新規 8 tf files)
- log_metrics.tf: 5 log-based metrics (STT winner 分布 / STT latency histogram / chat response latency / memory errors / fallback rate)
- alerts.tf: SLO burn-rate multi-window alert policies
- dashboard.tf: 4-section Monitoring dashboard (STT / Chat / Memory / Fallback)
- variables/outputs/locals/versions/providers.tf

### CI
- .github/workflows/terraform-plan.yml: PR 時に terraform plan 実行 (validation のみ、apply なし)

### Docs
- docs/adr/017-observability-phase1b.md: 設計判断 + SLO threshold justification
- docs/observability-runbook.md: alert 対応手順書

## Validation
- terraform fmt / workflow parse / git diff-check: local 全 pass
- terraform init/validate/plan: 実行は CI 側 (sandbox から network 不可のため)
- Apply は本 PR merge 後 terisuke が手動実行 (自動適用なし)

## Operational notes
- 必要 secret: GCP_WORKLOAD_IDENTITY_PROVIDER, GCP_SERVICE_ACCOUNT (CI が使用)
- GCP_PROJECT_ID default: aipartner-426616
- notification_channel_ids default: [] (paging 有効化前に設定)

## No runtime code changes
backend/frontend 変更なし。structured log 側は Phase 1a 完成済。

Closes #513
Refs #550