### PR TITLE
fix(build): prevent File is not defined at /admin/knowledge/upload prerender (Closes #645)

### DIFF
--- a/frontend/src/app/(admin)/admin/knowledge/utils/validation.ts
+++ b/frontend/src/app/(admin)/admin/knowledge/utils/validation.ts
@@ -11,24 +11,38 @@ export interface KnowledgeUploadFormData {
 // `File` global is only available in Node 20+ (and always in browsers). This
 // module is evaluated at Next.js prerender time on Node, so referencing
 // `File` directly there throws `ReferenceError: File is not defined` on
-// Node 18. We perform the instance check lazily inside a refine callback,
+// Node 18. We perform the instance check lazily inside a superRefine,
 // which only runs in the browser when validation is actually invoked.
 // See issue #645.
-const fileSchema = z
-  .unknown()
-  .refine(
-    (value): value is File =>
-      typeof File !== 'undefined' && value instanceof File,
-    { message: 'ファイルは必須です' },
-  )
-  .refine((file) => {
-    const ext = file.name.split('.').pop()?.toLowerCase();
-    return Boolean(ext && ['pdf', 'md', 'markdown'].includes(ext));
-  }, 'PDF または Markdown ファイルのみ対応しています')
-  .refine(
-    (file) => file.size <= 10 * 1024 * 1024,
-    'ファイルサイズは 10MB 以内にしてください',
-  );
+//
+// We use `superRefine` (instead of chained `.refine()` calls) so we can
+// short-circuit after the type check fails — chained refines keep running
+// even after a prior one returns false, which would crash on `file.name`
+// when `value` is null/undefined (e.g. user submits without picking a file).
+const fileSchema = z.unknown().superRefine((value, ctx) => {
+  if (typeof File === 'undefined' || !(value instanceof File)) {
+    ctx.addIssue({
+      code: z.ZodIssueCode.custom,
+      message: 'ファイルは必須です',
+    });
+    return;
+  }
+
+  const ext = value.name.split('.').pop()?.toLowerCase();
+  if (!ext || !['pdf', 'md', 'markdown'].includes(ext)) {
+    ctx.addIssue({
+      code: z.ZodIssueCode.custom,
+      message: 'PDF または Markdown ファイルのみ対応しています',
+    });
+  }
+
+  if (value.size > 10 * 1024 * 1024) {
+    ctx.addIssue({
+      code: z.ZodIssueCode.custom,
+      message: 'ファイルサイズは 10MB 以内にしてください',
+    });
+  }
+});
 
 const uploadSchema = z.object({
   file: fileSchema,

--- a/frontend/src/app/(admin)/admin/knowledge/utils/validation.ts
+++ b/frontend/src/app/(admin)/admin/knowledge/utils/validation.ts
@@ -7,17 +7,31 @@ export interface KnowledgeUploadFormData {
   title: string;
 }
 
+// NOTE: We avoid `z.instanceof(File, ...)` at module top-level because the
+// `File` global is only available in Node 20+ (and always in browsers). This
+// module is evaluated at Next.js prerender time on Node, so referencing
+// `File` directly there throws `ReferenceError: File is not defined` on
+// Node 18. We perform the instance check lazily inside a refine callback,
+// which only runs in the browser when validation is actually invoked.
+// See issue #645.
+const fileSchema = z
+  .unknown()
+  .refine(
+    (value): value is File =>
+      typeof File !== 'undefined' && value instanceof File,
+    { message: 'ファイルは必須です' },
+  )
+  .refine((file) => {
+    const ext = file.name.split('.').pop()?.toLowerCase();
+    return Boolean(ext && ['pdf', 'md', 'markdown'].includes(ext));
+  }, 'PDF または Markdown ファイルのみ対応しています')
+  .refine(
+    (file) => file.size <= 10 * 1024 * 1024,
+    'ファイルサイズは 10MB 以内にしてください',
+  );
+
 const uploadSchema = z.object({
-  file: z
-    .instanceof(File, { message: 'ファイルは必須です' })
-    .refine((file) => {
-      const ext = file.name.split('.').pop()?.toLowerCase();
-      return Boolean(ext && ['pdf', 'md', 'markdown'].includes(ext));
-    }, 'PDF または Markdown ファイルのみ対応しています')
-    .refine(
-      (file) => file.size <= 10 * 1024 * 1024,
-      'ファイルサイズは 10MB 以内にしてください',
-    ),
+  file: fileSchema,
   category: z.string().min(1, 'カテゴリは必須です'),
   language: z.enum(['ja', 'en']),
   title: z.string().max(200, 'タイトルは 200 文字以内にしてください').optional(),


### PR DESCRIPTION
## Summary

Fix Issue #645: `pnpm build` fails at `/admin/knowledge/upload` prerender with `ReferenceError: File is not defined`. Prevents Vercel production deploy on Node 18 environments.

## Root cause

`frontend/src/app/(admin)/admin/knowledge/utils/validation.ts:12` used `z.instanceof(File, ...)` at module top-level. Zod's `instanceof` schema captures the `File` constructor reference at schema-construction time (module load). The page is `'use client';`, but Next.js still imports/evaluates client modules during prerender on Node. The `File` global was added in Node 20 — on Node 18 (which `package.json engines: ">=18.0.0"` allows), reading `File` throws `ReferenceError`.

The 8 type-only `File` annotations in `page.tsx` were red herrings (erased by TypeScript). The actual culprit was the imported `validation.ts`.

## Fix

Replace top-level `z.instanceof(File, ...)` with a `superRefine` that performs the type check lazily and short-circuits on failure. The `File` reference is now only read inside the callback, which executes only when `validateKnowledgeUploadForm` runs (always in the browser).

- Picked over `dynamic = 'force-dynamic'` / runtime change / polyfill: surgical, addresses root cause, keeps Zod parity for callers.
- Initial commit used chained `.refine()` calls; Codex CLI 経路A review caught a P2 (chained refines keep running after a prior refine returns false → `Cannot read properties of null (reading 'name')` when user submits without selecting a file). Follow-up commit `8f28e4d` switches to `superRefine` for safe short-circuit.

## Verified locally

- `pnpm build`: PASS — `/admin/knowledge/upload  5.4 kB  129 kB` listed as `○ (Static)` prerendered
- `pnpm lint`: PASS (only pre-existing MarpViewer warnings)
- `pnpm typecheck`: PASS
- `codex exec review --base develop`: P2 found (null deref), addressed in follow-up commit `8f28e4d`

## Test plan

- [x] `pnpm build` exit 0 on Node 18
- [x] `/admin/knowledge/upload` still prerenders (Static `○`)
- [x] No regression in validation logic (Zod refine semantics preserved, null/undefined safely returns required-file error)

## Followup (not in scope)

Pin Node 20+ in `frontend/package.json` engines and/or add `.nvmrc` so local environments match CI.

Closes #645

🤖 Generated with [Claude Code](https://claude.com/claude-code)
