### PR TITLE
[codex] Restore avatar centering and Safari mic startup

### DIFF
--- a/frontend/e2e/reception-flow.spec.ts
+++ b/frontend/e2e/reception-flow.spec.ts
@@ -1,3 +1,6 @@
+import fs from 'node:fs';
+import path from 'node:path';
+
 import { expect, test } from '@playwright/test';
 
 /**
@@ -85,6 +88,32 @@ async function keepOcrCameraPending(page: import('@playwright/test').Page) {
   });
 }
 
+async function installDeterministicVoiceRecorder(page: import('@playwright/test').Page) {
+  const sampleAudioBase64 = fs
+    .readFileSync(path.resolve(__dirname, 'fixtures/voice/sample.wav'))
+    .toString('base64');
+
+  await page.addInitScript(({ audioBase64 }) => {
+    (window as Window & { __PLAYWRIGHT_VOICE_AUDIO_BASE64__?: string }).__PLAYWRIGHT_VOICE_AUDIO_BASE64__ =
+      audioBase64;
+  }, { audioBase64: sampleAudioBase64 });
+}
+
+async function rejectMicrophonePermission(page: import('@playwright/test').Page) {
+  await page.addInitScript(() => {
+    const existingMediaDevices = navigator.mediaDevices ?? {};
+    Object.defineProperty(navigator, 'mediaDevices', {
+      configurable: true,
+      value: {
+        ...existingMediaDevices,
+        getUserMedia: async () => {
+          throw new DOMException('Permission denied', 'NotAllowedError');
+        },
+      },
+    });
+  });
+}
+
 // ---------------------------------------------------------------------------
 // A. Welcome button triggers reception greeting
 // ---------------------------------------------------------------------------
@@ -148,6 +177,7 @@ test.describe('Reception flow — Welcome button', () => {
 
 test.describe('Reception flow — device sensor trigger', () => {
   test.beforeEach(async ({ page }) => {
+    await installDeterministicVoiceRecorder(page);
     await keepOcrCameraPending(page);
     await mockReceptionStart(page);
     await page.route('**/api/voice', async (route) => {
