### PR TITLE
fix: cap live TTS spoken length

### DIFF
--- a/backend/agents/voice_agent.py
+++ b/backend/agents/voice_agent.py
@@ -4,7 +4,7 @@ Phase 1 (TTS only):
 - Emotion tag parsing + alias normalization (TS EmotionTagParser / EmotionMapping compatible)
 - Text cleaning for TTS (TS VoiceOutputAgent.cleanTextForTTS compatible)
 - preprocessTTS (currently MTG -> ミーティング/meeting)
-- 5000 bytes truncation
+- Configurable byte truncation for practical spoken responses
 - Fallback handling
 - Google TTS REST client (service account -> bearer token)
   for integration (can be monkeypatched in unit tests)
@@ -254,8 +254,22 @@ def clean_text_for_tts(text: str) -> str:
 
 
 # -----------------------------------------------------------------------------
-# Truncate by UTF-8 bytes (limit 5000 by default)
+# Truncate by UTF-8 bytes
 # -----------------------------------------------------------------------------
+
+DEFAULT_TTS_MAX_BYTES = 900
+
+
+def get_tts_max_bytes() -> int:
+    raw = os.getenv("TTS_MAX_BYTES", "").strip()
+    if not raw:
+        return DEFAULT_TTS_MAX_BYTES
+    try:
+        value = int(raw)
+    except ValueError:
+        logger.warning("Invalid TTS_MAX_BYTES=%r; using %d", raw, DEFAULT_TTS_MAX_BYTES)
+        return DEFAULT_TTS_MAX_BYTES
+    return max(200, value)
 
 
 def truncate_by_bytes(text: str, max_bytes: int = 5000) -> str:
@@ -265,7 +279,7 @@ def truncate_by_bytes(text: str, max_bytes: int = 5000) -> str:
     truncated = text
     while truncated and byte_len(truncated) > max_bytes:
         if "。" in truncated:
-            parts = truncated.split("。")
+            parts = [part for part in truncated.split("。") if part.strip()]
             if len(parts) > 1:
                 parts.pop()
                 truncated = "。".join(parts).strip()
@@ -836,9 +850,10 @@ class VoiceAgent:
                 logger.error("Clarification handling failed: %s, proceeding with original text", e)
 
         # ステップ4: テキスト長チェック
-        if len(processed.encode("utf-8")) > 5000:
-            processed = truncate_by_bytes(processed, 5000)
-            logger.warning("Text truncated to 5000 bytes")
+        max_tts_bytes = get_tts_max_bytes()
+        if len(processed.encode("utf-8")) > max_tts_bytes:
+            processed = truncate_by_bytes(processed, max_tts_bytes)
+            logger.warning("Text truncated to %d bytes for TTS", max_tts_bytes)
 
         cache_store = getattr(self, "_tts_cache", None)
         if cache_store is None:

--- a/backend/tests/agents/test_voice_agent.py
+++ b/backend/tests/agents/test_voice_agent.py
@@ -2,9 +2,11 @@ import pytest
 from cachetools import TTLCache
 
 from backend.agents.voice_agent import (
+    DEFAULT_TTS_MAX_BYTES,
     parse_emotion_tags,
     preprocess_tts,
     clean_text_for_tts,
+    get_tts_max_bytes,
     truncate_by_bytes,
     map_vrm_to_tts_emotion,
     VoiceAgent,
@@ -100,6 +102,28 @@ def test_truncate_by_bytes_over_limit():
     text = "あ" * 3000
     out = truncate_by_bytes(text, 5000)
     assert len(out.encode("utf-8")) <= 5000
+
+
+def test_truncate_by_bytes_handles_sentence_ending_over_limit():
+    sentence = "エンジニアカフェの施設について詳しく説明します。"
+    out = truncate_by_bytes(sentence * 20, 300)
+    assert len(out.encode("utf-8")) <= 300
+    assert out.endswith("。")
+    assert out != sentence * 20
+
+
+def test_get_tts_max_bytes_defaults_and_guards_invalid_env(monkeypatch):
+    monkeypatch.delenv("TTS_MAX_BYTES", raising=False)
+    assert get_tts_max_bytes() == DEFAULT_TTS_MAX_BYTES
+
+    monkeypatch.setenv("TTS_MAX_BYTES", "1200")
+    assert get_tts_max_bytes() == 1200
+
+    monkeypatch.setenv("TTS_MAX_BYTES", "100")
+    assert get_tts_max_bytes() == 200
+
+    monkeypatch.setenv("TTS_MAX_BYTES", "invalid")
+    assert get_tts_max_bytes() == DEFAULT_TTS_MAX_BYTES
 
 
 def test_map_vrm_to_tts_emotion():
@@ -385,6 +409,30 @@ async def test_text_to_speech_piper_routes_japanese(monkeypatch):
     assert result["audioResponse"] == "PIPER_BASE64_JA"
     assert result["format"] == "audio/wav"
     assert result["language"] == "ja"
+
+
+@pytest.mark.asyncio
+async def test_text_to_speech_truncates_long_spoken_text(monkeypatch):
+    agent = VoiceAgent(tts_provider="google")
+    calls = {}
+
+    async def fake_google_synth(text, lang, tts_emotion):
+        calls["text"] = text
+        calls["lang"] = lang
+        calls["tts_emotion"] = tts_emotion
+        return "PIPER_BASE64_JA"
+
+    monkeypatch.setenv("TTS_MAX_BYTES", "300")
+    monkeypatch.setattr(agent.tts_client, "synthesize_mp3_base64", fake_google_synth)
+
+    result = await agent.text_to_speech(
+        text="。".join(["エンジニアカフェの施設について詳しく説明します"] * 30),
+        language="ja",
+    )
+
+    assert result["success"] is True
+    assert len(calls["text"].encode("utf-8")) <= 300
+    assert calls["text"].endswith("。")
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- cap processed TTS text with configurable TTS_MAX_BYTES so live alpha voice answers stay usable
- fix Japanese sentence-bound truncation when text already ends with punctuation
- add focused unit coverage for truncation and env guards

## Validation
- python -m black --check backend/agents/voice_agent.py backend/tests/agents/test_voice_agent.py
- python -m py_compile backend/agents/voice_agent.py backend/evaluation/live_quality_gates.py
- pytest backend/tests/evaluation/test_live_quality_gates.py backend/tests/agents/test_voice_agent.py::test_truncate_by_bytes_over_limit backend/tests/agents/test_voice_agent.py::test_truncate_by_bytes_handles_sentence_ending_over_limit backend/tests/agents/test_voice_agent.py::test_get_tts_max_bytes_defaults_and_guards_invalid_env backend/tests/agents/test_voice_agent.py::test_text_to_speech_truncates_long_spoken_text backend/tests/agents/test_voice_agent.py::test_text_to_speech_calls_tts_with_processed_text_and_emotion -q

Refs #571