### PR TITLE
Show kiosk response while processing

### DIFF
--- a/frontend/src/__tests__/kiosk-response-display.test.ts
+++ b/frontend/src/__tests__/kiosk-response-display.test.ts
@@ -60,6 +60,25 @@ test('shows the response while playback is pending', () => {
   });
 });
 
+test('shows the response while processing continues before playback starts', () => {
+  const now = 10_000;
+
+  const result = getKioskResponseDisplayState({
+    response: 'Thanks for visiting.',
+    sessionState: 'processing',
+    responseVisibleUntil: now - 1,
+    defaultPromptVisibleUntil: now + 5_000,
+    now,
+    defaultPrompt: 'Ask a question to get started.',
+  });
+
+  assert.deepEqual(result, {
+    text: 'Thanks for visiting.',
+    showBubble: true,
+    isLiveResponse: true,
+  });
+});
+
 test('hides the bubble when neither a live response nor the default prompt should be visible', () => {
   const now = 10_000;
 

--- a/frontend/src/lib/kiosk-response-display.ts
+++ b/frontend/src/lib/kiosk-response-display.ts
@@ -23,7 +23,8 @@ export function getKioskResponseDisplayState({
 } {
   const isLiveResponse =
     response.length > 0 &&
-    (sessionState === 'speaking' ||
+    (sessionState === 'processing' ||
+      sessionState === 'speaking' ||
       responsePendingPlayback ||
       responseVisibleUntil > now);
   const isDefaultPrompt =


### PR DESCRIPTION
## Summary
- Keep the kiosk response bubble visible while a voice turn remains in processing with an answer already available.
- Cover the post-QA/pre-playback processing state that develop push CI exposed.

## Verification
- pnpm --dir frontend exec tsx --test src/__tests__/kiosk-response-display.test.ts
- pnpm --dir frontend typecheck
- pnpm --dir frontend lint
- git diff --check