### PR TITLE
docs: record alpha verification status

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,10 +6,10 @@
 
 ## 現在の要約
 
-- フロントエンドの主要 API route は 2026-03-14 時点で FastAPI バックエンドへの proxy 化が進み、Mastra 依存の残骸除去も進行済みです。
-- 直近では Web Audio autoplay、VRM 互換性、WebM→WAV 変換などの修正が続いており、現在は機能追加より安定化フェーズの色が強いです。
-- バックエンドは `pytest --collect-only -q` ベースで 2,868 件のテストが収集されますが、リポジトリ全体では fix 連打と低い test commit 比率が続いています。
-- すぐに本番品質とみなせる状態ではありません。特に管理系 route の認証、受付フローの永続化、運用ガードレールが未完です。
+- 2026-05-02 時点で、alpha live verification の full-suite workflow は Cloud Run SHA match 付きで実行できます。
+- Cloud Run staging は develop SHA `fa7745b7420c0709fcff950ed3bf4c090f0dfc55` の revision `engineer-cafe-backend-00144-q85` で検証済みです。
+- RAGAS evaluator は GitHub Actions secret 修正後、direct OpenAI で動くことを確認済みです。
+- ただし alpha はまだ **NO-GO** です。STT latency、B routing、Welcome UI、Q/C answer quality、RAGAS 127-case coverage、Cloud Run log hygiene が残っています。
 
 詳細は [docs/STATUS.md](docs/STATUS.md) を参照してください。
 
@@ -36,10 +36,11 @@ Browser
 
 ## 現時点の主要リスク
 
-- フロント側の管理・監視系 endpoint に未認証 route が残っています。
-- バックエンドの API key 保護は local/dev では `API_SECRET_KEY` 未設定時に無効化されますが、`staging` / `preview` / `production` では fail-closed です。
-- `backend/api/reception.py` は受付セッションをメモリ保持しており、再起動や複数インスタンスに弱いです。
-- ドキュメント群には Mastra 前提や古い agent 構成が残っており、文書の現役/履歴の区別が不十分でした。
+- alpha gate は end-to-end で回るが、最新 full run は failure です。
+- `continue-on-error` のため、GitHub step が success に見えても suite outcome が failure の場合があります。
+- STT preflight は現行 revision と過去24h履歴が混ざり、release 判定として過敏/不透明です。
+- RAGAS は direct OpenAI に修正済みですが、JA answer_correctness と 29-vs-127 coverage が未解決です。
+- Welcome UI live scenario は `kiosk-welcome-ocr-overlay` が見つからず失敗します。
 
 この README は現況の入口だけを扱います。監査結果と production readiness の論点は [docs/STATUS.md](docs/STATUS.md) に集約しています。
 
@@ -80,23 +81,21 @@ make dev
 
 ## ドキュメント
 
-- [docs/STATUS.md](docs/STATUS.md): 2026-03-14 時点の実装状況、リスク、production gap
+- [docs/STATUS.md](docs/STATUS.md): 現在の alpha / production readiness 状態
 - [docs/README.md](docs/README.md): 現役ドキュメントと履歴ドキュメントの整理
+- [docs/testing/alpha-live-verification-status-2026-05-02.md](docs/testing/alpha-live-verification-status-2026-05-02.md): 最新 alpha live verification 結果
+- [docs/plans/alpha-remediation-plan-2026-05-02.md](docs/plans/alpha-remediation-plan-2026-05-02.md): 次実装順
 - [frontend/README.md](frontend/README.md): フロントエンドの現況と環境変数
 - [backend/README.md](backend/README.md): バックエンドの現況と運用上の注意
 - [docs/DEVELOPER-GUIDE.md](docs/DEVELOPER-GUIDE.md): 現行の開発導線
 
 ## GitHub の現況
 
-2026-03-14 時点で把握した主要な open items:
+2026-05-02 時点で把握した主要な alpha open items:
 
