### PR TITLE
docs: add alpha slide agent handoff

### DIFF
--- a/docs/handoffs/alpha-slide-agent-parallel-worker-2026-04-30.md
+++ b/docs/handoffs/alpha-slide-agent-parallel-worker-2026-04-30.md
@@ -1,0 +1,140 @@
+# Parallel Worker Handoff: SlideAgent Alpha Readiness
+
+Last updated: 2026-04-30 JST
+
+## Goal
+
+Complete the reception SlideAgent flow for alpha onsite testing using the new static PDF and narration assets:
+
+- `frontend/public/reception/engineer-cafe-ja.pdf`
+- `frontend/public/reception/engineer-cafe-en.pdf`
+- `frontend/public/reception/engineer-cafe-narration-ja.md`
+- `frontend/public/reception/engineer-cafe-narration-en.md`
+
+The slide tour must be deterministic. Do not use an LLM for normal slide playback.
+
+## Current findings
+
+- Both PDFs are 5 pages, 16:9, 720 x 405 pt.
+- Both Markdown narration files describe 5 slides.
+- Existing backend narration JSON has 10 slides, so it is stale for the new deck.
+- `ReceptionPdfGuide` currently hardcodes Japanese PDF/audio prefixes.
+- `startPresentation()` dispatches `autoStartPresentation`, but `ReceptionPdfGuide` does not listen to it. The PDF path does not auto-start today.
+- The current PDF panel is sized to fit portrait, so the horizontal deck appears too small for kiosk use.
+
+## Files likely owned by this task
+
+- `frontend/src/app/page.tsx`
+- `frontend/src/app/components/ReceptionPdfGuide.tsx`
+- `frontend/src/lib/reception/reception-pdf-constants.ts`
+- `frontend/e2e/reception-flow.spec.ts`
+- `frontend/e2e/marp-viewer.spec.ts` or a new `frontend/e2e/reception-pdf-guide.spec.ts`
+- optional script: `scripts/build-reception-narration.py` or `frontend/src/jobs/...`
+- optional generated JSON/audio assets if the team decides to commit them
+
+Do not change Welcome/OCR/PTT implementation in this branch unless coordinating with the primary lane.
+
+## Recommended implementation
+
+1. Add language-aware reception deck constants.
+
+```ts
+export const RECEPTION_GUIDE_PDFS = {
+  ja: '/reception/engineer-cafe-ja.pdf',
+  en: '/reception/engineer-cafe-en.pdf',
+} as const;
+```
+
+Add language-aware audio/lipsync prefixes for `ja` and `en`.
+
+2. Make `ReceptionPdfGuide` accept `language`, `autoStart`, and `landscapeReady` props.
+
+Expected behavior:
+
+- reset to page 1 when language changes;
+- use the correct PDF and audio prefix;
+- start playback once when `autoStart && landscapeReady && totalPages > 0`;
+- stop playback when leaving slide mode.
+
+3. Add a slide-mode orientation gate.
+
+Use viewport detection instead of trying to force orientation. iOS Safari cannot reliably lock orientation from a web page.
+
+Suggested detection:
+
+- `window.matchMedia('(orientation: landscape)')`
+- fallback to `window.innerWidth > window.innerHeight`
+- listen to `change`, `resize`, and `orientationchange`
+
+Portrait behavior:
+
+- show a full-screen instruction to rotate the device;
+- do not show the small slide panel;
+- do not start narration.
+
+Landscape behavior:
+
+- hide the rotate instruction;
+- show the PDF full-screen or nearly full-screen;
+- auto-start slide 1 once.
+
+4. Convert narration Markdown to the runtime format.
+
+Lowest-risk alpha option:
+
+- parse `## スライドN:` / `## Slide N:` sections;
+- emit 5-entry JSON with `slideNumber`, `narration.auto`, empty `onDemand`, and simple transitions;
+- assert PDF page count equals narration count in a test or build check.
+
+Alternatively, make the frontend read Markdown directly, but keep parsing deterministic and tested.
+
+5. Use PiperPlus narration without LLM.
+
+Preferred alpha path:
+
+- pre-generate audio per slide and language;
+- commit or deploy assets under `frontend/public/reception/audio/{ja,en}/NN.mp3`;
+- optionally precompute lipsync JSON under `frontend/public/reception/lipsync/{ja,en}/NN.json`.
+
+Acceptable fallback:
+
+- call existing TTS once per slide and cache/prefetch results;
+- prefetch next slide while current slide is playing;
+- expose measured first-audio and next-slide timings in logs.
+
+## Acceptance checks
+
+- Portrait `スライド案内` shows rotate instruction.
+- Landscape change auto-starts slide 1.
+- Japanese deck uses Japanese PDF and narration.
+- English deck uses English PDF and narration.
+- 5 PDF pages and 5 narration entries are verified.
+- No LLM/network search is used for normal narration.
+- Close returns to idle and stops audio/lipsync.
+- Completion returns to idle after the configured completion delay.
+- Playwright covers portrait, landscape, language, next/previous, close, and completion.
+
+## Suggested local commands
+
+```bash
+pnpm --dir frontend lint
+pnpm --dir frontend typecheck
+pnpm --dir frontend build
+pnpm --dir frontend test:e2e -- reception-flow.spec.ts
+pnpm --dir frontend test:e2e -- reception-pdf-guide.spec.ts
+```
+
+If the repo uses wrapper scripts on the active branch, prefer the existing package scripts over adding new tooling.
+
+## GitHub issue split
+
+Epic:
+
+- P0 SlideAgent landscape PDF tour and deterministic narration readiness
+
+Sub-issues:
+
+- P0 Slide narration asset ingestion: 5-page PDF/Markdown to runtime narration data
+- P0 Slide mode landscape gate and orientation auto-start
+- P0 PiperPlus per-slide narration playback/prefetch without LLM
+- P0 SlideAgent e2e/live validation gate

