### PR TITLE
[codex] Restore detailed Japanese Connpass answer

### DIFF
--- a/backend/agents/event_agent.py
+++ b/backend/agents/event_agent.py
@@ -369,9 +369,11 @@ class EventAgent:
     def _get_connpass_response(language: str) -> Dict:
         answers = {
             "ja": (
-                "[relaxed]はい、Connpassでエンジニアカフェのイベント情報を"
-                "確認できます。多くのイベントがConnpassで募集されており、"
-                "詳細や参加申し込みも各イベントページで確認できます。"
+                "[relaxed]はい、エンジニアカフェのイベント情報や参加申込は"
+                "Connpassで確認できます。多くのイベントがConnpassで募集されており、"
+                "イベント一覧は https://engineercafe.connpass.com/ から見られるので、"
+                "各イベントページで詳細や申込方法を確認してください。"
+                "参加費無料のイベントがほとんどで、定員がある場合は先着順が多いです。"
             ),
             "en": (
                 "[relaxed]Yes, you can check Engineer Cafe events on Connpass. "

--- a/backend/tests/agents/test_event_agent.py
+++ b/backend/tests/agents/test_event_agent.py
@@ -102,7 +102,9 @@ class TestEventAgent:
         response = self.agent._get_connpass_response("ja")
 
         assert "多くのイベント" in response["answer"]
+        assert "https://engineercafe.connpass.com/" in response["answer"]
         assert "申込" in response["answer"] or "申し込み" in response["answer"]
+        assert "参加費無料" in response["answer"]
 
 
 class TestEventDeduplication:


### PR DESCRIPTION
## Summary
- restore detailed Japanese Connpass guidance for live RAGAS JA target
- keep the already passing EN/ZH/KO canonical answers unchanged
- update the focused EventAgent expectation

## Validation
- uv run python -m black --check agents/event_agent.py tests/agents/test_event_agent.py
- uv run ruff check agents/event_agent.py tests/agents/test_event_agent.py
- uv run pytest tests/agents/test_event_agent.py -q

Refs #571