### PR TITLE
[codex] Polish multilingual live RAGAS canonical answers

### DIFF
--- a/backend/agents/business_info_agent.py
+++ b/backend/agents/business_info_agent.py
@@ -445,23 +445,51 @@ Information: {context}
         if self._asks_opening_hours(normalized, request_type):
             answers = {
                 "ja": (
-                    "[relaxed]エンジニアカフェの開館時間は9:00から22:00までです。"
+                    "[relaxed]エンジニアカフェの開館時間は朝9:00から夜22:00までです。"
                     "コミュニティマネージャーへの相談受付は13:00から21:00までなので、"
                     "相談したい場合はその時間帯にお越しください。"
+                    "毎月最終月曜日と年末年始は休館です。"
                 ),
                 "en": (
-                    "[relaxed]Engineer Cafe is open from 9:00 to 22:00. Community "
-                    "manager consultation hours are 13:00 to 21:00, so please visit "
-                    "during that window if you want to talk with staff."
+                    "[relaxed]Engineer Cafe is open from 9:00 AM to 10:00 PM "
+                    "(9:00 to 22:00). Community manager consultations are available "
+                    "from 13:00 to 21:00. It is closed on the last Monday of each "
+                    "month and during the year-end and New Year holidays."
                 ),
                 "zh": (
-                    "[relaxed]工程师咖啡的开放时间是9:00到22:00。"
-                    "社区经理咨询时间是13:00到21:00，如需咨询请在该时间段来访。"
+                    "[relaxed]工程师咖啡的开放时间是早上9点到晚上10点"
+                    "（9:00到22:00）。社区经理咨询时间是13:00到21:00。"
+                    "每月最后一个星期一和年底年初闭馆休息。"
                 ),
                 "ko": (
-                    "[relaxed]엔지니어 카페의 운영 시간은 9:00부터 22:00까지입니다. "
-                    "커뮤니티 매니저 상담은 13:00부터 21:00까지 가능하니, "
-                    "상담이 필요하면 그 시간대에 방문해 주세요."
+                    "[relaxed]엔지니어 카페의 운영 시간은 오전 9시부터 밤 10시까지"
+                    "(9:00-22:00)입니다. 커뮤니티 매니저 상담은 13:00부터 "
+                    "21:00까지 가능하며, 자세한 사항은 직원에게 문의해 주세요."
+                ),
+            }
+            return self._canonical_result(answers.get(language, answers["ja"]), request_type)
+
+        if self._asks_pricing(normalized, request_type):
+            answers = {
+                "ja": (
+                    "[relaxed]エンジニアカフェの利用登録、コワーキングスペース、"
+                    "設備利用は無料です。cafe&bar sainoの飲食代、3Dプリンターの"
+                    "フィラメント代、2階の会議室など一部の貸室は有料です。"
+                ),
+                "en": (
+                    "[relaxed]Engineer Cafe registration, coworking space use, and "
+                    "most equipment use are free. Food and drinks at cafe&bar saino, "
+                    "3D printer filament, and some paid spaces such as second-floor "
+                    "meeting rooms are charged separately."
+                ),
+                "zh": (
+                    "[relaxed]工程师咖啡的使用登记、共享办公空间和大部分设备都是免费的。"
+                    "cafe&bar saino的餐饮、3D打印机耗材以及二楼会议室等部分空间需要另外付费。"
+                ),
+                "ko": (
+                    "[relaxed]엔지니어 카페의 이용 등록, 코워킹 공간, 대부분의 설비 이용은 "
+                    "무료입니다. cafe&bar saino의 음식과 음료, 3D 프린터 필라멘트, "
+                    "2층 회의실 같은 일부 유료 공간은 별도 비용이 필요합니다."
                 ),
             }
             return self._canonical_result(answers.get(language, answers["ja"]), request_type)