-- Issue `#232`: 2026-03-14 production hardening umbrella tracker
-- Issue `#197`: Admin / CRON / Monitoring 保護
-- Issue `#209`: 音声主体 UI に対するバブルオーバーレイ整理
-- Issue `#224`: フロントの完全 backend proxy 化の残課題整理
-- Issue `#165`: Reception-2025 との統合境界と shared data 活用
-- PR `#132`: 管理認証 middleware の draft
-- PR `#215`: 新 knowledge UI
+- P0: `#658`, `#659`, `#660`, `#657`, `#643`, `#623`, `#612`, `#611`, `#585`, `#584`, `#583`
+- P1: `#672`, `#670`, `#669`, `#663`, `#662`, `#661`, `#655`, `#653`
+- `#671` は GitHub Actions RAGAS provider secret 問題として作成し、direct OpenAI 確認後に close 済みです。
 
 ## 注意
 

--- a/backend/docs/ALPHA_DEPLOYMENT_LOG.md
+++ b/backend/docs/ALPHA_DEPLOYMENT_LOG.md
@@ -11,3 +11,10 @@ verification.
 - Expected validation: `backend-deploy-staging` builds and deploys an image
   tagged with the merge commit SHA, then Cloud Run health and alpha suites can
   be verified against that exact commit.
+- Result:
+  - PR #667 merged to `develop`.
+  - Cloud Run revision `engineer-cafe-backend-00144-q85` deployed.
+  - Image tag matched `fa7745b7420c0709fcff950ed3bf4c090f0dfc55`.
+  - Full alpha run `25244933308` executed and ended failure.
+  - Targeted C/RAGAS run `25247945549` verified direct OpenAI after syncing
+    GitHub Actions `OPENAI_API_KEY`.

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,11 +1,13 @@
 # Documentation Map
 
-> 2026-04-30 時点での現役ドキュメント案内です。まずこのページから参照してください。
+> 2026-05-02 時点での現役ドキュメント案内です。まずこのページから参照してください。
 
 ## まず読む文書
 
 - [../README.md](../README.md): プロジェクト全体の現在地
 - [STATUS.md](STATUS.md): 実装済み事項と、いま残っている本当の運用リスク
+- [testing/alpha-live-verification-status-2026-05-02.md](testing/alpha-live-verification-status-2026-05-02.md): 最新 alpha live verification 結果
+- [plans/alpha-remediation-plan-2026-05-02.md](plans/alpha-remediation-plan-2026-05-02.md): 次実装順
 - [SECURITY.md](SECURITY.md): 現在の auth 連鎖と残課題
 - [DEPLOYMENT.md](DEPLOYMENT.md): Vercel + Cloud Run の現行デプロイ運用
 - [plans/alpha-fast-response-implementation-2026-04-30.md](plans/alpha-fast-response-implementation-2026-04-30.md): Alpha Phase 4 の高速応答 / identity routing 実装計画
@@ -21,6 +23,9 @@
 - [SECURITY.md](SECURITY.md)
 - [DEPLOYMENT.md](DEPLOYMENT.md)
 - [CHANGELOG.md](CHANGELOG.md)
+- [testing/alpha-live-verification-status-2026-05-02.md](testing/alpha-live-verification-status-2026-05-02.md)
+- [testing/alpha-final-scenarios.md](testing/alpha-final-scenarios.md)
+- [plans/alpha-remediation-plan-2026-05-02.md](plans/alpha-remediation-plan-2026-05-02.md)
 - [plans/alpha-fast-response-implementation-2026-04-30.md](plans/alpha-fast-response-implementation-2026-04-30.md)
 - [plans/production-readiness-followup-2026-04-19.md](plans/production-readiness-followup-2026-04-19.md)
 
@@ -47,6 +52,7 @@
 - `docs/plans/production-hardening-session-2026-03-14.md`
 - `docs/plans/alpha-trial-p1-remediation-2026-04-13.md`
 - `docs/plans/deployment-readiness-2026-03-15.md`
+- `docs/testing/alpha-live-verification-status-2026-04-25.md`
 - `docs/plans/production-readiness-followup-2026-04-19.md` は履歴ではないが、2026-04-30 以降の alpha blocker 判断では `alpha-fast-response-implementation-2026-04-30.md` を優先する
 
 ## 読むときに注意が必要な文書
@@ -73,8 +79,9 @@
 
 ## 直近の次アクション
 
