### PR TITLE
Tune alpha live verification gates

### DIFF
--- a/.github/workflows/alpha-live-verification.yml
+++ b/.github/workflows/alpha-live-verification.yml
@@ -5,7 +5,7 @@ on:
     inputs:
       suites:
         description: 'Comma-separated suites: stt,v,a,b,c,d,e,h-ui,h,q,m,t,all (h is a compatibility alias for h-ui)'
-        default: 'stt,v,b,d,e'
+        default: 'stt,v,b,c,q,h-ui'
         type: string
       timestamp:
         description: 'Stable timestamp marker. Empty uses current UTC time.'
@@ -135,6 +135,7 @@ jobs:
           API_SECRET_KEY: ${{ secrets.BACKEND_API_KEY }}
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
           OPENROUTER_API_KEY: ${{ secrets.OPENROUTER_API_KEY }}
+          RAG_API_LIVE_OPENAI_SECRET_NAMES: OPENAI_API_KEY,openai-api-key
           SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
           SUPABASE_KEY: ${{ secrets.SUPABASE_KEY }}
         run: scripts/rag-api-live-test.sh --timestamp "${ALPHA_TIMESTAMP}-c" --languages ja,en,zh,ko

--- a/frontend/playwright.config.ts
+++ b/frontend/playwright.config.ts
@@ -7,6 +7,7 @@ loadEnv({ path: '.env.local' });
 loadEnv({ path: '.env' });
 
 const baseURL = process.env.PLAYWRIGHT_BASE_URL ?? 'http://127.0.0.1:3000';
+const videoMode = process.env.PLAYWRIGHT_VIDEO === 'off' ? 'off' : 'retain-on-failure';
 
 export default defineConfig({
   testDir: './e2e',
@@ -19,7 +20,7 @@ export default defineConfig({
     baseURL,
     trace: process.env.CI ? 'retain-on-failure' : 'on-first-retry',
     screenshot: 'only-on-failure',
-    video: 'retain-on-failure',
+    video: videoMode,
     actionTimeout: 15_000,
     navigationTimeout: 30_000,
   },

--- a/scripts/rag-api-live-test.sh
+++ b/scripts/rag-api-live-test.sh
@@ -13,6 +13,7 @@ set -euo pipefail
 #   RAG_API_LIVE_SECRET_PROJECT    Overrides Secret Manager project.
 #   RAG_API_LIVE_METRICS           Comma-separated RAGAS metrics.
 #   OPENAI_API_KEY / OPENROUTER_API_KEY are required by the RAGAS evaluator.
+#   If neither is set, this script tries Secret Manager. Direct OpenAI is preferred.
 
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 RUNNER="$ROOT_DIR/backend/evaluation/run_live_api_eval.py"
@@ -21,6 +22,8 @@ BASE_URL="${RAG_API_LIVE_BASE_URL:-$DEFAULT_URL}"
 API_KEY="${API_SECRET_KEY:-}"
 SECRET_PROJECT="${RAG_API_LIVE_SECRET_PROJECT:-aipartner-426616}"
 SECRET_NAME="API_SECRET_KEY"
+OPENAI_SECRET_NAMES="${RAG_API_LIVE_OPENAI_SECRET_NAMES:-OPENAI_API_KEY,openai-api-key}"
+OPENROUTER_SECRET_NAMES="${RAG_API_LIVE_OPENROUTER_SECRET_NAMES:-OPENROUTER_API_KEY}"
 OUTPUT_DIR="$ROOT_DIR/backend/tests/evaluation/reports"
 LANGUAGES="ja,en,zh,ko"
 METRICS="${RAG_API_LIVE_METRICS:-answer_correctness}"
@@ -37,6 +40,9 @@ Options:
   --key VALUE            API key; skips Secret Manager lookup
   --secret-project ID    GCP project for Secret Manager (default: aipartner-426616)
   --secret-name NAME     Secret Manager secret name (default: API_SECRET_KEY)
+  --openai-secret-names  Comma-separated OpenAI judge secret names (default: OPENAI_API_KEY,openai-api-key)
+  --openrouter-secret-names
+                         Comma-separated OpenRouter fallback secret names (default: OPENROUTER_API_KEY)
   --languages LIST       Comma-separated languages (default: ja,en,zh,ko)
   --metrics LIST         Comma-separated RAGAS metrics (default: answer_correctness)
   --output-dir DIR       Report directory (default: backend/tests/evaluation/reports)
@@ -58,6 +64,8 @@ while [ "$#" -gt 0 ]; do
     --key) API_KEY="$2"; shift 2 ;;
     --secret-project) SECRET_PROJECT="$2"; shift 2 ;;
     --secret-name) SECRET_NAME="$2"; shift 2 ;;
+    --openai-secret-names) OPENAI_SECRET_NAMES="$2"; shift 2 ;;
+    --openrouter-secret-names) OPENROUTER_SECRET_NAMES="$2"; shift 2 ;;
     --languages) LANGUAGES="$2"; shift 2 ;;
     --metrics) METRICS="$2"; shift 2 ;;
     --output-dir) OUTPUT_DIR="$2"; shift 2 ;;