--- a/docs/handoffs/github-issue-bodies/p0-slide-agent-assets-2026-04-30.md
+++ b/docs/handoffs/github-issue-bodies/p0-slide-agent-assets-2026-04-30.md
@@ -1,0 +1,35 @@
+## Summary
+
+Ingest the new 5-page reception PDF/Markdown slide assets into the runtime narration format so SlideAgent/PDF playback no longer uses stale 10-slide narration.
+
+## Evidence
+
+- New PDFs are 5 pages.
+- New narration Markdown files are 5 sections.
+- Existing `backend/slides/narration/engineer-cafe-{ja,en}.json` is 10 slides and no longer matches the new deck.
+
+## Scope
+
+- Parse or convert:
+  - `frontend/public/reception/engineer-cafe-narration-ja.md`
+  - `frontend/public/reception/engineer-cafe-narration-en.md`
+- Produce deterministic runtime data with:
+  - `slideNumber`
+  - `narration.auto`
+  - empty or minimal `onDemand`
+  - minimal transitions
+- Make language selection explicit for Japanese and English.
+- Add a check that PDF page count equals narration entry count.
+
+## Acceptance criteria
+
+- JA runtime narration has exactly 5 slides.
+- EN runtime narration has exactly 5 slides.
+- The renderer can select JA/EN based on kiosk language.
+- A test fails if PDF pages and narration count diverge.
+- Normal narration playback does not call LLM/search.
+
+## Out of scope
+
+- Welcome/OCR/PTT changes.
+- General chat route changes.

