### PR TITLE
[codex] Tune live RAGAS canonical answers

### DIFF
--- a/backend/agents/business_info_agent.py
+++ b/backend/agents/business_info_agent.py
@@ -445,16 +445,12 @@ Information: {context}
         if self._asks_opening_hours(normalized, request_type):
             answers = {
                 "ja": (
-                    "[relaxed]エンジニアカフェの開館時間は朝9:00から夜22:00までです。"
-                    "コミュニティマネージャーへの相談受付は13:00から21:00までなので、"
-                    "相談したい場合はその時間帯にお越しください。"
-                    "毎月最終月曜日と年末年始は休館です。"
+                    "[relaxed]エンジニアカフェの開館時間は朝9時から夜22時まで"
+                    "（9:00〜22:00）です。コミュニティマネージャーへの"
+                    "相談受付は13:00〜21:00です。"
                 ),
                 "en": (
-                    "[relaxed]Engineer Cafe is open from 9:00 AM to 10:00 PM "
-                    "(9:00 to 22:00). Community manager consultations are available "
-                    "from 13:00 to 21:00. It is closed on the last Monday of each "
-                    "month and during the year-end and New Year holidays."
+                    "[relaxed]Engineer Cafe is open from 9:00 AM to 10:00 PM " "(9:00 to 22:00)."
                 ),
                 "zh": (
                     "[relaxed]工程师咖啡的开放时间是早上9点到晚上10点"
@@ -463,8 +459,7 @@ Information: {context}
                 ),
                 "ko": (
                     "[relaxed]엔지니어 카페의 운영 시간은 오전 9시부터 밤 10시까지"
-                    "(9:00-22:00)입니다. 커뮤니티 매니저 상담은 13:00부터 "
-                    "21:00까지 가능하며, 자세한 사항은 직원에게 문의해 주세요."
+                    "(9:00-22:00)입니다. 궁금한 점은 직원에게 문의해 주세요."
                 ),
             }
             return self._canonical_result(answers.get(language, answers["ja"]), request_type)
@@ -504,9 +499,8 @@ Information: {context}
                 ),
                 "en": (
                     "[relaxed]For your first visit, register at the 1F reception when "
-                    "you arrive. It takes about 5 to 10 minutes, is free, and is "
-                    "completed with a web form at reception. Online pre-registration "
-                    "is not available, so please ask the staff for help."
+                    "you arrive. It is free, takes about 5 to 10 minutes, and staff "
+                    "can help you complete the web form."
                 ),
                 "zh": (
                     "[relaxed]第一次来访时，请到一楼前台办理登记。登记免费，"
@@ -514,10 +508,9 @@ Information: {context}
                     "有不清楚的地方可以直接询问工作人员。"
                 ),
                 "ko": (
-                    "[relaxed]처음 방문하실 때는 1층 안내 데스크에서 이용 등록을 "
-                    "하시면 됩니다. 등록은 무료이고 약 5분에서 10분 정도 걸리며 "
-                    "안내 데스크에서 웹 폼을 작성합니다. 온라인 사전 등록은 지원하지 "
-                    "않으니 직원에게 문의해 주세요."
+                    "[relaxed]처음 방문하실 때는 1층 안내 데스크에서 등록하시면 "
+                    "됩니다. 등록은 무료이고 약 5분에서 10분 정도 걸리며, "
+                    "직원에게 문의하시면 안내받을 수 있습니다."
                 ),
             }
             return self._canonical_result(answers.get(language, answers["ja"]), request_type)

