### PR TITLE
RAGAS: NaN 評価を失敗扱いにし alpha live workflow の suite 判定を修正する

### DIFF
--- a/.github/workflows/alpha-live-verification.yml
+++ b/.github/workflows/alpha-live-verification.yml
@@ -80,13 +80,13 @@ jobs:
 
       - name: STT live preflight
         id: stt_preflight
-        if: contains(inputs.suites, 'all') || contains(inputs.suites, 'stt')
+        if: contains(format(',{0},', inputs.suites), ',stt,') || contains(format(',{0},', inputs.suites), ',all,')
         continue-on-error: true
         run: scripts/stt-live-preflight.sh --timestamp "${ALPHA_TIMESTAMP}-stt" --minutes 1440 --limit 1000
 
       - name: A voice round-trip smoke
         id: alpha_a
-        if: contains(inputs.suites, 'all') || contains(inputs.suites, 'a')
+        if: contains(format(',{0},', inputs.suites), ',a,') || contains(format(',{0},', inputs.suites), ',all,')
         continue-on-error: true
         env:
           API_SECRET_KEY: ${{ secrets.BACKEND_API_KEY }}
@@ -94,7 +94,7 @@ jobs:
 
       - name: B LangGraph routing live smoke
         id: alpha_b
-        if: contains(inputs.suites, 'all') || contains(inputs.suites, 'b')
+        if: contains(format(',{0},', inputs.suites), ',b,') || contains(format(',{0},', inputs.suites), ',all,')
         continue-on-error: true
         env:
           API_SECRET_KEY: ${{ secrets.BACKEND_API_KEY }}
@@ -102,7 +102,7 @@ jobs:
 
       - name: C live API RAGAS
         id: rag_api_live
-        if: contains(inputs.suites, 'all') || contains(inputs.suites, 'c')
+        if: contains(format(',{0},', inputs.suites), ',c,') || contains(format(',{0},', inputs.suites), ',all,')
         continue-on-error: true
         env:
           API_SECRET_KEY: ${{ secrets.BACKEND_API_KEY }}
@@ -114,7 +114,7 @@ jobs:
 
       - name: D memory and state durability smoke
         id: alpha_d
-        if: contains(inputs.suites, 'all') || contains(inputs.suites, 'd')
+        if: contains(format(',{0},', inputs.suites), ',d,') || contains(format(',{0},', inputs.suites), ',all,')
         continue-on-error: true
         env:
           API_SECRET_KEY: ${{ secrets.BACKEND_API_KEY }}
@@ -122,7 +122,7 @@ jobs:
 
       - name: E Cloud Logging verification
         id: cloud_logging
-        if: contains(inputs.suites, 'all') || contains(inputs.suites, 'e')
+        if: contains(format(',{0},', inputs.suites), ',e,') || contains(format(',{0},', inputs.suites), ',all,')
         continue-on-error: true
         run: scripts/cloud-logging-verify.sh --timestamp "${ALPHA_TIMESTAMP}-e" --minutes 240 --limit 1000
 

--- a/backend/evaluation/ragas_pipeline.py
+++ b/backend/evaluation/ragas_pipeline.py
@@ -142,6 +142,15 @@ class RagasReport:
     results: List[RagasResult] = field(default_factory=list)
     errors: List[str] = field(default_factory=list)
 
+    _ALL_METRIC_NAMES = (
+        "faithfulness",
+        "answer_relevancy",
+        "context_precision",
+        "context_recall",
+        "answer_correctness",
+        "answer_similarity",
+    )
+
     @property
     def metrics_summary(self) -> Dict[str, float]:
         """メトリクスの平均値サマリー（NaNだったメトリクスはそのメトリクスの平均から除外）"""
@@ -151,19 +160,33 @@ class RagasReport:
         if not valid:
             return {}
 
-        metric_names = (
-            "faithfulness",
-            "answer_relevancy",
-            "context_precision",
-            "context_recall",
-            "answer_correctness",
-            "answer_similarity",
-        )
         summary: Dict[str, float] = {}
