### PR TITLE
fix(routing): avoid slide fast-path for general explanations

### DIFF
--- a/backend/config/routing_constants.py
+++ b/backend/config/routing_constants.py
@@ -168,7 +168,6 @@ SLIDE_KEYWORDS = [
     "前のスライド",
     "slide",
     "presentation",
-    "説明して",
     "ナレーション",
     "narration",
 ]

--- a/backend/tests/agents/test_orchestrator_fast_routing.py
+++ b/backend/tests/agents/test_orchestrator_fast_routing.py
@@ -298,6 +298,18 @@ class TestOrchestratorFastRouting:
         assert result is not None
         assert result["category"] == "greeting"
 
+    def test_general_explanation_does_not_match_slide(self, orchestrator):
+        """一般的な説明依頼は slide fast-path に吸わせない"""
+        result = orchestrator._try_fast_routing("Docker を使うメリットを短く説明してください。")
+        assert result is None or result["agent"] != "slide"
+
+    def test_explicit_slide_explanation_still_matches_slide(self, orchestrator):
+        """スライド明示の説明依頼は slide fast-path のまま"""
+        result = orchestrator._try_fast_routing("このスライドを説明してください。")
+        assert result is not None
+        assert result["agent"] == "slide"
+        assert result["request_type"] == "slide"
+
 
 def test_zh_greeting_template_content():
     """Chinese greeting templates should exist for all time periods"""


### PR DESCRIPTION
## Summary

- removes the generic Japanese phrase `説明して` from `SLIDE_KEYWORDS`
- keeps explicit slide requests routed to `slide`
- adds regression coverage for `B1-GEN-007`

## Verification

- `pytest backend/tests/agents/test_orchestrator_fast_routing.py backend/tests/evaluation/test_fast_path_accuracy.py`
- `git diff --check`

## Factcheck

- Live B smoke on #577 found `B1-GEN-007` routing to `slide`.
- Root cause is deterministic fast-path matching, not the LLM router.
- The failing query contains `説明してください`, which matched the previous generic `説明して` slide keyword.

Closes #576
Refs #571