--- a/docs/handoffs/github-issue-bodies/p0-slide-agent-epic-2026-04-30.md
+++ b/docs/handoffs/github-issue-bodies/p0-slide-agent-epic-2026-04-30.md
@@ -1,0 +1,50 @@
+## Summary
+
+Make the reception SlideAgent flow alpha-ready by using the newly supplied 5-page Japanese/English PDFs and matching narration Markdown as a deterministic, no-LLM slide tour.
+
+This should be treated as a P0 alpha blocker if `スライド案内` remains in the first-screen kiosk controls for onsite testing.
+
+## Evidence
+
+- `frontend/public/reception/engineer-cafe-ja.pdf`: 5 pages, 16:9, 720 x 405 pt.
+- `frontend/public/reception/engineer-cafe-en.pdf`: 5 pages, 16:9, 720 x 405 pt.
+- `frontend/public/reception/engineer-cafe-narration-ja.md`: 5 slide narration sections.
+- `frontend/public/reception/engineer-cafe-narration-en.md`: 5 slide narration sections.
+- Existing `backend/slides/narration/engineer-cafe-{ja,en}.json` has 10 slides and is stale for the new deck.
+- `frontend/src/app/components/ReceptionPdfGuide.tsx` currently hardcodes Japanese PDF/audio prefixes.
+- `frontend/src/app/page.tsx` dispatches `autoStartPresentation`, but the PDF renderer does not subscribe to it. Auto-start currently applies to Marp only.
+- The current portrait panel makes a horizontal deck too small for kiosk use.
+
+## Scope
+
+- Use the supplied PDF and Markdown narration assets.
+- Add language-aware deck/narration/audio selection.
+- Add portrait rotate instruction and landscape auto-start.
+- Use PiperPlus/precomputed audio per slide, or live TTS with caching/prefetch as a fallback.
+- Do not use an LLM for normal narration playback.
+- Add e2e coverage for the full slide tour path.
+
+## Acceptance criteria
+
+- `スライド案内` tap in portrait shows a rotate instruction, not a cramped bottom-half panel.
+- When the viewport becomes landscape, slide 1 starts automatically without another tap.
+- Japanese language uses Japanese PDF and narration.
+- English language uses English PDF and narration.
+- PDF page count and narration count match: 5 pages / 5 narration entries.
+- Normal narration path calls no LLM and no web search.
+- First slide audio starts under 1s when cached/precomputed.
+- Next slide begins within 500ms after previous narration completes when cached.
+- Close/finish returns to idle and stops audio/lipsync.
+- Playwright covers portrait gate, landscape auto-start, language switching, navigation, close, and completion.
+
+## Suggested split
+
+- Asset ingestion: PDF/Markdown -> runtime narration data.
+- Orientation UX: landscape gate and auto-start.
+- Audio playback: PiperPlus per-slide narration and prefetch.
+- Validation: e2e/live gate and issue close evidence.
+
+## References
+
+- `docs/plans/alpha-parallel-blocker-plan-2026-04-30.md`
+- `docs/handoffs/alpha-slide-agent-parallel-worker-2026-04-30.md`

--- a/docs/handoffs/github-issue-bodies/p0-slide-agent-orientation-2026-04-30.md
+++ b/docs/handoffs/github-issue-bodies/p0-slide-agent-orientation-2026-04-30.md
@@ -1,0 +1,30 @@
+## Summary
+
+Fix the slide-mode UX for kiosk phones by gating portrait mode with a rotate instruction and auto-starting the slide tour when the viewport becomes landscape.
+
+## Evidence
+
+- The supplied slide PDFs are horizontal 16:9.
+- Current PDF panel is fitted into portrait, making the deck small and visually secondary.
+- `startPresentation()` emits `autoStartPresentation`, but `ReceptionPdfGuide` does not subscribe to it.
+
+## Scope
+
+- Detect landscape with `matchMedia('(orientation: landscape)')`, with `innerWidth > innerHeight` fallback.
+- Listen to `change`, `resize`, and `orientationchange`.
+- In portrait, show a full-screen rotate instruction and do not start narration.
+- In landscape, show the slide deck full-screen or nearly full-screen and auto-start slide 1 once.
+- Close button must remain reachable.
+
+## Acceptance criteria
+
+- Portrait slide mode shows only the rotate instruction and close affordance.
+- Switching to landscape starts slide 1 automatically.
+- Returning to portrait pauses/stops narration or prevents hidden continuing playback.
+- Close returns to idle.
+- Playwright covers portrait and emulated landscape behavior.
+
+## Out of scope
+
+- Generating narration audio.
+- Rewriting SlideAgent routing.