-        for name in metric_names:
+        for name in self._ALL_METRIC_NAMES:
             values = [getattr(r, name) for r in valid if name not in r.nan_metrics]
             summary[name] = sum(values) / len(values) if values else 0.0
         return summary
+
+    @property
+    def all_metrics_nan(self) -> bool:
+        if not self.results:
+            return False
+        valid = [r for r in self.results if r.error is None]
+        if not valid:
+            return False
+        return all(set(r.nan_metrics) == set(self._ALL_METRIC_NAMES) for r in valid)
+
+    @property
+    def nan_ratio(self) -> float:
+        if not self.results:
+            return 0.0
+        valid = [r for r in self.results if r.error is None]
+        if not valid:
+            return 0.0
+        total = len(valid) * len(self._ALL_METRIC_NAMES)
+        if total == 0:
+            return 0.0
+        nan_count = sum(len(r.nan_metrics) for r in valid)
+        return nan_count / total
 
 
 class RagasEvaluator:
@@ -390,6 +413,11 @@ class RagasEvaluator:
             report.errors.append(str(e))
 
         report.metrics = report.metrics_summary
+        if report.nan_ratio > 0.5:
+            report.errors.append(
+                f"RAGAS evaluation produced excessive NaN metrics "
+                f"({report.nan_ratio:.0%}). Results are unreliable."
+            )
         return report
 
     def _build_eval_kwargs(self, metrics_objs: list) -> Dict:

--- a/backend/tests/agents/test_stt_agent.py
+++ b/backend/tests/agents/test_stt_agent.py
@@ -1,9 +1,11 @@
 """Tests for STTAgent - Speech-to-Text integration"""
 
+import asyncio
 import logging
 import pytest
 import json
 import io
+import threading
 import time
 import wave
 import numpy as np
@@ -819,6 +821,102 @@ class TestQwenSTTClient:
                 )
 
         assert time.perf_counter() - started_at < 0.2
+
+    @pytest.mark.asyncio
+    async def test_shared_executor_reused_across_calls(self):
+        import concurrent.futures
+
+        import backend.agents.stt_agent as _mod
+
+        client = QwenSTTClient(model_variant="0.6b", device="cpu")
+        executor_ids = []
+
+        def capture_executor(*args, **kwargs):
+            executor_ids.append(threading.current_thread().name)
+            return TranscriptionResult(text="hi", confidence=None, language="ja")
+
+        with patch.object(client, "_sync_transcribe", side_effect=capture_executor):
+            with patch.object(_mod, "_get_qwen_stt_executor") as mock_get:
+                shared = concurrent.futures.ThreadPoolExecutor(
+                    max_workers=1, thread_name_prefix="qwen-stt-test"
+                )
+                mock_get.return_value = shared
+                try:
+                    await client.transcribe(b"RIFF" + b"\x00" * 40, language="ja")
+                    await client.transcribe(b"RIFF" + b"\x00" * 40, language="ja")
+                finally:
+                    shared.shutdown(wait=False)
+
+        assert mock_get.call_count == 2
+
+    @pytest.mark.asyncio
+    async def test_concurrent_requests_queue_on_single_worker(self):
+        import concurrent.futures
+
+        import backend.agents.stt_agent as _mod
+
+        client = QwenSTTClient(model_variant="0.6b", device="cpu")
+        call_order = []
+        call_lock = threading.Lock()
+
+        def slow_transcribe(*args, **kwargs):
+            with call_lock:
+                call_order.append("start")
+            time.sleep(0.15)
+            with call_lock:
+                call_order.append("end")
+            return TranscriptionResult(text="done", confidence=None, language="ja")
+
+        shared = concurrent.futures.ThreadPoolExecutor(
+            max_workers=1, thread_name_prefix="qwen-stt-queue"
+        )
+
+        with patch.object(client, "_sync_transcribe", side_effect=slow_transcribe):
+            with patch.object(_mod, "_get_qwen_stt_executor", return_value=shared):
+                try:
+                    t1 = asyncio.create_task(
+                        client.transcribe(b"RIFF" + b"\x00" * 40, language="ja")
+                    )
+                    t2 = asyncio.create_task(
+                        client.transcribe(b"RIFF" + b"\x00" * 40, language="ja")
+                    )
+                    await asyncio.gather(t1, t2)
+                finally:
+                    shared.shutdown(wait=False)
+
+        assert call_order == ["start", "end", "start", "end"]
+
+    @pytest.mark.asyncio
+    async def test_timeout_does_not_cancel_thread_future(self):
+        import concurrent.futures
+
+        import backend.agents.stt_agent as _mod
+
+        client = QwenSTTClient(model_variant="0.6b", device="cpu")
+        completed_flag = threading.Event()
+
+        def slow_transcribe(*args, **kwargs):
+            time.sleep(0.3)
+            completed_flag.set()
+            return TranscriptionResult(text="late", confidence=None, language="ja")
+
+        shared = concurrent.futures.ThreadPoolExecutor(
+            max_workers=1, thread_name_prefix="qwen-stt-timeout"
+        )
+
+        with patch.object(client, "_sync_transcribe", side_effect=slow_transcribe):
+            with patch.object(_mod, "_get_qwen_stt_executor", return_value=shared):
+                try:
+                    with pytest.raises(asyncio.TimeoutError):
+                        await asyncio.wait_for(
+                            client.transcribe(b"RIFF" + b"\x00" * 40, language="ja"),
+                            timeout=0.05,
+                        )
+                finally:
+                    pass
+
+        assert completed_flag.wait(timeout=1.0), "Thread should complete after timeout"
+        shared.shutdown(wait=True)
 
 
 # ==============================================================================