-- ADR 018 に従い、identity / help / capability を deterministic fast path にする
-- General fallback を daily/general light と current-info search path に分ける
-- Gemini / Cerebras の model id と latency を公式 API + live benchmark で確認してから Cloud Run env に反映する
-- API / architecture / development 文書の stale 記述を段階的に更新または archive に移す
-- Supabase の運用ログ確認手順を別途整備する
+- #658 STT preflight latency を current revision 観点で修正する
+- #660 H-UI Welcome OCR overlay / wait condition を修正する
+- #659 `B1-BIZ-002` routing を修正する
+- #653 / #672 の Q/C answer quality failure を修正する
+- #662 の Supabase UUID/log hygiene を修正する
+- #661 / #670 で artifact size と RAGAS progress telemetry を改善する

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -1,16 +1,18 @@
 # 現在の状態
 
-Last updated: 2026-04-30
+Last updated: 2026-05-02
 
 ## 概要
 
-このページは、`develop` 上の現行コード、2026-04-19 の live audit、2026-04-29 の実機音声 UX 確認をもとに更新しています。
+このページは、`develop` 上の現行コード、2026-04-19 の live audit、2026-04-29 の実機音声 UX 確認、
+2026-05-02 の alpha-live-verification full run / targeted C run をもとに更新しています。
 
 確認元:
 
 - 2026-04-16 から 2026-04-19 UTC の Cloud Run ログ
 - 2026-04-19 UTC の直近 Vercel production deploy
 - 2026-04-29 JST の mobile / kiosk 実地確認 screenshot と Cloud Run structured logs
+- 2026-05-02 JST の `alpha-live-verification` run `25244933308` / `25247945549`
 - 現在 open の GitHub Issue
 
 Supabase については、CLI で linked project の確認まではできましたが、このセッションでは recent runtime log
@@ -19,19 +21,48 @@ Supabase については、CLI で linked project の確認まではできまし
 現状の結論:
 
 - キオスクのコアフロー自体は実装済み
-- ただし 2026-04-29 の実地確認により、alpha release はそのまま GO できない
-- 現在の主リスクは「未実装の基本機能」ではなく「会話 UX の基本品質、実測 latency、route 整合性」
+- alpha live verification workflow は Cloud Run SHA match 付きで end-to-end 実行できる
+- RAGAS evaluator は direct OpenAI で動くことを確認済み
+- ただし 2026-05-02 の full run は failure で、alpha release はまだ GO できない
+- 現在の主リスクは「未実装の基本機能」ではなく「会話 UX の基本品質、実測 latency、route 整合性、評価 gate の透明性」
 
-特に優先度が高いのは次の 5 点です。
+特に優先度が高いのは次の 6 点です。
 
-1. identity / help / capability 質問が provider 自己紹介や雑な general answer に落ちる問題
-2. rank graph に入らない一般質問が RAG miss -> web search -> heavyweight LLM に流れる latency 問題
-3. stale request type / mode により、次 turn が SlideAgent など誤 route に流れる問題
-4. voice / chat / TTS の実機 p95 latency が alpha UX に達していない問題
-5. deploy 時の frontend -> backend 認証ドリフト
+1. STT preflight latency が alpha gate を落としている問題
+2. H-UI Welcome OCR overlay が live scenario で見つからない問題
+3. B routing の `B1-BIZ-002` 誤判定
+4. Q/C answer quality と RAGAS JA target miss
+5. RAGAS 29-case gate と 127-case requirement の不一致
+6. Cloud Run / Supabase log hygiene と artifact size / progress telemetry
 
 現行の実装判断は [ADR 018](adr/018-alpha-fast-response-and-assistant-profile-routing.md) と