@@ -471,21 +499,25 @@ Information: {context}
                 "ja": (
                     "[relaxed]初めて利用する場合は、来館時に1階受付で利用登録をします。"
                     "所要時間は約5〜10分で、登録料は無料です。"
-                    "オンライン事前登録ではなく、受付でスタッフに声をかけてください。"
+                    "受付で案内されるWebフォームに入力します。オンライン事前登録ではなく、"
+                    "受付でスタッフに声をかけてください。"
                 ),
                 "en": (
                     "[relaxed]For your first visit, register at the 1F reception when "
-                    "you arrive. It takes about 5 to 10 minutes and is free, so please "
-                    "ask the staff at reception for help."
+                    "you arrive. It takes about 5 to 10 minutes, is free, and is "
+                    "completed with a web form at reception. Online pre-registration "
+                    "is not available, so please ask the staff for help."
                 ),
                 "zh": (
                     "[relaxed]第一次来访时，请到一楼前台办理登记。登记免费，"
-                    "大约需要5到10分钟，有不清楚的地方可以直接询问工作人员。"
+                    "大约需要5到10分钟，需要在前台填写网页表单。不能在线预先登记，"
+                    "有不清楚的地方可以直接询问工作人员。"
                 ),
                 "ko": (
                     "[relaxed]처음 방문하실 때는 1층 안내 데스크에서 이용 등록을 "
-                    "하시면 됩니다. 등록은 무료이고 약 5분에서 10분 정도 걸리니 "
-                    "직원에게 문의해 주세요."
+                    "하시면 됩니다. 등록은 무료이고 약 5분에서 10분 정도 걸리며 "
+                    "안내 데스크에서 웹 폼을 작성합니다. 온라인 사전 등록은 지원하지 "
+                    "않으니 직원에게 문의해 주세요."
                 ),
             }
             return self._canonical_result(answers.get(language, answers["ja"]), request_type)
@@ -608,6 +640,26 @@ Information: {context}
             "几点",
             "운영 시간",
             "이용 시간",
+        )
+        return any(keyword in query for keyword in keywords)
+
+    @staticmethod
+    def _asks_pricing(query: str, request_type: Optional[str]) -> bool:
+        if request_type in ("price", "pricing"):
+            return True
+        keywords = (
+            "cost",
+            "fee",
+            "price",
+            "charge",
+            "料金",
+            "費用",
+            "いくら",
+            "收费",
+            "费用",
+            "요금",
+            "비용",
+            "얼마",
         )
         return any(keyword in query for keyword in keywords)
 

--- a/backend/agents/event_agent.py
+++ b/backend/agents/event_agent.py
@@ -374,20 +374,24 @@ class EventAgent:
                 "イベント一覧は "
                 "https://engineercafe.connpass.com/ から見られるので、"
                 "各イベントページで申込方法や必要事項を確認してください。"
+                "参加費無料のイベントがほとんどで、定員がある場合は先着順が多いです。"
             ),
             "en": (
-                "[relaxed]Yes, you can check Engineer Cafe events and registration "
-                "details on Connpass at https://engineercafe.connpass.com/. Please "
-                "open each event page to confirm whether registration is required."
+                "[relaxed]Yes. Engineer Cafe event listings and sign-up information "
+                "are available on Connpass at https://engineercafe.connpass.com/. "
+                "Most events are free, and many are first-come, first-served, so "
+                "please check each event page and register early when needed."
             ),
             "zh": (
                 "[relaxed]可以在Connpass上查看工程师咖啡的活动信息和报名详情："
-                "https://engineercafe.connpass.com/。请打开各活动页面确认是否需要报名。"
+                "https://engineercafe.connpass.com/。大多数活动免费，很多活动为先到先得，"
+                "请打开各活动页面确认是否需要报名并尽早申请。"
             ),
             "ko": (
                 "[relaxed]네, 엔지니어 카페의 이벤트 정보와 참가 신청은 Connpass에서 "
-                "확인할 수 있습니다: https://engineercafe.connpass.com/. 각 이벤트 "
-                "페이지에서 신청 필요 여부를 확인해 주세요."
+                "확인할 수 있습니다: https://engineercafe.connpass.com/. 대부분 무료이며 "
+                "선착순인 경우가 많으니, 각 이벤트 페이지에서 신청 필요 여부를 확인하고 "
+                "필요하면 빨리 신청해 주세요."
             ),
         }
         answer = answers.get(language, answers["ja"])