--- a/backend/tests/evaluation/run_ragas_evaluation.py
+++ b/backend/tests/evaluation/run_ragas_evaluation.py
@@ -244,6 +244,8 @@ async def run_evaluation(
         "evaluated_cases": report.evaluated_cases,
         "skipped_cases": report.skipped_cases,
         "metrics": report.metrics,
+        "nan_ratio": report.nan_ratio,
+        "all_metrics_nan": report.all_metrics_nan,
         "errors": report.errors,
     }
 
@@ -290,11 +292,13 @@ def _write_github_outputs(result: Dict) -> None:
             metrics = result.get("metrics", {})
             for key, value in metrics.items():
                 f.write(f"{key}={value}\n")
+            f.write(f"nan_ratio={result.get('nan_ratio', 0.0)}\n")
+            f.write(f"all_metrics_nan={result.get('all_metrics_nan', False)}\n")
             f.write(f"evaluated_cases={result.get('evaluated_cases', 0)}\n")
             f.write(f"skipped_cases={result.get('skipped_cases', 0)}\n")
             f.write(f"status={result.get('status', 'unknown')}\n")
             f.write(f"mode={result.get('mode', 'unknown')}\n")
-        logger.info("Wrote %d outputs to GITHUB_OUTPUT", len(metrics) + 4)
+        logger.info("Wrote %d outputs to GITHUB_OUTPUT", len(metrics) + 6)
     except Exception as e:
         logger.warning("Failed to write GITHUB_OUTPUT: %s", e)
 
@@ -360,6 +364,34 @@ def main():
     if args.ci_mode:
         _write_github_outputs(result)
         _write_github_summary(result)
