### PR TITLE
fix(alpha): stabilize live reception RAG fallback

### DIFF
--- a/backend/knowledge/data/general.yaml
+++ b/backend/knowledge/data/general.yaml
@@ -57,6 +57,7 @@ entries:
       エンジニアカフェは「エンジニアフレンドリーシティ福岡」の実現を目的とした官民一体型プロジェクトで、
       現役エンジニア、エンジニアを目指す方、エンジニアリング分野に関連する業務や学習に取り組む方が対象です。
       施設・設備の利用料は無料です。ただしcafe&bar sainoの飲食と3Dプリンターのフィラメント代は有料です。
+      コワーキングスペースの通常利用は予約不要です。初めて利用する場合も、来館後に1階受付で利用登録できます。
       【初回利用登録】初めて利用する場合は受付で利用登録を行います（所要時間: 約5〜10分）。
       施設の利用目的確認、飲食ルール、集中スペースでの私語禁止、15分以上の離席ルールについて説明を受けます。
       所定のWebフォームに氏名、住所、連絡先、所属コミュニティ、職業、当施設を知ったきっかけ等を入力して完了です。
@@ -70,6 +71,8 @@ entries:
       It is open to working engineers, aspiring engineers, and anyone in engineering-related fields.
       Membership registration and facility use are free. Only cafe&bar saino food/drinks and
       3D printer filament are paid.
+      Regular coworking use does not require a reservation. First-time visitors can register
+      at the 1F reception after arriving.
       First-time registration: Complete a form at reception (5-10 min, free, no ID required).
       You will receive a briefing on facility rules (food policy, quiet zones, 15-min seat policy).
       Registration is in-person only; no online pre-registration available.

--- a/backend/tests/tools/test_enhanced_rag.py
+++ b/backend/tests/tools/test_enhanced_rag.py
@@ -670,6 +670,21 @@ class TestTextFallbackSearch:
         assert results
         assert "SSID" in results[0]["content"] or "engnecf" in results[0]["content"]
 
+    def test_local_yaml_fallback_keeps_reception_queries_on_general_guides(self, rag_search):
+        """受付・予約なし質問ではイベント予約ではなく一般受付案内を優先する"""
+        results = rag_search._local_knowledge_fallback_search(
+            query="予約なしで利用できますか。",
+            category="general",
+            language="ja",
+            max_results=3,
+        )
+
+        assert results
+        assert results[0]["id"] == "general-pricing"
+        assert results[0]["category"] == "pricing"
+        assert "予約不要" in results[0]["content"]
+        assert "受付" in results[0]["content"]
+
     @pytest.mark.asyncio
     async def test_search_uses_local_yaml_when_embedding_fails(self, rag_search):
         """embedding API障害時も公式ナレッジ由来の通常検索レスポンスを返す"""
@@ -686,6 +701,49 @@ class TestTextFallbackSearch:
         assert result["success"] is True
         assert result["data"]["context"]
         assert "SSID" in result["data"]["context"]
+
+    @pytest.mark.asyncio
+    async def test_search_uses_local_yaml_when_text_results_grade_out(self, rag_search):
+        """DBテキスト候補がgradingで全落ちした場合も公式YAMLへ降りる"""
+        rag_search._generate_embedding = AsyncMock(return_value=[0.1] * 1536)
+        mock_execute = MagicMock()
+        mock_execute.execute.return_value = MagicMock(
+            data=[
+                {
+                    "id": "weak",
+                    "content": "これは質問と関係のない短い説明です。",
+                    "category": "general",
+                    "language": "ja",
+                    "source": "official",
+                    "metadata": {},
+                    "similarity": 0.01,
+                }
+            ]
+        )
+        rag_search.supabase.rpc.return_value = mock_execute
+        rag_search._text_fallback_search = AsyncMock(
+            return_value=[
+                {
+                    "id": "weak-text",
+                    "content": "これは質問と関係のない短い説明です。",
+                    "category": "general",
+                    "language": "ja",
+                    "source": "official",
+                    "metadata": {},
+                    "similarity": 0.01,
+                }
+            ]
+        )
+
+        result = await rag_search.search(
+            query="予約なしで利用できますか。",
+            category="general",
+            language="ja",
+            include_advice=False,
+        )
+
+        assert result["success"] is True
+        assert "予約不要" in result["data"]["context"]
 
 
 # ==============================================================================

--- a/backend/tools/enhanced_rag.py
+++ b/backend/tools/enhanced_rag.py
@@ -322,6 +322,15 @@ class EnhancedRAGSearch:
             scored_results = self._grade_result_relevance(
                 scored_results, query, category, context_signals=context_signals
             )