-[Alpha Fast Response Implementation Plan](plans/alpha-fast-response-implementation-2026-04-30.md) を優先する。
+[Alpha Remediation Plan 2026-05-02](plans/alpha-remediation-plan-2026-05-02.md) を優先する。
+
+## 2026-05-02 Alpha Live Verification Snapshot
+
+最新の正本は [Alpha Live Verification Status 2026-05-02](testing/alpha-live-verification-status-2026-05-02.md)。
+
+- Full run: `25244933308`
+- Targeted C/RAGAS run: `25247945549`
+- Cloud Run revision: `engineer-cafe-backend-00144-q85`
+- develop SHA: `fa7745b7420c0709fcff950ed3bf4c090f0dfc55`
+- SHA match: pass
+- Full run conclusion: failure
+- Direct OpenAI RAGAS: confirmed after GitHub Secret `OPENAI_API_KEY` sync
+
+Resolved in this session:
+
+- #671: RAGAS provider secret issue. `OPENAI_API_KEY` is now available to the workflow, and C uses direct OpenAI.
+
+Still blocking:
+
+- #658: STT preflight latency
+- #659: B routing `B1-BIZ-002`
+- #660: H-UI Welcome OCR overlay
+- #657 / #583: RAGAS 29 vs 127 coverage
+- #653 / #672: Q/C answer quality
+- #662: Supabase UUID/log errors
+- #661 / #670: artifact size and RAGAS telemetry
 
 ## 実装済みとして確認できたこと
 
@@ -182,36 +213,34 @@ current turn の high-confidence intent なしに route を固定してはいけ
 
 ## いま重要な Open Issues
 
-- `#618`: daily / identity / general fallback の lightweight no-thinking model 分離
-- `#617`: stale request type / mode による誤 route
-- `#616`: Welcome camera/OCR-first と push-to-talk UX
-- `#615`: identity / general question の回答品質
-- `#613`: 実機音声 turn latency
+- `#658`: STT preflight latency
+- `#660`: Welcome UI live scenario
+- `#659`: B routing / slide live smoke
+- `#657`: RAGAS gate 29 vs 127
+- `#653`: Q-content quality
+- `#672`: Direct OpenAI C/RAGAS JA target miss
+- `#662`: Supabase UUID/log hygiene
+- `#661`: alpha artifact size
+- `#669`: deployed tRAG translation model missing
+- `#670`: C/RAGAS runtime and telemetry
 - `#611`: Cerebras dynamic filler / fast first-response path
-- `#468`: deploy-time auth drift guardrails
-- `#140`: load / latency baseline
-- `#458`: emotion / expression / animation alignment
-- `#190`: live character validation
-- `#117`: autonomous reception flow integration
-- `#138`: multilingual quality improvements
-- `#398`: multilingual RAGAS improvement phase 2
 
 ## 推奨する実装順
 
-1. identity / help / capability fast path を実装する (`#615`, `#618`)
-2. General fallback を daily/general light と current-info search path に分ける (`#618`, `#617`)
-3. Gemini / Cerebras 候補を公式 API availability + live benchmark で選定する (`#611`, `#613`)
-4. Welcome camera/OCR-first と push-to-talk UX を直す (`#616`)
-5. deploy-time authenticated smoke check を維持・強化する (`#468`)
-6. live latency baseline と load test を整備する (`#140`)
-7. emotion -> expression -> animation の契約を一本化する (`#458`, `#190`)
-8. multilingual quality を評価基準込みで閉じる (`#138`, `#398`)
-9. reception の残作業を行動フロー中心に進める (`#117`)
+1. STT preflight latency と current revision scoping を直す (`#658`)
+2. H-UI Welcome OCR overlay / wait condition を直す (`#660`)
+3. B routing `B1-BIZ-002` を直す (`#659`)
+4. Q/C answer quality を直す (`#653`, `#672`)
+5. Supabase UUID/log hygiene を直す (`#662`)
+6. artifact size と RAGAS progress telemetry を直す (`#661`, `#670`)
+7. RAGAS 127-case gate を定義・実装する (`#657`, `#583`)
 
 ## 参照
 
 - [SECURITY.md](SECURITY.md)
 - [DEPLOYMENT.md](DEPLOYMENT.md)
+- [testing/alpha-live-verification-status-2026-05-02.md](testing/alpha-live-verification-status-2026-05-02.md)
+- [plans/alpha-remediation-plan-2026-05-02.md](plans/alpha-remediation-plan-2026-05-02.md)
 - [plans/alpha-fast-response-implementation-2026-04-30.md](plans/alpha-fast-response-implementation-2026-04-30.md)
 - [adr/018-alpha-fast-response-and-assistant-profile-routing.md](adr/018-alpha-fast-response-and-assistant-profile-routing.md)
 - [plans/production-readiness-followup-2026-04-19.md](plans/production-readiness-followup-2026-04-19.md)

