### PR TITLE
fix(infra): Phase 1b pre-apply — message cardinality + depends_on (#564)

### DIFF
--- a/.claude/analysis/codex-2026-04-25-complete-564.md
+++ b/.claude/analysis/codex-2026-04-25-complete-564.md
@@ -1,0 +1,29 @@
+# Codex completion summary: Issue #564
+
+## Scope
+
+- Follow-up to PR #563 / commit `6d940d6` for Phase 1b pre-apply safety.
+- Route C bounded Terraform/docs implementation.
+
+## Changes
+
+- Dropped the `message` label from `google_logging_metric.memory_helper_error_count`.
+- Removed dashboard grouping by `metric.label.message`.
+- Changed Terraform metric type locals to reference `google_logging_metric.*.name`, so alert policies and dashboard filters have implicit Terraform graph dependencies on the log-based metrics.
+- Updated ADR 017 with the adopted M1/P2 decisions.
+
+## Validation
+
+- `terraform fmt -recursive -check -diff infra/terraform`: pass.
+- `terraform init -backend=false`: blocked locally because the sandbox cannot resolve `registry.terraform.io` and no local Google provider cache is present.
+- `terraform validate`: blocked locally by missing `registry.terraform.io/hashicorp/google` provider after init could not complete.
+- `terraform plan -no-color -input=false > /tmp/plan.txt`: blocked locally because Terraform has not been initialized.
+
+CI should run init/validate and plan via `.github/workflows/terraform-plan.yml` when GitHub Actions has network access and GCP Workload Identity secrets are configured.
+
+## Operational readiness
+
+- Env vars/secrets: no application env vars changed. CI plan still requires optional `GCP_PROJECT_ID`, `GCP_WORKLOAD_IDENTITY_PROVIDER`, and `GCP_SERVICE_ACCOUNT`.
+- Permissions/IAM: no IAM resources changed. The GitHub Actions service account still needs enough Monitoring/Logging read/plan permissions for Terraform plan.
+- Terraform/apply: apply remains manual after merge. Operator should review `terraform plan` before apply.
+- Rollback: revert this commit or restore the previous metric label/dashboard grouping before manual apply. If already applied, run Terraform apply with the reverted configuration.

--- a/docs/adr/017-observability-phase1b.md
+++ b/docs/adr/017-observability-phase1b.md
@@ -101,6 +101,19 @@ log の `logger=backend.utils.memory_helper` と `level=ERROR` を使う。
 - 既存 structured log schema を前提にする。
 - Terraform apply までは GCP Monitoring resource は変更されない。
 
+## Phase 1b pre-apply fix (#564)
+
+Terraform apply 前の安全対策として、memory helper error metric の `message` label は採用しない。
+`backend.utils.memory_helper` の ERROR log は `"Error storing message: %s"` など例外内容を含む
+free-form message であり、Supabase/PostgREST の response、session/key、接続エラー詳細などが
+混入すると log-based metric label の cardinality が無制限に増える。alert と dashboard では
+message 別内訳よりも 15m error count の検知を優先する。
+
+また、alert policy と dashboard の Monitoring filter は
+`google_logging_metric.*.name` から組み立てた metric type を使う。これにより初回 apply 時に
+log-based metric descriptor が alert/dashboard より先に作成される Terraform graph になるため、
+静的文字列だけで参照した場合の descriptor 作成順序リスクを避ける。
+
 ## ロールバック
 
 問題が出た場合は、該当 alert policy の notification を停止するか、Terraform で対象 resource

--- a/infra/terraform/dashboard.tf
+++ b/infra/terraform/dashboard.tf
@@ -87,7 +87,6 @@ resource "google_monitoring_dashboard" "observability_phase1b" {
                         alignmentPeriod    = "900s"
                         perSeriesAligner   = "ALIGN_DELTA"
                         crossSeriesReducer = "REDUCE_SUM"
-                        groupByFields      = ["metric.label.message"]
                       }
                     }
                   }