--- a/docs/handoffs/github-issue-bodies/p0-slide-agent-piperplus-audio-2026-04-30.md
+++ b/docs/handoffs/github-issue-bodies/p0-slide-agent-piperplus-audio-2026-04-30.md
@@ -1,0 +1,38 @@
+## Summary
+
+Wire per-slide PiperPlus narration for the reception PDFs without involving an LLM during normal slide playback.
+
+## Preferred alpha path
+
+Pre-generate static audio from the Markdown narration:
+
+```text
+frontend/public/reception/audio/ja/01.mp3
+frontend/public/reception/audio/en/01.mp3
+frontend/public/reception/lipsync/ja/01.json
+frontend/public/reception/lipsync/en/01.json
+```
+
+This is preferred because the narration text is static and alpha needs predictable first-audio latency.
+
+## Acceptable fallback
+
+Use live PiperPlus TTS per slide only if:
+
+- the result is cached for the session;
+- the next slide is prefetched while current narration plays;
+- latency logs record first-audio and next-slide timings.
+
+## Acceptance criteria
+
+- Normal slide narration uses no LLM.
+- First slide audio starts under 1s when precomputed/cached.
+- Next slide narration starts within 500ms after previous narration completes when cached.
+- Missing audio does not dead-end the presentation.
+- Stopping/closing slide mode aborts playback and lipsync.
+- JA and EN audio paths are separate.
+
+## Out of scope
+
+- Changing chat model routing.
+- Welcome/OCR/PTT changes.

--- a/docs/handoffs/github-issue-bodies/p0-slide-agent-validation-2026-04-30.md
+++ b/docs/handoffs/github-issue-bodies/p0-slide-agent-validation-2026-04-30.md
@@ -1,0 +1,31 @@
+## Summary
+
+Add the validation gate needed to close the SlideAgent alpha blocker after asset ingestion, orientation UX, and narration playback are implemented.
+
+## Scope
+
+- Add or update Playwright coverage for:
+  - portrait rotate instruction;
+  - landscape auto-start;
+  - Japanese deck/narration;
+  - English deck/narration;
+  - next/previous/reset;
+  - close/finish returns to idle;
+  - audio stop on close.
+- Add backend/frontend unit coverage for narration count if conversion is implemented.
+- Run local and CI checks.
+- Attach results to the epic before close.
+
+## Acceptance criteria
+
+- `pnpm --dir frontend lint` passes.
+- `pnpm --dir frontend typecheck` passes.
+- `pnpm --dir frontend build` passes.
+- Relevant Playwright slide/reception specs pass.
+- Evidence includes measured first-audio latency and next-slide transition latency.
+- Evidence includes a statement that normal narration used no LLM/search.
+
+## Out of scope
+
+- Implementing the feature itself.
+- Closing unrelated P0/P1 issues.

