### PR TITLE
STT: Qwen3-ASR primary を prewarm して alpha preflight を通す

### DIFF
--- a/.github/workflows/alpha-live-verification.yml
+++ b/.github/workflows/alpha-live-verification.yml
@@ -4,8 +4,8 @@ on:
   workflow_dispatch:
     inputs:
       suites:
-        description: 'Comma-separated suites: stt,a,b,c,d,e,all'
-        default: 'stt,b,d,e'
+        description: 'Comma-separated suites: stt,v,a,b,c,d,e,h,all'
+        default: 'stt,v,b,d,e'
         type: string
       timestamp:
         description: 'Stable timestamp marker. Empty uses current UTC time.'
@@ -84,6 +84,14 @@ jobs:
         continue-on-error: true
         run: scripts/stt-live-preflight.sh --timestamp "${ALPHA_TIMESTAMP}-stt" --minutes 1440 --limit 1000
 
+      - name: V voice pipeline live preflight
+        id: voice_pipeline
+        if: contains(format(',{0},', inputs.suites), ',v,') || contains(format(',{0},', inputs.suites), ',all,')
+        continue-on-error: true
+        env:
+          API_SECRET_KEY: ${{ secrets.BACKEND_API_KEY }}
+        run: scripts/voice-pipeline-live-preflight.sh --timestamp "${ALPHA_TIMESTAMP}-v" --host "$ALPHA_SMOKE_BASE_URL" --case-set smoke
+
       - name: A voice round-trip smoke
         id: alpha_a
         if: contains(format(',{0},', inputs.suites), ',a,') || contains(format(',{0},', inputs.suites), ',all,')
@@ -126,6 +134,38 @@ jobs:
         continue-on-error: true
         run: scripts/cloud-logging-verify.sh --timestamp "${ALPHA_TIMESTAMP}-e" --minutes 240 --limit 1000
 
+      - name: Setup pnpm for H suite
+        if: contains(format(',{0},', inputs.suites), ',h,') || contains(format(',{0},', inputs.suites), ',all,')
+        uses: pnpm/action-setup@v2
+        with:
+          version: 10.12.1
+
+      - name: Setup Node for H suite
+        if: contains(format(',{0},', inputs.suites), ',h,') || contains(format(',{0},', inputs.suites), ',all,')
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: pnpm
+          cache-dependency-path: frontend/pnpm-lock.yaml
+
+      - name: Install frontend dependencies for H suite
+        if: contains(format(',{0},', inputs.suites), ',h,') || contains(format(',{0},', inputs.suites), ',all,')
+        working-directory: frontend
+        run: pnpm install --frozen-lockfile
+
+      - name: Install Playwright browser for H suite
+        if: contains(format(',{0},', inputs.suites), ',h,') || contains(format(',{0},', inputs.suites), ',all,')
+        working-directory: frontend
+        run: pnpm exec playwright install --with-deps chromium
+
+      - name: H Welcome live scenario
+        id: welcome_live
+        if: contains(format(',{0},', inputs.suites), ',h,') || contains(format(',{0},', inputs.suites), ',all,')
+        continue-on-error: true
+        env:
+          BACKEND_API_KEY: ${{ secrets.BACKEND_API_KEY }}
+        run: scripts/welcome-live-preflight.sh --timestamp "${ALPHA_TIMESTAMP}-h" --host "$ALPHA_SMOKE_BASE_URL" --delays 0,5,10
+
       - name: Upload alpha reports
         if: always()
         uses: actions/upload-artifact@v4
@@ -134,6 +174,8 @@ jobs:
           path: |
             backend/tests/reports/
             backend/tests/evaluation/reports/
+            frontend/playwright-report/
+            frontend/test-results/
           if-no-files-found: warn
           retention-days: 30
 
@@ -153,11 +195,13 @@ jobs:
           | Step | Outcome |
           | --- | --- |
           | stt_preflight | ${{ steps.stt_preflight.outcome }} |
+          | voice_pipeline | ${{ steps.voice_pipeline.outcome }} |
           | alpha_a | ${{ steps.alpha_a.outcome }} |
           | alpha_b | ${{ steps.alpha_b.outcome }} |
           | rag_api_live | ${{ steps.rag_api_live.outcome }} |
           | alpha_d | ${{ steps.alpha_d.outcome }} |
           | cloud_logging | ${{ steps.cloud_logging.outcome }} |
+          | welcome_live | ${{ steps.welcome_live.outcome }} |
           EOF
 
       - name: Fail when any selected suite failed
@@ -168,11 +212,13 @@ jobs:
           failed=0
           for outcome in \
             "${{ steps.stt_preflight.outcome }}" \
+            "${{ steps.voice_pipeline.outcome }}" \
             "${{ steps.alpha_a.outcome }}" \
             "${{ steps.alpha_b.outcome }}" \
             "${{ steps.rag_api_live.outcome }}" \
             "${{ steps.alpha_d.outcome }}" \
-            "${{ steps.cloud_logging.outcome }}"; do
+            "${{ steps.cloud_logging.outcome }}" \
+            "${{ steps.welcome_live.outcome }}"; do
             if [[ "$outcome" == "failure" ]]; then
               failed=1
             fi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -476,10 +476,11 @@ jobs:
             --allow-unauthenticated \
             --port 8000 \
             --memory 8Gi \
-            --cpu 2 \
+            --cpu 4 \
+            --concurrency 1 \
             --min-instances 1 \
             --max-instances 3 \
-            --update-env-vars "ENVIRONMENT=production,TTS_PROVIDER=piper,STT_PROVIDER=qwen-primary,QWEN_STT_TIMEOUT=4,HF_HOME=/app/.hf_cache,FRONTEND_PRODUCTION_ORIGIN=${FRONTEND_PRODUCTION_ORIGIN},ALLOWED_ORIGINS=${FRONTEND_PRODUCTION_ORIGIN}" \
+            --update-env-vars "ENVIRONMENT=production,TTS_PROVIDER=piper,STT_PROVIDER=qwen-primary,QWEN_STT_TIMEOUT=8,STT_PRELOAD_QWEN_PRIMARY=true,HF_HOME=/app/.hf_cache,FRONTEND_PRODUCTION_ORIGIN=${FRONTEND_PRODUCTION_ORIGIN},ALLOWED_ORIGINS=${FRONTEND_PRODUCTION_ORIGIN}" \
             --update-secrets "OPENROUTER_API_KEY=OPENROUTER_API_KEY:latest,SUPABASE_URL=SUPABASE_URL:latest,SUPABASE_KEY=SUPABASE_KEY:latest,SUPABASE_DB_URI=SUPABASE_DB_URI:latest,API_SECRET_KEY=API_SECRET_KEY:latest,TAVILY_API_KEY=TAVILY_API_KEY:latest"
         env:
           FRONTEND_PRODUCTION_ORIGIN: ${{ vars.FRONTEND_PRODUCTION_ORIGIN }}

--- a/backend/agents/stt_agent.py
+++ b/backend/agents/stt_agent.py
@@ -271,6 +271,15 @@ def _stt_preload_vosk_fallback_enabled() -> bool:
     )
 
 
+def _stt_preload_qwen_primary_enabled() -> bool:
+    """Preload Qwen primary model before serving production traffic."""
+
+    return _env_flag(
+        "STT_PRELOAD_QWEN_PRIMARY",
+        default=os.getenv("ENVIRONMENT") == "production" and not _env_flag("CI"),
+    )
+
+
 def _qwen_postprocess_enabled() -> bool:
     return os.getenv("STT_QWEN_POSTPROCESS_ENABLED", "false").lower() == "true"
 
@@ -977,6 +986,11 @@ class QwenSTTClient:
 
         return result
 
+    async def preload_model(self) -> None:
+        """Load the Qwen model in the shared executor before serving traffic."""
+        loop = asyncio.get_running_loop()
+        await loop.run_in_executor(_get_qwen_stt_executor(), self._load_model)
+
 
 class Qwen06BCpuSTTClient(QwenSTTClient):
     """Qwen3-ASR 0.6B CPU固定の軽量クライアント。"""
@@ -1075,6 +1089,16 @@ class STTAgent:
             except ImportError:
                 logger.warning("LanguageProcessor not available, skipping language validation")
                 self.language_processor = None
