### PR TITLE
Record alpha backend redeploy intent

### DIFF
--- a/backend/docs/ALPHA_DEPLOYMENT_LOG.md
+++ b/backend/docs/ALPHA_DEPLOYMENT_LOG.md
@@ -1,0 +1,13 @@
+# Alpha Deployment Log
+
+This file records backend redeploys that are intentionally created to align the
+Cloud Run image tag with the current `develop` commit before alpha live
+verification.
+
+## 2026-05-02
+
+- Purpose: redeploy the backend after frontend-only alpha gate fixes so
+  `alpha-live-verification` can run with `require_deployed_sha_match=true`.
+- Expected validation: `backend-deploy-staging` builds and deploys an image
+  tagged with the merge commit SHA, then Cloud Run health and alpha suites can
+  be verified against that exact commit.


### PR DESCRIPTION
## Summary
- add a backend alpha deployment log entry for the SHA-sync redeploy
- intentionally touch backend/** so the normal develop backend-deploy-staging path builds and deploys a Cloud Run image tagged with the merge SHA

## Validation
- git diff --cached --check

## Follow-up
- after merge, confirm backend-deploy-staging passes and Cloud Run image contains the develop merge SHA before dispatching alpha-live-verification with require_deployed_sha_match=true