### PR TITLE
fix(alpha): unlock Safari audio and compact slide guide

### DIFF
--- a/frontend/src/app/components/InitialSettingsModal.tsx
+++ b/frontend/src/app/components/InitialSettingsModal.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { markAudioUserInteraction } from '@/lib/audio/audio-user-interaction-gate';
+import { unlockAudioForUserGesture } from '@/lib/audio/audio-interaction-manager';
 import {
   initialSettingsModalLabels,
   kioskSettingsLabels,
@@ -104,16 +104,8 @@ export default function InitialSettingsModal({
       triggerMode,
       micMode,
     });
-    markAudioUserInteraction();
+    unlockAudioForUserGesture();
     onClose();
-    void (async () => {
-      try {
-        const { AudioInteractionManager } = await import('@/lib/audio/audio-interaction-manager');
-        await AudioInteractionManager.getInstance().ensureAudioContext();
-      } catch {
-        // Autoplay gate may still block until further gesture; kiosk flow continues.
-      }
-    })();
   }, [micMode, onClose, onPreferencesSaved, triggerMode, uiLanguage]);
 
   if (!open) {

--- a/frontend/src/app/components/KioskBottomBar.tsx
+++ b/frontend/src/app/components/KioskBottomBar.tsx
@@ -1,10 +1,11 @@
 'use client';
 
-import { markAudioUserInteraction } from '@/lib/audio/audio-user-interaction-gate';
+import { unlockAudioForUserGesture } from '@/lib/audio/audio-interaction-manager';
 import { cn } from '@/lib/cn';
 import { overlayLabels } from '@/lib/kiosk-labels';
 import type { KioskMicMode, KioskPhase } from '@/lib/kiosk-constants';
 import { Camera, Mic, PenLine, Presentation, Sparkles } from 'lucide-react';
+import { useRef } from 'react';
 import { KioskVoiceStatusStack } from './KioskVoiceStatusStack';
 import type { VoiceInterfaceRenderProps } from './VoiceInterface';
 
@@ -47,6 +48,7 @@ export function KioskBottomBar({
 }) {
   const isVoiceCaptureActive = kioskPhase === 'voice' && kioskVoiceLocked;
   const isPushToTalk = micInputMode === 'push_to_talk';
+  const pushToTalkPointerActiveRef = useRef(false);
   const voiceButtonLabel = isPushToTalk
     ? isVoiceCaptureActive
       ? labels.kioskVoicePushActive
@@ -56,7 +58,7 @@ export function KioskBottomBar({
       : labels.kioskVoice;
 
   const handleKioskVoiceStart = () => {
-    markAudioUserInteraction();
+    unlockAudioForUserGesture();
     clearReturnToIdleTimer();
     setWelcomeMemberOcrOpen(false);
     setKioskPhase('voice');
@@ -100,6 +102,7 @@ export function KioskBottomBar({
             <button
               type="button"
               onClick={() => {
+                unlockAudioForUserGesture();
                 void onPlayWelcome();
               }}
               disabled={isVoiceCaptureActive || voice.isLoading || welcomeCooldown}
@@ -125,6 +128,7 @@ export function KioskBottomBar({
                 }
                 event.preventDefault();
                 event.currentTarget.setPointerCapture(event.pointerId);
+                pushToTalkPointerActiveRef.current = true;
                 if (!isVoiceCaptureActive) {
                   handleKioskVoiceStart();
                 }
@@ -136,7 +140,8 @@ export function KioskBottomBar({
                 if (event.currentTarget.hasPointerCapture(event.pointerId)) {
                   event.currentTarget.releasePointerCapture(event.pointerId);
                 }
-                if (isVoiceCaptureActive) {
+                if (pushToTalkPointerActiveRef.current) {
+                  pushToTalkPointerActiveRef.current = false;
                   handleKioskVoiceStop();
                 }
               }}
@@ -147,7 +152,8 @@ export function KioskBottomBar({
                 if (event.currentTarget.hasPointerCapture(event.pointerId)) {
                   event.currentTarget.releasePointerCapture(event.pointerId);
                 }
-                if (isVoiceCaptureActive) {
+                if (pushToTalkPointerActiveRef.current) {
+                  pushToTalkPointerActiveRef.current = false;
                   handleKioskVoiceStop();
                 }
               }}
@@ -177,7 +183,7 @@ export function KioskBottomBar({
             <button
               type="button"
               onClick={() => {
-                markAudioUserInteraction();
+                unlockAudioForUserGesture();
                 setWelcomeMemberOcrOpen(false);
                 setOcrMode('member_card');
                 setKioskPhase('ocr');
@@ -198,7 +204,7 @@ export function KioskBottomBar({
             <button
               type="button"
               onClick={() => {
-                markAudioUserInteraction();
+                unlockAudioForUserGesture();
                 setWelcomeMemberOcrOpen(false);
                 setOcrMode('handwriting');
                 setKioskPhase('ocr');
@@ -220,7 +226,7 @@ export function KioskBottomBar({
               data-testid="kiosk-slides-button"
               type="button"
               onClick={() => {
-                markAudioUserInteraction();
+                unlockAudioForUserGesture();
                 setWelcomeMemberOcrOpen(false);
                 onStartPresentation();
               }}

--- a/frontend/src/app/components/ReceptionPdfGuide.tsx
+++ b/frontend/src/app/components/ReceptionPdfGuide.tsx
@@ -792,16 +792,16 @@ export default function ReceptionPdfGuide({
   return (
     <div
       data-testid="reception-pdf-guide"
-      className={cn('flex h-full min-h-0 flex-col', className)}
+      className={cn('relative flex h-full min-h-0 flex-col', className)}
     >
-      <div className="flex shrink-0 flex-wrap items-center justify-between gap-2 border-b bg-gray-50 px-3 py-2.5">
+      <div className="absolute left-2 right-12 top-2 z-20 flex flex-wrap items-center justify-between gap-1.5 rounded-xl border border-white/70 bg-white/85 px-2 py-1.5 shadow-lg backdrop-blur-md sm:left-3 sm:right-14 sm:top-3 sm:gap-2 sm:px-3 sm:py-2">
         <div className="flex items-center gap-2">
           <button
             type="button"
             data-testid="reception-pdf-prev"
             onClick={previousSlide}
             disabled={currentPage === 1}
-            className="rounded bg-blue-500 p-2 text-white disabled:bg-gray-300"
+            className="rounded bg-blue-500 p-1.5 text-white disabled:bg-gray-300 sm:p-2"
           >
             <ChevronLeft className="h-4 w-4" />
           </button>
@@ -810,7 +810,7 @@ export default function ReceptionPdfGuide({
             data-testid="reception-pdf-next"
             onClick={nextSlide}
             disabled={currentPage >= totalPages}
-            className="rounded bg-blue-500 p-2 text-white disabled:bg-gray-300"
+            className="rounded bg-blue-500 p-1.5 text-white disabled:bg-gray-300 sm:p-2"
           >
             <ChevronRight className="h-4 w-4" />
           </button>
@@ -826,14 +826,14 @@ export default function ReceptionPdfGuide({
             aria-pressed={isPlaying}
             data-state={isPlaying ? 'playing' : 'paused'}
             className={cn(
-              'rounded p-2 text-white',
+              'rounded p-1.5 text-white sm:p-2',
               isPlaying ? 'bg-red-500' : 'bg-green-500'
             )}
           >
             {isPlaying ? <Pause className="h-4 w-4" /> : <Play className="h-4 w-4" />}
           </button>
           {isNarrating ? (
-            <span className="text-xs text-blue-700">
+            <span className="hidden text-xs text-blue-700 sm:inline">
               {language === 'ja' ? 'ナレーション中…' : 'Narrating…'}
             </span>
           ) : null}
@@ -841,7 +841,7 @@ export default function ReceptionPdfGuide({
             type="button"
             data-testid="reception-pdf-reset"
             onClick={() => gotoSlide(1)}
-            className="rounded bg-gray-500 p-2 text-white"
+            className="rounded bg-gray-500 p-1.5 text-white sm:p-2"
           >
             <RotateCcw className="h-4 w-4" />
           </button>
@@ -853,7 +853,7 @@ export default function ReceptionPdfGuide({
                 setSettings((s) => ({ ...s, enableLipSync: e.target.checked }))
               }
             />
-            {language === 'ja' ? 'リップ' : 'Lip'}
+            <span className="hidden sm:inline">{language === 'ja' ? 'リップ' : 'Lip'}</span>
           </label>
           <label className="flex items-center gap-1 text-xs text-gray-600">
             <input
@@ -863,14 +863,14 @@ export default function ReceptionPdfGuide({
                 setSettings((s) => ({ ...s, autoAdvance: e.target.checked }))
               }
             />
-            {language === 'ja' ? '自動送り' : 'Auto-advance'}
+            <span className="hidden sm:inline">{language === 'ja' ? '自動送り' : 'Auto-advance'}</span>
           </label>
         </div>
       </div>
       <div
         ref={wrapRef}
         data-testid="reception-pdf-landscape-panel"
-        className="relative flex min-h-0 flex-1 items-center justify-center overflow-hidden bg-slate-100 p-2 sm:p-3"
+        className="relative flex min-h-0 flex-1 items-center justify-center overflow-hidden bg-slate-100 p-0.5 sm:p-1"
       >
         <canvas ref={canvasRef} className="max-h-full max-w-full shadow-lg" data-testid="reception-pdf-canvas" />
       </div>

--- a/frontend/src/app/components/VoiceInterface.tsx
+++ b/frontend/src/app/components/VoiceInterface.tsx
@@ -2,6 +2,7 @@
 
 import { AudioQueue } from '@/lib/audio-queue';
 import { AudioDataProcessor } from '@/lib/audio/audio-data-processor';
+import { unlockAudioForUserGesture } from '@/lib/audio/audio-interaction-manager';
 import { markAudioUserInteraction } from '@/lib/audio/audio-user-interaction-gate';
 import { MobileAudioService } from '@/lib/audio/mobile-audio-service';
 import { audioStateManager } from '@/lib/audio-state-manager';
@@ -248,6 +249,7 @@ export default function VoiceInterface({
   const mobileAudioServiceRef = useRef<MobileAudioService | null>(null);
   const audioUrlRef = useRef<string | null>(null);
   const isRecordingRef = useRef(false);
+  const shouldListenRef = useRef(false);
   const fastFillerTimerRef = useRef<number | null>(null);
   const fastFillerUtteranceRef = useRef<SpeechSynthesisUtterance | null>(null);
 
@@ -356,6 +358,10 @@ export default function VoiceInterface({
   });
 
   const sessionState = normalizeSessionState(voiceController.mode);
+
+  useEffect(() => {
+    shouldListenRef.current = voiceController.shouldListen;
+  }, [voiceController.shouldListen]);
 
   const setVolume = useCallback((nextVolume: number) => {
     setVolumeState(nextVolume);
@@ -876,6 +882,14 @@ export default function VoiceInterface({
       await new Promise<void>((resolve) => {
         queueMicrotask(() => resolve());
       });
+      if (!shouldListenRef.current) {
+        recorder.cleanup();
+        if (recorderRef.current === recorder) {
+          recorderRef.current = null;
+          setMediaStream(null);
+        }
+        return;
+      }
       if (recorder.getState() === 'recording') {
         return;
       }
@@ -912,7 +926,7 @@ export default function VoiceInterface({
   }, [sessionState, startRecorderCapture, stopRecorderCapture, voiceController.shouldListen]);
 
   const startListening = useCallback(() => {
-    markAudioUserInteraction();
+    unlockAudioForUserGesture();
     sendSttWarmup({ language: currentLanguage, sessionId: sessionIdRef.current });
     cancelPendingRequest();
     stopPlayback(false);
@@ -921,12 +935,8 @@ export default function VoiceInterface({
   }, [cancelPendingRequest, currentLanguage, stopPlayback, voiceController]);
 
   const stopListening = useCallback(() => {
-    if (sessionState !== 'listening') {
-      return;
-    }
-
     voiceController.notifyProcessing();
-  }, [sessionState, voiceController]);
+  }, [voiceController]);
 
   const cancelSession = useCallback(() => {
     cancelSttWarmup();

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { markAudioUserInteraction } from '@/lib/audio/audio-user-interaction-gate';
+import { unlockAudioForUserGesture } from '@/lib/audio/audio-interaction-manager';
 import { startSensorPolling, stopSensorPolling } from '@/lib/api/device-webhook';
 import { getStageBackgroundStyle } from '@/lib/get-stage-background-style';
 import { overlayLabels } from '@/lib/kiosk-labels';
@@ -258,6 +258,7 @@ export default function Home() {
 
   const startPresentation = useCallback(
     (language: 'ja' | 'en') => {
+      unlockAudioForUserGesture();
       clearReturnToIdleTimer();
       setCurrentLanguage(language);
       setPresentationAutoStartKey((key) => key + 1);
@@ -337,7 +338,7 @@ export default function Home() {
             if (!armWelcomeCooldown()) {
               return;
             }
-            markAudioUserInteraction();
+            unlockAudioForUserGesture();
             sendSttWarmup({ language: voice.currentLanguage, sessionId: voice.sessionId });
             clearReturnToIdleTimer();
             setWelcomeMemberOcrOpen(false);
@@ -364,10 +365,18 @@ export default function Home() {
           const stageBackgroundStyle = getStageBackgroundStyle(characterBackground);
 
           const screenPadding = {
-            paddingTop: 'max(1.5rem, env(safe-area-inset-top))',
-            paddingBottom: 'max(1.5rem, env(safe-area-inset-bottom))',
-            paddingLeft: 'max(1.5rem, env(safe-area-inset-left))',
-            paddingRight: 'max(1.5rem, env(safe-area-inset-right))',
+            paddingTop: showSlideMode
+              ? 'max(0.25rem, env(safe-area-inset-top))'
+              : 'max(1.5rem, env(safe-area-inset-top))',
+            paddingBottom: showSlideMode
+              ? 'max(0.25rem, env(safe-area-inset-bottom))'
+              : 'max(1.5rem, env(safe-area-inset-bottom))',
+            paddingLeft: showSlideMode
+              ? 'max(0.25rem, env(safe-area-inset-left))'
+              : 'max(1.5rem, env(safe-area-inset-left))',
+            paddingRight: showSlideMode
+              ? 'max(0.25rem, env(safe-area-inset-right))'
+              : 'max(1.5rem, env(safe-area-inset-right))',
           } satisfies CSSProperties;
 
 
@@ -635,22 +644,22 @@ export default function Home() {
                       style={screenPadding}
                     >
                       <div
-                        className="pointer-events-auto relative flex h-full min-h-0 w-full flex-col overflow-hidden rounded-[32px] bg-white/95 shadow-2xl transition-all duration-300 ease-out"
+                        className="pointer-events-auto relative flex h-full min-h-0 w-full flex-col overflow-hidden rounded-2xl bg-white/95 shadow-2xl transition-all duration-300 ease-out sm:rounded-[28px]"
                         onPointerDownCapture={bumpUserActivity}
                       >
                         <button
                           type="button"
                           onClick={handleCloseSlides}
                           aria-label={labels.closeSlides}
-                          className="absolute right-3 top-3 z-20 inline-flex size-11 items-center justify-center rounded-full bg-black/70 text-white shadow-lg transition-transform duration-200 ease-out hover:scale-105"
+                          className="absolute right-2 top-2 z-30 inline-flex size-9 items-center justify-center rounded-full bg-black/70 text-white shadow-lg transition-transform duration-200 ease-out hover:scale-105 sm:right-3 sm:top-3 sm:size-10"
                         >
-                          <X className="size-5" />
+                          <X className="size-4 sm:size-5" />
                         </button>
                         <ReceptionPdfGuide
                           language={voice.currentLanguage}
                           rotateLandscapeHint={labels.slideRotateHint}
                           autoStartKey={presentationAutoStartKey}
-                          className="min-h-0 flex-1 pt-11"
+                          className="min-h-0 flex-1"
                           onVisemeControl={setVisemeFunction}
                           onExpressionControl={setExpressionFunction}
                           volume={Math.round(voice.volume * 100)}

--- a/frontend/src/lib/audio/audio-interaction-manager.ts
+++ b/frontend/src/lib/audio/audio-interaction-manager.ts
@@ -390,3 +390,23 @@ export const useAudioInteraction = () => {
     getState
   };
 };
+
+/**
+ * Call directly from a trusted user gesture. Safari/iOS needs the actual
+ * AudioContext creation/resume to start during that gesture, not after later
+ * async STT/QA/TTS work.
+ */
+export const unlockAudioForUserGesture = (): void => {
+  if (typeof window === 'undefined') {
+    return;
+  }
+
+  try {
+    markAudioUserInteraction();
+    void AudioInteractionManager.getInstance().forceInitialize().catch((error) => {
+      console.warn('[AudioInteractionManager] Failed to unlock audio from user gesture:', error);
+    });
+  } catch (error) {
+    console.warn('[AudioInteractionManager] Failed to start audio unlock:', error);
+  }
+};


### PR DESCRIPTION
## Summary
- unlock Safari/iOS audio by initializing AudioContext from real user gestures before async TTS/STT/slide playback
- make push-to-talk release robust against stale React state and avoid starting capture after a quick release
- compact the PDF slide guide in landscape so the canvas keeps the available viewport height

## Root Cause
Cloud Logging showed /api/voice returning 200, STT traces completing with non-empty audio bytes, and TTS cache events in the reported window. The Safari failures were therefore frontend playback unlock/PTT state issues rather than backend audio generation failures.

## Validation
- pnpm lint (passes with existing MarpViewer hook warnings)
- pnpm exec tsc --noEmit
- pnpm exec playwright test e2e/reception-pdf-guide.spec.ts e2e/reception-flow.spec.ts -g "landscape|voice button transitions kiosk to voice mode|device-detection is ignored" --project=chromium

## Issues Updated
- #614
- #616
- #621
- #625