+
+    async def warmup(self) -> None:
+        """Warm STT models that must not load on the first user request."""
+        if (
+            self.stt_provider == "qwen-primary"
+            and isinstance(self.stt_client, QwenSTTClient)
+            and _stt_preload_qwen_primary_enabled()
+        ):
+            logger.info("Preloading Qwen primary STT model before serving traffic")
+            await self.stt_client.preload_model()
 
     async def _validate_language(
         self,

--- a/backend/main.py
+++ b/backend/main.py
@@ -150,6 +150,17 @@ async def lifespan(app: FastAPI):
     except Exception as e:
         logger.warning("Checkpointer warm-up failed (non-critical): %s", e)
 
+    if os.getenv("STT_PROVIDER") == "qwen-primary":
+        try:
+            stt_agent = _get_stt_agent()
+            warmup = getattr(stt_agent, "warmup", None)
+            if warmup is not None:
+                await warmup()
+        except Exception as e:
+            logger.error("STT warm-up failed: %s", e)
+            if _ENVIRONMENT == "production":
+                raise
+
     yield
 
     # Shutdown

--- a/backend/main.py
+++ b/backend/main.py
@@ -27,6 +27,7 @@ from starlette.requests import Request
 
 from backend.tools.calendar_service import CalendarService, TimeRange
 from backend.observability.structured_logger import log_chat_response
+from backend.services.stt_warmup_service import get_stt_warmup_service
 from backend.utils.structured_logging import (
     get_request_id,
     request_id_var,
@@ -152,10 +153,12 @@ async def lifespan(app: FastAPI):
 
     if os.getenv("STT_PROVIDER") == "qwen-primary":
         try:
-            stt_agent = _get_stt_agent()
-            warmup = getattr(stt_agent, "warmup", None)
-            if warmup is not None:
-                await warmup()
+            await get_stt_warmup_service().warmup(
+                provider=os.getenv("STT_PROVIDER"),
+                warmup_factory=lambda: _get_stt_agent().warmup(),
+                wait=True,
+                raise_on_failure=_ENVIRONMENT == "production",
+            )
         except Exception as e:
             logger.error("STT warm-up failed: %s", e)
             if _ENVIRONMENT == "production":
@@ -560,7 +563,13 @@ class VoiceResponse(BaseModel):
     error: Optional[str] = None
     detectedLanguage: Optional[str] = None
     confidence: Optional[float] = None
+    sttProvider: Optional[str] = None
+    sttPostprocessed: Optional[bool] = None
     interruptStatus: Optional[str] = None
+    sttWarmupStatus: Optional[str] = None
+    sttWarmupProvider: Optional[str] = None
+    sttWarmupError: Optional[str] = None
+    sttWarmupDurationMs: Optional[int] = None
     cleanText: Optional[str] = None  # TTS 前処理後（includeVrmControl 時）
     # CharacterControlAgent.process（チャット metadata 相当）
     vrmControl: Optional[Dict[str, Any]] = None
@@ -697,7 +706,27 @@ async def _handle_stt(body: VoiceRequest) -> VoiceResponse:
         emotion="neutral",
         detectedLanguage=stt_result.get("language"),
         confidence=stt_result.get("confidence"),
+        sttProvider=stt_result.get("provider"),
+        sttPostprocessed=stt_result.get("postprocessed"),
         sessionId=body.sessionId,
+    )
+
+
+async def _handle_stt_warmup(body: VoiceRequest) -> VoiceResponse:
+    """Start STT model warmup without tying it to the user audio request."""
+    snapshot = await get_stt_warmup_service().warmup(
+        provider=os.getenv("STT_PROVIDER"),
+        warmup_factory=lambda: _get_stt_agent().warmup(),
+        session_id=body.sessionId,
+        wait=False,
+    )
+    return VoiceResponse(
+        success=True,
+        sessionId=body.sessionId,
+        sttWarmupStatus=snapshot.status,
+        sttWarmupProvider=snapshot.provider,
+        sttWarmupError=snapshot.error,
+        sttWarmupDurationMs=snapshot.duration_ms,
     )
 
 
@@ -713,7 +742,7 @@ async def voice_get_api(action: str = ""):
     default_tts = (os.getenv("TTS_PROVIDER", "voicevox") or "voicevox").strip().lower()
     return {
         "status": "ok",
-        "actions": ["speech_to_text", "text_to_speech", "supported_languages"],
+        "actions": ["speech_to_text", "text_to_speech", "warmup", "supported_languages"],
         "defaultTtsProvider": default_tts,
         "ttsProviders": [
             {"id": "voicevox", "label": "VoiceVox"},
@@ -836,6 +865,9 @@ async def voice_api(request: Request, body: VoiceRequest):
 
         elif body.action == "speech_to_text":
             return await _handle_stt(body)
+
+        elif body.action == "warmup":
+            return await _handle_stt_warmup(body)
 
         elif body.action == "interrupt":
             if not body.sessionId:

--- a/backend/services/stt_warmup_service.py
+++ b/backend/services/stt_warmup_service.py
@@ -1,0 +1,158 @@
+"""STT warmup orchestration for Qwen-primary voice sessions."""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import time
+from collections.abc import Awaitable, Callable
+from dataclasses import dataclass
+from typing import Literal
+
+from backend.observability.structured_logger import log_stt_event
+
+logger = logging.getLogger(__name__)
+
+STTWarmupStatus = Literal["started", "warming", "ready", "failed", "skipped"]
+
+
+@dataclass(frozen=True)
+class STTWarmupSnapshot:
+    status: STTWarmupStatus
+    provider: str
+    error: str | None = None
+    duration_ms: int | None = None
+
+
+class STTWarmupService:
+    """Start Qwen warmup once and expose non-blocking readiness state."""
+
+    def __init__(self) -> None:
+        self._lock: asyncio.Lock | None = None
+        self._task: asyncio.Task[STTWarmupSnapshot] | None = None
+        self._status: STTWarmupStatus | None = None
+        self._provider = "unknown"
+        self._error: str | None = None
+        self._duration_ms: int | None = None
+
+    async def _get_lock(self) -> asyncio.Lock:
+        if self._lock is None:
+            self._lock = asyncio.Lock()
+        return self._lock
+
+    def snapshot(self) -> STTWarmupSnapshot:
+        return STTWarmupSnapshot(
+            status=self._status or "skipped",
+            provider=self._provider,
+            error=self._error,
+            duration_ms=self._duration_ms,
+        )
+
+    async def warmup(
+        self,
+        *,
+        provider: str | None,
+        warmup_factory: Callable[[], Awaitable[None]],
+        session_id: str | None = None,
+        wait: bool = False,
+        raise_on_failure: bool = False,
+    ) -> STTWarmupSnapshot:
+        normalized_provider = (provider or "").strip().lower()
+        if normalized_provider != "qwen-primary":
+            self._status = "skipped"
+            self._provider = normalized_provider or "default"
+            self._error = None
+            self._duration_ms = None
+            return self.snapshot()
+
+        async with await self._get_lock():
+            self._provider = normalized_provider
+            if self._status == "ready":
+                snapshot = self.snapshot()
+            elif self._status == "failed":
+                snapshot = self.snapshot()
+            elif self._task is not None and not self._task.done():
+                snapshot = STTWarmupSnapshot(status="warming", provider=normalized_provider)
+            else:
+                self._status = "warming"
+                self._error = None
+                self._duration_ms = None
+                self._task = asyncio.create_task(
+                    self._run_warmup(
+                        provider=normalized_provider,
+                        session_id=session_id,
+                        warmup_factory=warmup_factory,
+                    )
+                )
+                snapshot = STTWarmupSnapshot(status="started", provider=normalized_provider)
+
+        if not wait:
+            return snapshot
+
+        if self._task is not None:
+            snapshot = await self._task
+        else:
+            snapshot = self.snapshot()
+        if raise_on_failure and snapshot.status == "failed":
+            raise RuntimeError(snapshot.error or "STT warmup failed")
+        return snapshot
+
+    async def _run_warmup(
+        self,
+        *,
+        provider: str,
+        session_id: str | None,
+        warmup_factory: Callable[[], Awaitable[None]],
+    ) -> STTWarmupSnapshot:
+        started_at = time.perf_counter()
+        log_stt_event(
+            event="stt_warmup_start",
+            provider=provider,
+            session_id=session_id,
+        )
+        try:
+            await warmup_factory()
+        except Exception as exc:
+            duration_ms = int((time.perf_counter() - started_at) * 1000)
+            error = f"{type(exc).__name__}: {exc}"
+            self._status = "failed"
+            self._error = error
+            self._duration_ms = duration_ms
+            logger.warning("STT warmup failed: %s", error)
+            log_stt_event(
+                event="stt_warmup_complete",
+                provider=provider,
+                session_id=session_id,
+                success=False,
+                error_type=type(exc).__name__,
+                stt_warmup_duration_ms=duration_ms,
+            )
+            return self.snapshot()
+
+        duration_ms = int((time.perf_counter() - started_at) * 1000)
+        self._status = "ready"
+        self._error = None
+        self._duration_ms = duration_ms
+        log_stt_event(
+            event="stt_warmup_complete",
+            provider=provider,
+            session_id=session_id,
+            success=True,
+            stt_warmup_duration_ms=duration_ms,
+        )
+        return self.snapshot()
+
+
+_stt_warmup_service: STTWarmupService | None = None
+
+
+def get_stt_warmup_service() -> STTWarmupService:
+    global _stt_warmup_service
+    if _stt_warmup_service is None:
+        _stt_warmup_service = STTWarmupService()
+    return _stt_warmup_service
+
+
+def reset_stt_warmup_service() -> None:
+    global _stt_warmup_service
+    _stt_warmup_service = None

--- a/backend/tests/agents/test_stt_agent.py
+++ b/backend/tests/agents/test_stt_agent.py
@@ -1039,6 +1039,46 @@ class TestSTTAgent:
 
         mock_vosk_client.return_value.preload_models.assert_not_called()
 
+    @pytest.mark.asyncio
+    async def test_qwen_primary_warmup_preloads_qwen_in_production(self, monkeypatch):
+        """Production qwen-primary warmup loads Qwen before serving traffic."""
+        monkeypatch.setenv("ENVIRONMENT", "production")
+        monkeypatch.delenv("CI", raising=False)
+        monkeypatch.setenv("STT_PRELOAD_QWEN_PRIMARY", "true")
+
+        mock_qwen = MagicMock(spec=Qwen06BCpuSTTClient)
+        mock_qwen.preload_model = AsyncMock()
+        agent = STTAgent(
+            stt_provider="qwen-primary",
+            stt_client=mock_qwen,
+            fallback_client=None,
+            language_processor=None,
+        )
+
+        await agent.warmup()
+
+        mock_qwen.preload_model.assert_awaited_once_with()
+
+    @pytest.mark.asyncio
+    async def test_qwen_primary_warmup_can_be_disabled(self, monkeypatch):
+        """STT_PRELOAD_QWEN_PRIMARY=false skips Qwen startup warmup."""
+        monkeypatch.setenv("ENVIRONMENT", "production")
+        monkeypatch.delenv("CI", raising=False)
+        monkeypatch.setenv("STT_PRELOAD_QWEN_PRIMARY", "false")
+
+        mock_qwen = MagicMock(spec=Qwen06BCpuSTTClient)
+        mock_qwen.preload_model = AsyncMock()
+        agent = STTAgent(
+            stt_provider="qwen-primary",
+            stt_client=mock_qwen,
+            fallback_client=None,
+            language_processor=None,
+        )
+
+        await agent.warmup()
+
+        mock_qwen.preload_model.assert_not_awaited()
+
     def test_init_invalid_provider_raises_error(self):
         """STTAgent raises ValueError for unknown provider"""
         with pytest.raises(ValueError) as exc_info:

--- a/backend/tests/services/test_stt_warmup_service.py
+++ b/backend/tests/services/test_stt_warmup_service.py
@@ -1,0 +1,95 @@
+import asyncio
+
+import pytest
+
+from backend.services.stt_warmup_service import STTWarmupService
+
+
+@pytest.mark.asyncio
+async def test_warmup_skips_non_qwen_primary_provider():
+    service = STTWarmupService()
+    called = False
+
+    async def warmup():
+        nonlocal called
+        called = True
+
+    snapshot = await service.warmup(provider="vosk", warmup_factory=warmup)
+
+    assert snapshot.status == "skipped"
+    assert snapshot.provider == "vosk"
+    assert called is False
+
+
+@pytest.mark.asyncio
+async def test_warmup_does_not_start_duplicate_tasks():
+    service = STTWarmupService()
+    started = asyncio.Event()
+    release = asyncio.Event()
+    calls = 0
+
+    async def warmup():
+        nonlocal calls
+        calls += 1
+        started.set()
+        await release.wait()
+
+    first = await service.warmup(provider="qwen-primary", warmup_factory=warmup)
+    await started.wait()
+    second = await service.warmup(provider="qwen-primary", warmup_factory=warmup)
+
+    assert first.status == "started"
+    assert second.status == "warming"
+    assert calls == 1
+
+    release.set()
+    ready = await service.warmup(
+        provider="qwen-primary",
+        warmup_factory=warmup,
+        wait=True,
+    )
+
+    assert ready.status == "ready"
+    assert calls == 1
+
+
+@pytest.mark.asyncio
+async def test_warmup_failure_is_reported_as_status():
+    service = STTWarmupService()
+    calls = 0
+
+    async def warmup():
+        nonlocal calls
+        calls += 1
+        raise RuntimeError("model load failed")
+
+    failed = await service.warmup(
+        provider="qwen-primary",
+        warmup_factory=warmup,
+        wait=True,
+    )
+
+    assert failed.status == "failed"
+    assert failed.provider == "qwen-primary"
+    assert "model load failed" in (failed.error or "")
+
+    next_call = await service.warmup(provider="qwen-primary", warmup_factory=warmup)
+
+    assert next_call.status == "failed"
+    assert calls == 1
+
+
+@pytest.mark.asyncio
+async def test_warmup_can_raise_for_startup_failure():
+    service = STTWarmupService()
+
+    async def warmup():
+        raise RuntimeError("startup warmup failed")
+
+    with pytest.raises(RuntimeError, match="startup warmup failed"):
+        await service.warmup(
+            provider="qwen-primary",
+            warmup_factory=warmup,
+            wait=True,
+            raise_on_failure=True,
+        )

--- a/backend/tests/test_main_endpoints.py
+++ b/backend/tests/test_main_endpoints.py
@@ -38,6 +38,72 @@ class TestHealthCheck:
         assert data["service"] == "engineer-cafe-navigator-backend"
 
 
+class TestVoiceWarmupEndpoint:
+    def test_voice_get_lists_warmup_action(self):
+        from backend.main import app
+
+        client = TestClient(app)
+        response = client.get("/api/voice")
+
+        assert response.status_code == 200
+        assert "warmup" in response.json()["actions"]
+
+    def test_voice_warmup_returns_status_without_waiting(self, monkeypatch):
+        from backend.main import app
+        from backend.services.stt_warmup_service import STTWarmupSnapshot
+
+        monkeypatch.setenv("STT_PROVIDER", "qwen-primary")
+        fake_service = MagicMock()
+        fake_service.warmup = AsyncMock(
+            return_value=STTWarmupSnapshot(status="started", provider="qwen-primary")
+        )
+
+        with patch("backend.main.get_stt_warmup_service", return_value=fake_service):
+            client = TestClient(app)
+            response = client.post(
+                "/api/voice",
+                json={"action": "warmup", "sessionId": "session-123"},
+            )
+
+        assert response.status_code == 200
+        body = response.json()
+        assert body["success"] is True
+        assert body["sessionId"] == "session-123"
+        assert body["sttWarmupStatus"] == "started"
+        assert body["sttWarmupProvider"] == "qwen-primary"
+        fake_service.warmup.assert_awaited_once()
+        call_kwargs = fake_service.warmup.await_args.kwargs
+        assert call_kwargs["provider"] == "qwen-primary"
+        assert call_kwargs["session_id"] == "session-123"
+        assert call_kwargs["wait"] is False
+
+    def test_voice_warmup_failure_status_is_not_500(self, monkeypatch):
+        from backend.main import app
+        from backend.services.stt_warmup_service import STTWarmupSnapshot
+
+        monkeypatch.setenv("STT_PROVIDER", "qwen-primary")
+        fake_service = MagicMock()
+        fake_service.warmup = AsyncMock(
+            return_value=STTWarmupSnapshot(
+                status="failed",
+                provider="qwen-primary",
+                error="RuntimeError: model load failed",
+                duration_ms=1234,
+            )
+        )
+
+        with patch("backend.main.get_stt_warmup_service", return_value=fake_service):
+            client = TestClient(app)
+            response = client.post("/api/voice", json={"action": "warmup"})
+
+        assert response.status_code == 200
+        body = response.json()
+        assert body["success"] is True
+        assert body["sttWarmupStatus"] == "failed"
+        assert body["sttWarmupError"] == "RuntimeError: model load failed"
+        assert body["sttWarmupDurationMs"] == 1234
+
+
 class TestLifespan:
     @pytest.mark.asyncio
     async def test_lifespan_prewarms_checkpointer(self):
@@ -208,6 +274,31 @@ class TestVoiceEndpoint:
             with pytest.raises(HTTPException) as exc_info:
                 await voice_api(_mock_request(), body)
             assert "credential" not in exc_info.value.detail.lower()
+
+    @pytest.mark.asyncio
+    async def test_voice_stt_exposes_selected_provider(self):
+        mock_stt = AsyncMock()
+        mock_stt.speech_to_text = AsyncMock(
+            return_value={
+                "success": True,
+                "transcript": "営業時間を教えてください",
+                "confidence": 0.91,
+                "language": "ja",
+                "provider": "qwen-primary",
+                "postprocessed": False,
+            }
+        )
+
+        with patch("backend.main._get_stt_agent", return_value=mock_stt):
+            from backend.main import voice_api, VoiceRequest
+
+            body = VoiceRequest(action="speech_to_text", audioData="ZHVtbXk=", sessionId="s1")
+            response = await voice_api(_mock_request(), body)
+
+        assert response.success is True
+        assert response.transcript == "営業時間を教えてください"
+        assert response.sttProvider == "qwen-primary"
+        assert response.sttPostprocessed is False
 
     @pytest.mark.asyncio
     async def test_voice_invalid_tts_provider_returns_400(self):

--- a/frontend/e2e/reception-flow.spec.ts
+++ b/frontend/e2e/reception-flow.spec.ts
@@ -322,3 +322,110 @@ test.describe('Reception flow — settings', () => {
     });
   });
 });
