### PR TITLE
Show kiosk response before playback starts

### DIFF
--- a/frontend/src/__tests__/kiosk-response-display.test.ts
+++ b/frontend/src/__tests__/kiosk-response-display.test.ts
@@ -40,6 +40,26 @@ test('keeps showing the response while its visibility window is still active', (
   });
 });
 
+test('shows the response while playback is pending', () => {
+  const now = 10_000;
+
+  const result = getKioskResponseDisplayState({
+    response: 'Thanks for visiting.',
+    sessionState: 'processing',
+    responseVisibleUntil: now - 1,
+    responsePendingPlayback: true,
+    defaultPromptVisibleUntil: now + 5_000,
+    now,
+    defaultPrompt: 'Ask a question to get started.',
+  });
+
+  assert.deepEqual(result, {
+    text: 'Thanks for visiting.',
+    showBubble: true,
+    isLiveResponse: true,
+  });
+});
+
 test('hides the bubble when neither a live response nor the default prompt should be visible', () => {
   const now = 10_000;
 

--- a/frontend/src/app/components/KioskVoiceStatusStack.tsx
+++ b/frontend/src/app/components/KioskVoiceStatusStack.tsx
@@ -151,6 +151,7 @@ export function KioskVoiceStatusStack({
     response,
     sessionState,
     responseVisibleUntil,
+    responsePendingPlayback: isTtsSynthesizing,
     defaultPromptVisibleUntil,
     now,
     defaultPrompt: labels.defaultPrompt,

--- a/frontend/src/lib/kiosk-response-display.ts
+++ b/frontend/src/lib/kiosk-response-display.ts
@@ -4,6 +4,7 @@ export function getKioskResponseDisplayState({
   response,
   sessionState,
   responseVisibleUntil,
+  responsePendingPlayback = false,
   defaultPromptVisibleUntil,
   now,
   defaultPrompt,
@@ -11,6 +12,7 @@ export function getKioskResponseDisplayState({
   response: string;
   sessionState: KioskResponseSessionState;
   responseVisibleUntil: number;
+  responsePendingPlayback?: boolean;
   defaultPromptVisibleUntil: number;
   now: number;
   defaultPrompt: string;
@@ -21,7 +23,9 @@ export function getKioskResponseDisplayState({
 } {
   const isLiveResponse =
     response.length > 0 &&
-    (sessionState === 'speaking' || responseVisibleUntil > now);
+    (sessionState === 'speaking' ||
+      responsePendingPlayback ||
+      responseVisibleUntil > now);
   const isDefaultPrompt =
     sessionState === 'idle' &&
     defaultPromptVisibleUntil > now &&


### PR DESCRIPTION
## Summary
- Show the kiosk response bubble once QA has produced an answer and TTS playback is pending.
- Avoid depending on browser audio playback start before the live response text becomes observable.
- Add coverage for the pending-playback response display state.

## Verification
- pnpm --dir frontend exec tsx --test src/__tests__/kiosk-response-display.test.ts
- pnpm --dir frontend typecheck
- pnpm --dir frontend exec playwright test --list --project=chromium-voice-live e2e/voice-live.spec.ts
- pnpm --dir frontend lint
- git diff --check