@@ -292,6 +322,7 @@ test.describe('Reception flow — member card OCR', () => {
 
 test.describe('Reception flow — voice mode', () => {
   test.beforeEach(async ({ page }) => {
+    await installDeterministicVoiceRecorder(page);
     await mockReceptionStart(page);
     await page.route(`**${QA_CHAT_URL}`, async (route) => {
       await route.fulfill({
@@ -318,6 +349,38 @@ test.describe('Reception flow — voice mode', () => {
     // In voice mode the button remains visible but its label changes to recording.
     await expect(page.getByTestId('kiosk-voice-button')).toBeVisible();
     await expect(page.getByTestId('kiosk-voice-button')).toContainText(/録音中|Recording/);
+  });
+});
+
+test.describe('Reception flow — microphone errors', () => {
+  test.beforeEach(async ({ page }) => {
+    await rejectMicrophonePermission(page);
+    await mockReceptionStart(page);
+    await page.route(`**${QA_CHAT_URL}`, async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({ answer: 'テスト応答', emotion: 'neutral', metadata: {} }),
+      });
+    });
+    await page.route('**/api/voice', async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({ success: true }),
+      });
+    });
+    await page.goto('/', { waitUntil: 'domcontentloaded' });
+    await dismissInitialModal(page);
+  });
+
+  test('permission denial shows a microphone error and does not stay recording', async ({ page }) => {
+    await page.getByRole('button', { name: /音声応対|Voice chat/ }).click();
+
+    await expect(page.getByTestId('kiosk-voice-status')).toContainText(/マイク.*拒否|Microphone access/, {
+      timeout: 5_000,
+    });
+    await expect(page.getByTestId('kiosk-voice-button')).not.toContainText(/録音中|Recording/);
   });
 });
 
@@ -379,6 +442,7 @@ test.describe('Reception flow — settings', () => {
 
 test.describe('Reception flow — STT warmup', () => {
   test.beforeEach(async ({ page }) => {
+    await installDeterministicVoiceRecorder(page);
     await keepOcrCameraPending(page);
     await mockReceptionStart(page);
     await page.route(`**${QA_CHAT_URL}`, async (route) => {

--- a/frontend/src/__tests__/error-messages.test.ts
+++ b/frontend/src/__tests__/error-messages.test.ts
@@ -1,0 +1,38 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import { formatError } from "../lib/error-messages";
+
+test("formatError preserves Safari microphone permission failures by DOMException name", () => {
+  const error = Object.assign(new Error("Permission denied"), {
+    name: "NotAllowedError",
+    originalName: "NotAllowedError",
+  });
+
+  assert.match(formatError(error, "ja"), /マイク.*拒否/);
+  assert.match(formatError(error, "en"), /Microphone access was denied/);
+});
+
+test("formatError maps microphone device and state failures to actionable messages", () => {
+  assert.match(
+    formatError(
+      Object.assign(new Error("missing"), { name: "NotFoundError" }),
+      "ja",
+    ),
+    /検出されません/,
+  );
+  assert.match(
+    formatError(
+      Object.assign(new Error("busy"), { name: "NotReadableError" }),
+      "ja",
+    ),
+    /他のアプリ/,
+  );
+  assert.match(
+    formatError(
+      Object.assign(new Error("state"), { name: "InvalidStateError" }),
+      "ja",
+    ),
+    /もう一度ボタン/,
+  );
+});

--- a/frontend/src/app/components/KioskBottomBar.tsx
+++ b/frontend/src/app/components/KioskBottomBar.tsx
@@ -57,13 +57,16 @@ export function KioskBottomBar({
       ? labels.kioskVoiceToggleActive
       : labels.kioskVoice;
 
-  const handleKioskVoiceStart = () => {
+  const handleKioskVoiceStart = async () => {
     unlockAudioForUserGesture();
     clearReturnToIdleTimer();
     setWelcomeMemberOcrOpen(false);
     setKioskPhase('voice');
     setKioskVoiceLocked(true);
-    void voice.startListening();
+    const started = await voice.startListening();
+    if (!started) {
+      setKioskVoiceLocked(false);
+    }
   };
 
   const handleKioskVoiceStop = () => {
@@ -130,7 +133,7 @@ export function KioskBottomBar({
                 event.currentTarget.setPointerCapture(event.pointerId);
                 pushToTalkPointerActiveRef.current = true;
                 if (!isVoiceCaptureActive) {
-                  handleKioskVoiceStart();
+                  void handleKioskVoiceStart();
                 }
               }}
               onPointerUp={(event) => {
@@ -166,7 +169,7 @@ export function KioskBottomBar({
                   handleKioskVoiceStop();
                   return;
                 }
-                handleKioskVoiceStart();
+                void handleKioskVoiceStart();
               }}
               className={cn(
                 'flex min-h-[72px] min-w-[min(100%,7rem)] flex-1 flex-col items-center justify-center gap-1 rounded-2xl px-3 py-3 shadow-md backdrop-blur-sm transition-transform sm:min-h-[80px] sm:flex-initial sm:px-5',

--- a/frontend/src/app/components/VoiceInterface.tsx
+++ b/frontend/src/app/components/VoiceInterface.tsx
@@ -69,7 +69,7 @@ export interface VoiceInterfaceRenderProps {
     error: string | null;
     lastMatch: WakeWordMatch | null;
   };
-  startListening: () => void;
+  startListening: () => Promise<boolean>;
   stopListening: () => void;
   cancelSession: () => void;
   clearConversation: () => void;
@@ -241,6 +241,7 @@ export default function VoiceInterface({
   const sessionIdRef = useRef(createSessionId());
   const visitorIdRef = useRef<string>('anonymous');
   const recorderRef = useRef<VoiceRecorder | null>(null);
+  const lastRecorderInitErrorRef = useRef<Error | null>(null);
   const shouldDiscardNextAudioRef = useRef(false);
   const requestAbortRef = useRef<AbortController | null>(null);
   const lipSyncAnalyzerRef = useRef<LipSyncAnalyzer | null>(null);
@@ -831,16 +832,19 @@ export default function VoiceInterface({
       return existingRecorder;
     }
 
+    lastRecorderInitErrorRef.current = null;
     const recorder = new VoiceRecorder(
       (audioBlob) => {
         void handleRecordedAudio(audioBlob);
       },
       (recorderError) => {
+        lastRecorderInitErrorRef.current = recorderError;
         setError(formatError(recorderError, currentLanguage));
         setIsLoading(false);
         setLoadingMessage('');
         setLoadingPhase(null);
         isRecordingRef.current = false;
+        shouldListenRef.current = false;
       },
       () => {
         if (recorderRef.current !== recorder) {
@@ -861,7 +865,10 @@ export default function VoiceInterface({
       setIsLoading(false);
       setLoadingMessage('');
       setLoadingPhase(null);
-      throw new Error(currentLanguage === 'ja' ? 'マイクを初期化できませんでした' : 'Unable to initialize the microphone');
+      throw (
+        lastRecorderInitErrorRef.current ??
+        new Error(currentLanguage === 'ja' ? 'マイクを初期化できませんでした' : 'Unable to initialize the microphone')
+      );
     }
 
     recorderRef.current = recorder;
@@ -873,35 +880,48 @@ export default function VoiceInterface({
     return recorder;
   }, [currentLanguage, handleRecordedAudio]);
 
-  const startRecorderCapture = useCallback(async () => {
-    if (isRecordingRef.current || isStartingRecorderRef.current) {
-      return;
+  const startRecorderCapture = useCallback(async (): Promise<boolean> => {
+    if (isRecordingRef.current) {
+      return true;
+    }
+    if (isStartingRecorderRef.current) {
+      return false;
     }
 
     isStartingRecorderRef.current = true;
     try {
       const recorder = await ensureRecorder();
-      await new Promise<void>((resolve) => {
-        queueMicrotask(() => resolve());
-      });
       if (!shouldListenRef.current) {
         recorder.cleanup();
         if (recorderRef.current === recorder) {
           recorderRef.current = null;
           setMediaStream(null);
         }
-        return;
+        return false;
       }
       if (recorder.getState() === 'recording') {
-        return;
+        return true;
       }
 
       recorder.start();
+      if (!recorder.isCurrentlyRecording()) {
+        shouldListenRef.current = false;
+        isRecordingRef.current = false;
+        voiceController.endManualSession();
+        return false;
+      }
       isRecordingRef.current = true;
       shouldDiscardNextAudioRef.current = false;
+      return true;
     } catch (startError) {
+      shouldListenRef.current = false;
+      isRecordingRef.current = false;
+      setIsLoading(false);
+      setLoadingMessage('');
+      setLoadingPhase(null);
       setError(formatError(startError, currentLanguage));
       voiceController.endManualSession();
+      return false;
     } finally {
       isStartingRecorderRef.current = false;
     }
@@ -929,15 +949,20 @@ export default function VoiceInterface({
     }
   }, [sessionState, startRecorderCapture, stopRecorderCapture, voiceController.shouldListen]);
 
-  const startListening = useCallback(() => {
+  const startListening = useCallback(async (): Promise<boolean> => {
     unlockAudioForUserGesture();
     shouldListenRef.current = true;
-    sendSttWarmup({ language: currentLanguage, sessionId: sessionIdRef.current });
     cancelPendingRequest();
     stopPlayback(false);
     setError(null);
+    const started = await startRecorderCapture();
+    if (!started) {
+      shouldListenRef.current = false;
+      return false;
+    }
     voiceController.startManualSession();
-    void startRecorderCapture();
+    sendSttWarmup({ language: currentLanguage, sessionId: sessionIdRef.current });
+    return true;
   }, [cancelPendingRequest, currentLanguage, startRecorderCapture, stopPlayback, voiceController]);
 
   const stopListening = useCallback(() => {

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -381,7 +381,9 @@ export default function Home() {
 
 
           const characterCameraOffset = { x: 0, y: 0, z: 0 };
-          const characterModelOffset = { x: 0, y: 0, z: 0 };
+          // Sakura's neutral VRM root renders slightly left at x=0. Keep this
+          // single parent offset so every session state and animation stays centered.
+          const characterModelOffset = { x: 0.15, y: 0, z: 0 };
           const characterRotationOffset = { x: 0, y: -0.2, z: 0 };
 
           const setOcrStatusMessage = (

--- a/frontend/src/lib/error-messages.ts
+++ b/frontend/src/lib/error-messages.ts
@@ -17,6 +17,14 @@ export const ERROR_MESSAGES: Record<string, ErrorMessage> = {
     ja: 'マイクが検出されませんでした。マイクが正しく接続されているか確認してください。',
     en: 'No microphone was detected. Please check that your microphone is properly connected.',
   },
+  MICROPHONE_IN_USE: {
+    ja: 'マイクが他のアプリに使用されています。他のアプリを閉じてからもう一度お試しください。',
+    en: 'The microphone is being used by another app. Please close other apps and try again.',
+  },
+  MICROPHONE_START_FAILED: {
+    ja: 'マイクの起動に失敗しました。もう一度ボタンをタップしてください。',
+    en: 'Failed to start the microphone. Please tap the button again.',
+  },
   VOICE_PROCESSING_ERROR: {
     ja: '音声の処理中にエラーが発生しました。もう一度お試しください。',
     en: 'An error occurred while processing your voice. Please try again.',
@@ -128,6 +136,25 @@ export function formatError(
   error: any,
   language: 'ja' | 'en' = 'ja'
 ): string {
+  const errorName = String(error?.originalName ?? error?.name ?? '').toLowerCase();
+  if (errorName) {
+    switch (errorName) {
+      case 'notallowederror':
+      case 'permissiondeniederror':
+      case 'securityerror':
+        return getErrorMessage('MICROPHONE_PERMISSION_DENIED', language);
+      case 'notfounderror':
+      case 'devicesnotfounderror':
+      case 'overconstrainederror':
+        return getErrorMessage('MICROPHONE_NOT_FOUND', language);
+      case 'notreadableerror':
+      case 'trackstarterror':
+        return getErrorMessage('MICROPHONE_IN_USE', language);
+      case 'invalidstateerror':
+        return getErrorMessage('MICROPHONE_START_FAILED', language);
+    }
+  }
+
   // Check for known error codes
   if (error.code && ERROR_MESSAGES[error.code]) {
     return getErrorMessage(error.code, language);
@@ -175,6 +202,23 @@ export function formatError(
       message.includes('mediarecorder') ||
       message.includes('recorder')
     ) {
+      if (
+        message.includes('not found') ||
+        message.includes('no microphone') ||
+        message.includes('unavailable')
+      ) {
+        return getErrorMessage('MICROPHONE_NOT_FOUND', language);
+      }
+      if (message.includes('in use') || message.includes('not readable')) {
+        return getErrorMessage('MICROPHONE_IN_USE', language);
+      }
+      if (
+        message.includes('invalidstate') ||
+        message.includes('already recording') ||
+        message.includes('failed to start')
+      ) {
+        return getErrorMessage('MICROPHONE_START_FAILED', language);
+      }
       return getErrorMessage('MICROPHONE_PERMISSION_DENIED', language);
     }
     if (message.includes('network') || message.includes('fetch')) {

--- a/frontend/src/lib/voice-recorder.ts
+++ b/frontend/src/lib/voice-recorder.ts
@@ -17,6 +17,25 @@ export class VoiceRecorder {
     private onHardwareReleased?: () => void,
   ) {}
 
+  private createRecorderError(message: string, source?: unknown): Error & { originalName?: string } {
+    const originalName =
+      source && typeof source === 'object' && 'name' in source
+        ? String((source as { name?: unknown }).name ?? '')
+        : '';
+    const originalMessage =
+      source && typeof source === 'object' && 'message' in source
+        ? String((source as { message?: unknown }).message ?? '')
+        : '';
+    const error = new Error(originalMessage ? `${message}: ${originalMessage}` : message) as Error & {
+      originalName?: string;
+    };
+    if (originalName) {
+      error.name = originalName;
+      error.originalName = originalName;
+    }
+    return error;
+  }
+
   private createDeterministicMediaRecorder(audioBase64: string): MediaRecorder {
     const bytes = Uint8Array.from(atob(audioBase64), (char) => char.charCodeAt(0));
 
@@ -81,8 +100,9 @@ export class VoiceRecorder {
         // Check if we're on HTTPS (required for getUserMedia outside local development).
         if (window.location.protocol !== 'https:' && !isLocalDevHost) {
           this.onError(
-            new Error(
+            this.createRecorderError(
               'Microphone access requires HTTPS connection. Please use HTTPS or localhost.',
+              { name: 'SecurityError' },
             ),
           );
           return;
@@ -152,22 +172,24 @@ export class VoiceRecorder {
           // Handle specific error cases
           if (error.name === 'NotAllowedError') {
             this.onError(
-              new Error(
+              this.createRecorderError(
                 'Microphone permission denied. Please allow microphone access and try again.',
+                error,
               ),
             );
           } else if (error.name === 'NotFoundError') {
-            this.onError(new Error('No microphone found. Please connect a microphone and try again.'));
+            this.onError(this.createRecorderError('No microphone found. Please connect a microphone and try again.', error));
           } else if (error.name === 'NotReadableError') {
             this.onError(
-              new Error(
+              this.createRecorderError(
                 'Microphone is in use by another application. Please close other apps using the microphone.',
+                error,
               ),
             );
           } else if (error.name === 'OverconstrainedError') {
-            this.onError(new Error('Selected microphone is unavailable. Please choose another microphone.'));
+            this.onError(this.createRecorderError('Selected microphone is unavailable. Please choose another microphone.', error));
           } else {
-            this.onError(new Error(`Failed to access microphone: ${error.message || error.name}`));
+            this.onError(this.createRecorderError('Failed to access microphone', error));
           }
           return;
         }
@@ -187,7 +209,7 @@ export class VoiceRecorder {
         const recorderResult = this.createMediaRecorder(this.stream);
         if (!recorderResult.recorder) {
           console.error('MediaRecorder creation failed:', recorderResult.error);
-          this.onError(new Error(recorderResult.error));
+          this.onError(this.createRecorderError(recorderResult.error, { name: 'NotSupportedError' }));
           this.stream.getTracks().forEach((track) => track.stop());
           this.stream = null;
           return;
@@ -217,10 +239,11 @@ export class VoiceRecorder {
       };
 
       this.mediaRecorder.onerror = (event) => {
-        this.onError(new Error(`MediaRecorder error: ${event}`));
+        const errorEvent = event as Event & { error?: unknown };
+        this.onError(this.createRecorderError('MediaRecorder error', errorEvent.error ?? event));
       };
     } catch (error) {
-      this.onError(new Error(`Failed to initialize recorder: ${error}`));
+      this.onError(this.createRecorderError('Failed to initialize recorder', error));
     }
   }
 
@@ -247,7 +270,7 @@ export class VoiceRecorder {
       this.isRecording = true;
     } catch (error) {
       this.isRecording = false;
-      this.onError(new Error(`Failed to start recording: ${error}`));
+      this.onError(this.createRecorderError('Failed to start recording', error));
     }
   }
 
@@ -260,7 +283,7 @@ export class VoiceRecorder {
       this.mediaRecorder.stop();
       this.isRecording = false;
     } catch (error) {
-      this.onError(new Error(`Failed to stop recording: ${error}`));
+      this.onError(this.createRecorderError('Failed to stop recording', error));
     }
   }
 
@@ -281,7 +304,7 @@ export class VoiceRecorder {
     try {
       this.mediaRecorder.pause();
     } catch (error) {
-      this.onError(new Error(`Failed to pause recording: ${error}`));
+      this.onError(this.createRecorderError('Failed to pause recording', error));
     }
   }
 
@@ -293,7 +316,7 @@ export class VoiceRecorder {
     try {
       this.mediaRecorder.resume();
     } catch (error) {
-      this.onError(new Error(`Failed to resume recording: ${error}`));
+      this.onError(this.createRecorderError('Failed to resume recording', error));
     }
   }
 


### PR DESCRIPTION
## Summary
- restore Sakura VRM parent x offset to +0.15 so every session state stays centered
- start kiosk voice capture before marking the session as recording, and roll back the lock when mic startup fails
- preserve MediaRecorder/getUserMedia DOMException names so Safari permission/state errors show actionable messages
- add regression coverage for mic permission denial and deterministic voice startup

## Root Cause
PR #637 removed the global +0.15 model correction and still let voice UI enter recording state before asynchronous recorder startup finished. Safari failures then lost their DOMException names and fell through to the generic unexpected-error message.

## Validation
- pnpm exec tsc --noEmit
- pnpm exec tsx --test src/__tests__/error-messages.test.ts
- pnpm exec playwright test e2e/reception-flow.spec.ts -g "voice button transitions kiosk to voice mode|permission denial shows a microphone error|voice button click fires warmup request" --project=chromium
- pnpm build