--- a/infra/terraform/locals.tf
+++ b/infra/terraform/locals.tf
@@ -3,13 +3,13 @@ locals {
   cloud_run_metric_scope = "resource.type=\"cloud_run_revision\" resource.label.service_name=\"${var.cloud_run_service_name}\" resource.label.location=\"${var.region}\""
 
   metric_type = {
-    chat_response_count       = "logging.googleapis.com/user/engineer_cafe_chat_response_count"
-    chat_rag_fallback_count   = "logging.googleapis.com/user/engineer_cafe_chat_rag_fallback_count"
-    chat_response_latency_ms  = "logging.googleapis.com/user/engineer_cafe_chat_response_latency_ms"
-    stt_winner_count          = "logging.googleapis.com/user/engineer_cafe_stt_winner_count"
-    stt_none_count            = "logging.googleapis.com/user/engineer_cafe_stt_none_count"
-    stt_overall_duration_ms   = "logging.googleapis.com/user/engineer_cafe_stt_overall_duration_ms"
-    memory_helper_error_count = "logging.googleapis.com/user/engineer_cafe_memory_helper_error_count"
+    chat_response_count       = "logging.googleapis.com/user/${google_logging_metric.chat_response_count.name}"
+    chat_rag_fallback_count   = "logging.googleapis.com/user/${google_logging_metric.chat_rag_fallback_count.name}"
+    chat_response_latency_ms  = "logging.googleapis.com/user/${google_logging_metric.chat_response_latency_ms.name}"
+    stt_winner_count          = "logging.googleapis.com/user/${google_logging_metric.stt_winner_count.name}"
+    stt_none_count            = "logging.googleapis.com/user/${google_logging_metric.stt_none_count.name}"
+    stt_overall_duration_ms   = "logging.googleapis.com/user/${google_logging_metric.stt_overall_duration_ms.name}"
+    memory_helper_error_count = "logging.googleapis.com/user/${google_logging_metric.memory_helper_error_count.name}"
   }
 
   slo = {

--- a/infra/terraform/log_metrics.tf
+++ b/infra/terraform/log_metrics.tf
@@ -189,20 +189,9 @@ resource "google_logging_metric" "memory_helper_error_count" {
   description = "Count of existing structured root logs from backend.utils.memory_helper at ERROR level."
   filter      = "${local.cloud_run_filter} jsonPayload.logger=\"backend.utils.memory_helper\" jsonPayload.level=\"ERROR\""
 
-  label_extractors = {
-    message = "EXTRACT(jsonPayload.message)"
-  }
-
   metric_descriptor {
     metric_kind = "DELTA"
     value_type  = "INT64"
     unit        = "1"
-
-    labels {
-      key         = "message"
-      value_type  = "STRING"
-      description = "Memory helper error message template."
-    }
   }
 }
-


### PR DESCRIPTION
## Summary

Issue #564 Phase 1b pre-apply fix。PR #563 (#513 Phase 1b) merged 後、terraform apply 前に対応必要な 2 件を解消。

## Changes

### M1: memory_helper_error_count message label cardinality
- infra/terraform/log_metrics.tf: memory_helper_error_count の message label を drop (unbounded cardinality 回避)
- infra/terraform/dashboard.tf: dashboard grouping from metric.label.message を削除

### P2: alert/dashboard の depends_on / resource 参照
- infra/terraform/locals.tf: metric type 参照を static local string から google_logging_metric.*.name へ置換 (implicit dependency 構築)

### Docs
- docs/adr/017-observability-phase1b.md: M1/P2 decision notes を追記

## Validation
- terraform fmt -recursive -check -diff infra/terraform: pass
- git diff --check: pass
- terraform init/validate/plan: CI 側で実行 (sandbox 制約で local 不可)

## Operational
- Apply は merge 後 terisuke が手動実行
- runtime (backend / frontend / Cloud Run) への影響なし

Closes #564
Refs #513, #563