+
+// ---------------------------------------------------------------------------
+// G. STT warmup fires on Welcome and voice button
+// ---------------------------------------------------------------------------
+
+test.describe('Reception flow — STT warmup', () => {
+  test.beforeEach(async ({ page }) => {
+    await keepOcrCameraPending(page);
+    await mockReceptionStart(page);
+    await page.route(`**${QA_CHAT_URL}`, async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({ answer: 'テスト応答', emotion: 'neutral', metadata: {} }),
+      });
+    });
+    await page.route('**/api/voice', async (route) => {
+      await route.fulfill({ status: 200, contentType: 'application/json', body: '{}' });
+    });
+    await page.goto('/');
+    await dismissInitialModal(page);
+  });
+
+  test('Welcome click fires warmup request to /api/voice', async ({ page }) => {
+    const warmupRequests: Array<Record<string, unknown>> = [];
+    await page.route('**/api/voice', async (route) => {
+      const body = route.request().postDataJSON();
+      if (body && body.action === 'warmup') {
+        warmupRequests.push(body);
+      }
+      await route.fulfill({ status: 200, contentType: 'application/json', body: '{}' });
+    });
+
+    await page.getByRole('button', { name: 'Welcome' }).click();
+
+    await expect
+      .poll(() => warmupRequests.length, { timeout: 5_000 })
+      .toBeGreaterThanOrEqual(1);
+    expect(warmupRequests[0]!.action).toBe('warmup');
+    expect(typeof warmupRequests[0]!.sessionId).toBe('string');
+  });
+
+  test('voice button click fires warmup request to /api/voice', async ({ page }) => {
+    const warmupRequests: Array<Record<string, unknown>> = [];
+    await page.route('**/api/voice', async (route) => {
+      const body = route.request().postDataJSON();
+      if (body && body.action === 'warmup') {
+        warmupRequests.push(body);
+      }
+      await route.fulfill({ status: 200, contentType: 'application/json', body: '{}' });
+    });
+
+    await page.getByRole('button', { name: /音声応対|Voice chat/ }).click();
+
+    await expect
+      .poll(() => warmupRequests.length, { timeout: 5_000 })
+      .toBeGreaterThanOrEqual(1);
+    expect(warmupRequests[0]!.action).toBe('warmup');
+    expect(typeof warmupRequests[0]!.sessionId).toBe('string');
+  });
+
+  test('OCR overlay is visible during welcome flow', async ({ page }) => {
+    await page.getByRole('button', { name: 'Welcome' }).click();
+    await expect(page.getByTestId('kiosk-welcome-ocr-overlay')).toBeVisible({ timeout: 5_000 });
+    await expect(page.getByTestId('kiosk-welcome-ocr-title')).toBeVisible();
+  });
+
+  test('warmup does not block greeting TTS playback', async ({ page }) => {
+    let warmupStarted = false;
+    let ttsRequests = 0;
+    let releaseWarmup: (() => void) | null = null;
+    await page.route('**/api/voice', async (route) => {
+      const body = route.request().postDataJSON();
+      if (body && body.action === 'warmup') {
+        warmupStarted = true;
+        await new Promise<void>((resolve) => {
+          releaseWarmup = resolve;
+        });
+        await route.fulfill({
+          status: 200,
+          contentType: 'application/json',
+          body: JSON.stringify({ success: true, sttWarmupStatus: 'ready' }),
+        });
+        return;
+      }
+      if (body && body.action === 'text_to_speech') {
+        ttsRequests += 1;
+      }
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({ success: true }),
+      });
+    });
+
+    await page.getByRole('button', { name: 'Welcome' }).click();
+
+    await expect(page.getByTestId('kiosk-welcome-ocr-overlay')).toBeVisible({ timeout: 5_000 });
+    await expect
+      .poll(() => warmupStarted, { timeout: 5_000 })
+      .toBe(true);
+    await expect
+      .poll(() => ttsRequests, { timeout: 5_000 })
+      .toBeGreaterThanOrEqual(1);
+    releaseWarmup?.();
+  });
+});