--- a/docs/adr/008-operational-verification-and-deployment-guardrails.md
+++ b/docs/adr/008-operational-verification-and-deployment-guardrails.md
@@ -82,3 +82,13 @@ live log review と documented baseline が必要です。
 - Issue `#468`: deploy smoke gate による auth drift 防止
 - Issue `#140`: latency / load baseline
 - `docs/STATUS.md`, `docs/SECURITY.md`, `docs/DEPLOYMENT.md` を 2026-04-19 時点に更新
+
+## 2026-05-02 追記
+
+Alpha live verification の運用結果を踏まえ、以下をガードレールに追加する。
+
+- `alpha-live-verification` の GO 証跡は `require_deployed_sha_match=true` を必須にする。
+- GitHub Actions の `continue-on-error` step conclusion は正本にしない。workflow summary と report artifact の suite outcome を正本にする。
+- Alpha RAGAS は direct OpenAI を必須にする。`OPENAI_API_KEY` が空で OpenRouter fallback になった run は diagnostic として扱う。
+- Artifact は compact failure summary と heavy trace/video を分ける。932MB 級 artifact は triage 阻害として扱う。
+- STT preflight は historical 24h risk と current revision release gate を分ける。過去 revision の outlier だけで現行 release gate を落とさない。

--- a/docs/adr/018-alpha-fast-response-and-assistant-profile-routing.md
+++ b/docs/adr/018-alpha-fast-response-and-assistant-profile-routing.md
@@ -157,6 +157,23 @@ fast path は env flag と route condition で無効化できる構成にする�
 5. benchmark: Gemini 3.1 Flash-Lite, Gemini 2.5 Flash-Lite, Cerebras `gpt-oss-120b` を同一 prompt set で p50 / p95 比較すること
 6. live: Cloud Run logs の `chat_response.latency_ms`, `stt_overall_duration_ms`, TTS duration を issue #613 に追記すること
 
+## 2026-05-02 検証結果
+
+`alpha-live-verification` full run `25244933308` で、Cerebras fast path は live log 上で
+`gpt-oss-120b` を使っていることを確認した。ただし alpha GO はまだ不可。
+
+残る優先課題:
+
+- #658: STT preflight latency
+- #660: H-UI Welcome OCR overlay
+- #659: B routing `B1-BIZ-002`
+- #653 / #672: Q/C answer quality
+- #662: Supabase UUID/log hygiene
+
+また、RAGAS は fast response の product path ではなく evaluation path だが、alpha gate の信頼性に直結する。
+2026-05-02 に GitHub Actions `OPENAI_API_KEY` を更新し、run `25247945549` で direct OpenAI
+`gpt-5.2-2025-12-11` が使われることを確認した。OpenRouter fallback は GO 証跡として使わない。
+
 ## 参照
 
 - https://blog.google/innovation-and-ai/models-and-research/gemini-models/gemini-3-1-flash-lite/