--- a/docs/plans/alpha-parallel-blocker-plan-2026-04-30.md
+++ b/docs/plans/alpha-parallel-blocker-plan-2026-04-30.md
@@ -1,0 +1,97 @@
+# Alpha Parallel Blocker Plan
+
+Last updated: 2026-04-30 JST
+
+## 結論
+
+次に潰す alpha blocker は、主線を `#616 -> #611/#610 -> #617 live validation` に置く。
+ただし SlideAgent は、画面上の主要導線として `スライド案内` ボタンが存在し、2026-04-30 に日本語/英語 PDF と対応ナレーション Markdown が投入済みであるため、alpha 現地テスト対象に含めるなら P0 として並列実装する。
+
+## 優先順位
+
+1. `#616` Welcome UX / Push-to-talk clarity
+   - Welcome が会話開始ではなくカメラ/OCRを先に開くため、受付体験の初回導線を壊している。
+   - `frontend/src/app/page.tsx` は Welcome 実行時に `setWelcomeMemberOcrOpen(true)` を呼んでいる。
+   - `frontend/e2e/reception-flow.spec.ts` も現状の camera-first を期待しており、仕様とテストの両方を直す必要がある。
+
+2. `#611/#610` Fast first response / filler
+   - `#620` で Cerebras fast QA first-pass は入ったが、フロント側の first audible feedback はまだ未実装。
+   - `frontend/src/lib/audio-queue.ts` は priority queue を持っているため、短い filler/prepared audio を優先再生する土台はある。
+   - `/api/voice/filler` は未実装なので、最短は静的 filler audio + 既存 audio queue priority で始める。
+
+3. SlideAgent deterministic tour
+   - `frontend/public/reception/engineer-cafe-ja.pdf` と `engineer-cafe-en.pdf` は 5 pages / 16:9。
+   - `frontend/public/reception/engineer-cafe-narration-ja.md` と `engineer-cafe-narration-en.md` は各 5 slides。
+   - 既存 `backend/slides/narration/engineer-cafe-{ja,en}.json` は 10 slides で、投入済み PDF/Markdown と一致しない。
+   - `ReceptionPdfGuide` は日本語 PDF/audio prefix 固定で、英語 PDF と Markdown narration を読まない。
+   - `startPresentation()` は `autoStartPresentation` を発火するが、PDF renderer 側は購読していない。自動開始は Marp viewer 側だけ。
+
+4. `#617` stale route validation
+   - `#620` の routing 改善後も、live/e2e で「地下について」直後の「明日のイベント」が SlideAgent に入らないことを証明する必要がある。
+
+5. `#583/#584/#585` final gates
+   - 127-case RAGAS、edge/live fault、2h kiosk は実装後の GO/NO-GO gate として残す。
+
+## 並列分担
+
+### Primary lane
+
+Owner: main engineer
+
+Scope:
+
+- `#616` Welcome should enter voice-first, not OCR-first.
+- Member card button should be the only path that opens member-card OCR.
+- Push-to-talk must expose pressed/listening/released states clearly.
+- Then `#611/#610` first audible feedback path.
+
+Why:
+
+- `#616` touches first-run kiosk UX and existing reception e2e expectations.
+- `#611/#610` touches voice timing, audio queue behavior, and alpha latency metrics.
+
+### Parallel lane
+
+Owner: second engineer
+
+Scope:
+
+- New SlideAgent P0 issue set.
+- PDF/Markdown assets to deterministic slide tour.
+- Landscape gate and auto-start.
+- Per-slide PiperPlus narration playback/prefetch, no LLM for narration.
+
+Why:
+
+- The work is mostly isolated to `frontend/src/app/components/ReceptionPdfGuide.tsx`, `frontend/src/lib/reception/reception-pdf-constants.ts`, slide narration assets, and slide e2e tests.
+- It should not conflict with Welcome and voice first-response implementation.
+
+## SlideAgent acceptance criteria
+
+- `スライド案内` tap in portrait shows a full-screen rotate instruction, not a cramped bottom-half slide panel.
+- When viewport becomes landscape, slide 1 starts automatically without a second tap.
+- Japanese UI uses `engineer-cafe-ja.pdf` and Japanese narration.
+- English UI uses `engineer-cafe-en.pdf` and English narration.
+- PDF page count and narration count must match: 5 pages / 5 narration entries.
+- Narration is deterministic. LLM is not called for ordinary slide playback.
+- First slide audible start is under 1s when audio is precomputed/cached, or the implementation must show measured reason if live PiperPlus TTS is used.
+- Next slide starts within 500ms after the previous narration completes when audio is cached.
+- Close/finish returns to idle and stops audio/lipsync.
+- E2E covers portrait rotate gate, landscape auto-start, language switching, next/previous, completion, and close.
+
+## Implementation note
+
+For alpha reliability, prefer pre-generated PiperPlus audio and optional lipsync JSON under:
+
+```text
+frontend/public/reception/audio/ja/01.mp3
+frontend/public/reception/audio/en/01.mp3
+frontend/public/reception/lipsync/ja/01.json
+frontend/public/reception/lipsync/en/01.json
+```
+
+Live PiperPlus generation is acceptable only if it prefetches the next slide and records latency. Since the source text is static, pre-generation is the lower-risk alpha path.
+
+## Current CI note
+
+After PR #620 merge, CI run `25121216454` had core jobs green at 2026-04-30 JST: backend tests, frontend typecheck/lint/build, Playwright e2e, and Playwright voice-live. Staging deploy was still in progress at the last check and should be rechecked before live validation.


### PR DESCRIPTION
## Summary

- add the alpha parallel blocker plan for Welcome/FIR/SlideAgent sequencing
- add the SlideAgent parallel worker handoff
- add GitHub issue body docs for the new SlideAgent P0 epic and sub-issues

## Validation

- git diff --cached --check

## Notes

- This PR intentionally stages only docs. Existing local reception PDFs, narration Markdown, parking image, and thinking2.vrma remain unstaged user-provided assets.
- GitHub issues created: #621, #622, #623, #624, #625.