### PR TITLE
fix(routing): add identity-intent fast-path to prevent web_search self-disclosure leak (#615)

### DIFF
--- a/backend/agents/general_knowledge_agent.py
+++ b/backend/agents/general_knowledge_agent.py
@@ -630,18 +630,47 @@ class GeneralKnowledgeAgent:
             return f"福岡市 天神 {query}"
         return query
 
+    # Hardcoded multilingual self-introduction. Must NEVER reference any LLM
+    # provider (Google/OpenAI/etc). See issue #615 — web_search previously
+    # leaked "I am trained by Google..." into identity replies.
+    _ASSISTANT_PROFILE_MESSAGES: Dict[str, str] = {
+        "ja": (
+            "私は Engineer Cafe Navigator です。福岡市のエンジニアカフェの受付キオスク"
+            "として、施設利用、イベント、会員証、Wi-Fi、スライド案内に加えて、"
+            "受付でよくある日常的な質問にもお答えします。"
+        ),
+        "en": (
+            "I am Engineer Cafe Navigator, the reception kiosk for Engineer Cafe in "
+            "Fukuoka. I can help with facilities, events, membership check-in, Wi-Fi, "
+            "slide guidance, and everyday questions visitors commonly ask at reception."
+        ),
+        "ko": (
+            "저는 Engineer Cafe Navigator 입니다. 후쿠오카의 엔지니어 카페 안내 키오스크로서, "
+            "시설 이용, 이벤트, 회원증, Wi-Fi, 슬라이드 안내와 함께 접수처에서 자주 받는 "
+            "일상적인 질문에도 답해 드립니다."
+        ),
+        "zh": (
+            "我是 Engineer Cafe Navigator，福冈工程师咖啡馆的前台导览终端。我可以为您介绍"
+            "设施使用、活动信息、会员证、Wi-Fi、幻灯片导览，以及前台常见的日常问题。"
+        ),
+    }
+
     def _assistant_profile_response(self, language: SupportedLanguage) -> Dict[str, Any]:
-        if language == "en":
-            message = (
-                "I am Engineer Cafe Navigator. I can help with Engineer Cafe facilities, "
-                "events, membership check-in, Wi-Fi, slide guidance, and everyday questions "
-                "visitors commonly ask at reception."
-            )
-        else:
-            message = (
-                "私は Engineer Cafe Navigator です。エンジニアカフェの施設利用、イベント、"
-                "会員証、Wi-Fi、スライド案内に加えて、受付でよくある日常的な質問にもお答えします。"
-            )
+        """Return the hardcoded self-introduction; never calls any LLM/web_search.
+
+        Args:
+            language: Visitor language (ja/en/ko/zh). Falls back to ja when unknown.
+
+        Returns:
+            Response dict with metadata.web_search_used=False and provider_called=False.
+        """
+        message = self._ASSISTANT_PROFILE_MESSAGES.get(
+            language, self._ASSISTANT_PROFILE_MESSAGES["ja"]
+        )
+        logger.info(
+            "Identity fast-path response served (language=%s, no LLM, no web_search)",
+            language,
+        )
         return {
             "answer": message,
             "emotion": "helpful",

--- a/backend/tests/agents/test_identity_routing.py
+++ b/backend/tests/agents/test_identity_routing.py
@@ -1,0 +1,195 @@
+"""
+Tests for the identity-intent fast-path that prevents the GeneralKnowledgeAgent
+from leaking LLM-provider self-disclosure (e.g. "I am trained by Google...")
+when visitors ask "what's your name" / "who are you" in any supported language.
+
+See issue #615.
+
+Coverage:
+- Fast-path detection in ja/en/ko/zh (multilingual identity + capability queries)
+- _assistant_profile_response returns hardcoded "Engineer Cafe Navigator" text
+  in all four languages, never calls web_search or any LLM provider
+- Visitor self-introduction ("私の名前は田中です") is NOT misrouted
+- Returned metadata has web_search_used=False and provider_called=False
+- No supported language returns a response containing any LLM-provider name
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from backend.agents.general_knowledge_agent import GeneralKnowledgeAgent
+from backend.utils.intent_classifier import (
+    classify_fast_intent,
+    is_assistant_profile_question,
+)
+
+# Identity-style queries that MUST route to the assistant_profile fast-path.
+IDENTITY_QUERIES = {
+    "ja": [
+        "あなたの名前は？",
+        "お名前を教えてください",
+        "あなたは誰ですか",
+        "何者ですか",
+        "自己紹介してください",
+        "どんなAIなの？",
+        "どのモデルを使ってる？",
+    ],
+    "en": [
+        "what's your name?",
+        "what is your name",
+        "who are you?",
+        "what model are you?",
+        "are you trained by openai?",
+        "introduce yourself",
+        "which AI is this",
+    ],
+    "ko": [
+        "당신의 이름은 무엇입니까",
+        "너 이름이 뭐야",
+        "누구세요?",
+        "자기소개 해주세요",
+    ],
+    "zh": [
+        "你叫什么名字",
+        "你是谁",
+        "你的名字是什么",
+        "请自我介绍",
+        "您是谁",
+    ],
+}
+
+# These must NOT trigger the identity fast-path — they're visitor self-intros.
+VISITOR_NAME_QUERIES = [
+    "私の名前は田中です。覚えて",
+    "my name is alice",
+    "call me Bob",
+    "내 이름은 김철수입니다",
+    "我的名字叫小明",
+    "我叫李华",
+]
+
+# LLM-provider tokens that must NEVER appear in a hardcoded identity response.
+FORBIDDEN_PROVIDER_TOKENS = (
+    "google",
+    "gemini",
+    "openai",
+    "gpt",
+    "anthropic",
+    "claude",
+    "trained by",
+)
+
+
+class TestIdentityIntentDetection:
+    """is_assistant_profile_question must catch identity queries in ja/en/ko/zh."""
+
+    @pytest.mark.parametrize("language", ["ja", "en", "ko", "zh"])
+    def test_identity_queries_detected(self, language: str) -> None:
+        for query in IDENTITY_QUERIES[language]:
+            assert is_assistant_profile_question(
+                query.lower()
+            ), f"[{language}] identity query not detected: {query!r}"
+
+    @pytest.mark.parametrize("query", VISITOR_NAME_QUERIES)
+    def test_visitor_self_introduction_not_misrouted(self, query: str) -> None:
+        assert not is_assistant_profile_question(
+            query.lower()
+        ), f"visitor self-intro misrouted to assistant_profile: {query!r}"
+
+
+class TestIdentityFastRoute:
+    """classify_fast_intent must return an assistant_profile route, not None."""
+
+    @pytest.mark.parametrize("language", ["ja", "en", "ko", "zh"])
+    def test_fast_intent_routes_assistant_profile(self, language: str) -> None:
+        for query in IDENTITY_QUERIES[language]:
+            route = classify_fast_intent(query)
+            assert route is not None, f"[{language}] no fast route for {query!r}"
+            assert route.agent == "general_knowledge", (
+                f"[{language}] expected general_knowledge agent, got {route.agent!r} "
+                f"for query {query!r}"
+            )
+            assert route.request_type == "assistant_profile", (
+                f"[{language}] expected request_type=assistant_profile, "
+                f"got {route.request_type!r} for query {query!r}"
+            )
+            assert route.category == "assistant_profile"
+
+
+class TestAssistantProfileResponse:
+    """_assistant_profile_response must NOT call web_search/LLM in any language."""
+
+    @pytest.fixture
+    def gka(self) -> GeneralKnowledgeAgent:
+        # Patch heavyweight constructors so we don't hit external services.
+        with (
+            patch("backend.agents.general_knowledge_agent.OpenRouterProvider") as mock_provider,
+            patch("backend.agents.general_knowledge_agent.TavilySearchTool") as mock_tavily,
+            patch("backend.agents.general_knowledge_agent.EnhancedRAGSearch") as mock_rag,
+            patch("backend.agents.general_knowledge_agent.get_model_config"),
+        ):
+            mock_provider.return_value.generate = AsyncMock(
+                side_effect=AssertionError("LLM must not be called for identity")
+            )
+            mock_tavily.return_value.search = AsyncMock(
+                side_effect=AssertionError("web_search must not be called for identity")
+            )
+            mock_rag.return_value.search = AsyncMock(
+                side_effect=AssertionError("RAG must not be called for identity")
+            )
+            agent = GeneralKnowledgeAgent(memory_system=MagicMock())
+            # Re-attach the mocks to the agent instance for assertion access.
+            agent.provider = mock_provider.return_value
+            agent.web_search = mock_tavily.return_value
+            agent.rag_search = mock_rag.return_value
+            return agent
+
+    @pytest.mark.parametrize("language", ["ja", "en", "ko", "zh"])
+    @pytest.mark.asyncio
+    async def test_answer_query_assistant_profile_never_invokes_llm_or_web(
+        self, gka: GeneralKnowledgeAgent, language: str
+    ) -> None:
+        result = await gka.answer_query(
+            query=IDENTITY_QUERIES[language][0],
+            language=language,
+            session_id="test-session",
+            query_type="assistant_profile",
+        )
+
+        # Hardcoded brand string MUST appear, regardless of language.
+        assert (
+            "Engineer Cafe Navigator" in result["answer"]
+        ), f"[{language}] response missing brand identity: {result['answer']!r}"
+
+        # Provider/web_search must not have been touched.
+        gka.provider.generate.assert_not_called()
+        gka.web_search.search.assert_not_called()
+        gka.rag_search.search.assert_not_called()
+
+        meta = result["metadata"]
+        assert meta["query_type"] == "assistant_profile"
+        assert meta["web_search_used"] is False
+        assert meta["provider_called"] is False
+        assert meta["sources"] == []
+
+    @pytest.mark.parametrize("language", ["ja", "en", "ko", "zh"])
+    def test_response_contains_no_llm_provider_disclosure(
+        self, gka: GeneralKnowledgeAgent, language: str
+    ) -> None:
+        result = gka._assistant_profile_response(language)  # type: ignore[arg-type]
+        answer_lower = result["answer"].lower()
+        for token in FORBIDDEN_PROVIDER_TOKENS:
+            assert token not in answer_lower, (
+                f"[{language}] forbidden provider token {token!r} leaked in "
+                f"response: {result['answer']!r}"
+            )
+
+    def test_unknown_language_falls_back_to_japanese(self, gka: GeneralKnowledgeAgent) -> None:
+        # SupportedLanguage is Literal["ja","en","zh","ko"]; passing an unknown
+        # value is a defensive guard. We expect the ja fallback string.
+        result = gka._assistant_profile_response("xx")  # type: ignore[arg-type]
+        assert "Engineer Cafe Navigator" in result["answer"]
+        assert result["metadata"]["web_search_used"] is False

--- a/backend/tests/agents/test_identity_routing.py
+++ b/backend/tests/agents/test_identity_routing.py
@@ -71,6 +71,19 @@ VISITOR_NAME_QUERIES = [
     "我叫李华",
 ]
 
+# These must NOT trigger the identity fast-path — they're domain queries that
+# happen to contain ambiguous tokens (貴方 as 2nd-person pronoun, "AI" as a
+# topic label, Chinese 能帮我 as a generic capability ask).
+# Per Codex CLI 経路A review on PR #648 (#615 follow-up).
+NON_IDENTITY_AMBIGUOUS_QUERIES = [
+    # 貴方 used as 2nd-person pronoun in a Wi-Fi question (not asking about bot)
+    "貴方にWi-Fiの設定を聞きたい",
+    # "AI" as topic of an event lookup, not asking which AI the bot is
+    "which AI events are held here?",
+    # Chinese capability marker without self-referential identity token
+    "能帮我连接 Wi-Fi 吗",
+]
+
 # LLM-provider tokens that must NEVER appear in a hardcoded identity response.
 FORBIDDEN_PROVIDER_TOKENS = (
     "google",
@@ -98,6 +111,29 @@ class TestIdentityIntentDetection:
         assert not is_assistant_profile_question(
             query.lower()
         ), f"visitor self-intro misrouted to assistant_profile: {query!r}"
+
+    @pytest.mark.parametrize("query", NON_IDENTITY_AMBIGUOUS_QUERIES)
+    def test_ambiguous_tokens_do_not_misroute(self, query: str) -> None:
+        """Regression: PR #648 false positives from Codex CLI 経路A review.
+
+        - 貴方 alone (used as 2nd-person pronoun, not identity subject)
+        - bare 'AI' substring inside an event query
+        - bare Chinese 能 capability marker inside a Wi-Fi help request
+
+        These must NOT route to the assistant_profile fast-path.
+        """
+        assert not is_assistant_profile_question(
+            query.lower()
+        ), f"ambiguous-token query misrouted to assistant_profile: {query!r}"
+
+        # Also verify they don't get a fast assistant_profile route from the
+        # higher-level classifier (defense in depth — the orchestrator path).
+        route = classify_fast_intent(query)
+        if route is not None:
+            assert route.request_type != "assistant_profile", (
+                f"classify_fast_intent misrouted ambiguous query to "
+                f"assistant_profile: {query!r}"
+            )
 
 
 class TestIdentityFastRoute:

--- a/backend/utils/intent_classifier.py
+++ b/backend/utils/intent_classifier.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import re
 from dataclasses import dataclass
 from typing import Optional
 
@@ -68,12 +69,51 @@ class FastIntent:
         }
 
 
+# --- Identity-intent regex patterns (see is_assistant_profile_question) ---
+#
+# These patterns require co-occurrence of an identity-asking signal with the
+# matched token, so that bare second-person pronouns ("貴方"), bare model/AI
+# tokens ("which AI events..."), or bare Chinese capability markers ("能帮我
+# 连接 Wi-Fi") do NOT false-route to the assistant_profile fast-path.
+#
+# Per Codex CLI 経路A review on PR #648 (#615 follow-up).
+
+# Japanese: 貴方 used as identity subject — "貴方の名前", "貴方は誰", etc.
+# Excludes "貴方にWi-Fi..." (used as 2nd-person pronoun, not asking-about-bot).
+_JA_ANATA_IDENTITY = re.compile(
+    r"貴方(の|は|って|わ)[^。！？!?]*?(名前|誰|何者|モデル|ai|ボット|自己紹介)",
+    re.IGNORECASE,
+)
+# English: "model" / "AI" only when in identity-asking context (possessive or
+# explicit asking pattern). Excludes "which AI events are held here?".
+_EN_MODEL_AI_IDENTITY = re.compile(
+    r"\b("
+    r"(what|which)\s+(model|ai|assistant|bot)\s+(are|is)\s+(you|this)"  # what model are you
+    r"|your\s+(model|ai|assistant|bot)\b"  # your model
+    r"|(am|are)\s+i\s+talking\s+to\s+(an?\s+)?(model|ai|assistant|bot)"
+    r")",
+    re.IGNORECASE,
+)
+# Chinese: capability marker 能 only counts as identity when paired with a
+# self-referential identity token ("你是谁", "你叫什么", "什么模型"). Plain
+# "能帮我连接Wi-Fi" should NOT route to identity.
+_ZH_CAPABILITY_IDENTITY = re.compile(
+    r"(你|您)[^。！？!?]*?(是谁|是誰|叫什么|叫什麼|什么模型|什麼模型|什么ai|什麼ai|什么助手|什麼助手|哪个模型|哪個模型)",
+    re.IGNORECASE,
+)
+
+
 def is_assistant_profile_question(lower_query: str) -> bool:
     """Detect questions about this kiosk assistant, not the visitor's name.
 
     Covers ja/en/ko/zh identity and capability queries. Used as a fast-path
     route to short-circuit LLM/web_search and force a hardcoded
     "Engineer Cafe Navigator" self-introduction. See issue #615.
+
+    Tightened per Codex CLI 経路A review on PR #648:
+    - 貴方 requires identity-asking co-occurrence (not bare 2nd-person)
+    - bare model/AI requires possessive or asking pattern
+    - Chinese 能帮我 requires self-referential identity token co-occurrence
     """
     visitor_name_markers = (
         "私の名前",
@@ -90,6 +130,7 @@ def is_assistant_profile_question(lower_query: str) -> bool:
     if any(marker in lower_query for marker in visitor_name_markers):
         return False
 
+    # Substring identity markers that are unambiguous on their own.
     identity_markers = (
         # Japanese
         "あなたの名前",
@@ -101,21 +142,15 @@ def is_assistant_profile_question(lower_query: str) -> bool:
         "あなたは誰",
         "君は誰",
         "何者",
-        "貴方",
         "自己紹介",
-        "どんなai",
         "どんなボット",
         "どんなモデル",
         "どのモデル",
-        "どのai",
         # English
         "what is your name",
         "what's your name",
         "what are you called",
         "who are you",
-        "what model are you",
-        "which model",
-        "which ai",
         "are you trained",
         "are you made",
         "introduce yourself",
@@ -130,7 +165,8 @@ def is_assistant_profile_question(lower_query: str) -> bool:
         "누구야",
         "누구신가요",
         "자기소개",
-        # Chinese (Simplified + Traditional)
+        # Chinese (Simplified + Traditional) — these are unambiguous identity
+        # questions. Bare 能 / 能帮我 is excluded; see _ZH_CAPABILITY_IDENTITY.
         "你叫什么",
         "你叫什麼",
         "你是谁",
@@ -142,6 +178,9 @@ def is_assistant_profile_question(lower_query: str) -> bool:
         "自我介绍",
         "自我介紹",
     )
+    if any(marker in lower_query for marker in identity_markers):
+        return True
+
     capability_markers = (
         # Japanese
         "何ができます",
@@ -151,6 +190,8 @@ def is_assistant_profile_question(lower_query: str) -> bool:
         "ヘルプ",
         "使い方を教えて",
         "どんな案内",
+        "どんなai",
+        "どのai",
         # English
         "what can you do",
         "how can you help",
@@ -162,10 +203,20 @@ def is_assistant_profile_question(lower_query: str) -> bool:
         # Chinese
         "你能做什么",
         "你能做什麼",
-        "能帮我",
-        "能幫我",
     )
-    return any(marker in lower_query for marker in (*identity_markers, *capability_markers))
+    if any(marker in lower_query for marker in capability_markers):
+        return True
+
+    # Tightened regex checks — require co-occurrence of identity-asking context
+    # with otherwise-ambiguous tokens.
+    if _JA_ANATA_IDENTITY.search(lower_query):
+        return True
+    if _EN_MODEL_AI_IDENTITY.search(lower_query):
+        return True
+    if _ZH_CAPABILITY_IDENTITY.search(lower_query):
+        return True
+
+    return False
 
 
 def is_daily_conversation_request(lower_query: str) -> bool:

--- a/backend/utils/intent_classifier.py
+++ b/backend/utils/intent_classifier.py
@@ -69,7 +69,12 @@ class FastIntent:
 
 
 def is_assistant_profile_question(lower_query: str) -> bool:
-    """Detect questions about this kiosk assistant, not the visitor's name."""
+    """Detect questions about this kiosk assistant, not the visitor's name.
+
+    Covers ja/en/ko/zh identity and capability queries. Used as a fast-path
+    route to short-circuit LLM/web_search and force a hardcoded
+    "Engineer Cafe Navigator" self-introduction. See issue #615.
+    """
     visitor_name_markers = (
         "私の名前",
         "僕の名前",
@@ -77,11 +82,16 @@ def is_assistant_profile_question(lower_query: str) -> bool:
         "わたしの名前",
         "my name",
         "call me",
+        "내 이름",
+        "제 이름",
+        "我的名字",
+        "我叫",
     )
     if any(marker in lower_query for marker in visitor_name_markers):
         return False
 
     identity_markers = (
+        # Japanese
         "あなたの名前",
         "君の名前",
         "きみの名前",
@@ -91,11 +101,49 @@ def is_assistant_profile_question(lower_query: str) -> bool:
         "あなたは誰",
         "君は誰",
         "何者",
+        "貴方",
+        "自己紹介",
+        "どんなai",
+        "どんなボット",
+        "どんなモデル",
+        "どのモデル",
+        "どのai",
+        # English
         "what is your name",
         "what's your name",
+        "what are you called",
         "who are you",
+        "what model are you",
+        "which model",
+        "which ai",
+        "are you trained",
+        "are you made",
+        "introduce yourself",
+        # Korean
+        "너의 이름",
+        "너 이름",
+        "당신의 이름",
+        "당신 이름",
+        "이름이 뭐",
+        "이름이 무엇",
+        "누구세요",
+        "누구야",
+        "누구신가요",
+        "자기소개",
+        # Chinese (Simplified + Traditional)
+        "你叫什么",
+        "你叫什麼",
+        "你是谁",
+        "你是誰",
+        "你的名字",
+        "您的名字",
+        "您是谁",
+        "您是誰",
+        "自我介绍",
+        "自我介紹",
     )
     capability_markers = (
+        # Japanese
         "何ができます",
         "なにができます",
         "できること",
@@ -103,9 +151,19 @@ def is_assistant_profile_question(lower_query: str) -> bool:
         "ヘルプ",
         "使い方を教えて",
         "どんな案内",
+        # English
         "what can you do",
         "how can you help",
         "help me with",
+        # Korean
+        "무엇을 할 수 있",
+        "뭘 할 수 있",
+        "어떻게 도와",
+        # Chinese
+        "你能做什么",
+        "你能做什麼",
+        "能帮我",
+        "能幫我",
     )
     return any(marker in lower_query for marker in (*identity_markers, *capability_markers))
 


### PR DESCRIPTION
## Summary

Fix Issue #615: Identity queries ("あなたの名前は？", "who are you?") routed to GeneralKnowledgeAgent → web_search → leaked Google self-disclosure. Observed live 2026-04-29.

## Root cause

The codebase already had a fast-path (`backend/utils/intent_classifier.py:is_assistant_profile_question`) that short-circuits identity queries. Two gaps:
1. **ko/zh patterns missing** in the detector — Korean/Chinese identity queries fell through to LLM routing
2. **ko/zh hardcoded responses missing** in `backend/agents/general_knowledge_agent.py:_assistant_profile_response` — even when query_type was `assistant_profile`, ko/zh fell back to web_search

## Changes

- `backend/utils/intent_classifier.py` — extend `is_assistant_profile_question` with ko/zh patterns + ja/en gaps; add ko/zh visitor-name exclusions to avoid misrouting visitor self-intros
- `backend/agents/general_knowledge_agent.py` — replace inline ja/en branches with `_ASSISTANT_PROFILE_MESSAGES` dict (ja/en/ko/zh) + structured logger info + ja fallback
- `backend/tests/agents/test_identity_routing.py` (NEW) — 23 tests covering ja/en/ko/zh identity queries + ko/zh visitor-name exclusion regression

## Verified locally

- `uv run pytest -m 'not ragas and not slow' --tb=short -q backend/tests/agents/` — **68 passed**
- `ruff check backend/` — All checks passed
- `black --check backend/` — clean
- `codex exec review --base develop` — 3 P2 (LOW) findings on marker breadth, 0 CRITICAL/HIGH/MEDIUM

## Out of scope (separate follow-up)

Alpha verification (run 25215925625) also flagged `Q-RECV-JA-002` (business_info leak) and `Q-FAREWELL-JA-001` (farewell leak). These are different routing-keyword bugs, not identity intent. Need separate fixes.

## Test plan

- [x] ja/en/ko/zh identity query → IdentityAgent response, no web_search
- [x] ko/zh visitor-name self-intro NOT misrouted to identity
- [x] No 'google' / 'gemini' / 'openai' / 'gpt' / 'claude' tokens in response

Closes #615

🤖 Generated with [Claude Code](https://claude.com/claude-code)