--- a/docs/plans/alpha-remediation-plan-2026-05-02.md
+++ b/docs/plans/alpha-remediation-plan-2026-05-02.md
@@ -1,0 +1,119 @@
+# Alpha Remediation Plan 2026-05-02
+
+This is the execution plan for the next implementation session after the 2026-05-02 alpha live
+verification run.
+
+## Current State
+
+The workflow infrastructure is now complete enough to run the alpha gate end to end:
+
+- Cloud Run SHA match gate works.
+- Full suite dispatch works.
+- C/RAGAS can run with direct OpenAI after syncing `OPENAI_API_KEY`.
+- Reports and artifacts are uploaded.
+
+The product is still **NO-GO** for alpha because the latest full suite ended in failure.
+
+## Implementation Order
+
+### 1. #658 STT preflight latency
+
+Goal: make the preflight evaluate the current deployed revision and remove avoidable long-tail
+latency before relying on voice gates.
+
+Tasks:
+
+- Scope `scripts/stt-live-preflight.sh` to the current Cloud Run revision when
+  `ALPHA_SMOKE_CLOUD_RUN_REVISION` is present.
+- Separate historical 24h risk reporting from the release gate for the current revision.
+- Investigate current revision outliers above 30s.
+- Re-run `stt` and `v` suites.
+
+### 2. #660 H-UI Welcome OCR overlay
+
+Goal: make the live welcome scenario assert the real UI state without depending on a missing or
+renamed test id.
+
+Tasks:
+
+- Inspect `frontend/e2e/welcome-live.spec.ts` around the `kiosk-welcome-ocr-overlay` assertion.
+- Confirm whether the overlay is intentionally absent, hidden behind a timing transition, or renamed.
+- Fix the UI/test contract, then run the H-UI suite.
+
+### 3. #659 B routing
+
+Goal: make `B1-BIZ-002` route to `business_info`.
+
+Tasks:
+
+- Reproduce the single query locally or with a targeted live request.
+- Inspect route metadata and classifier decision path for `今日の最終受付は何時ですか。`.
+- Add a focused regression test.
+- Re-run suite `b`.
+
+### 4. #653 / #672 answer quality
+
+Goal: remove current Q/C answer-quality failures without masking real product issues.
+
+Current Q failures:
+
+- `Q-BIZ-EN-003`
+- `Q-EVT-EN-001`
+- `Q-DAILY-JA-001`
+
+Current C/RAGAS direct OpenAI failure:
+
+- JA answer_correctness `0.8295`, target `0.85`
+- weak cases: `ml-ja-003`, `ml-ja-004`
+
+Tasks:
+
+- Read the report artifacts for exact expected facts and actual answers.
+- Decide whether each failure is response generation, source retrieval, ground truth, or threshold drift.
+- Fix the smallest product-side issue first; only adjust tests when the expected answer is wrong.
+- Re-run `q` and `c`.
+
+### 5. #662 Supabase UUID/log hygiene
+
+Goal: stop synthetic alpha session IDs from causing 400 UUID lookup noise.
+
+Tasks:
+
+- Guard UUID-only Supabase queries before hitting `reception_sessions` and `conversation_sessions`.
+- Keep synthetic session IDs valid for test isolation without logging avoidable errors.
+- Add tests around non-UUID session IDs.
+- Re-run the suites that exercise A/B/D.
+
+### 6. #661 / #670 test infrastructure
+
+Goal: make failures obvious and keep artifacts usable.
+
+Tasks:
+
+- Upload compact Markdown/JSON failure summaries separately from Playwright videos and traces.
+- Keep video/trace upload opt-in or failure-only.
+- Emit RAGAS provider/model/case progress while the C gate runs.
+
+### 7. #657 / #583 RAGAS coverage
+
+Goal: reconcile the 29-case diagnostic gate with the 127-case alpha requirement.
+
+Tasks:
+
+- Define which cases are release-blocking versus diagnostic/soak.
+- Add explicit workflow inputs for diagnostic C and full C-127.
+- Do not expand to 127 until #670 telemetry is in place.
+
+## Re-run Strategy
+
+Use targeted suites until the relevant blocker is fixed:
+
+```bash
+gh workflow run alpha-live-verification.yml --ref develop -f suites=stt,v -f require_deployed_sha_match=true
+gh workflow run alpha-live-verification.yml --ref develop -f suites=h-ui -f require_deployed_sha_match=true
+gh workflow run alpha-live-verification.yml --ref develop -f suites=b -f require_deployed_sha_match=true
+gh workflow run alpha-live-verification.yml --ref develop -f suites=q,c -f require_deployed_sha_match=true
+```
+
+Only run `suites=all` after the current P0 blockers have targeted green runs.
+

--- a/docs/testing/alpha-final-scenarios.md
+++ b/docs/testing/alpha-final-scenarios.md
@@ -1,10 +1,17 @@
 # Alpha Final Live Verification Scenarios
 
-Alpha 最終 Live 検証は **2026-04-26** に Cloud Run live 環境で実施予定です。このドキュメントは、事前準備スクリプトがそのまま参照できるように、音声発話、LangGraph routing、adversarial prompt、長文発話サンプルを固定 ID 付きで定義します。
+Alpha 最終 Live 検証は Cloud Run live 環境で実施します。このドキュメントは、事前準備スクリプトがそのまま参照できるように、音声発話、LangGraph routing、adversarial prompt、長文発話サンプルを固定 ID 付きで定義します。
 
 ## Current Status
 
