### PR TITLE
fix(frontend): restore alias-aware extractExpression (#566 H1)

### DIFF
--- a/frontend/src/__tests__/emotion-tagger-extract-expression.test.ts
+++ b/frontend/src/__tests__/emotion-tagger-extract-expression.test.ts
@@ -1,0 +1,32 @@
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+
+import { EmotionTagger } from '../lib/emotion-tagger';
+
+test('extractExpression maps apologetic → sad (alias)', () => {
+  assert.strictEqual(EmotionTagger.extractExpression('[apologetic]Text'), 'sad');
+});
+
+test('extractExpression maps helpful → happy (alias)', () => {
+  assert.strictEqual(EmotionTagger.extractExpression('[helpful]x'), 'happy');
+});
+
+test('extractExpression maps neutral → neutral (direct)', () => {
+  assert.strictEqual(EmotionTagger.extractExpression('[neutral]x'), 'neutral');
+});
+
+test('extractExpression maps surprised → surprised (direct)', () => {
+  assert.strictEqual(EmotionTagger.extractExpression('[surprised]x'), 'surprised');
+});
+
+test('extractExpression returns null when no tag present', () => {
+  assert.strictEqual(EmotionTagger.extractExpression('No tag here'), null);
+});
+
+test('extractExpression maps sad → sad with trailing text', () => {
+  assert.strictEqual(EmotionTagger.extractExpression('[sad]Some text'), 'sad');
+});
+
+test('extractExpression maps confused → sad (alias)', () => {
+  assert.strictEqual(EmotionTagger.extractExpression('[confused]text'), 'sad');
+});

--- a/frontend/src/lib/emotion-tagger.ts
+++ b/frontend/src/lib/emotion-tagger.ts
@@ -1,3 +1,5 @@
+import { EmotionMapping } from './emotion-mapping';
+
 /**
  * Unified Emotion Tagging System
  * Ensures consistent emotion tags across all agents
@@ -174,7 +176,7 @@ export class EmotionTagger {
   static extractExpression(text: string): SupportedExpression | null {
     const match = text.match(/^\[([a-zA-Z_]+)(?::\d*\.?\d+)?\]/);
     if (match) {
-      return this.getExpressionFromText(match[1]);
+      return EmotionMapping.mapToExpression(match[1]);
     }
     return null;
   }


### PR DESCRIPTION
## Summary

Fixes the CRITICAL regression (H1) identified in #566 review: `extractExpression` was using `getExpressionFromText()` (keyword substring matching) instead of the alias-aware `EmotionMapping.mapToExpression()`.

### Root Cause
PR #566 refactored `emotion-tagger.ts` but the `extractExpression` method was mechanically replaced with `getExpressionFromText(match[1])`. This function scans for keyword patterns in text (e.g., "sorry" in body text), but when given a bare tag name like `"apologetic"` or `"helpful"`, it never matches any rule pattern and falls through to `'happy'` — resurrecting the 薄ら笑い bug from #458.

### Fix
- `emotion-tagger.ts`: Replace `this.getExpressionFromText(match[1])` with `EmotionMapping.mapToExpression(match[1])` — uses the alias-aware `EXPRESSION_MAP` lookup
- Added 7 unit tests for `extractExpression` covering alias and direct mappings

### Test Results
```
✓ extractExpression maps apologetic → sad (alias)
✓ extractExpression maps helpful → happy (alias)
✓ extractExpression maps neutral → neutral (direct)
✓ extractExpression maps surprised → surprised (direct)
✓ extractExpression returns null when no tag present
✓ extractExpression maps sad → sad with trailing text
✓ extractExpression maps confused → sad (alias)

7/7 pass
```

### Verification
- `pnpm lint` ✅
- `pnpm build` ✅
- Unit tests ✅ (7/7)
- typecheck: pre-existing `.next` cache errors (not from this change)

### Remaining for #566
- [ ] H2: Manual browser verify on Vercel Preview (happy/sad/surprised/neutral)
- [ ] Screenshot/video attachment to PR #566