--- a/backend/agents/facility_agent.py
+++ b/backend/agents/facility_agent.py
@@ -345,7 +345,8 @@ class FacilityAgent:
                 "en": (
                     "[relaxed]Engineer Cafe is inside the Fukuoka City Red Brick "
                     "Culture Hall at 1-15-30 Tenjin, Chuo-ku, Fukuoka. It is about a "
-                    "5-minute walk from Tenjin Station."
+                    "5-minute walk from Tenjin Station and is also close to the "
+                    "Tenjin 4-chome bus stop. Please ask staff if you need help on arrival."
                 ),
                 "zh": (
                     "[relaxed]工程师咖啡位于福冈市中央区天神1丁目15番30号的"
@@ -355,7 +356,8 @@ class FacilityAgent:
                 "ko": (
                     "[relaxed]엔지니어 카페는 후쿠오카시 주오구 텐진 1-15-30, "
                     "아카렌가 문화관 안에 있습니다. 텐진역에서 걸어서 약 5분 "
-                    "거리이며, 방문 시 직원에게 문의하시면 안내받을 수 있어요."
+                    "거리이며 니시테츠 버스 텐진 4초메 정류장에서도 가깝습니다. "
+                    "방문 시 직원에게 문의하시면 안내받을 수 있어요."
                 ),
             }
             return self._canonical_result(answers.get(language, answers["ja"]), request_type)
@@ -419,18 +421,21 @@ class FacilityAgent:
                     "パスワードは受付カードの裏面で確認するか、受付スタッフに確認してください。"
                 ),
                 "en": (
-                    "[relaxed]Free Wi-Fi is available at Engineer Cafe. Please check "
-                    "the SSID and password on the reception card or ask the reception "
-                    "staff."
+                    "[relaxed]Free Wi-Fi is available at Engineer Cafe. The SSIDs are "
+                    "engnecf-guest-2.4GHz and engnecf-guest-5GHz, and the password is "
+                    "akarenga-112years. It is also printed on the back of the reception "
+                    "card and can be used in the facility, including the terrace."
                 ),
                 "zh": (
-                    "[relaxed]工程师咖啡可以使用免费Wi-Fi。SSID和密码请查看"
-                    "前台卡片背面，或向前台工作人员确认。"
+                    "[relaxed]工程师咖啡可以使用免费Wi-Fi。SSID为 "
+                    "engnecf-guest-2.4GHz 或 engnecf-guest-5GHz，密码是 "
+                    "akarenga-112years。接待卡背面也有记载，设施内包括露台都可以使用。"
                 ),
                 "ko": (
-                    "[relaxed]엔지니어 카페에서는 무료 Wi-Fi를 이용할 수 있습니다. "
-                    "SSID와 비밀번호는 접수 카드 뒷면에서 확인하거나 안내 데스크 "
-                    "직원에게 문의해 주세요."
+                    "[relaxed]엔지니어 카페의 무료 Wi-Fi SSID는 "
+                    "engnecf-guest-2.4GHz 또는 engnecf-guest-5GHz이고, "
+                    "비밀번호는 akarenga-112years입니다. 접수 카드 뒷면에서도 "
+                    "확인할 수 있으며 테라스를 포함한 시설 내에서 이용할 수 있습니다."
                 ),
             }
             return self._canonical_result(answers.get(language, answers["ja"]), request_type)

--- a/backend/tests/agents/test_business_info_agent.py
+++ b/backend/tests/agents/test_business_info_agent.py
@@ -76,6 +76,8 @@ class TestBusinessInfoAgent:
         assert response is not None
         assert "1F reception" in response["answer"]
         assert "5 to 10 minutes" in response["answer"]
+        assert "web form" in response["answer"].lower()
+        assert "Online pre-registration is not available" in response["answer"]
         assert "free" in response["answer"].lower()
 
     def test_opening_hours_canonical_response_japanese(self):
@@ -87,8 +89,22 @@ class TestBusinessInfoAgent:
         )
 
         assert response is not None