+
+    per_case = result.get("per_case", [])
+    all_metric_names = [
+        "faithfulness",
+        "answer_relevancy",
+        "context_precision",
+        "context_recall",
+        "answer_correctness",
+        "answer_similarity",
+    ]
+
+    if per_case and all(
+        set(case.get("nan_metrics", [])) == set(all_metric_names) for case in per_case
+    ):
+        logger.error(
+            "All %d cases produced NaN for every metric. "
+            "Evaluation is invalid - treating as CI failure.",
+            len(per_case),
+        )
+        sys.exit(1)
+
+    nan_ratio = float(result.get("nan_ratio", 0.0) or 0.0)
+    if nan_ratio > 0.5:
+        logger.error(
+            "RAGAS evaluation produced excessive NaN metrics (%.0f%%). " "Treating as CI failure.",
+            nan_ratio * 100,
+        )
+        sys.exit(1)
 
     if result.get("status") == "completed":
         logger.info("Evaluation completed successfully.")

--- a/backend/tests/evaluation/test_ragas_pipeline.py
+++ b/backend/tests/evaluation/test_ragas_pipeline.py
@@ -504,3 +504,52 @@ class TestReportRagasMetrics:
             timestamp="2026-02-15",
         )
         assert report.ragas_metrics is None
+
+
+class TestNanMetricsDetection:
+    def test_all_nan_metrics_detected_as_failure(self):
+        from backend.evaluation.ragas_pipeline import RagasReport, RagasResult
+
+        all_nan = (
+            "faithfulness",
+            "answer_relevancy",
+            "context_precision",
+            "context_recall",
+            "answer_correctness",
+            "answer_similarity",
+        )
+        report = RagasReport(
+            total_cases=2,
+            evaluated_cases=2,
+            results=[
+                RagasResult(question="q1", nan_metrics=all_nan),
+                RagasResult(question="q2", nan_metrics=all_nan),
+            ],
+        )
+        assert report.all_metrics_nan is True
+        assert report.nan_ratio == 1.0
+
+    def test_nan_ratio_partial(self):
+        from backend.evaluation.ragas_pipeline import RagasReport, RagasResult
+
+        report = RagasReport(
+            total_cases=2,
+            evaluated_cases=2,
+            results=[
+                RagasResult(
+                    question="q1",
+                    faithfulness=0.9,
+                    nan_metrics=("answer_correctness",),
+                ),
+                RagasResult(question="q2", nan_metrics=()),
+            ],
+        )
+        assert report.all_metrics_nan is False
+        assert report.nan_ratio == pytest.approx(1 / 12, abs=0.01)
+
+    def test_nan_ratio_empty_report(self):
+        from backend.evaluation.ragas_pipeline import RagasReport
+
+        report = RagasReport()
+        assert report.all_metrics_nan is False
+        assert report.nan_ratio == 0.0


### PR DESCRIPTION
## 概要
- RAGAS live 評価で全メトリクス NaN、または NaN が過半になった結果を CI 成功扱いにしないようにしました。
- alpha live verification workflow の suite 選択条件を、部分文字列一致からカンマ区切りトークンの完全一致に変更しました。
- #587 で入った STT 共有 executor の挙動を固定するテストを追加しました。

## 背景
#583 の RAGAS 127 ケース実行では workflow 自体は成功しましたが、全ケースの評価メトリクスが NaN 由来の 0.0 になっており、品質ゲートとしては無効でした。この PR は同じ事象を今後 CI pass にしないためのガードです。

## 確認
- pytest backend/tests/evaluation/test_ragas_pipeline.py -k "NanMetricsDetection or ragas" : 39 passed
- pytest backend/tests/agents/test_stt_agent.py : 104 passed
- uv run ruff check backend/evaluation/ragas_pipeline.py backend/tests/evaluation/run_ragas_evaluation.py backend/tests/evaluation/test_ragas_pipeline.py backend/tests/agents/test_stt_agent.py : pass
- uv run black --check backend/evaluation/ragas_pipeline.py backend/tests/evaluation/run_ragas_evaluation.py backend/tests/evaluation/test_ragas_pipeline.py backend/tests/agents/test_stt_agent.py : pass
- bash -n scripts/alpha-smoke-comprehensive.sh scripts/rag-live-test.sh scripts/cloud-logging-verify.sh : pass
- git diff --check : pass

Refs #583
Refs #571