### PR TITLE
Fix voice live CI response wait

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -246,6 +246,7 @@ jobs:
         env:
           CI: true
           PLAYWRIGHT_VOICE_LIVE: '1'
+          PLAYWRIGHT_VIDEO: 'off'
           NEXT_PUBLIC_SUPABASE_URL: ${{ secrets.NEXT_PUBLIC_SUPABASE_URL || 'https://placeholder.supabase.co' }}
           NEXT_PUBLIC_SUPABASE_ANON_KEY: ${{ secrets.NEXT_PUBLIC_SUPABASE_ANON_KEY || 'placeholder-anon-key' }}
           SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.SUPABASE_SERVICE_ROLE_KEY || 'placeholder-service-role-key' }}
@@ -268,22 +269,6 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: playwright-voice-live-test-results
-          path: frontend/test-results
-          retention-days: 14
-
-      - name: Upload Playwright HTML report
-        if: failure()
-        uses: actions/upload-artifact@v4
-        with:
-          name: playwright-report
-          path: frontend/playwright-report
-          retention-days: 14
-
-      - name: Upload Playwright test results
-        if: failure()
-        uses: actions/upload-artifact@v4
-        with:
-          name: playwright-test-results
           path: frontend/test-results
           retention-days: 14
 

--- a/frontend/e2e/voice-live.spec.ts
+++ b/frontend/e2e/voice-live.spec.ts
@@ -51,6 +51,19 @@ function parseAction(request: Request): string | undefined {
   }
 }
 
+async function readResponseText(page: Page): Promise<string> {
+  const responseText = page.getByTestId('response-text');
+  if ((await responseText.count()) === 0) {
+    return '';
+  }
+
+  try {
+    return ((await responseText.first().textContent({ timeout: 1_000 })) ?? '').trim();
+  } catch {
+    return '';
+  }
+}
+
 const ENGINEER_CAFE_PATTERN = /engineer\s*cafe|エンジニア\s*カフェ/i;
 
 test.describe('Voice live (browser voice round-trip against live backend)', () => {
@@ -83,9 +96,8 @@ test.describe('Voice live (browser voice round-trip against live backend)', () =
     await expect(voiceButton).toBeVisible({ timeout: 15_000 });
     await expect(voiceButton).toBeEnabled();
 
-    const responseText = page.getByTestId('response-text');
-    await expect(responseText).toBeVisible();
-    const baselineText = ((await responseText.textContent()) ?? '').trim();
+    await expect(page.getByTestId('response-text')).toBeVisible();
+    const baselineText = await readResponseText(page);
 
     // Pre-arm the response waiters BEFORE clicking so fast backends can't race
     // us to the timeout threshold. Each promise resolves on the first matching
@@ -162,13 +174,18 @@ test.describe('Voice live (browser voice round-trip against live backend)', () =
       typeof audioResponse === 'string' && audioResponse.length > 0,
     ).toBe(true);
 
+    let finalText = '';
     await expect
-      .poll(async () => ((await responseText.textContent()) ?? '').trim(), {
-        timeout: 60_000,
-      })
-      .not.toBe(baselineText);
+      .poll(
+        async () => {
+          const currentText = await readResponseText(page);
+          finalText = normalizeText(currentText);
+          return currentText && currentText !== baselineText ? finalText : '';
+        },
+        { timeout: 90_000 },
+      )
+      .toBe(qaAnswer);
 
-    const finalText = normalizeText((await responseText.textContent()) ?? '');
     expect(finalText.length).toBeGreaterThan(20);
     expect(finalText).toMatch(/[A-Za-z\u3040-\u30ff\u4e00-\u9fff]/);
     expect(finalText.toLowerCase()).not.toContain('internal server error');


### PR DESCRIPTION
## Summary
- Make the live voice E2E response assertion resilient to the kiosk response bubble being conditionally mounted.
- Wait until the displayed response normalizes exactly to the live QA answer instead of only checking it changed from the default prompt.
- Disable Playwright video for the voice-live CI job and remove duplicate failure artifact uploads.

## Verification
- pnpm --dir frontend exec playwright test --list --project=chromium-voice-live e2e/voice-live.spec.ts
- git diff --check
- pnpm --dir frontend lint
- pnpm --dir frontend typecheck