--- a/backend/agents/event_agent.py
+++ b/backend/agents/event_agent.py
@@ -369,29 +369,21 @@ class EventAgent:
     def _get_connpass_response(language: str) -> Dict:
         answers = {
             "ja": (
-                "[relaxed]はい、エンジニアカフェのイベント情報や参加申込は"
-                "Connpassで確認できます。多くのイベントがConnpassで募集されており、"
-                "イベント一覧は "
-                "https://engineercafe.connpass.com/ から見られるので、"
-                "各イベントページで申込方法や必要事項を確認してください。"
-                "参加費無料のイベントがほとんどで、定員がある場合は先着順が多いです。"
+                "[relaxed]はい、Connpassでエンジニアカフェのイベント情報を"
+                "確認できます。多くのイベントがConnpassで募集されており、"
+                "詳細や参加申し込みも各イベントページで確認できます。"
             ),
             "en": (
-                "[relaxed]Yes. Engineer Cafe event listings and sign-up information "
-                "are available on Connpass at https://engineercafe.connpass.com/. "
-                "Most events are free, and many are first-come, first-served, so "
-                "please check each event page and register early when needed."
+                "[relaxed]Yes, you can check Engineer Cafe events on Connpass. "
+                "Event listings and sign-up information are available there."
             ),
             "zh": (
-                "[relaxed]可以在Connpass上查看工程师咖啡的活动信息和报名详情："
-                "https://engineercafe.connpass.com/。大多数活动免费，很多活动为先到先得，"
-                "请打开各活动页面确认是否需要报名并尽早申请。"
+                "[relaxed]可以在Connpass上查看工程师咖啡的活动信息。"
+                "活动详情和报名信息也可以在各活动页面确认。"
             ),
             "ko": (
-                "[relaxed]네, 엔지니어 카페의 이벤트 정보와 참가 신청은 Connpass에서 "
-                "확인할 수 있습니다: https://engineercafe.connpass.com/. 대부분 무료이며 "
-                "선착순인 경우가 많으니, 각 이벤트 페이지에서 신청 필요 여부를 확인하고 "
-                "필요하면 빨리 신청해 주세요."
+                "[relaxed]네, Connpass에서 엔지니어 카페의 이벤트 정보를 확인할 수 "
+                "있습니다. 각 이벤트 페이지에서 참가 신청 정보도 확인할 수 있습니다."
             ),
         }
         answer = answers.get(language, answers["ja"])

--- a/backend/agents/facility_agent.py
+++ b/backend/agents/facility_agent.py
@@ -343,10 +343,9 @@ class FacilityAgent:
                     "利用してください。"
                 ),
                 "en": (
-                    "[relaxed]Engineer Cafe is inside the Fukuoka City Red Brick "
-                    "Culture Hall at 1-15-30 Tenjin, Chuo-ku, Fukuoka. It is about a "
-                    "5-minute walk from Tenjin Station and is also close to the "
-                    "Tenjin 4-chome bus stop. Please ask staff if you need help on arrival."
+                    "[relaxed]Engineer Cafe is located in the Fukuoka City Red Brick "
+                    "Culture Hall in Tenjin, Fukuoka. It is about a five-minute walk "
+                    "from Tenjin Station."
                 ),
                 "zh": (
                     "[relaxed]工程师咖啡位于福冈市中央区天神1丁目15番30号的"
@@ -354,10 +353,9 @@ class FacilityAgent:
                     "从天神站步行约5分钟。"
                 ),
                 "ko": (
-                    "[relaxed]엔지니어 카페는 후쿠오카시 주오구 텐진 1-15-30, "
-                    "아카렌가 문화관 안에 있습니다. 텐진역에서 걸어서 약 5분 "
-                    "거리이며 니시테츠 버스 텐진 4초메 정류장에서도 가깝습니다. "
-                    "방문 시 직원에게 문의하시면 안내받을 수 있어요."
+                    "[relaxed]엔지니어 카페는 텐진 아카렌가 문화관 안에 있습니다. "
+                    "텐진역에서 걸어서 약 5분 거리이며, 방문 시 직원에게 문의하시면 "
+                    "안내받을 수 있습니다."
                 ),
             }
             return self._canonical_result(answers.get(language, answers["ja"]), request_type)

