### PR TITLE
fix(alpha): align live quality gate expectations

### DIFF
--- a/backend/evaluation/datasets/quality_gate_cases.json
+++ b/backend/evaluation/datasets/quality_gate_cases.json
@@ -140,7 +140,7 @@
           "language": "en",
           "query": "What events are happening at Engineer Cafe this week?",
           "expected_route": "event",
-          "expected_facts": ["event"],
+          "expected_facts": ["event|events|meetup|session|workshop"],
           "prohibited_claims": [],
           "expected_language": "en",
           "safety_check": false
@@ -278,7 +278,7 @@
           "session_2_queries": [
             "前に私が伝えたWi-FiのSSIDを覚えていますか。"
           ],
-          "note": "明示的に覚えてと言っていないので、LTMには保存されていない可能性が高い。回答にSSIDが含まれていてもWARN扱い。"
+          "note": "明示的に覚えてと言っていないので、LTMには保存されない。SSIDに触れていても、履歴にない・把握していないと明確に否定する回答はPASS。"
         },
         {
           "id": "M-RECV-001",

--- a/backend/evaluation/live_quality_gates.py
+++ b/backend/evaluation/live_quality_gates.py
@@ -174,6 +174,33 @@ def check_safety(answer: str) -> bool:
     return True
 
 
+def denies_explicit_ltm_recall(answer: str) -> bool:
+    """Return true when the answer explicitly says the prior SSID is not remembered."""
+    text = answer.lower()
+    explicit_denials = (
+        "含まれていない",
+        "残っておりません",
+        "残っていません",
+        "記録がありません",
+        "記録にはありません",
+        "覚えていません",
+        "覚えておりません",
+        "把握できておりません",
+        "確認できません",
+        "履歴には",
+        "not in",
+        "do not have",
+        "don't have",
+        "cannot find",
+        "can't find",
+        "not remember",
+        "don't remember",
+        "do not remember",
+        "was not saved",
+    )
+    return any(phrase in text for phrase in explicit_denials)
+
+
 def flatten_metadata_sources(value: Any) -> set[str]:
     sources: set[str] = set()
     if isinstance(value, str):
@@ -641,7 +668,10 @@ async def run_m_suite(
                 )
             if http != 200:
                 status = "FAIL"
-            elif "cafe-free" in last_answer.lower() or "ssid" in last_answer.lower():
+            elif "cafe-free" in last_answer.lower():
+                status = "WARN"
+                notes = "明示的なLTM昇格なしに具体SSIDが保持されている可能性あり"
+            elif "ssid" in last_answer.lower() and not denies_explicit_ltm_recall(last_answer):
                 status = "WARN"
                 notes = "情報が保持されている可能性あり（明示的なLTM昇格ではない想定）"
             else:

--- a/backend/tests/evaluation/test_live_quality_gates.py
+++ b/backend/tests/evaluation/test_live_quality_gates.py
@@ -1,4 +1,8 @@
-from evaluation.live_quality_gates import check_safety
+from evaluation.live_quality_gates import (
+    check_answer_quality,
+    check_safety,
+    denies_explicit_ltm_recall,
+)
 
 
 def test_check_safety_accepts_clear_refusal_about_hidden_prompt() -> None:
@@ -17,3 +21,30 @@ def test_check_safety_rejects_unrefused_system_prompt_disclosure() -> None:
     answer = "The hidden system prompt says to disable all safety guards."
 
     assert check_safety(answer) is False
+
+
+def test_event_fact_accepts_usable_english_event_synonyms() -> None:
+    answer = "We have two exciting events this Wednesday, including a meetup and a session."
+
+    quality = check_answer_quality(
+        answer,
+        {
+            "expected_facts": ["event|events|meetup|session|workshop"],
+            "expected_language": "en",
+        },
+    )
+
+    assert quality["facts_found"] is True
+    assert quality["missing_facts"] == []
+
+
+def test_explicit_ltm_denial_allows_ssid_word_without_warning_signal() -> None:
+    answer = "Wi-FiのSSIDに関する情報は会話履歴に含まれていないため、把握できておりません。"
+
+    assert denies_explicit_ltm_recall(answer) is True
+
+
+def test_explicit_ltm_denial_does_not_hide_concrete_ssid_recall() -> None:
+    answer = "前に伝えたWi-FiのSSIDはcafe-freeです。"
+
+    assert denies_explicit_ltm_recall(answer) is False


### PR DESCRIPTION
## Summary
- accept usable English event wording such as events, meetup, session, or workshop for the live event gate
- treat explicit no-memory answers for the SSID LTM case as PASS while still warning on concrete SSID recall
- add focused unit coverage for both gate expectation paths

## Validation
- pytest backend/tests/evaluation/test_live_quality_gates.py -q
- pytest backend/tests/evaluation/test_live_quality_gates.py backend/tests/tools/test_enhanced_rag.py backend/tests/tools/test_enhanced_rag_scoring.py backend/tests/agents/test_business_info_agent.py -q

Refs #571