@@ -91,12 +99,38 @@ fetch_secret_from_gcloud() {
   fi
 }
 
+fetch_first_secret_from_gcloud() {
+  local names_csv="$1"
+  local value
+  IFS=',' read -r -a names <<< "$names_csv"
+  for secret_name in "${names[@]}"; do
+    secret_name="$(printf '%s' "$secret_name" | xargs)"
+    if [ -z "$secret_name" ]; then
+      continue
+    fi
+    value="$(fetch_secret_from_gcloud "$secret_name")"
+    if [ -n "$value" ]; then
+      printf '%s' "$value"
+      return 0
+    fi
+  done
+}
+
 require_ragas_judge_key() {
+  if [ -z "${OPENAI_API_KEY:-}" ]; then
+    OPENAI_API_KEY="$(fetch_first_secret_from_gcloud "$OPENAI_SECRET_NAMES")"
+    export OPENAI_API_KEY
+  fi
   if [ -z "${OPENAI_API_KEY:-}" ] && [ -z "${OPENROUTER_API_KEY:-}" ]; then
-    OPENROUTER_API_KEY="$(fetch_secret_from_gcloud OPENROUTER_API_KEY)"
+    OPENROUTER_API_KEY="$(fetch_first_secret_from_gcloud "$OPENROUTER_SECRET_NAMES")"
     export OPENROUTER_API_KEY
   fi
-  if [ -n "${OPENAI_API_KEY:-}" ] || [ -n "${OPENROUTER_API_KEY:-}" ]; then
+  if [ -n "${OPENAI_API_KEY:-}" ]; then
+    echo "RAGAS judge provider: direct OpenAI"
+    return
+  fi
+  if [ -n "${OPENROUTER_API_KEY:-}" ]; then
+    echo "RAGAS judge provider: OpenRouter fallback"
     return
   fi
 

--- a/scripts/welcome-live-preflight.sh
+++ b/scripts/welcome-live-preflight.sh
@@ -78,7 +78,7 @@ if [ "$DRY_RUN" = "1" ]; then
   echo "Delays: $DELAYS"
   echo "Output: $OUTPUT_DIR/welcome-live-preflight-$TIMESTAMP.md"
   echo "Audio source: frontend/e2e/fixtures/voice/sample.wav (fixture, not on-site microphone)"
-  echo "Command: PLAYWRIGHT_WELCOME_LIVE=1 BACKEND_API_URL=$BASE_URL BACKEND_API_KEY=<redacted> PLAYWRIGHT_WELCOME_VOICE_DELAYS=$DELAYS pnpm --dir frontend exec playwright test --config=playwright.config.ts e2e/welcome-live.spec.ts --project=chromium-voice-live --workers=1"
+  echo "Command: PLAYWRIGHT_WELCOME_LIVE=1 BACKEND_API_URL=$BASE_URL BACKEND_API_KEY=<redacted> PLAYWRIGHT_WELCOME_VOICE_DELAYS=$DELAYS PLAYWRIGHT_VIDEO=\${PLAYWRIGHT_VIDEO:-off} pnpm --dir frontend exec playwright test --config=playwright.config.ts e2e/welcome-live.spec.ts --project=chromium-voice-live --workers=1"
   exit 0
 fi
 
@@ -92,6 +92,7 @@ BACKEND_API_KEY="$API_KEY" \
 PLAYWRIGHT_WELCOME_LIVE=1 \
 PLAYWRIGHT_WELCOME_TIMESTAMP="$TIMESTAMP" \
 PLAYWRIGHT_WELCOME_VOICE_DELAYS="$DELAYS" \
+PLAYWRIGHT_VIDEO="${PLAYWRIGHT_VIDEO:-off}" \
 pnpm --dir "$ROOT_DIR/frontend" exec playwright test \
   --config=playwright.config.ts \
   e2e/welcome-live.spec.ts \


### PR DESCRIPTION
## Summary
- narrow the default alpha-live-verification dispatch to the current alpha-scope loop: stt,v,b,c,q,h-ui
- prefer direct OpenAI for live RAGAS judge resolution, including the existing GCP Secret Manager name openai-api-key, with OpenRouter as fallback
- allow Welcome live Playwright runs to disable video by default to avoid oversized artifacts while retaining traces/screenshots

## Verification
- bash -n scripts/rag-api-live-test.sh
- bash -n scripts/welcome-live-preflight.sh
- scripts/rag-api-live-test.sh --dry-run --languages ja --metrics answer_correctness --timestamp codex-dry-run
- scripts/welcome-live-preflight.sh --dry-run --timestamp codex-dry-run
- pnpm --dir frontend exec playwright test --list --project=chromium-voice-live e2e/welcome-live.spec.ts
- git diff --check

## Notes
- GitHub Actions already has OPENAI_API_KEY; GCP Secret Manager has openai-api-key. This change makes both paths usable without exposing secret values.
- Issue #583 still claims 127 live RAGAS cases, but the current live API dataset has 29 cases. That needs separate gate coverage triage.