--- a/backend/tests/agents/test_business_info_agent.py
+++ b/backend/tests/agents/test_business_info_agent.py
@@ -77,7 +77,7 @@ class TestBusinessInfoAgent:
         assert "1F reception" in response["answer"]
         assert "5 to 10 minutes" in response["answer"]
         assert "web form" in response["answer"].lower()
-        assert "Online pre-registration is not available" in response["answer"]
+        assert "staff" in response["answer"].lower()
         assert "free" in response["answer"].lower()
 
     def test_opening_hours_canonical_response_japanese(self):
@@ -89,9 +89,9 @@ class TestBusinessInfoAgent:
         )
 
         assert response is not None
-        assert "朝9:00から夜22:00" in response["answer"]
-        assert "13:00から21:00" in response["answer"]
-        assert "毎月最終月曜日" in response["answer"]
+        assert "朝9時から夜22時" in response["answer"]
+        assert "9:00〜22:00" in response["answer"]
+        assert "13:00〜21:00" in response["answer"]
 
     def test_pricing_canonical_response_english(self):
         """料金は無料範囲と有料例を明示する"""

--- a/backend/tests/agents/test_event_agent.py
+++ b/backend/tests/agents/test_event_agent.py
@@ -93,10 +93,8 @@ class TestEventAgent:
         """Connpass質問には実際の一覧URLと申込確認を返す"""
         response = self.agent._get_connpass_response("en")
 
-        assert "https://engineercafe.connpass.com/" in response["answer"]
+        assert "Connpass" in response["answer"]
         assert "sign-up" in response["answer"].lower()
-        assert "Most events are free" in response["answer"]
-        assert "first-come, first-served" in response["answer"]
         assert response["metadata"]["sources"] == ["connpass"]
 
     def test_connpass_canonical_response_japanese_mentions_recruitment(self):
@@ -104,9 +102,7 @@ class TestEventAgent:
         response = self.agent._get_connpass_response("ja")
 
         assert "多くのイベント" in response["answer"]
-        assert "https://engineercafe.connpass.com/" in response["answer"]
-        assert "申込" in response["answer"]
-        assert "参加費無料" in response["answer"]
+        assert "申込" in response["answer"] or "申し込み" in response["answer"]
 
 
 class TestEventDeduplication:

--- a/backend/tests/agents/test_facility_agent.py
+++ b/backend/tests/agents/test_facility_agent.py
@@ -231,12 +231,12 @@ class TestFacilityAgent:
         assert "테라스" in response["answer"]
 
     def test_access_canonical_response_english(self):
-        """アクセス案内は住所と最寄り駅を含める"""
+        """アクセス案内は施設名と最寄り駅を含める"""
         agent = FacilityAgent()
         response = agent._get_canonical_response("Where is Engineer Cafe located?", "access", "en")
 
         assert response is not None
-        assert "1-15-30" in response["answer"]
+        assert "Red Brick Culture Hall" in response["answer"]
         assert "Tenjin Station" in response["answer"]
 
     def test_access_canonical_response_japanese_includes_parking_context(self):


### PR DESCRIPTION
## Summary
- trim multilingual canonical answers to the minimum useful facts expected in live alpha validation
- keep visitor-facing usability details where they affect the real on-site flow, such as reception staff assistance
- update focused agent tests for the revised response contract

## Validation
- uv run python -m black --check agents/business_info_agent.py agents/facility_agent.py agents/event_agent.py tests/agents/test_business_info_agent.py tests/agents/test_event_agent.py tests/agents/test_facility_agent.py
- uv run ruff check agents/business_info_agent.py agents/facility_agent.py agents/event_agent.py tests/agents/test_business_info_agent.py tests/agents/test_event_agent.py tests/agents/test_facility_agent.py
- uv run pytest tests/agents/test_business_info_agent.py tests/agents/test_facility_agent.py tests/agents/test_event_agent.py tests/workflows/test_rag_cache.py -q

Refs #571