-2026-04-25 時点の live verification は **NO-GO** です。最新の実行結果、残 blocker、再開手順は [Alpha Live Verification Status 2026-04-25](alpha-live-verification-status-2026-04-25.md) を正本として参照してください。
+2026-05-02 時点の live verification は **NO-GO** です。最新の実行結果、残 blocker、再開手順は [Alpha Live Verification Status 2026-05-02](alpha-live-verification-status-2026-05-02.md) を正本として参照してください。
+
+Current confirmed target:
+
+- develop SHA: `fa7745b7420c0709fcff950ed3bf4c090f0dfc55`
+- Cloud Run revision: `engineer-cafe-backend-00144-q85`
+- Full run: `25244933308`
+- Direct OpenAI C/RAGAS run: `25247945549`
 
 ## Live Target
 
@@ -21,6 +28,8 @@ Alpha 最終 Live 検証は **2026-04-26** に Cloud Run live 環境で実施予
 - 受付系の質問では visitor/session ID をスクリプト側で付与し、同一 ID の多ターン文脈維持を検証します。
 - RAGAS は direct RAG 評価と `/api/chat` live API 評価を分離します。`scripts/rag-live-test.sh` は `EnhancedRAGSearch` 直評価、`scripts/rag-api-live-test.sh` は `/api/chat` 経由評価です。
 - A 系の音声本実行前に `scripts/stt-live-preflight.sh` で直近の `stt_winner` latency / timeout 分布を確認します。
+- Alpha GO proof の C/RAGAS は direct OpenAI を必須にします。`RAGAS judge provider: direct OpenAI` が出ない run は diagnostic として扱い、GO 証跡にしません。
+- GitHub step conclusion だけで suite の成否を判断しないでください。`continue-on-error` のため、summary / artifact の suite outcome を正本にします。
 
 ## A-1 Japanese Realistic Utterances
 

