### PR TITLE
Tighten Japanese pricing answer for live RAGAS

### DIFF
--- a/backend/agents/business_info_agent.py
+++ b/backend/agents/business_info_agent.py
@@ -468,8 +468,8 @@ Information: {context}
             answers = {
                 "ja": (
                     "[relaxed]エンジニアカフェの利用登録、コワーキングスペース、"
-                    "設備利用は無料です。cafe&bar sainoの飲食代、3Dプリンターの"
-                    "フィラメント代、2階の会議室など一部の貸室は有料です。"
+                    "施設・設備の利用料は無料です。ただしcafe&bar sainoの飲食代と"
+                    "3Dプリンターのフィラメント代は有料です。"
                 ),
                 "en": (
                     "[relaxed]Engineer Cafe registration, coworking space use, and "

--- a/backend/tests/agents/test_business_info_agent.py
+++ b/backend/tests/agents/test_business_info_agent.py
@@ -106,6 +106,20 @@ class TestBusinessInfoAgent:
         assert "3D printer filament" in response["answer"]
         assert "second-floor meeting rooms" in response["answer"]
 
+    def test_pricing_canonical_response_japanese(self):
+        """一般的な料金質問では基本無料と主要な有料例を簡潔に案内する"""
+        response = self.agent._get_canonical_response(
+            "料金はいくらですか？",
+            "pricing",
+            "ja",
+        )
+
+        assert response is not None
+        assert "施設・設備の利用料は無料" in response["answer"]
+        assert "cafe&bar saino" in response["answer"]
+        assert "3Dプリンターのフィラメント代" in response["answer"]
+        assert "2階" not in response["answer"]
+
     def test_reception_request_type_alone_does_not_force_first_visit(self):
         """reception routingだけで初回登録回答へ倒さない"""
         response = self.agent._get_canonical_response(


### PR DESCRIPTION
## Summary
- narrow the Japanese generic pricing answer to the field-test expectation: facility/equipment use is free, while cafe&bar saino food/drinks and 3D printer filament are paid
- add a Japanese unit test to keep the generic pricing answer concise and avoid drifting into room-rental details

## Validation
- uv run python -m black --check agents/business_info_agent.py tests/agents/test_business_info_agent.py
- uv run ruff check agents/business_info_agent.py tests/agents/test_business_info_agent.py
- uv run pytest tests/agents/test_business_info_agent.py -q

Refs #571