--- a/frontend/e2e/welcome-live.spec.ts
+++ b/frontend/e2e/welcome-live.spec.ts
@@ -1,0 +1,233 @@
+import fs from 'node:fs';
+import path from 'node:path';
+
+import { expect, test, type Page, type Request } from '@playwright/test';
+
+const welcomeLive = process.env.PLAYWRIGHT_WELCOME_LIVE === '1';
+const voiceDelays = (process.env.PLAYWRIGHT_WELCOME_VOICE_DELAYS ?? '0,5,10')
+  .split(',')
+  .map((value) => Number.parseInt(value.trim(), 10))
+  .filter((value) => Number.isFinite(value) && value >= 0);
+
+interface ObservedCall {
+  action?: string;
+  durationMs?: number;
+  method: string;
+  startedAt: number;
+  status?: number;
+  url: string;
+}
+
+function parseAction(request: Request): string | undefined {
+  const raw = request.postData();
+  if (!raw) return undefined;
+  try {
+    const parsed = JSON.parse(raw) as { action?: unknown };
+    return typeof parsed.action === 'string' ? parsed.action : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+async function installDeterministicVoiceRecorder(page: Page): Promise<void> {
+  const sampleAudioBase64 = fs
+    .readFileSync(path.resolve(__dirname, 'fixtures/voice/sample.wav'))
+    .toString('base64');
+
+  await page.addInitScript(({ audioBase64 }) => {
+    (
+      window as Window & { __PLAYWRIGHT_VOICE_AUDIO_BASE64__?: string }
+    ).__PLAYWRIGHT_VOICE_AUDIO_BASE64__ = audioBase64;
+  }, { audioBase64: sampleAudioBase64 });
+}
+
+async function keepOcrCameraPending(page: Page): Promise<void> {
+  await page.addInitScript(() => {
+    if (!navigator.mediaDevices) {
+      return;
+    }
+    navigator.mediaDevices.getUserMedia = async (constraints?: MediaStreamConstraints) => {
+      if (constraints?.video) {
+        return new Promise<MediaStream>(() => {});
+      }
+      return new MediaStream();
+    };
+  });
+}
+
+async function closeInitialSettings(page: Page): Promise<void> {
+  const closeButton = page.getByTestId('initial-settings-close');
+  if (await closeButton.isVisible({ timeout: 15_000 }).catch(() => false)) {
+    await closeButton.click();
+  }
+  await expect(page.getByRole('button', { name: 'Welcome' })).toBeVisible({ timeout: 15_000 });
+}
+
+function observeApiCalls(page: Page): ObservedCall[] {
+  const calls: ObservedCall[] = [];
+  const byRequest = new WeakMap<Request, ObservedCall>();
+
+  page.on('request', (request) => {
+    const method = request.method();
+    const url = request.url();
+    if (method !== 'POST') return;
+    if (!(url.includes('/api/voice') || url.includes('/api/reception/start') || url.includes('/api/qa'))) {
+      return;
+    }
+    const call: ObservedCall = {
+      action: parseAction(request),
+      method,
+      startedAt: Date.now(),
+      url,
+    };
+    calls.push(call);
+    byRequest.set(request, call);
+  });
+
+  page.on('response', (response) => {
+    const request = response.request();
+    const call = byRequest.get(request);
+    if (!call) return;
+    call.status = response.status();
+    call.durationMs = Date.now() - call.startedAt;
+  });
+
+  return calls;
+}
+
+async function setupWelcomeLivePage(page: Page): Promise<ObservedCall[]> {
+  await keepOcrCameraPending(page);
+  await installDeterministicVoiceRecorder(page);
+  const calls = observeApiCalls(page);
+  await page.goto('/', { waitUntil: 'domcontentloaded' });
+  await closeInitialSettings(page);
+  return calls;
+}
+
+function firstCall(calls: ObservedCall[], predicate: (call: ObservedCall) => boolean) {
+  return calls.find(predicate);
+}
+
+test.describe('Welcome live (Welcome → OCR → STT warmup → first voice)', () => {
+  test.skip(
+    !welcomeLive || !process.env.BACKEND_API_URL || !process.env.BACKEND_API_KEY,
+    'Set PLAYWRIGHT_WELCOME_LIVE=1 + BACKEND_API_URL + BACKEND_API_KEY to run welcome live E2E.',
+  );
+
+  test('Welcome starts STT warmup while greeting TTS and OCR sidecar are active', async ({
+    page,
+  }) => {
+    test.setTimeout(180_000);
+    const calls = await setupWelcomeLivePage(page);
+
+    const warmupResponse = page.waitForResponse(
+      (response) =>
+        response.url().includes('/api/voice') &&
+        parseAction(response.request()) === 'warmup',
+      { timeout: 90_000 },
+    );
+    const ttsResponse = page.waitForResponse(
+      (response) =>
+        response.url().includes('/api/voice') &&
+        parseAction(response.request()) === 'text_to_speech',
+      { timeout: 120_000 },
+    );
+    const receptionResponse = page.waitForResponse(
+      (response) => response.url().includes('/api/reception/start'),
+      { timeout: 90_000 },
+    );
+
+    await page.getByRole('button', { name: 'Welcome' }).click();
+
+    const [warmup, reception, tts] = await Promise.all([
+      warmupResponse,
+      receptionResponse,
+      ttsResponse,
+    ]);
+    expect(warmup.ok(), 'warmup response').toBeTruthy();
+    expect(reception.ok(), 'reception start response').toBeTruthy();
+    expect(tts.ok(), 'greeting TTS response').toBeTruthy();
+    await expect(page.getByTestId('kiosk-welcome-ocr-overlay')).toBeVisible({
+      timeout: 15_000,
+    });
+
+    const warmupCall = firstCall(calls, (call) => call.action === 'warmup');
+    const ttsCall = firstCall(calls, (call) => call.action === 'text_to_speech');
+    const receptionCall = firstCall(calls, (call) => call.url.includes('/api/reception/start'));
+    expect(warmupCall, 'warmup request missing').toBeTruthy();
+    expect(ttsCall, 'greeting TTS request missing').toBeTruthy();
+    expect(receptionCall, 'reception request missing').toBeTruthy();
+    expect(warmupCall!.startedAt).toBeLessThanOrEqual(ttsCall!.startedAt);
+  });
+
+  for (const delaySeconds of voiceDelays.length > 0 ? voiceDelays : [0]) {
+    test(`first voice turn after Welcome + ${delaySeconds}s reaches STT → QA → TTS`, async ({
+      page,
+    }) => {
+      test.setTimeout(240_000 + delaySeconds * 1000);
+      const calls = await setupWelcomeLivePage(page);
+
+      const warmupResponse = page.waitForResponse(
+        (response) =>
+          response.url().includes('/api/voice') &&
+          parseAction(response.request()) === 'warmup',
+        { timeout: 90_000 },
+      );
+
+      await page.getByRole('button', { name: 'Welcome' }).click();
+      const warmup = await warmupResponse;
+      expect(warmup.ok(), 'warmup response').toBeTruthy();
+      await expect(page.getByTestId('kiosk-welcome-ocr-overlay')).toBeVisible({
+        timeout: 15_000,
+      });
+
+      if (delaySeconds > 0) {
+        await page.waitForTimeout(delaySeconds * 1000);
+      }
+
+      const sttResponse = page.waitForResponse(
+        (response) =>
+          response.url().includes('/api/voice') &&
+          parseAction(response.request()) === 'speech_to_text',
+        { timeout: 120_000 },
+      );
+      const qaResponse = page.waitForResponse(
+        (response) => response.url().includes('/api/qa') && response.request().method() === 'POST',
+        { timeout: 120_000 },
+      );
+      const ttsResponse = page.waitForResponse(
+        (response) =>
+          response.url().includes('/api/voice') &&
+          parseAction(response.request()) === 'text_to_speech',
+        { timeout: 120_000 },
+      );
+
+      const voiceButton = page.getByTestId('kiosk-voice-button');
+      await voiceButton.click();
+      await page.waitForTimeout(250);
+      await voiceButton.click();
+
+      const [stt, qa, tts] = await Promise.all([sttResponse, qaResponse, ttsResponse]);
+      expect(stt.ok(), 'speech_to_text response').toBeTruthy();
+      expect(qa.ok(), 'QA response').toBeTruthy();
+      expect(tts.ok(), 'answer TTS response').toBeTruthy();
+
+      const sttPayload = (await stt.json().catch(() => null)) as {
+        transcript?: unknown;
+        success?: unknown;
+      } | null;
+      expect(sttPayload?.success ?? true).not.toBe(false);
+      expect(typeof sttPayload?.transcript === 'string' && sttPayload.transcript.length > 5).toBe(
+        true,
+      );
+
+      const sttCall = firstCall(calls, (call) => call.action === 'speech_to_text');
+      const qaCall = firstCall(calls, (call) => call.url.includes('/api/qa'));
+      const warmupCall = firstCall(calls, (call) => call.action === 'warmup');
+      expect(warmupCall, 'warmup request missing').toBeTruthy();
+      expect(sttCall, 'speech_to_text request missing').toBeTruthy();
+      expect(qaCall, 'QA request missing').toBeTruthy();
+      expect(sttCall!.startedAt).toBeGreaterThanOrEqual(warmupCall!.startedAt);
+    });
+  }
+});

--- a/frontend/playwright.config.ts
+++ b/frontend/playwright.config.ts
@@ -26,7 +26,7 @@ export default defineConfig({
   projects: [
     {
       name: 'chromium',
-      testIgnore: /voice-live\.spec\.ts/,
+      testIgnore: /(voice-live|welcome-live)\.spec\.ts/,
       use: {
         ...devices['Desktop Chrome'],
         launchOptions: {
@@ -36,7 +36,7 @@ export default defineConfig({
     },
     {
       name: 'chromium-voice-live',
-      testMatch: /voice-live\.spec\.ts/,
+      testMatch: /(voice-live|welcome-live)\.spec\.ts/,
       use: {
         ...devices['Desktop Chrome'],
         launchOptions: {

--- a/frontend/src/__tests__/api-proxy-contract.test.ts
+++ b/frontend/src/__tests__/api-proxy-contract.test.ts
@@ -128,3 +128,47 @@ test(
     assert.equal('GET' in slidesRoute, false);
   }
 );
+
+test(
+  'voice POST forwards warmup action to backend',
+  { concurrency: false },
+  async () => {
+    process.env.BACKEND_API_URL = 'https://backend.example.com';
+    (process.env as Record<string, string | undefined>).NODE_ENV = 'test';
+    let capturedBody: Record<string, unknown> | null = null;
+    global.fetch = (async (_input, init) => {
+      capturedBody =
+        typeof init?.body === 'string' ? (JSON.parse(init.body) as Record<string, unknown>) : null;
+      return new Response(
+        JSON.stringify({
+          success: true,
+          sttWarmupStatus: 'started',
+          sttWarmupProvider: 'qwen-primary',
+        }),
+        {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' },
+        }
+      );
+    }) as typeof fetch;
+
+    const { POST } = await import('../app/api/voice/route');
+    const response = await POST(
+      new NextRequest('https://example.com/api/voice', {
+        method: 'POST',
+        body: JSON.stringify({ action: 'warmup', language: 'ja', sessionId: 'session-123' }),
+        headers: { 'Content-Type': 'application/json' },
+      })
+    );
+
+    assert.equal(response.status, 200);
+    const body = (await response.json()) as Record<string, unknown>;
+    assert.equal(body.success, true);
+    assert.deepEqual(capturedBody, {
+      action: 'warmup',
+      sessionId: 'session-123',
+      language: 'ja',
+      streaming: false,
+    });
+  }
+);

--- a/frontend/src/app/components/VoiceInterface.tsx
+++ b/frontend/src/app/components/VoiceInterface.tsx
@@ -27,6 +27,7 @@ import {
 } from '../hooks/useVoiceSessionController';
 import type { WakeWordMatch } from '../hooks/useWakeWord';
 import { VoiceRecorder } from '@/lib/voice-recorder';
+import { cancelSttWarmup, sendSttWarmup } from '@/lib/stt-warmup';
 import type { CharacterAnimationData } from '../utils/character-animation-utils';
 
 export type VoiceSessionState = 'idle' | 'listening' | 'processing' | 'speaking';
@@ -841,11 +842,12 @@ export default function VoiceInterface({
 
   const startListening = useCallback(() => {
     markAudioUserInteraction();
+    sendSttWarmup({ language: currentLanguage, sessionId: sessionIdRef.current });
     cancelPendingRequest();
     stopPlayback(false);
     setError(null);
     voiceController.startManualSession();
-  }, [cancelPendingRequest, stopPlayback, voiceController]);
+  }, [cancelPendingRequest, currentLanguage, stopPlayback, voiceController]);
 
   const stopListening = useCallback(() => {
     if (sessionState !== 'listening') {
@@ -856,6 +858,7 @@ export default function VoiceInterface({
   }, [sessionState, voiceController]);
 
   const cancelSession = useCallback(() => {
+    cancelSttWarmup();
     cancelPendingRequest();
     stopPlayback(false);
     shouldDiscardNextAudioRef.current = true;

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -40,6 +40,7 @@ import VoiceInterface, {
 } from './components/VoiceInterface';
 import type { OcrResponse } from '@/lib/api/ocr-api';
 import { startReception } from '@/lib/reception-api';
+import { cancelSttWarmup, sendSttWarmup } from '@/lib/stt-warmup';
 
 const kioskReceptionSlidesUsePdf =
   process.env.NEXT_PUBLIC_RECEPTION_SLIDE_RENDERER !== 'marp';
@@ -323,6 +324,7 @@ export default function Home() {
       >
         {(voice) => {
           kioskVisitCleanupRef.current = () => {
+            cancelSttWarmup();
             voice.clearVisitState();
             setKioskVoiceLocked(false);
             setWelcomeMemberOcrOpen(false);
@@ -337,6 +339,7 @@ export default function Home() {
               return;
             }
             markAudioUserInteraction();
+            sendSttWarmup({ language: voice.currentLanguage, sessionId: voice.sessionId });
             clearReturnToIdleTimer();
             setWelcomeMemberOcrSessionKey((n) => n + 1);
             setWelcomeMemberOcrOpen(true);

--- a/frontend/src/lib/stt-warmup.ts
+++ b/frontend/src/lib/stt-warmup.ts
@@ -1,0 +1,53 @@
+const STT_WARMUP_REQUEST_TIMEOUT_MS = 5000;
+
+let warmupAbortController: AbortController | null = null;
+let warmupTimeoutId: ReturnType<typeof setTimeout> | null = null;
+
+export function sendSttWarmup({
+  language = 'ja',
+  sessionId,
+}: {
+  language?: string;
+  sessionId?: string;
+} = {}): void {
+  if (warmupAbortController) {
+    return;
+  }
+  const controller = new AbortController();
+  warmupAbortController = controller;
+  warmupTimeoutId = setTimeout(() => {
+    controller.abort();
+  }, STT_WARMUP_REQUEST_TIMEOUT_MS);
+
+  const body: Record<string, string> = { action: 'warmup', language };
+  if (sessionId) {
+    body.sessionId = sessionId;
+  }
+
+  fetch('/api/voice', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(body),
+    signal: controller.signal,
+  })
+    .catch(() => {})
+    .finally(() => {
+      if (warmupAbortController !== controller) {
+        return;
+      }
+      if (warmupTimeoutId) {
+        clearTimeout(warmupTimeoutId);
+        warmupTimeoutId = null;
+      }
+      warmupAbortController = null;
+    });
+}
+
+export function cancelSttWarmup(): void {
+  warmupAbortController?.abort();
+  if (warmupTimeoutId) {
+    clearTimeout(warmupTimeoutId);
+    warmupTimeoutId = null;
+  }
+  warmupAbortController = null;
+}

--- a/scripts/voice-pipeline-live-preflight.sh
+++ b/scripts/voice-pipeline-live-preflight.sh
@@ -1,0 +1,612 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Live voice pipeline preflight for alpha GO/no-GO.
+#
+# Validates the critical path without slide narration:
+#   STT warmup -> PiperPlus source TTS -> Qwen-primary STT -> LangGraph route -> PiperPlus answer TTS
+#
+# Usage:
+#   scripts/voice-pipeline-live-preflight.sh
+#   scripts/voice-pipeline-live-preflight.sh --host https://... --key "$API_SECRET_KEY"
+#   scripts/voice-pipeline-live-preflight.sh --case-set extended --dry-run
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+export VOICE_PIPELINE_ROOT_DIR="$ROOT_DIR"
+
+python3 - "$@" <<'PY'
+from __future__ import annotations
+
+import argparse
+import csv
+import json
+import os
+import pathlib
+import subprocess
+import sys
+import time
+import urllib.error
+import urllib.request
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from difflib import SequenceMatcher
+from typing import Any
+
+
+DEFAULT_URL = "https://engineer-cafe-backend-639959525777.asia-northeast1.run.app"
+ROOT_DIR = pathlib.Path(os.environ["VOICE_PIPELINE_ROOT_DIR"])
+
+
+@dataclass(frozen=True)
+class Case:
+    case_id: str
+    language: str
+    expected_route: str
+    query: str
+
+
+SMOKE_CASES = [
+    Case("VP-BIZ-001", "ja", "business_info", "エンジニアカフェの営業時間を教えてください。"),
+    Case("VP-FAC-001", "ja", "facility", "Wi-Fi の接続方法を教えてください。"),
+    Case("VP-EVT-001", "ja", "event", "今日開催されるイベントを教えてください。"),
+    Case("VP-GEN-001", "ja", "general_knowledge", "Python の仮想環境とは何ですか。"),
+]
+
+EXTENDED_CASES = [
+    *SMOKE_CASES,
+    Case("VP-BIZ-EN-001", "en", "business_info", "Can I use Engineer Cafe without a reservation?"),
+    Case("VP-FAC-EN-001", "en", "facility", "How can I connect to the Wi-Fi?"),
+    Case("VP-EVT-EN-001", "en", "event", "What events are happening at Engineer Cafe this week?"),
+    Case("VP-GEN-EN-001", "en", "general_knowledge", "What is the difference between an API and an SDK?"),
+]
+
+
+def utc_now() -> str:
+    return datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+def compact(value: Any, max_len: int = 140) -> str:
+    text = "" if value is None else str(value)
+    text = " ".join(text.split())
+    return text[:max_len]
+
+
+def normalize_route(raw: Any) -> str:
+    value = str(raw or "").strip().lower().replace("-", "_")
+    aliases = {
+        "businessinfoagent": "business_info",
+        "business_hours": "business_info",
+        "hours": "business_info",
+        "pricing": "business_info",
+        "price": "business_info",
+        "reception": "business_info",
+        "community": "business_info",
+        "consultation": "business_info",
+        "facilityagent": "facility",
+        "facility_info": "facility",
+        "basement_facility": "facility",
+        "wifi": "facility",
+        "access": "facility",
+        "facilities": "facility",
+        "parking": "facility",
+        "eventagent": "event",
+        "events": "event",
+        "generalknowledgeagent": "general_knowledge",
+        "general": "general_knowledge",
+        "memory": "general_knowledge",
+        "slideagent": "slide",
+        "farewellagent": "farewell",
+    }
+    return aliases.get(value, value)
+
+
+def response_route(body: dict[str, Any]) -> str:
+    metadata = body.get("metadata") if isinstance(body.get("metadata"), dict) else {}
+    for key in ("agent", "route", "category", "request_type"):
+        if metadata.get(key):
+            return normalize_route(metadata[key])
+    return ""
+
+
+def similarity(expected: str, actual: str) -> float:
+    def norm(text: str) -> str:
+        return "".join(text.lower().split())
+
+    return SequenceMatcher(None, norm(expected), norm(actual)).ratio()
+
+
+def fetch_api_key(args: argparse.Namespace) -> str:
+    if args.key:
+        return args.key
+    env_key = os.getenv("API_SECRET_KEY") or os.getenv("BACKEND_API_KEY")
+    if env_key:
+        return env_key
+    if args.dry_run:
+        return ""
+    try:
+        result = subprocess.run(
+            [
+                "gcloud",
+                "secrets",
+                "versions",
+                "access",
+                "latest",
+                f"--secret={args.secret_name}",
+                f"--project={args.secret_project}",
+            ],
+            check=False,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.DEVNULL,
+            text=True,
+        )
+    except FileNotFoundError:
+        return ""
+    return result.stdout.strip() if result.returncode == 0 else ""
+
+
+def post_json(
+    *,
+    base_url: str,
+    api_key: str,
+    endpoint: str,
+    body: dict[str, Any],
+    timeout: int,
+) -> tuple[int, int, dict[str, Any], str]:
+    payload = json.dumps(body, ensure_ascii=False).encode("utf-8")
+    request = urllib.request.Request(
+        f"{base_url.rstrip('/')}{endpoint}",
+        data=payload,
+        headers={
+            "Content-Type": "application/json",
+            "X-API-Key": api_key,
+        },
+        method="POST",
+    )
+    started = time.perf_counter()
+    raw = ""
+    status = 0
+    try:
+        with urllib.request.urlopen(request, timeout=timeout) as response:
+            status = int(response.status)
+            raw = response.read().decode("utf-8", errors="replace")
+    except urllib.error.HTTPError as exc:
+        status = int(exc.code)
+        raw = exc.read().decode("utf-8", errors="replace")
+    except Exception as exc:
+        duration_ms = int((time.perf_counter() - started) * 1000)
+        return 0, duration_ms, {}, f"{type(exc).__name__}: {exc}"
+
+    duration_ms = int((time.perf_counter() - started) * 1000)
+    try:
+        parsed = json.loads(raw) if raw else {}
+    except json.JSONDecodeError:
+        parsed = {}
+    return status, duration_ms, parsed, raw
+
+
+def record(
+    rows: list[dict[str, Any]],
+    *,
+    case_id: str,
+    step: str,
+    status: str,
+    http: int,
+    duration_ms: int,
+    language: str,
+    expected: str,
+    actual: str,
+    notes: str = "",
+) -> None:
+    rows.append(
+        {
+            "timestamp": utc_now(),
+            "case_id": case_id,
+            "step": step,
+            "status": status,
+            "http": http,
+            "duration_ms": duration_ms,
+            "language": language,
+            "expected": expected,
+            "actual": actual,
+            "notes": notes,
+        }
+    )
+    print(
+        f"[{status}] {case_id} {step} http={http} duration_ms={duration_ms} "
+        f"expected={compact(expected, 48)} actual={compact(actual, 72)}"
+    )
+
+
+def status_counts(rows: list[dict[str, Any]]) -> dict[str, int]:
+    return {
+        "PASS": sum(1 for row in rows if row["status"] == "PASS"),
+        "WARN": sum(1 for row in rows if row["status"] == "WARN"),
+        "FAIL": sum(1 for row in rows if row["status"] == "FAIL"),
+    }
+
+
+def percentile(values: list[int], ratio: float) -> int | None:
+    if not values:
+        return None
+    ordered = sorted(values)
+    index = round((len(ordered) - 1) * ratio)
+    return ordered[index]
+
+
+def write_reports(
+    *,
+    rows: list[dict[str, Any]],
+    args: argparse.Namespace,
+    report_md: pathlib.Path,
+    report_csv: pathlib.Path,
+) -> None:
+    report_md.parent.mkdir(parents=True, exist_ok=True)
+    fieldnames = [
+        "timestamp",
+        "case_id",
+        "step",
+        "status",
+        "http",
+        "duration_ms",
+        "language",
+        "expected",
+        "actual",
+        "notes",
+    ]
+    with report_csv.open("w", encoding="utf-8", newline="") as fh:
+        writer = csv.DictWriter(fh, fieldnames=fieldnames)
+        writer.writeheader()
+        writer.writerows(rows)
+
+    counts = status_counts(rows)
+    by_step: dict[str, list[int]] = {}
+    for row in rows:
+        try:
+            by_step.setdefault(str(row["step"]), []).append(int(row["duration_ms"]))
+        except Exception:
+            pass
+
+    lines = [
+        "# Voice Pipeline Live Preflight",
+        "",
+        f"- Timestamp: {args.timestamp}",
+        f"- Backend: {args.host}",
+        f"- Case set: {args.case_set}",
+        f"- TTS provider: {args.tts_provider}",
+        f"- Strict Qwen primary: {'no' if args.allow_vosk_fallback else 'yes'}",
+        f"- STT warn/max: {args.stt_warn_ms}ms / {args.stt_max_ms}ms",
+        f"- Similarity threshold: {args.stt_similarity_threshold}",
+        f"- Summary: {counts['PASS']} PASS / {counts['WARN']} WARN / {counts['FAIL']} FAIL",
+        f"- Detail CSV: {report_csv.name}",
+        "",
+        "## Gate Position",
+        "",
+        "- Welcome warmup の実装を、STT初回速度の補助導線として扱う。",
+        "- GO判断は同一セッションの STT provider、LangGraph route、PiperPlus 出力で判定する。",
+        "- スライド差し替え予定のため、slide narration はこの gate から除外する。",
+        "",
+        "## Latency",
+        "",
+        "| Step | Count | p50 ms | p95 ms | max ms |",
+        "| --- | ---: | ---: | ---: | ---: |",
+    ]
+    for step in sorted(by_step):
+        values = by_step[step]
+        lines.append(
+            f"| {step} | {len(values)} | {percentile(values, 0.50)} | "
+            f"{percentile(values, 0.95)} | {max(values)} |"
+        )
+
+    problem_rows = [row for row in rows if row["status"] in {"FAIL", "WARN"}]
+    if problem_rows:
+        lines.extend(["", "## Problems", "", "| Status | Case | Step | Expected | Actual | Notes |", "| --- | --- | --- | --- | --- | --- |"])
+        for row in problem_rows[:80]:
+            lines.append(
+                f"| {row['status']} | {row['case_id']} | {row['step']} | "
+                f"{compact(row['expected'])} | {compact(row['actual'])} | {compact(row['notes'])} |"
+            )
+
+    report_md.write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+
+def warmup_gate(args: argparse.Namespace, api_key: str, rows: list[dict[str, Any]]) -> None:
+    session_id = f"voice-pipeline-warmup-{args.timestamp}"
+    body = {"action": "warmup", "language": "ja", "sessionId": session_id}
+    http, duration_ms, parsed, raw = post_json(
+        base_url=args.host,
+        api_key=api_key,
+        endpoint="/api/voice",
+        body=body,
+        timeout=args.timeout,
+    )
+    warmup_status = str(parsed.get("sttWarmupStatus") or "")
+    provider = str(parsed.get("sttWarmupProvider") or "")
+    if http == 200 and warmup_status in {"started", "warming", "ready"}:
+        status = "PASS"
+    elif http == 200 and warmup_status == "skipped" and not args.allow_warmup_skipped:
+        status = "FAIL"
+    elif http == 200 and warmup_status == "skipped":
+        status = "WARN"
+    else:
+        status = "FAIL"
+    record(
+        rows,
+        case_id="VP-WARMUP",
+        step="warmup_start",
+        status=status,
+        http=http,
+        duration_ms=duration_ms,
+        language="ja",
+        expected="started|warming|ready",
+        actual=f"{warmup_status}:{provider}",
+        notes=compact(raw),
+    )
+
+    deadline = time.monotonic() + args.warmup_poll_seconds
+    last_status = warmup_status
+    last_provider = provider
+    while warmup_status in {"started", "warming"} and time.monotonic() < deadline:
+        time.sleep(args.warmup_poll_interval)
+        http, duration_ms, parsed, raw = post_json(
+            base_url=args.host,
+            api_key=api_key,
+            endpoint="/api/voice",
+            body=body,
+            timeout=args.timeout,
+        )
+        warmup_status = str(parsed.get("sttWarmupStatus") or "")
+        provider = str(parsed.get("sttWarmupProvider") or "")
+        last_status = warmup_status or last_status
+        last_provider = provider or last_provider
+        if warmup_status in {"ready", "failed", "skipped"}:
+            break
+
+    if last_status == "ready":
+        status = "PASS"
+    elif args.require_warmup_ready:
+        status = "FAIL"
+    else:
+        status = "WARN"
+    record(
+        rows,
+        case_id="VP-WARMUP",
+        step="warmup_ready",
+        status=status,
+        http=http,
+        duration_ms=duration_ms,
+        language="ja",
+        expected="ready",
+        actual=f"{last_status}:{last_provider}",
+        notes=f"poll_seconds={args.warmup_poll_seconds}",
+    )
+
+
+def run_case(args: argparse.Namespace, api_key: str, rows: list[dict[str, Any]], case: Case) -> None:
+    session_id = f"voice-pipeline-{args.timestamp}-{case.case_id}"
+
+    http, duration_ms, tts_source, raw = post_json(
+        base_url=args.host,
+        api_key=api_key,
+        endpoint="/api/voice",
+        body={
+            "action": "text_to_speech",
+            "text": case.query,
+            "language": case.language,
+            "sessionId": session_id,
+            "ttsProvider": args.tts_provider,
+        },
+        timeout=args.timeout,
+    )
+    audio = tts_source.get("audioResponse")
+    if http == 200 and tts_source.get("success") is True and isinstance(audio, str) and len(audio) > 64:
+        record(
+            rows,
+            case_id=case.case_id,
+            step="piper_source_tts",
+            status="PASS",
+            http=http,
+            duration_ms=duration_ms,
+            language=case.language,
+            expected=args.tts_provider,
+            actual=str(tts_source.get("audioFormat") or "audio"),
+            notes=f"audio_chars={len(audio)}",
+        )
+    else:
+        record(
+            rows,
+            case_id=case.case_id,
+            step="piper_source_tts",
+            status="FAIL",
+            http=http,
+            duration_ms=duration_ms,
+            language=case.language,
+            expected="audioResponse",
+            actual="missing",
+            notes=compact(raw),
+        )
+        return
+
+    http, duration_ms, stt, raw = post_json(
+        base_url=args.host,
+        api_key=api_key,
+        endpoint="/api/voice",
+        body={
+            "action": "speech_to_text",
+            "audioData": audio,
+            "language": case.language,
+            "sessionId": session_id,
+        },
+        timeout=args.timeout,
+    )
+    transcript = str(stt.get("transcript") or "").strip()
+    provider = str(stt.get("sttProvider") or "")
+    sim = similarity(case.query, transcript) if transcript else 0.0
+    provider_ok = provider == "qwen-primary" or (args.allow_vosk_fallback and provider == "vosk-fallback")
+    latency_ok = duration_ms <= args.stt_max_ms
+    if not (http == 200 and stt.get("success") is True and transcript):
+        stt_status = "FAIL"
+    elif not provider_ok:
+        stt_status = "FAIL"
+    elif not latency_ok:
+        stt_status = "FAIL"
+    elif duration_ms > args.stt_warn_ms or sim < args.stt_similarity_threshold:
+        stt_status = "WARN"
+    else:
+        stt_status = "PASS"
+    record(
+        rows,
+        case_id=case.case_id,
+        step="qwen_primary_stt",
+        status=stt_status,
+        http=http,
+        duration_ms=duration_ms,
+        language=case.language,
+        expected=f"provider=qwen-primary latency<={args.stt_max_ms}ms",
+        actual=f"provider={provider or 'unknown'} similarity={sim:.3f} transcript={compact(transcript)}",
+        notes=compact(raw),
+    )
+    if not transcript:
+        return
+
+    http, duration_ms, chat, raw = post_json(
+        base_url=args.host,
+        api_key=api_key,
+        endpoint="/api/chat",
+        body={
+            "query": transcript,
+            "language": case.language,
+            "session_id": session_id,
+        },
+        timeout=args.timeout,
+    )
+    answer = str(chat.get("answer") or "").strip()
+    actual_route = response_route(chat)
+    if http == 200 and answer and actual_route == case.expected_route:
+        route_status = "PASS"
+    else:
+        route_status = "FAIL"
+    record(
+        rows,
+        case_id=case.case_id,
+        step="langgraph_route",
+        status=route_status,
+        http=http,
+        duration_ms=duration_ms,
+        language=case.language,
+        expected=case.expected_route,
+        actual=actual_route or "unknown",
+        notes=f"answer={compact(answer)} raw={compact(raw, 80)}",
+    )
+    if not answer:
+        return
+
+    http, duration_ms, tts_answer, raw = post_json(
+        base_url=args.host,
+        api_key=api_key,
+        endpoint="/api/voice",
+        body={
+            "action": "text_to_speech",
+            "text": answer,
+            "language": case.language,
+            "sessionId": session_id,
+            "ttsProvider": args.tts_provider,
+        },
+        timeout=args.timeout,
+    )
+    answer_audio = tts_answer.get("audioResponse")
+    if (
+        http == 200
+        and tts_answer.get("success") is True
+        and isinstance(answer_audio, str)
+        and len(answer_audio) > 64
+    ):
+        answer_status = "PASS"
+        actual = str(tts_answer.get("audioFormat") or "audio")
+    else:
+        answer_status = "FAIL"
+        actual = "missing"
+    record(
+        rows,
+        case_id=case.case_id,
+        step="piper_answer_tts",
+        status=answer_status,
+        http=http,
+        duration_ms=duration_ms,
+        language=case.language,
+        expected=args.tts_provider,
+        actual=actual,
+        notes=compact(raw),
+    )
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Live STT -> LangGraph -> PiperPlus pipeline gate for alpha."
+    )
+    parser.add_argument("--host", default=os.getenv("VOICE_PIPELINE_BASE_URL", DEFAULT_URL))
+    parser.add_argument("--key", default="")
+    parser.add_argument("--secret-project", default=os.getenv("VOICE_PIPELINE_SECRET_PROJECT", "aipartner-426616"))
+    parser.add_argument("--secret-name", default="API_SECRET_KEY")
+    parser.add_argument("--output-dir", default=str(ROOT_DIR / "backend/tests/reports"))
+    parser.add_argument("--timestamp", default=datetime.now().strftime("%Y%m%d_%H%M%S"))
+    parser.add_argument("--case-set", choices=("smoke", "extended"), default="smoke")
+    parser.add_argument("--tts-provider", default="piper")
+    parser.add_argument("--timeout", type=int, default=120)
+    parser.add_argument("--sleep", type=float, default=1.0)
+    parser.add_argument("--stt-warn-ms", type=int, default=5000)
+    parser.add_argument("--stt-max-ms", type=int, default=10000)
+    parser.add_argument("--stt-similarity-threshold", type=float, default=0.50)
+    parser.add_argument("--warmup-poll-seconds", type=int, default=30)
+    parser.add_argument("--warmup-poll-interval", type=float, default=2.0)
+    parser.add_argument("--require-warmup-ready", action="store_true")
+    parser.add_argument("--allow-warmup-skipped", action="store_true")
+    parser.add_argument("--allow-vosk-fallback", action="store_true")
+    parser.add_argument("--dry-run", action="store_true")
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    cases = EXTENDED_CASES if args.case_set == "extended" else SMOKE_CASES
+    output_dir = pathlib.Path(args.output_dir)
+    report_md = output_dir / f"voice-pipeline-live-{args.timestamp}.md"
+    report_csv = output_dir / f"voice-pipeline-live-{args.timestamp}.csv"
+
+    if args.dry_run:
+        print("Dry run: no live API calls will be executed.")
+        print(f"Backend: {args.host}")
+        print(f"Case set: {args.case_set} ({len(cases)} cases)")
+        print(f"TTS provider: {args.tts_provider}")
+        print(f"Reports: {report_md} / {report_csv}")
+        for case in cases:
+            print(f"- {case.case_id}: {case.language} {case.expected_route} {case.query}")
+        return 0
+
+    api_key = fetch_api_key(args)
+    if not api_key:
+        print(
+            "Error: API_SECRET_KEY/BACKEND_API_KEY is required "
+            "(pass --key, set env, or allow gcloud Secret Manager access)",
+            file=sys.stderr,
+        )
+        return 2
+
+    rows: list[dict[str, Any]] = []
+    warmup_gate(args, api_key, rows)
+    if args.sleep > 0:
+        time.sleep(args.sleep)
+    for case in cases:
+        run_case(args, api_key, rows, case)
+        if args.sleep > 0:
+            time.sleep(args.sleep)
+
+    write_reports(rows=rows, args=args, report_md=report_md, report_csv=report_csv)
+    counts = status_counts(rows)
+    print(report_md)
+    print(f"Summary: {counts['PASS']} PASS / {counts['WARN']} WARN / {counts['FAIL']} FAIL")
+    return 1 if counts["FAIL"] else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())
+PY

--- a/scripts/welcome-live-preflight.sh
+++ b/scripts/welcome-live-preflight.sh
@@ -1,0 +1,118 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Browser-level Welcome live preflight for alpha H scenarios.
+#
+# Usage:
+#   scripts/welcome-live-preflight.sh
+#   scripts/welcome-live-preflight.sh --host https://... --key "$API_SECRET_KEY"
+#   scripts/welcome-live-preflight.sh --delays 0,5,10
+#   scripts/welcome-live-preflight.sh --dry-run
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+DEFAULT_URL="https://engineer-cafe-backend-639959525777.asia-northeast1.run.app"
+BASE_URL="${WELCOME_LIVE_BASE_URL:-${BACKEND_API_URL:-$DEFAULT_URL}}"
+API_KEY="${API_SECRET_KEY:-${BACKEND_API_KEY:-}}"
+SECRET_PROJECT="${WELCOME_LIVE_SECRET_PROJECT:-aipartner-426616}"
+SECRET_NAME="API_SECRET_KEY"
+OUTPUT_DIR="$ROOT_DIR/backend/tests/reports"
+TIMESTAMP="$(date +%Y%m%d_%H%M%S)"
+DELAYS="${PLAYWRIGHT_WELCOME_VOICE_DELAYS:-0,5,10}"
+DRY_RUN=0
+
+usage() {
+  sed -n '3,10p' "$0"
+  cat <<'EOF'
+
+Options:
+  --host URL             Backend base URL (default: Cloud Run live URL)
+  --key VALUE            API key; skips Secret Manager lookup
+  --secret-project ID    GCP project for Secret Manager (default: aipartner-426616)
+  --secret-name NAME     Secret Manager secret name (default: API_SECRET_KEY)
+  --output-dir DIR       Report directory (default: backend/tests/reports)
+  --timestamp VALUE      Stable timestamp marker for logs
+  --delays LIST          Seconds after Welcome before first voice turn (default: 0,5,10)
+  --dry-run              Print planned command without network/browser execution
+  -h, --help             Show this usage
+EOF
+  exit "${1:-0}"
+}
+
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --host) BASE_URL="$2"; shift 2 ;;
+    --key) API_KEY="$2"; shift 2 ;;
+    --secret-project) SECRET_PROJECT="$2"; shift 2 ;;
+    --secret-name) SECRET_NAME="$2"; shift 2 ;;
+    --output-dir) OUTPUT_DIR="$2"; shift 2 ;;
+    --timestamp) TIMESTAMP="$2"; shift 2 ;;
+    --delays) DELAYS="$2"; shift 2 ;;
+    --dry-run) DRY_RUN=1; shift ;;
+    -h|--help) usage 0 ;;
+    *) echo "Unknown arg: $1" >&2; usage 1 ;;
+  esac
+done
+
+fetch_api_key_from_gcloud() {
+  if command -v gcloud >/dev/null 2>&1; then
+    gcloud secrets versions access latest \
+      --secret="$SECRET_NAME" --project="$SECRET_PROJECT" 2>/dev/null || true
+  fi
+}
+
+if [ -z "$API_KEY" ]; then
+  API_KEY="$(fetch_api_key_from_gcloud)"
+fi
+
+if [ -z "$API_KEY" ] && [ "$DRY_RUN" != "1" ]; then
+  echo "Error: API_SECRET_KEY/BACKEND_API_KEY is required (pass --key, set env, or allow gcloud Secret Manager access)" >&2
+  exit 2
+fi
+
+if [ "$DRY_RUN" = "1" ]; then
+  echo "Dry run: no browser or network calls will be executed."
+  echo "Backend: $BASE_URL"
+  echo "Timestamp: $TIMESTAMP"
+  echo "Delays: $DELAYS"
+  echo "Output: $OUTPUT_DIR/welcome-live-preflight-$TIMESTAMP.md"
+  echo "Command: PLAYWRIGHT_WELCOME_LIVE=1 BACKEND_API_URL=$BASE_URL BACKEND_API_KEY=<redacted> PLAYWRIGHT_WELCOME_VOICE_DELAYS=$DELAYS pnpm --dir frontend exec playwright test --config=playwright.config.ts e2e/welcome-live.spec.ts --project=chromium-voice-live --workers=1"
+  exit 0
+fi
+
+mkdir -p "$OUTPUT_DIR"
+REPORT="$OUTPUT_DIR/welcome-live-preflight-$TIMESTAMP.md"
+LOG="$OUTPUT_DIR/welcome-live-preflight-$TIMESTAMP.log"
+
+set +e
+BACKEND_API_URL="$BASE_URL" \
+BACKEND_API_KEY="$API_KEY" \
+PLAYWRIGHT_WELCOME_LIVE=1 \
+PLAYWRIGHT_WELCOME_TIMESTAMP="$TIMESTAMP" \
+PLAYWRIGHT_WELCOME_VOICE_DELAYS="$DELAYS" \
+pnpm --dir "$ROOT_DIR/frontend" exec playwright test \
+  --config=playwright.config.ts \
+  e2e/welcome-live.spec.ts \
+  --project=chromium-voice-live \
+  --workers=1 \
+  --reporter=line,html 2>&1 | tee "$LOG"
+STATUS="${PIPESTATUS[0]}"
+set -e
+
+{
+  echo "# Welcome Live Preflight"
+  echo
+  echo "- Timestamp: $TIMESTAMP"
+  echo "- Backend: $BASE_URL"
+  echo "- Delays: $DELAYS"
+  echo "- Status: $([ "$STATUS" = "0" ] && echo PASS || echo FAIL)"
+  echo "- Playwright log: $(basename "$LOG")"
+  echo
+  echo "## Scope"
+  echo
+  echo "- H-1: Welcome 起動 → greeting TTS → OCR sidecar → STT warmup"
+  echo "- H-2/H-3: Welcome 後 0秒/5秒/10秒の初回発話"
+  echo "- H-6/H-7: frontend cleanup / stale warmup の回帰は mocked E2E と合わせて確認"
+} > "$REPORT"
+
+echo "$REPORT"
+exit "$STATUS"


### PR DESCRIPTION
## 概要
- Qwen3-ASR primary を維持したまま、production startup で Qwen model を prewarm します。
- Cloud Run deploy 設定を Qwen CPU 推論向けに `cpu=4`, `concurrency=1`, `QWEN_STT_TIMEOUT=8`, `STT_PRELOAD_QWEN_PRIMARY=true` へ調整します。
- production で Qwen warmup に失敗した場合は deploy/startup を失敗扱いにします。

## 背景
#590 の Vosk-only 案は取り下げました。#529/#559 を確認した結果、Qwen3-ASR は warm 状態なら fast-path として成立します。

再調査結果:
- #529: Qwen 0.6B CPU は post-alpha で ONNX/量子化 or GPU を検討する親 issue。ただし既存観測では warm 8-9s。
- #559: Qwen-only fast-path 実装 issue。Phase A profile では `qwen_inference p50 3098ms`、Qwen 成功時に Vosk 完了待ちをしないことが目的。
- 今回の live 再測定では、未 warm instance で model load が request 中に乗り、Qwen timeout/fallback していました。
- `engineer-cafe-backend-00111-xq5` で `cpu=4`, `concurrency=1`, `max-instances=1`, `QWEN_STT_TIMEOUT=20` を手動適用したところ、warm 後の Qwen は `4855ms`、次リクエストで `1822ms` で成功しました。

したがって、alpha では Qwen を捨てず、未 warm traffic を防ぐ方針で詰めます。

## 確認
- `pytest backend/tests/agents/test_stt_agent.py` : 106 passed
- `pytest backend/tests/agents/test_stt_agent.py -k "qwen_primary or QwenSTTClient"` : 17 passed
- `pytest backend/tests/test_main_endpoints.py -k "lifespan or health"` : 2 passed
- `uv run ruff check backend/agents/stt_agent.py backend/tests/agents/test_stt_agent.py backend/main.py` : pass
- `uv run black --check backend/agents/stt_agent.py backend/tests/agents/test_stt_agent.py backend/main.py` : pass
- `git diff --check` : pass

## merge 後に必要な確認
1. develop deploy が Qwen prewarm 後に成功すること
2. 新 revision で `stt_model_load_complete` が startup 側で出ること
3. 新 revision に voice traffic を当て、Qwen winner が出ること
4. `scripts/stt-live-preflight.sh` で p95 gate を再判定すること

Refs #529
Refs #559
Refs #575
Refs #571
