### PR TITLE
[codex] Stop TTS from rewriting source text

### DIFF
--- a/backend/agents/voice_agent.py
+++ b/backend/agents/voice_agent.py
@@ -30,10 +30,7 @@ import httpx
 from cachetools import TTLCache
 
 from backend.observability.structured_logger import log_tts_cache_event
-from backend.utils.clarification_templates import (
-    ClarificationCategory,
-    get_clarification_response,
-)
+from backend.utils.clarification_templates import ClarificationCategory
 from backend.utils.language_processor import LanguageProcessor
 
 logger = logging.getLogger(__name__)
@@ -667,7 +664,7 @@ class PiperPlusTTSClient:
 
 
 # =============================================================================
-# VoiceAgent class (modified for provider switching + language detection + clarification)
+# VoiceAgent class (modified for provider switching + language detection)
 # =============================================================================
 
 
@@ -687,9 +684,8 @@ class VoiceAgent:
                 If None, creates default client based on provider.
             language_processor: LanguageProcessor for language
                 detection. If None, creates default instance.
-            clarification_agent: Optional clarification handler for
-                ambiguity resolution. If None, built-in clarification
-                templates are used.
+            clarification_agent: Deprecated. Clarification is handled by the
+                chat workflow; TTS speaks the supplied text without rewriting it.
         """
         self.tts_provider = tts_provider
 
@@ -713,7 +709,6 @@ class VoiceAgent:
         logger.info("LanguageProcessor initialized for voice_agent")
 
         self.clarification_agent = clarification_agent
-        logger.info("Clarification handler initialized for voice_agent")
 
         # Kokoro TTSクライアント（英語TTS用 / piper障害時の英語フォールバック）
         # Cloud Run環境でKOKORO_API_URL未設定の場合は初期化しない
@@ -785,11 +780,10 @@ class VoiceAgent:
         language: Optional[str] = None,
         emotion: Optional[str] = None,
     ) -> Dict[str, Any]:
-        """Convert text to speech with language detection and clarification.
+        """Convert text to speech with language detection.
 
         Features:
             - Automatic language detection (when language is None)
-            - Ambiguity checking (clarification template integration)
             - TTS provider switching (voicevox / google / kokoro)
 
         Args:
@@ -805,7 +799,7 @@ class VoiceAgent:
                 - cleanText (str): Processed text after cleaning and emotion tag removal.
                 - format (str): Audio format ('audio/wav' or 'audio/mpeg').
                 - language (str): Language used for synthesis.
-                - ambiguity_resolved (bool): Whether ambiguity was detected and resolved.
+                - ambiguity_resolved (bool): Always False. Kept for response compatibility.
                 - error (str): Error message if failed. Optional.
         """
         # ステップ1: 言語自動検出（未指定時）
@@ -825,29 +819,6 @@ class VoiceAgent:
         vrm_emotion = (
             map_to_vrm_emotion(emotion) if emotion else (parsed.primary_emotion or "neutral")
         )
-
-        # ステップ3: 曖昧性チェック
-        ambiguity_category = self._detect_category(text, language)
-        if ambiguity_category:
-            logger.info("Ambiguity detected: %s", ambiguity_category)
-            try:
-                if self.clarification_agent is None:
-                    clarification_result = get_clarification_response(
-                        category=ambiguity_category,
-                        language=language,
-                    )
-                else:
-                    clarification_result = await self.clarification_agent.handle_clarification(
-                        query=text,
-                        category=ambiguity_category,
-                        language=language,
-                    )
-                clarification_text = clarification_result["response"]
-                logger.info("Using clarification response instead of original query")
-                processed = preprocess_tts(clarification_text, language)
-                vrm_emotion = clarification_result.get("emotion", "surprised")
-            except Exception as e:
-                logger.error("Clarification handling failed: %s, proceeding with original text", e)
 
         # ステップ4: テキスト長チェック
         max_tts_bytes = get_tts_max_bytes()
@@ -871,7 +842,7 @@ class VoiceAgent:
                 "cleanText": processed,
                 "format": self._tts_audio_format(language),
                 "language": language,
-                "ambiguity_resolved": ambiguity_category is not None,
+                "ambiguity_resolved": False,
                 "tts_cache_hit": True,
             }
 
@@ -913,7 +884,7 @@ class VoiceAgent:
                 "cleanText": processed,
                 "format": audio_format,
                 "language": language,
-                "ambiguity_resolved": ambiguity_category is not None,
+                "ambiguity_resolved": False,
                 "tts_cache_hit": False,
             }
         except Exception as e:

--- a/backend/tests/agents/test_voice_agent.py
+++ b/backend/tests/agents/test_voice_agent.py
@@ -1,3 +1,5 @@
+from unittest.mock import AsyncMock
+
 import pytest
 from cachetools import TTLCache
 
@@ -172,6 +174,29 @@ async def test_text_to_speech_calls_tts_with_processed_text_and_emotion(monkeypa
 
     # VRM happy -> TTS happy
     assert calls["tts_emotion"] == "happy"
+
+
+@pytest.mark.asyncio
+async def test_text_to_speech_does_not_replace_ambiguous_source_text(monkeypatch):
+    agent = VoiceAgent(tts_provider="piper")
+    calls = {}
+    agent.clarification_agent = AsyncMock()
+
+    async def fake_synth(text, lang):
+        calls["text"] = text
+        calls["lang"] = lang
+        return "PIPER_BASE64_DUMMY"
+
+    monkeypatch.setattr(agent.tts_client, "synthesize_wav_base64", fake_synth)
+    source_text = "What are good conversation topics when meeting engineers in Fukuoka?"
+
+    result = await agent.text_to_speech(text=source_text, language="en")
+
+    assert result["success"] is True
+    assert calls["text"] == source_text
+    assert calls["lang"] == "en"
+    assert result["ambiguity_resolved"] is False
+    agent.clarification_agent.handle_clarification.assert_not_awaited()
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- keep /api/voice text_to_speech as a true TTS operation that speaks the supplied text
- leave clarification behavior in the chat workflow instead of mutating TTS input
- add regression coverage for ambiguous English source text used by alpha voice smoke

## Validation
- uv run ruff check agents/voice_agent.py tests/agents/test_voice_agent.py
- uv run python -m black --check agents/voice_agent.py tests/agents/test_voice_agent.py
- uv run python -m py_compile agents/voice_agent.py
- uv run pytest tests/agents/test_voice_agent.py -q

Closes #571