+            if not scored_results:
+                local_results = self._local_knowledge_fallback_search(
+                    query, category, language, max_results
+                )
+                if local_results:
+                    scored_results = self._score_results(local_results, query, category, language)
+                    scored_results = self._grade_result_relevance(
+                        scored_results, query, category, context_signals=context_signals
+                    )
 
             # 6. トップ結果を取得
             top_results = scored_results[:max_results]
@@ -627,6 +636,13 @@ class EnhancedRAGSearch:
 
         scored_results = self._score_results(results, query, category, language)
         scored_results = self._grade_result_relevance(scored_results, query, category)
+        if not scored_results:
+            local_results = self._local_knowledge_fallback_search(
+                query, category, language, max_results
+            )
+            if local_results:
+                scored_results = self._score_results(local_results, query, category, language)
+                scored_results = self._grade_result_relevance(scored_results, query, category)
         top_results = scored_results[:max_results]
         context = self._build_context_from_results(top_results, category, language)
 
@@ -717,7 +733,21 @@ class EnhancedRAGSearch:
         ).lower()
         terms = self._extract_text_query_terms(query, category, language)
 
-        if category != "general" and row.get("category") != category:
+        row_category = row.get("category")
+        if category != "general" and row_category != category:
+            return 0.0
+        if category == "general" and row_category not in {
+            "general",
+            "hours",
+            "pricing",
+            "access",
+            "contact",
+            "policy",
+            "parking",
+            "bicycle",
+            "food_drink",
+            "smoking",
+        }:
             return 0.0
 
         match_score = 0.0
@@ -726,9 +756,6 @@ class EnhancedRAGSearch:
             if term in searchable:
                 match_score += 0.08 if self._contains_cjk(term) else 0.12
                 has_content_match = True
-
-        if row.get("category") == category:
-            match_score += 0.18
 
         query_lower = query.lower()
         if any(term in query_lower for term in ("wi-fi", "wifi", "ssid", "接続")) and any(
@@ -741,14 +768,39 @@ class EnhancedRAGSearch:
         ):
             match_score += 0.24
             has_content_match = True
+        if (
+            any(term in query for term in ("予約", "予約なし", "予約不要"))
+            or any(
+                term in query_lower
+                for term in ("reservation", "without a reservation", "no reservation")
+            )
+        ) and any(
+            term in searchable
+            for term in (
+                "予約不要",
+                "予約なし",
+                "does not require a reservation",
+                "no reservation",
+            )
+        ):
+            match_score += 0.35
+            has_content_match = True
         if any(term in query for term in ("受付", "初めて", "再受付", "登録")) and any(
             term in searchable for term in ("受付", "registration", "会員番号", "reception")
         ):
             match_score += 0.2
             has_content_match = True
+        if any(term in query for term in ("再受付", "以前登録", "登録した", "2回目")) and any(
+            term in searchable for term in ("2回目以降", "会員番号", "受付カード", "受付")
+        ):
+            match_score += 0.3
+            has_content_match = True
 
         if not has_content_match:
             return 0.0
+
+        if row_category == category:
+            match_score += 0.18
 
         priority = row.get("metadata", {}).get("priority", 50)
         if isinstance(priority, int):


### PR DESCRIPTION
## Summary
- add official no-reservation coworking guidance to the checked-in live-seeded general knowledge
- keep general fallback broad enough for pricing/reception/access facts while blocking unrelated event/facility reservation content
- fall back to official YAML knowledge when weak DB/text candidates grade out

## Validation
- pytest backend/tests/tools/test_enhanced_rag.py backend/tests/tools/test_enhanced_rag_scoring.py backend/tests/agents/test_business_info_agent.py -q
- pytest backend/tests/tools/test_enhanced_rag.py backend/tests/tools/test_enhanced_rag_scoring.py backend/tests/tools/test_enhanced_rag_context.py backend/tests/tools/test_enhanced_rag_i18n.py backend/tests/agents/test_business_info_agent.py backend/tests/agents/test_facility_agent.py backend/tests/evaluation/test_live_quality_gates.py backend/tests/utils/test_memory_extractor.py backend/tests/agents/test_stt_agent.py -q
- bash -n scripts/alpha-smoke-comprehensive.sh scripts/rag-live-test.sh scripts/cloud-logging-verify.sh scripts/alpha-quality-gates.sh scripts/voice-pipeline-live-preflight.sh scripts/welcome-live-preflight.sh

Refs #571