### PR TITLE
fix(alpha): add Safari MediaRecorder fallback

### DIFF
--- a/frontend/src/lib/error-messages.ts
+++ b/frontend/src/lib/error-messages.ts
@@ -135,23 +135,24 @@ export function formatError(
   
   // Check for API-specific error patterns
   if (error.message) {
+    const message = String(error.message).toLowerCase();
     if (
-      error.message.includes('音声認識に失敗') ||
-      error.message.includes('speech recognition')
+      message.includes('音声認識に失敗') ||
+      message.includes('speech recognition')
     ) {
       return getErrorMessage('STT_ERROR', language);
     }
     if (
-      error.message.includes('質問の送信に失敗') ||
-      error.message.includes('send question') ||
-      error.message.includes('chat')
+      message.includes('質問の送信に失敗') ||
+      message.includes('send question') ||
+      message.includes('chat')
     ) {
       return getErrorMessage('QA_ERROR', language);
     }
     if (
-      error.message.includes('音声の生成に失敗') ||
-      error.message.includes('voice generation') ||
-      error.message.includes('text_to_speech')
+      message.includes('音声の生成に失敗') ||
+      message.includes('voice generation') ||
+      message.includes('text_to_speech')
     ) {
       return getErrorMessage('TTS_ERROR', language);
     }
@@ -164,13 +165,22 @@ export function formatError(
 
   // Check for specific error messages
   if (error.message) {
-    if (error.message.includes('microphone')) {
+    const message = String(error.message).toLowerCase();
+    if (message.includes('not supported') || message.includes('not available')) {
+      return getErrorMessage('NOT_SUPPORTED', language);
+    }
+    if (
+      message.includes('microphone') ||
+      message.includes('getusermedia') ||
+      message.includes('mediarecorder') ||
+      message.includes('recorder')
+    ) {
       return getErrorMessage('MICROPHONE_PERMISSION_DENIED', language);
     }
-    if (error.message.includes('network') || error.message.includes('fetch')) {
+    if (message.includes('network') || message.includes('fetch')) {
       return getErrorMessage('NETWORK_ERROR', language);
     }
-    if (error.message.includes('rate limit')) {
+    if (message.includes('rate limit')) {
       return getErrorMessage('RATE_LIMIT_EXCEEDED', language);
     }
   }

--- a/frontend/src/lib/voice-recorder.ts
+++ b/frontend/src/lib/voice-recorder.ts
@@ -184,20 +184,16 @@ export class VoiceRecorder {
           return;
         }
 
-        const mimeType = this.getSupportedMimeType();
-        const recorderOptions: MediaRecorderOptions = mimeType ? { mimeType } : {};
-
-        try {
-          this.mediaRecorder = new MediaRecorder(this.stream, recorderOptions);
-        } catch (recorderError: any) {
-          console.error('MediaRecorder creation failed:', recorderError);
-          this.onError(
-            new Error(`Failed to create MediaRecorder: ${recorderError.message || 'Unknown error'}`),
-          );
+        const recorderResult = this.createMediaRecorder(this.stream);
+        if (!recorderResult.recorder) {
+          console.error('MediaRecorder creation failed:', recorderResult.error);
+          this.onError(new Error(recorderResult.error));
           this.stream.getTracks().forEach((track) => track.stop());
           this.stream = null;
           return;
         }
+
+        this.mediaRecorder = recorderResult.recorder;
       }
 
       this.mediaRecorder.ondataavailable = (event) => {
@@ -337,12 +333,10 @@ export class VoiceRecorder {
     return this.stream;
   }
 
-  private getSupportedMimeType(): string {
-    // Check if we're on iOS
+  private getCandidateMimeTypes(): string[] {
     const isIOS = /iPad|iPhone|iPod/.test(navigator.userAgent) && !(window as any).MSStream;
-    
-    // iOS Safari prefers mp4/aac
-    const mimeTypes = isIOS ? [
+
+    const preferredTypes = isIOS ? [
       'audio/mp4',
       'audio/aac',
       'audio/mpeg',
@@ -355,15 +349,49 @@ export class VoiceRecorder {
       'audio/wav',
     ];
 
-    for (const mimeType of mimeTypes) {
-      if (MediaRecorder.isTypeSupported(mimeType)) {
-        return mimeType;
+    if (typeof MediaRecorder.isTypeSupported !== 'function') {
+      return [];
+    }
+
+    return preferredTypes.filter((mimeType) => {
+      try {
+        return MediaRecorder.isTypeSupported(mimeType);
+      } catch {
+        return false;
+      }
+    });
+  }
+
+  private createMediaRecorder(stream: MediaStream): {
+    recorder: MediaRecorder | null;
+    error: string;
+  } {
+    const errors: string[] = [];
+
+    for (const mimeType of this.getCandidateMimeTypes()) {
+      try {
+        return {
+          recorder: new MediaRecorder(stream, { mimeType }),
+          error: '',
+        };
+      } catch (error: any) {
+        errors.push(`${mimeType}: ${error?.message || error?.name || 'failed'}`);
       }
     }
 
-    // Fallback - let the browser choose
-    console.warn('No supported mime type found, using default');
-    return '';
+    try {
+      return {
+        recorder: new MediaRecorder(stream),
+        error: '',
+      };
+    } catch (error: any) {
+      errors.push(`default: ${error?.message || error?.name || 'failed'}`);
+    }
+
+    return {
+      recorder: null,
+      error: `Microphone recording is not supported by this browser. MediaRecorder creation failed (${errors.join('; ') || 'no compatible format'}).`,
+    };
   }
 
   // Static utility methods


### PR DESCRIPTION
## Summary
- try all supported MediaRecorder mime candidates instead of failing on the first Safari-reported type
- fall back to constructing MediaRecorder without a mimeType before surfacing a recording setup failure
- classify MediaRecorder/getUserMedia errors as microphone/browser-support errors instead of generic unexpected errors

## Root Cause
The latest Production deployment was Ready and Vercel runtime logs did not show a Next/API server error while monitored. The failure occurs when the browser starts recording before any request necessarily reaches Vercel. Safari can report audio/mp4/audio/aac support via MediaRecorder.isTypeSupported(), then still throw when constructing MediaRecorder with that mime type. The previous code treated that first constructor failure as terminal, so tapping the voice button could immediately show an error and never enter conversation.

## Validation
- pnpm lint
- pnpm exec tsc --noEmit
- pnpm exec playwright test e2e/reception-flow.spec.ts -g "voice button transitions kiosk to voice mode|device-detection is ignored" --project=chromium
- pnpm build

## Issue Updated
- #616