### PR TITLE
STT: qwen-primary 用 Vosk fallback を起動時 preload する

### DIFF
--- a/backend/agents/stt_agent.py
+++ b/backend/agents/stt_agent.py
@@ -244,6 +244,22 @@ def _parse_qwen_stt_timeout(raw_value: Optional[str], default: float = 10.0) -> 
     return timeout
 
 
+def _env_flag(name: str, default: bool = False) -> bool:
+    raw_value = os.getenv(name)
+    if raw_value is None:
+        return default
+    return raw_value.strip().lower() in {"1", "true", "yes", "on"}
+
+
+def _stt_preload_vosk_fallback_enabled() -> bool:
+    """Preload fallback Vosk models by default in production qwen-primary mode."""
+
+    return _env_flag(
+        "STT_PRELOAD_VOSK_FALLBACK",
+        default=os.getenv("ENVIRONMENT") == "production" and not _env_flag("CI"),
+    )
+
+
 def _qwen_postprocess_enabled() -> bool:
     return os.getenv("STT_QWEN_POSTPROCESS_ENABLED", "false").lower() == "true"
 
@@ -470,6 +486,15 @@ class LocalSTTClient:
         self.model_paths = {**DEFAULT_MODEL_PATHS, **(model_paths or {})}
         self._models: Dict[str, Any] = {}
         logger.info("LocalSTTClient initialized (models will be loaded on first use)")
+
+    def preload_models(self, languages: Optional[List[str]] = None) -> None:
+        """Load configured Vosk models before the first user-facing fallback."""
+
+        for lang in languages or list(SUPPORTED_LANGUAGES):
+            try:
+                self._load_model(lang)
+            except Exception as exc:
+                logger.warning("Vosk preload failed for %s: %s", lang, exc)
 
     def _convert_audio_to_wav(self, audio_data: bytes) -> bytes:
         """Convert WebM/Opus audio bytes to WAV PCM for Vosk."""
@@ -1016,6 +1041,8 @@ class STTAgent:
             )
             self._vosk_fallback_client = LocalSTTClient()
             self._qwen_timeout = _parse_qwen_stt_timeout(os.getenv("QWEN_STT_TIMEOUT"))
+            if _stt_preload_vosk_fallback_enabled():
+                self._vosk_fallback_client.preload_models()
         else:
             raise ValueError(f"Unknown STT provider: {self.stt_provider}")
 

--- a/backend/tests/agents/test_stt_agent.py
+++ b/backend/tests/agents/test_stt_agent.py
@@ -877,6 +877,48 @@ class TestSTTAgent:
 
         assert agent._qwen_timeout == pytest.approx(2.5)
 
+    def test_qwen_primary_preloads_vosk_fallback_in_production(self, monkeypatch):
+        """Production qwen-primary preloads fallback models to avoid first-request latency."""
+        monkeypatch.setenv("ENVIRONMENT", "production")
+        monkeypatch.delenv("CI", raising=False)
+        monkeypatch.delenv("STT_PRELOAD_VOSK_FALLBACK", raising=False)
+
+        with (
+            patch("backend.agents.stt_agent.Qwen06BCpuSTTClient"),
+            patch("backend.agents.stt_agent.LocalSTTClient") as mock_vosk_client,
+        ):
+            STTAgent(stt_provider="qwen-primary")
+
+        mock_vosk_client.return_value.preload_models.assert_called_once_with()
+
+    def test_qwen_primary_vosk_preload_disabled_by_default_in_ci(self, monkeypatch):
+        """CI should not load real Vosk models just because ENVIRONMENT=production."""
+        monkeypatch.setenv("ENVIRONMENT", "production")
+        monkeypatch.setenv("CI", "true")
+        monkeypatch.delenv("STT_PRELOAD_VOSK_FALLBACK", raising=False)
+
+        with (
+            patch("backend.agents.stt_agent.Qwen06BCpuSTTClient"),
+            patch("backend.agents.stt_agent.LocalSTTClient") as mock_vosk_client,
+        ):
+            STTAgent(stt_provider="qwen-primary")
+
+        mock_vosk_client.return_value.preload_models.assert_not_called()
+
+    def test_qwen_primary_vosk_preload_can_be_disabled(self, monkeypatch):
+        """STT_PRELOAD_VOSK_FALLBACK=false keeps startup lightweight when needed."""
+        monkeypatch.setenv("ENVIRONMENT", "production")
+        monkeypatch.delenv("CI", raising=False)
+        monkeypatch.setenv("STT_PRELOAD_VOSK_FALLBACK", "false")
+
+        with (
+            patch("backend.agents.stt_agent.Qwen06BCpuSTTClient"),
+            patch("backend.agents.stt_agent.LocalSTTClient") as mock_vosk_client,
+        ):
+            STTAgent(stt_provider="qwen-primary")
+
+        mock_vosk_client.return_value.preload_models.assert_not_called()
+
     def test_init_invalid_provider_raises_error(self):
         """STTAgent raises ValueError for unknown provider"""
         with pytest.raises(ValueError) as exc_info:


### PR DESCRIPTION
## 概要

- production の `qwen-primary` STT で、Vosk fallback model を起動時に preload するようにしました。
- `STT_PRELOAD_VOSK_FALLBACK=false` で preload を無効化できます。
- CI ではデフォルト無効にし、テスト中に実モデルロードが走らないようにしました。
- production preload / CI無効化 / 明示無効化の回帰テストを追加しました。

## 背景

#575 の STT preflight で、現行 revision でも timeout risk が確認されました。

- p95: `59672ms`
- Qwen TimeoutError: 5件
- 現行 revision `engineer-cafe-backend-00103-r6s` でも `vosk-fallback` が `59672ms`

長い sample は「Qwen timeout 後に Vosk fallback を初回ロードする」ケースと整合します。起動時に Vosk model を読ませておくことで、最初の user-facing fallback に model load cost が乗ることを避けます。

## 検証

- `pytest backend/tests/agents/test_stt_agent.py -k "qwen_primary or preload"`
- `pytest backend/tests/agents/test_stt_agent.py`
- `uv run ruff check backend/agents/stt_agent.py backend/tests/agents/test_stt_agent.py`
- `git diff --check`

## 注意

- このPRは短期対策です。
- merge/deploy 後に `scripts/stt-live-preflight.sh` を再実行し、p95 と TimeoutError の改善を確認する必要があります。

Refs #575
Refs #571