--- a/docs/testing/alpha-live-verification-status-2026-05-02.md
+++ b/docs/testing/alpha-live-verification-status-2026-05-02.md
@@ -1,0 +1,135 @@
+# Alpha Live Verification Status 2026-05-02
+
+このドキュメントは、2026-05-02 JST 時点の alpha live verification 正本です。古い
+2026-04-25 status は履歴として残しますが、次の実装判断ではこのファイルを優先します。
+
+## 結論
+
+**NO-GO** です。
+
+`develop` と Cloud Run staging の SHA 同期、full-suite workflow、C/RAGAS direct OpenAI
+実行経路は成立しました。一方で、alpha GO を止める blocker がまだ残っています。
+
+## Deploy / SHA Sync
+
+- PR: #667
+- develop SHA: `fa7745b7420c0709fcff950ed3bf4c090f0dfc55`
+- Cloud Run revision: `engineer-cafe-backend-00144-q85`
+- Image:
+  `asia-northeast1-docker.pkg.dev/aipartner-426616/cloud-run-source-deploy/engineer-cafe-backend:fa7745b7420c0709fcff950ed3bf4c090f0dfc55`
+- Health: `/health` OK
+- `require_deployed_sha_match=true`: PASS
+
+## Runs
+
+### Full Suite
+
+- Run: <https://github.com/EngineerCafeJP/engineercafe-navigator/actions/runs/25244933308>
+- Suites: `all`
+- Result: failure
+- Artifact: `alpha-live-verification-25244933308`, artifact ID `6761318600`
+- Artifact size: `932,009,663` bytes
+
+Final failing outcomes:
+
+| Outcome | Status | Current issue |
+| --- | --- | --- |
+| `stt_preflight` | failure | #658 |
+| `alpha_b` | failure | #659 |
+| `rag_api_live` | failure | #657, #583, #672 |
+| `cloud_logging` | failure | #662 |
+| `quality_q` | failure | #653 |
+| `welcome_live` | failure | #660 |
+
+Important hidden behavior: several workflow steps use `continue-on-error`, so the GitHub step
+conclusion can read `success` while the suite outcome is still `failure`. Always inspect the
+workflow summary and report artifacts before closing alpha issues.
+
+### Targeted C/RAGAS Provider Verification
+
+- Run: <https://github.com/EngineerCafeJP/engineercafe-navigator/actions/runs/25247945549>
+- Suites: `c`
+- Result: failure
+- Provider: direct OpenAI
+- Model: `gpt-5.2-2025-12-11`
+- Runtime: about 6m52s for the current 29-case C gate
+
+This run was dispatched after syncing GCP Secret Manager `openai-api-key` to GitHub Actions
+`OPENAI_API_KEY`. It confirmed that #671 is fixed. The remaining C failure is now answer quality /
+coverage, not provider configuration.
+
+## Current Blockers
+
+### P0
+
+- #658: STT preflight latency still fails. Reconstructed 1440-minute report showed p95 `11067ms`,
+  max `34076ms`, and 11.6% samples over 10s.
+- #659: B routing still fails at `B1-BIZ-002` (`今日の最終受付は何時ですか。`).
+- #660: H-UI Welcome live scenario still fails because `kiosk-welcome-ocr-overlay` is not found.
+- #657 / #583: C/RAGAS gate still runs 29 cases while #583 requires 127.
+- #643 / #612: umbrella issues remain open until the alpha gate is green.
+- #623: slide narration endpoint smoke is covered by B, but full 5-page ingestion proof remains open.
+- #611 / #584 / #585: fast first-response, edge/failure tolerance, and 2h kiosk soak still need final proof.
+
+### P1
+
+- #672: Direct OpenAI C/RAGAS still misses JA answer_correctness target.
+  - JA: `0.8295`, target `0.85`
+  - weakest cases: `ml-ja-003` access guidance and `ml-ja-004` Connpass/event check
+- #653: Q content quality still fails.
+  - `Q-BIZ-EN-003`
+  - `Q-EVT-EN-001`
+  - `Q-DAILY-JA-001`
+- #662: Cloud Run still logs Supabase UUID parsing errors for synthetic alpha session IDs.
+- #661: alpha artifact remains too large and hides compact failure details.
+- #669: deployed tRAG translation model assets are missing, causing retry/fallback logs.
+- #670: C/RAGAS runtime improved after direct OpenAI, but progress telemetry and gate splitting remain weak.
+- #655: memory WARNs remain; TTS long Japanese case passed in the latest run.
+- #663: SHA-match gate still blocks harness-only commits without backend deploy.
+- #668: GitHub Actions Node.js 20 deprecation warnings need post-alpha cleanup.
+
+## RAGAS Provider Decision
+
+Alpha RAGAS must use direct OpenAI unless explicitly running a diagnostic fallback.
+
+Required behavior:
+
+- `OPENAI_API_KEY` must be non-empty in GitHub Actions.
+- The C step must print `RAGAS judge provider: direct OpenAI`.
+- OpenRouter fallback must not be accepted for alpha GO proof unless the run is explicitly marked
+  diagnostic.
+
+Observed impact:
+
+- OpenRouter fallback: about 22m46s for 29 cases.
+- Direct OpenAI: about 6m52s for 29 cases.
+
+## Next Implementation Order
+
+1. #658: STT preflight latency and report scoping.
+2. #660: H-UI Welcome OCR overlay / wait condition.
+3. #659: `B1-BIZ-002` routing.
+4. #653 and #672: Q/C answer quality for current failing cases.
+5. #662: Supabase UUID/log hygiene.
+6. #661 and #670: artifact size and live progress telemetry.
+7. #657/#583: expand or correctly define the 127-case alpha RAGAS gate.
+
+## Useful Commands
+
+```bash
+gh workflow run alpha-live-verification.yml \
+  --ref develop \
+  -f suites=all \
+  -f require_deployed_sha_match=true
+
+gh workflow run alpha-live-verification.yml \
+  --ref develop \
+  -f suites=c \
+  -f require_deployed_sha_match=true
+
+gcloud run services describe engineer-cafe-backend \
+  --project aipartner-426616 \
+  --region asia-northeast1 \
+  --format='value(status.latestReadyRevisionName,spec.template.spec.containers[0].image,status.url)'
+```
+


### PR DESCRIPTION
## Summary
- record the 2026-05-02 alpha live verification status after PR #667 and Cloud Run SHA sync
- add a focused alpha remediation plan for #658, #660, #659, #653/#672, #662, #661/#670, and #657/#583
- update README, docs index, STATUS, ADR guardrails, and deployment log so the next implementation pass starts from the current gate state

## Validation
- git diff --check
- docs-only update; no runtime code changed