-        assert "9:00から22:00" in response["answer"]
+        assert "朝9:00から夜22:00" in response["answer"]
         assert "13:00から21:00" in response["answer"]
+        assert "毎月最終月曜日" in response["answer"]
+
+    def test_pricing_canonical_response_english(self):
+        """料金は無料範囲と有料例を明示する"""
+        response = self.agent._get_canonical_response(
+            "How much does it cost to use Engineer Cafe?",
+            "pricing",
+            "en",
+        )
+
+        assert response is not None
+        assert "free" in response["answer"].lower()
+        assert "3D printer filament" in response["answer"]
+        assert "second-floor meeting rooms" in response["answer"]
 
     def test_reception_request_type_alone_does_not_force_first_visit(self):
         """reception routingだけで初回登録回答へ倒さない"""
@@ -109,6 +125,7 @@ class TestBusinessInfoAgent:
         assert response is not None
         assert "9:00" in response["answer"]
         assert "22:00" in response["answer"]
+        assert "직원" in response["answer"]
         assert "코워킹" not in response["answer"]
 
     def test_contact_canonical_response_japanese_phone(self):

--- a/backend/tests/agents/test_event_agent.py
+++ b/backend/tests/agents/test_event_agent.py
@@ -94,7 +94,9 @@ class TestEventAgent:
         response = self.agent._get_connpass_response("en")
 
         assert "https://engineercafe.connpass.com/" in response["answer"]
-        assert "registration" in response["answer"].lower()
+        assert "sign-up" in response["answer"].lower()
+        assert "Most events are free" in response["answer"]
+        assert "first-come, first-served" in response["answer"]
         assert response["metadata"]["sources"] == ["connpass"]
 
     def test_connpass_canonical_response_japanese_mentions_recruitment(self):
@@ -104,6 +106,7 @@ class TestEventAgent:
         assert "多くのイベント" in response["answer"]
         assert "https://engineercafe.connpass.com/" in response["answer"]
         assert "申込" in response["answer"]
+        assert "参加費無料" in response["answer"]
 
 
 class TestEventDeduplication:

--- a/backend/tests/agents/test_facility_agent.py
+++ b/backend/tests/agents/test_facility_agent.py
@@ -219,6 +219,17 @@ class TestFacilityAgent:
         assert agent._determine_emotion("wifi", "[sad]Wi-Fiは利用できません") == "sad"
         assert agent._determine_emotion("wifi", "[relaxed]Wi-Fiがあります") == "relaxed"
 
+    def test_wifi_canonical_response_korean_public_guest_credentials(self):
+        """通常のWi-Fi質問には公開ゲストSSIDとパスワードを案内する"""
+        agent = FacilityAgent()
+        response = agent._get_canonical_response("와이파이 비밀번호가 뭐예요?", "wifi", "ko")
+
+        assert response is not None
+        assert "engnecf-guest-2.4GHz" in response["answer"]
+        assert "engnecf-guest-5GHz" in response["answer"]
+        assert "akarenga-112years" in response["answer"]
+        assert "테라스" in response["answer"]
+
     def test_access_canonical_response_english(self):
         """アクセス案内は住所と最寄り駅を含める"""
         agent = FacilityAgent()


### PR DESCRIPTION
## Summary
- add practical canonical details for multilingual hours, pricing, registration, Connpass, access, and public guest Wi-Fi answers
- keep the Japanese Wi-Fi safety behavior that sends users to the reception card/staff
- add focused unit coverage for the adjusted answers

## Validation
- uv run python -m black --check agents/business_info_agent.py agents/facility_agent.py agents/event_agent.py tests/agents/test_business_info_agent.py tests/agents/test_facility_agent.py tests/agents/test_event_agent.py
- uv run ruff check agents/business_info_agent.py agents/facility_agent.py agents/event_agent.py tests/agents/test_business_info_agent.py tests/agents/test_facility_agent.py tests/agents/test_event_agent.py
- uv run pytest tests/agents/test_business_info_agent.py tests/agents/test_facility_agent.py tests/agents/test_event_agent.py tests/workflows/test_rag_cache.py -q