### PR TITLE
fix(api): add Zod validation to /api/voice/filler proxy (#642 F-1)

### DIFF
--- a/frontend/src/__tests__/api-voice-filler-route.test.ts
+++ b/frontend/src/__tests__/api-voice-filler-route.test.ts
@@ -1,0 +1,79 @@
+import assert from 'node:assert/strict';
+import { afterEach, test } from 'node:test';
+import { NextRequest } from 'next/server';
+
+const originalBackendApiUrl = process.env.BACKEND_API_URL;
+const originalBackendApiKey = process.env.BACKEND_API_KEY;
+const originalNodeEnv = process.env.NODE_ENV;
+const originalFetch = global.fetch;
+
+afterEach(() => {
+  process.env.BACKEND_API_URL = originalBackendApiUrl;
+  process.env.BACKEND_API_KEY = originalBackendApiKey;
+  (process.env as Record<string, string | undefined>).NODE_ENV = originalNodeEnv;
+  global.fetch = originalFetch;
+});
+
+test(
+  'voice filler POST rejects invalid body (missing language)',
+  { concurrency: false },
+  async () => {
+    process.env.BACKEND_API_URL = 'https://backend.example.com';
+    (process.env as Record<string, string | undefined>).NODE_ENV = 'test';
+
+    const { POST } = await import('../app/api/voice/filler/route');
+    const response = await POST(
+      new NextRequest('https://example.com/api/voice/filler', {
+        method: 'POST',
+        body: JSON.stringify({ query: 'hello' }),
+        headers: { 'Content-Type': 'application/json' },
+      }),
+    );
+
+    assert.equal(response.status, 400);
+    const json = (await response.json()) as { error: string; details: unknown };
+    assert.equal(json.error, 'INVALID_REQUEST');
+    assert.ok(json.details);
+  },
+);
+
+test(
+  'voice filler POST forwards validated body to backend',
+  { concurrency: false },
+  async () => {
+    process.env.BACKEND_API_URL = 'https://backend.example.com';
+    process.env.BACKEND_API_KEY = 'k';
+    (process.env as Record<string, string | undefined>).NODE_ENV = 'test';
+
+    let postedBody: string | undefined;
+    global.fetch = (async (_input: RequestInfo | URL, init?: RequestInit) => {
+      postedBody = init?.body as string;
+      return new Response(
+        JSON.stringify({
+          audioResponse: 'qqq',
+          intent: 'fallback',
+          audioFormat: 'audio/wav',
+          fillerText: '',
+          source: 'static',
+        }),
+        { status: 200, headers: { 'Content-Type': 'application/json' } },
+      );
+    }) as typeof fetch;
+
+    const { POST } = await import('../app/api/voice/filler/route');
+    const response = await POST(
+      new NextRequest('https://example.com/api/voice/filler', {
+        method: 'POST',
+        body: JSON.stringify({ query: '営業時間は？', language: 'ja', sessionId: 's-1' }),
+        headers: { 'Content-Type': 'application/json' },
+      }),
+    );
+
+    assert.equal(response.status, 200);
+    const json = (await response.json()) as { audioResponse: string; intent: string };
+    assert.equal(json.intent, 'fallback');
+    assert.equal(json.audioResponse, 'qqq');
+    assert.ok(postedBody);
+    assert.deepStrictEqual(JSON.parse(postedBody!), { query: '営業時間は？', language: 'ja' });
+  },
+);

--- a/frontend/src/app/api/voice/filler/route.ts
+++ b/frontend/src/app/api/voice/filler/route.ts
@@ -5,14 +5,25 @@ import {
   createInternalServerErrorResponse,
 } from '@/app/api/_shared/backend-error-response';
 import { backendFetch } from '@/lib/api/backend-proxy';
+import { fillerRequestSchema } from '@/lib/schemas/voice-filler';
 
 const FILLER_PROXY_TIMEOUT_MS = 15_000;
 
 export async function POST(request: NextRequest) {
   try {
-    const body = await request.json();
+    const raw = await request.json().catch(() => null);
+    const parsed = fillerRequestSchema.safeParse(raw);
+    if (!parsed.success) {
+      return NextResponse.json(
+        { error: 'INVALID_REQUEST', details: parsed.error.flatten() },
+        { status: 400 },
+      );
+    }
+
+    const { query, language } = parsed.data;
+
     const response = await backendFetch('/api/voice/filler', {
-      body,
+      body: { query, language },
       timeoutMs: FILLER_PROXY_TIMEOUT_MS,
     });
 

--- a/frontend/src/lib/schemas/voice-filler.ts
+++ b/frontend/src/lib/schemas/voice-filler.ts
@@ -1,0 +1,10 @@
+import { z } from 'zod';
+
+/** Body for `POST /api/voice/filler` (frontend proxy → backend `/api/voice/filler`). */
+export const fillerRequestSchema = z.object({
+  query: z.string().min(1).max(2000),
+  language: z.enum(['ja', 'en', 'zh', 'ko']),
+  sessionId: z.string().optional(),
+});
+
+export type FillerRequestInput = z.infer<typeof fillerRequestSchema>;


### PR DESCRIPTION
## Summary

Add Zod input validation to the `/api/voice/filler` Next.js proxy. Previously the route forwarded the raw `request.json()` to the backend with no shape check, violating the project's `Zodで入力バリデーション` rule.

## Changes

- `frontend/src/lib/schemas/voice-filler.ts` (new) — `fillerRequestSchema` for `{ query: string, language: 'ja'|'en'|'zh'|'ko', sessionId?: string }`
- `frontend/src/app/api/voice/filler/route.ts` — `safeParse` the body, return 400 with `{ error, details }` on invalid input, only forward validated fields to backend
- `frontend/src/__tests__/api-voice-filler-route.test.ts` (new) — unit tests for invalid/valid bodies

## Verified locally

- `npx tsx --test src/__tests__/api-voice-filler-route.test.ts`: PASS
- `pnpm lint`: PASS (only existing 3 MarpViewer.tsx hook-deps warnings)
- `pnpm typecheck`: PASS
- `codex exec review --base develop`: LGTM (no introduced bug)

## Known unrelated issue

`pnpm build` fails at `/admin/knowledge/upload` prerender (`File is not defined`). This is a **pre-existing issue unrelated to this change** — see #645.

## Test plan

- [x] Invalid body (missing `language`) → 400 + `{ error, details }`
- [x] Valid body → forwarded to backend (mock)
- [x] Lint + typecheck green
- [x] Codex CLI 経路A LGTM

Closes #642 (F-1 only — B-1 is a separate PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)