### PR TITLE
fix: tighten alpha live verification gates

### DIFF
--- a/.github/workflows/alpha-live-verification.yml
+++ b/.github/workflows/alpha-live-verification.yml
@@ -101,7 +101,7 @@ jobs:
         id: stt_preflight
         if: contains(format(',{0},', inputs.suites), ',stt,') || contains(format(',{0},', inputs.suites), ',all,')
         continue-on-error: true
-        run: scripts/stt-live-preflight.sh --timestamp "${ALPHA_TIMESTAMP}-stt" --minutes 1440 --limit 1000
+        run: scripts/stt-live-preflight.sh --timestamp "${ALPHA_TIMESTAMP}-stt" --revision "$ALPHA_SMOKE_CLOUD_RUN_REVISION" --minutes 1440 --limit 1000
 
       - name: V voice pipeline live preflight
         id: voice_pipeline
@@ -210,18 +210,45 @@ jobs:
           BACKEND_API_KEY: ${{ secrets.BACKEND_API_KEY }}
         run: scripts/welcome-live-preflight.sh --timestamp "${ALPHA_TIMESTAMP}-h" --host "$ALPHA_SMOKE_BASE_URL" --delays 0,5,10
 
-      - name: Upload alpha reports
+      - name: Upload alpha compact reports
         if: always()
         uses: actions/upload-artifact@v4
         with:
-          name: alpha-live-verification-${{ github.run_id }}
+          name: alpha-live-verification-summary-${{ github.run_id }}
           path: |
-            backend/tests/reports/
-            backend/tests/evaluation/reports/
+            backend/tests/reports/*.md
+            backend/tests/reports/*.csv
+            backend/tests/reports/*.json
+            backend/tests/reports/*.log
+            backend/tests/evaluation/reports/*.md
+            backend/tests/evaluation/reports/*.csv
+            backend/tests/evaluation/reports/*.json
+          if-no-files-found: warn
+          retention-days: 30
+
+      - name: Upload alpha heavy browser artifacts
+        if: >-
+          always() && (
+            steps.stt_preflight.outcome == 'failure' ||
+            steps.voice_pipeline.outcome == 'failure' ||
+            steps.alpha_a.outcome == 'failure' ||
+            steps.alpha_b.outcome == 'failure' ||
+            steps.rag_api_live.outcome == 'failure' ||
+            steps.alpha_d.outcome == 'failure' ||
+            steps.cloud_logging.outcome == 'failure' ||
+            steps.quality_q.outcome == 'failure' ||
+            steps.quality_m.outcome == 'failure' ||
+            steps.quality_t.outcome == 'failure' ||
+            steps.welcome_live.outcome == 'failure'
+          )
+        uses: actions/upload-artifact@v4
+        with:
+          name: alpha-live-verification-browser-artifacts-${{ github.run_id }}
+          path: |
             frontend/playwright-report/
             frontend/test-results/
           if-no-files-found: warn
-          retention-days: 30
+          retention-days: 7
 
       - name: Summarize outcomes
         if: always()

--- a/backend/config/routing_constants.py
+++ b/backend/config/routing_constants.py
@@ -52,6 +52,8 @@ WIFI_KEYWORDS = ["wi-fi", "wifi", "ワイファイ", "インターネット", "i
 
 BUSINESS_HOURS_KEYWORDS = [
     "営業時間",
+    "最終受付",
+    "受付時間",
     "何時まで",
     "何時から",
     "開いて",
@@ -64,6 +66,8 @@ BUSINESS_HOURS_KEYWORDS = [
     "閉館",
     "opening hours",
     "business hours",
+    "last reception",
+    "reception hours",
     "hours",
     "open",
     "close",

--- a/backend/evaluation/ragas_pipeline.py
+++ b/backend/evaluation/ragas_pipeline.py
@@ -536,7 +536,10 @@ class RagasEvaluator:
         report: RagasReport,
     ) -> RagasReport:
         """Evaluate cases one by one so provider stalls do not fail the full language batch."""
-        for case in cases:
+        total = len(cases)
+        for index, case in enumerate(cases, start=1):
+            case_id = case.get("query_id", case["question"][:40])
+            print(f"RAGAS case {index}/{total} start: {case_id}", flush=True)
             result = await self.evaluate_single(
                 question=case["question"],
                 answer=case["answer"],
@@ -545,8 +548,15 @@ class RagasEvaluator:
             )
             report.results.append(result)
             if result.error:
-                case_id = case.get("query_id", case["question"][:40])
                 report.errors.append(f"{case_id}: {result.error}")
+                print(f"RAGAS case {index}/{total} error: {case_id}: {result.error}", flush=True)
+            else:
+                print(
+                    "RAGAS case "
+                    f"{index}/{total} done: {case_id} "
+                    f"answer_correctness={result.answer_correctness:.4f}",
+                    flush=True,
+                )
 
         report.evaluated_cases = len([result for result in report.results if result.error is None])
         return report

--- a/backend/infrastructure/reception_repository.py
+++ b/backend/infrastructure/reception_repository.py
@@ -75,6 +75,12 @@ class SupabaseReceptionSessionRepository(ReceptionSessionRepository):
         Returns:
             A ``ReceptionSession`` or ``None``.
         """
+        try:
+            uuid.UUID(session_id)
+        except (TypeError, ValueError):
+            logger.debug("Skipping reception session UUID lookup for non-UUID session_id")
+            return None
+
         client = await self._get_client()
         try:
             result = client.table("reception_sessions").select("*").eq("id", session_id).execute()

--- a/backend/tests/agents/test_orchestrator_fast_routing.py
+++ b/backend/tests/agents/test_orchestrator_fast_routing.py
@@ -138,6 +138,8 @@ class TestOrchestratorFastRouting:
             ("定休日はありますか？", "hours"),
             ("開館時間を教えてください", "hours"),
             ("閉館は何時ですか？", "hours"),
+            ("今日の最終受付は何時ですか。", "hours"),
+            ("受付時間を教えてください。", "hours"),
             ("お休みの日はありますか？", "hours"),
         ]
         for query, expected_type in test_cases:
@@ -155,6 +157,7 @@ class TestOrchestratorFastRouting:
         test_cases = [
             ("Is the cafe closed on weekends?", "hours"),
             ("Are there any holidays?", "hours"),
+            ("What is the last reception time today?", "hours"),
         ]
         for query, expected_type in test_cases:
             result = orchestrator._try_fast_routing(query)

--- a/backend/tests/api/test_reception_persistence.py
+++ b/backend/tests/api/test_reception_persistence.py
@@ -6,7 +6,7 @@ from copy import deepcopy
 from dataclasses import dataclass
 from datetime import datetime, timedelta, timezone
 from typing import Any, Iterator, Optional
-from unittest.mock import AsyncMock, patch
+from unittest.mock import AsyncMock, Mock, patch
 
 import pytest
 from fastapi.testclient import TestClient
@@ -16,6 +16,10 @@ from backend.main import app
 from backend.utils.reception_repository import ReceptionRepository
 
 client = TestClient(app)
+
+_VALID_RECEPTION_ID = "11111111-1111-1111-1111-111111111111"
+_EXPIRED_RECEPTION_ID = "22222222-2222-2222-2222-222222222222"
+_ACTIVE_RECEPTION_ID = "33333333-3333-3333-3333-333333333333"
 
 
 def _parse_timestamp(value: Any) -> Any:
@@ -167,7 +171,7 @@ def _sample_session_data(
     expires_at: Optional[str] = None,
 ) -> dict[str, Any]:
     return {
-        "id": "rs-001",
+        "id": _VALID_RECEPTION_ID,
         "session_id": "session-001",
         "stage": stage,
         "language": "ja",
@@ -205,18 +209,29 @@ async def test_repository_store_get_complete_lifecycle() -> None:
     repo = ReceptionRepository(fake_client)  # type: ignore[arg-type]
 
     session_data = _sample_session_data()
-    await repo.store_session("rs-001", session_data)
+    await repo.store_session(_VALID_RECEPTION_ID, session_data)
 
-    stored = await repo.get_session("rs-001")
+    stored = await repo.get_session(_VALID_RECEPTION_ID)
     assert stored is not None
     assert stored["session_data"]["session_id"] == "session-001"
     assert stored["visitor_name"] == "Taro"
     assert stored["status"] == "active"
 
-    await repo.complete_session("rs-001")
+    await repo.complete_session(_VALID_RECEPTION_ID)
 
-    assert fake_client.storage["reception_sessions"]["rs-001"]["status"] == "completed"
-    assert await repo.get_session("rs-001") is None
+    assert fake_client.storage["reception_sessions"][_VALID_RECEPTION_ID]["status"] == "completed"
+    assert await repo.get_session(_VALID_RECEPTION_ID) is None
+
+
+@pytest.mark.asyncio
+async def test_repository_non_uuid_session_id_skips_primary_key_lookup() -> None:
+    mock_client = Mock()
+    repo = ReceptionRepository(mock_client)  # type: ignore[arg-type]
+
+    assert await repo.get_session("alpha-b-20260502-B1-BIZ-002") is None
+    await repo.complete_session("alpha-b-20260502-B1-BIZ-002")
+
+    mock_client.table.assert_not_called()
 
 
 @pytest.mark.asyncio
@@ -225,25 +240,25 @@ async def test_repository_cleanup_expired_sessions() -> None:
     repo = ReceptionRepository(fake_client)  # type: ignore[arg-type]
 
     await repo.store_session(
-        "expired-session",
+        _EXPIRED_RECEPTION_ID,
         _sample_session_data(
             expires_at=(datetime.now(timezone.utc) - timedelta(minutes=5)).isoformat(),
         ),
     )
     await repo.store_session(
-        "active-session",
+        _ACTIVE_RECEPTION_ID,
         _sample_session_data(
             expires_at=(datetime.now(timezone.utc) + timedelta(hours=1)).isoformat(),
         )
-        | {"id": "active-session", "session_id": "session-002"},
+        | {"id": _ACTIVE_RECEPTION_ID, "session_id": "session-002"},
     )
 
     expired_count = await repo.cleanup_expired()
     active_sessions = await repo.list_active_sessions()
 
     assert expired_count == 1
-    assert fake_client.storage["reception_sessions"]["expired-session"]["status"] == "expired"
-    assert [row["id"] for row in active_sessions] == ["active-session"]
+    assert fake_client.storage["reception_sessions"][_EXPIRED_RECEPTION_ID]["status"] == "expired"
+    assert [row["id"] for row in active_sessions] == [_ACTIVE_RECEPTION_ID]
 
 
 @pytest.mark.asyncio

--- a/backend/tests/infrastructure/test_reception_repository.py
+++ b/backend/tests/infrastructure/test_reception_repository.py
@@ -18,6 +18,8 @@ from backend.infrastructure.reception_repository import (
     SupabaseVisitRepository,
 )
 
+_RECEPTION_ID = "11111111-1111-1111-1111-111111111111"
+
 # ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------
@@ -74,7 +76,7 @@ def _sample_session(
         purpose = VisitPurpose(category="facility_use", detail="Co-working")
 
     return ReceptionSession(
-        id="rs-001",
+        id=_RECEPTION_ID,
         session_id=session_id,
         visitor_identity=identity,
         purpose=purpose,
@@ -104,14 +106,14 @@ async def test_save_and_find_reception_session(mock_client: MagicMock):
     mock_client.table.assert_called_with("reception_sessions")
     upsert_builder.upsert.assert_called_once()
     upserted_data = upsert_builder.upsert.call_args[0][0]
-    assert upserted_data["id"] == "rs-001"
+    assert upserted_data["id"] == _RECEPTION_ID
     assert upserted_data["user_id"] == 42
     assert upserted_data["stage"] == "greeting"
     assert upserted_data["purpose"] == "facility_use"
 
     # --- find_by_id ---
     row = {
-        "id": "rs-001",
+        "id": _RECEPTION_ID,
         "session_id": "sess-001",
         "user_id": 42,
         "stage": "greeting",
@@ -122,16 +124,27 @@ async def test_save_and_find_reception_session(mock_client: MagicMock):
     find_builder = _chainable_builder(execute_result=_make_query_result(data=[row]))
     mock_client.table = MagicMock(return_value=find_builder)
 
-    found = await repo.find_by_id("rs-001")
+    found = await repo.find_by_id(_RECEPTION_ID)
 
     assert found is not None
-    assert found.id == "rs-001"
+    assert found.id == _RECEPTION_ID
     assert found.stage == "greeting"
     assert found.visitor_identity is not None
     assert found.visitor_identity.user_id == 42
     assert found.visitor_identity.visitor_type == VisitorType(value="returning")
     assert found.purpose is not None
     assert found.purpose.category == "facility_use"
+
+
+@pytest.mark.asyncio
+async def test_find_by_id_skips_non_uuid_session_id(mock_client: MagicMock):
+    """Synthetic IDs should not be sent to reception_sessions.id UUID lookup."""
+    repo = SupabaseReceptionSessionRepository(supabase_client=mock_client)
+
+    found = await repo.find_by_id("alpha-b-20260502-B1-BIZ-002")
+
+    assert found is None
+    mock_client.table.assert_not_called()
 
 
 @pytest.mark.asyncio

--- a/backend/tests/utils/test_memory_helper.py
+++ b/backend/tests/utils/test_memory_helper.py
@@ -8,7 +8,6 @@ from unittest.mock import Mock, AsyncMock, patch
 
 from backend.utils.memory_helper import SimplifiedMemoryHelper, get_memory_helper
 
-
 ACTIVE_SESSION_ID = "11111111-1111-4111-8111-111111111111"
 ENDED_SESSION_ID = "22222222-2222-4222-8222-222222222222"
 MISSING_SESSION_ID = "33333333-3333-4333-8333-333333333333"

--- a/backend/tests/utils/test_memory_helper.py
+++ b/backend/tests/utils/test_memory_helper.py
@@ -9,6 +9,11 @@ from unittest.mock import Mock, AsyncMock, patch
 from backend.utils.memory_helper import SimplifiedMemoryHelper, get_memory_helper
 
 
+ACTIVE_SESSION_ID = "11111111-1111-4111-8111-111111111111"
+ENDED_SESSION_ID = "22222222-2222-4222-8222-222222222222"
+MISSING_SESSION_ID = "33333333-3333-4333-8333-333333333333"
+
+
 class TestSimplifiedMemoryHelper:
     """SimplifiedMemoryHelper のテストクラス"""
 
@@ -234,12 +239,14 @@ class TestSimplifiedMemoryHelper:
         mock_client.table = Mock(return_value=mock_table)
         mock_table.select = Mock(return_value=mock_select)
         mock_select.eq = Mock(return_value=mock_eq)
-        mock_eq.execute = Mock(return_value=Mock(data=[{"id": "test-session", "status": "active"}]))
+        mock_eq.execute = Mock(
+            return_value=Mock(data=[{"id": ACTIVE_SESSION_ID, "status": "active"}])
+        )
 
         mock_create_client.return_value = mock_client
 
         helper = SimplifiedMemoryHelper()
-        result = await helper._is_session_active("test-session")
+        result = await helper._is_session_active(ACTIVE_SESSION_ID)
 
         assert result is True
 
@@ -255,12 +262,14 @@ class TestSimplifiedMemoryHelper:
         mock_client.table = Mock(return_value=mock_table)
         mock_table.select = Mock(return_value=mock_select)
         mock_select.eq = Mock(return_value=mock_eq)
-        mock_eq.execute = Mock(return_value=Mock(data=[{"id": "test-session", "status": "ended"}]))
+        mock_eq.execute = Mock(
+            return_value=Mock(data=[{"id": ENDED_SESSION_ID, "status": "ended"}])
+        )
 
         mock_create_client.return_value = mock_client
 
         helper = SimplifiedMemoryHelper()
-        result = await helper._is_session_active("test-session")
+        result = await helper._is_session_active(ENDED_SESSION_ID)
 
         assert result is False
 
@@ -281,7 +290,7 @@ class TestSimplifiedMemoryHelper:
         mock_create_client.return_value = mock_client
 
         helper = SimplifiedMemoryHelper()
-        result = await helper._is_session_active("nonexistent-session")
+        result = await helper._is_session_active(MISSING_SESSION_ID)
 
         assert result is False
 
@@ -305,7 +314,7 @@ class TestSimplifiedMemoryHelper:
         mock_sessions_select = Mock()
         mock_sessions_eq = Mock()
         mock_sessions_eq.execute = Mock(
-            return_value=Mock(data=[{"id": "test-session", "status": "ended"}])
+            return_value=Mock(data=[{"id": ENDED_SESSION_ID, "status": "ended"}])
         )
         mock_sessions_select.eq = Mock(return_value=mock_sessions_eq)
         mock_sessions_table.select = Mock(return_value=mock_sessions_select)
@@ -319,7 +328,7 @@ class TestSimplifiedMemoryHelper:
         mock_create_client.return_value = mock_client
 
         helper = SimplifiedMemoryHelper()
-        messages = await helper._get_recent_messages("test-session")
+        messages = await helper._get_recent_messages(ENDED_SESSION_ID)
 
         assert messages == []
 

--- a/backend/tests/utils/test_memory_helper_unit.py
+++ b/backend/tests/utils/test_memory_helper_unit.py
@@ -20,6 +20,10 @@ from unittest.mock import Mock, AsyncMock, patch, MagicMock
 import backend.utils.memory_helper as memory_helper_module
 from backend.utils.memory_helper import SimplifiedMemoryHelper, get_memory_helper
 
+_ACTIVE_SESSION_ID = "11111111-1111-1111-1111-111111111111"
+_ENDED_SESSION_ID = "22222222-2222-2222-2222-222222222222"
+_MISSING_SESSION_ID = "33333333-3333-3333-3333-333333333333"
+
 # =============================================================================
 # フィクスチャ
 # =============================================================================
@@ -164,10 +168,10 @@ class TestIsSessionActive:
     async def test_returns_true_for_active_session(self, helper_with_client):
         """アクティブなセッションに対して True を返す"""
         helper, client = helper_with_client
-        chain = _build_chain_mock(Mock(data=[{"id": "session-1", "status": "active"}]))
+        chain = _build_chain_mock(Mock(data=[{"id": _ACTIVE_SESSION_ID, "status": "active"}]))
         client.table.return_value = chain
 
-        result = await helper._is_session_active("session-1")
+        result = await helper._is_session_active(_ACTIVE_SESSION_ID)
 
         assert result is True
         client.table.assert_called_with("conversation_sessions")
@@ -179,7 +183,7 @@ class TestIsSessionActive:
         chain = _build_chain_mock(Mock(data=[]))
         client.table.return_value = chain
 
-        result = await helper._is_session_active("nonexistent")
+        result = await helper._is_session_active(_MISSING_SESSION_ID)
 
         assert result is False
 
@@ -187,12 +191,22 @@ class TestIsSessionActive:
     async def test_returns_false_for_ended_session(self, helper_with_client):
         """ended ステータスのセッションに対して False を返す"""
         helper, client = helper_with_client
-        chain = _build_chain_mock(Mock(data=[{"id": "session-1", "status": "ended"}]))
+        chain = _build_chain_mock(Mock(data=[{"id": _ENDED_SESSION_ID, "status": "ended"}]))
         client.table.return_value = chain
 
-        result = await helper._is_session_active("session-1")
+        result = await helper._is_session_active(_ENDED_SESSION_ID)
 
         assert result is False
+
+    @pytest.mark.asyncio
+    async def test_non_uuid_session_id_skips_conversation_session_lookup(self, helper_with_client):
+        """synthetic session_id は UUID カラムへ問い合わせず active 扱いにする"""
+        helper, client = helper_with_client
+
+        result = await helper._is_session_active("alpha-b-20260502-B1-BIZ-002")
+
+        assert result is True
+        client.table.assert_not_called()
 
     @pytest.mark.asyncio
     async def test_returns_true_on_exception_fallback(self, helper_with_client):

--- a/backend/utils/memory_helper.py
+++ b/backend/utils/memory_helper.py
@@ -65,6 +65,12 @@ class SimplifiedMemoryHelper:
             return False
 
         try:
+            uuid.UUID(session_id)
+        except (TypeError, ValueError):
+            logger.debug("Skipping conversation_sessions UUID lookup for non-UUID session_id")
+            return True
+
+        try:
             response = (
                 self.supabase.table("conversation_sessions")
                 .select("id, status")

--- a/backend/utils/reception_repository.py
+++ b/backend/utils/reception_repository.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import asyncio
 import logging
 import os
+import uuid
 from datetime import datetime, timedelta, timezone
 from typing import Any, Callable, Optional, TypeVar
 
@@ -23,6 +24,14 @@ def _db_timeout_seconds() -> float:
     except ValueError:
         return 3.0
     return value if value > 0 else 3.0
+
+
+def _is_uuid(value: str) -> bool:
+    try:
+        uuid.UUID(value)
+    except (TypeError, ValueError):
+        return False
+    return True
 
 
 async def _run_db_call(call: Callable[[], _T]) -> _T:
@@ -75,6 +84,9 @@ class ReceptionRepository:
     async def get_session_record(
         self, session_id: str, *, include_completed: bool = False
     ) -> dict[str, Any] | None:
+        if not _is_uuid(session_id):
+            logger.debug("Skipping reception_sessions UUID lookup for non-UUID session_id")
+            return None
         client = await self._get_client()
         query = client.table("reception_sessions").select("*").eq("id", session_id)
         if include_completed:
@@ -130,6 +142,9 @@ class ReceptionRepository:
         return await self.get_session_by_conversation_id(session_id)
 
     async def complete_session(self, session_id: str) -> None:
+        if not _is_uuid(session_id):
+            logger.debug("Skipping reception_sessions completion for non-UUID session_id")
+            return
         client = await self._get_client()
         await _run_db_call(
             lambda: client.table("reception_sessions")

--- a/frontend/e2e/welcome-live.spec.ts
+++ b/frontend/e2e/welcome-live.spec.ts
@@ -137,13 +137,13 @@ async function triggerVoiceTurn(page: Page): Promise<void> {
   });
 }
 
-test.describe('Welcome live (Welcome → OCR → STT warmup → first voice)', () => {
+test.describe('Welcome live (Welcome → STT warmup → first voice)', () => {
   test.skip(
     !welcomeLive || !process.env.BACKEND_API_URL || !process.env.BACKEND_API_KEY,
     'Set PLAYWRIGHT_WELCOME_LIVE=1 + BACKEND_API_URL + BACKEND_API_KEY to run welcome live E2E.',
   );
 
-  test('Welcome starts STT warmup while greeting TTS and OCR sidecar are active', async ({
+  test('Welcome starts STT warmup while greeting TTS is active without OCR overlay', async ({
     page,
   }) => {
     test.setTimeout(180_000);
@@ -176,9 +176,8 @@ test.describe('Welcome live (Welcome → OCR → STT warmup → first voice)', (
     expect(warmup.ok(), 'warmup response').toBeTruthy();
     expect(reception.ok(), 'reception start response').toBeTruthy();
     expect(tts.ok(), 'greeting TTS response').toBeTruthy();
-    await expect(page.getByTestId('kiosk-welcome-ocr-overlay')).toBeVisible({
-      timeout: 15_000,
-    });
+    await expect(page.getByTestId('kiosk-welcome-ocr-overlay')).toBeHidden({ timeout: 5_000 });
+    await expect(page.getByTestId('kiosk-voice-mode-badge')).toBeVisible({ timeout: 15_000 });
 
     const warmupCall = firstCall(calls, (call) => call.action === 'warmup');
     const ttsCall = firstCall(calls, (call) => call.action === 'text_to_speech');
@@ -222,9 +221,8 @@ test.describe('Welcome live (Welcome → OCR → STT warmup → first voice)', (
       expect(warmup.ok(), 'warmup response').toBeTruthy();
       expect(reception.ok(), 'reception start response').toBeTruthy();
       expect(greetingTts.ok(), 'greeting TTS response').toBeTruthy();
-      await expect(page.getByTestId('kiosk-welcome-ocr-overlay')).toBeVisible({
-        timeout: 15_000,
-      });
+      await expect(page.getByTestId('kiosk-welcome-ocr-overlay')).toBeHidden({ timeout: 5_000 });
+      await expect(page.getByTestId('kiosk-voice-mode-badge')).toBeVisible({ timeout: 15_000 });
 
       if (delaySeconds > 0) {
         await page.waitForTimeout(delaySeconds * 1000);

--- a/scripts/rag-api-live-test.sh
+++ b/scripts/rag-api-live-test.sh
@@ -127,10 +127,12 @@ require_ragas_judge_key() {
   fi
   if [ -n "${OPENAI_API_KEY:-}" ]; then
     echo "RAGAS judge provider: direct OpenAI"
+    echo "RAGAS judge model: ${RAGAS_EVAL_MODEL:-gpt-5.2-2025-12-11}"
     return
   fi
   if [ -n "${OPENROUTER_API_KEY:-}" ]; then
     echo "RAGAS judge provider: OpenRouter fallback"
+    echo "RAGAS judge model: ${RAGAS_OPENROUTER_MODEL:-openai/gpt-5-mini}"
     return
   fi
 
@@ -214,6 +216,8 @@ main() {
   echo "Base URL: $BASE_URL"
   echo "Languages: ${LANG_ARGS[*]}"
   echo "Metrics: ${METRIC_ARGS[*]}"
+  echo "RAGAS batch strategy: ${RAGAS_BATCH_STRATEGY:-single}"
+  echo "RAGAS per-case timeout: ${RAGAS_OUTER_SINGLE_TIMEOUT:-300}s"
 
   cmd=(python evaluation/run_live_api_eval.py --base-url "$BASE_URL" --languages "${LANG_ARGS[@]}" --metrics "${METRIC_ARGS[@]}" --output-dir "$OUTPUT_DIR")
   if [ "$CHECK_TARGETS" = "1" ]; then

--- a/scripts/stt-live-preflight.sh
+++ b/scripts/stt-live-preflight.sh
@@ -15,6 +15,7 @@ MINUTES=1440
 LIMIT=500
 OUTPUT_DIR="$ROOT_DIR/backend/tests/reports"
 TIMESTAMP="$(date +%Y%m%d_%H%M%S)"
+GATE_REVISION="${ALPHA_SMOKE_CLOUD_RUN_REVISION:-}"
 DRY_RUN=0
 
 usage() {
@@ -25,6 +26,7 @@ Options:
   --project ID        GCP project (default: aipartner-426616)
   --service NAME      Cloud Run service (default: engineer-cafe-backend)
   --region REGION     Cloud Run region (default: asia-northeast1)
+  --revision NAME     Gate only this Cloud Run revision (default: ALPHA_SMOKE_CLOUD_RUN_REVISION)
   --minutes N         Lookback window in minutes (default: 1440)
   --limit N           Max log rows to read (default: 500)
   --output-dir DIR    Report directory (default: backend/tests/reports)
@@ -54,6 +56,7 @@ while [ "$#" -gt 0 ]; do
     --project) [ "$#" -ge 2 ] || die "--project requires a value"; PROJECT_ID="$2"; shift 2 ;;
     --service) [ "$#" -ge 2 ] || die "--service requires a value"; SERVICE_NAME="$2"; shift 2 ;;
     --region) [ "$#" -ge 2 ] || die "--region requires a value"; REGION="$2"; shift 2 ;;
+    --revision) [ "$#" -ge 2 ] || die "--revision requires a value"; GATE_REVISION="$2"; shift 2 ;;
     --minutes) [ "$#" -ge 2 ] || die "--minutes requires a value"; MINUTES="$2"; shift 2 ;;
     --limit) [ "$#" -ge 2 ] || die "--limit requires a value"; LIMIT="$2"; shift 2 ;;
     --output-dir) [ "$#" -ge 2 ] || die "--output-dir requires a value"; OUTPUT_DIR="$2"; shift 2 ;;
@@ -75,60 +78,79 @@ minutes = int(sys.argv[1])
 print((datetime.now(timezone.utc) - timedelta(minutes=minutes)).isoformat().replace("+00:00", "Z"))
 PY
 )"
-FILTER="resource.type=\"cloud_run_revision\" AND resource.labels.service_name=\"$SERVICE_NAME\" AND resource.labels.location=\"$REGION\" AND jsonPayload.event=\"stt_winner\" AND timestamp >= \"$SINCE\""
+BASE_FILTER="resource.type=\"cloud_run_revision\" AND resource.labels.service_name=\"$SERVICE_NAME\" AND resource.labels.location=\"$REGION\" AND jsonPayload.event=\"stt_winner\" AND timestamp >= \"$SINCE\""
+GATE_FILTER="$BASE_FILTER"
+if [ -n "$GATE_REVISION" ]; then
+  GATE_FILTER="$GATE_FILTER AND resource.labels.revision_name=\"$GATE_REVISION\""
+fi
 REPORT="$OUTPUT_DIR/stt-live-preflight-$TIMESTAMP.md"
 
 if [ "$DRY_RUN" = "1" ]; then
   echo "Dry run: no gcloud logging read calls will be executed."
   echo "Project: $PROJECT_ID"
-  echo "Filter: $FILTER"
+  echo "Gate revision: ${GATE_REVISION:-all revisions}"
+  echo "Gate filter: $GATE_FILTER"
+  echo "History filter: $BASE_FILTER"
   echo "Output: $REPORT"
   exit 0
 fi
 
 require_cmd gcloud
 mkdir -p "$OUTPUT_DIR"
-TMP_JSON="$(mktemp)"
-trap 'rm -f "$TMP_JSON"' EXIT
+GATE_JSON="$(mktemp)"
+HISTORY_JSON="$(mktemp)"
+trap 'rm -f "$GATE_JSON" "$HISTORY_JSON"' EXIT
 
-gcloud logging read "$FILTER" \
+gcloud logging read "$GATE_FILTER" \
   --project "$PROJECT_ID" \
   --limit "$LIMIT" \
-  --format=json > "$TMP_JSON"
+  --format=json > "$GATE_JSON"
 
-python3 - "$TMP_JSON" "$REPORT" "$TIMESTAMP" "$PROJECT_ID" "$SERVICE_NAME" "$REGION" "$MINUTES" "$LIMIT" <<'PY'
+if [ -n "$GATE_REVISION" ]; then
+  gcloud logging read "$BASE_FILTER" \
+    --project "$PROJECT_ID" \
+    --limit "$LIMIT" \
+    --format=json > "$HISTORY_JSON"
+else
+  cp "$GATE_JSON" "$HISTORY_JSON"
+fi
+
+python3 - "$GATE_JSON" "$HISTORY_JSON" "$REPORT" "$TIMESTAMP" "$PROJECT_ID" "$SERVICE_NAME" "$REGION" "$MINUTES" "$LIMIT" "${GATE_REVISION:-}" <<'PY'
 from __future__ import annotations
 
 import json
 import pathlib
-import statistics
 import sys
 from collections import Counter
 from typing import Any
 
-raw_path, report_path, timestamp, project, service, region, minutes, limit = sys.argv[1:9]
-entries = json.load(open(raw_path, encoding="utf-8"))
-rows: list[dict[str, Any]] = []
-for entry in entries if isinstance(entries, list) else []:
-    payload = entry.get("jsonPayload") or {}
-    if payload.get("event") != "stt_winner":
-        continue
-    duration = payload.get("stt_overall_duration_ms")
-    try:
-        duration_ms = int(duration)
-    except Exception:
-        continue
-    rows.append(
-        {
-            "timestamp": entry.get("timestamp"),
-            "revision": (entry.get("resource") or {}).get("labels", {}).get("revision_name"),
-            "winner": payload.get("stt_winner") or payload.get("provider") or "unknown",
-            "provider": payload.get("provider") or "unknown",
-            "duration_ms": duration_ms,
-            "success": payload.get("success"),
-            "qwen_error_type": payload.get("qwen_error_type") or "",
-        }
-    )
+gate_path, history_path, report_path, timestamp, project, service, region, minutes, limit, gate_revision = sys.argv[1:11]
+
+
+def load_rows(raw_path: str) -> list[dict[str, Any]]:
+    entries = json.load(open(raw_path, encoding="utf-8"))
+    rows: list[dict[str, Any]] = []
+    for entry in entries if isinstance(entries, list) else []:
+        payload = entry.get("jsonPayload") or {}
+        if payload.get("event") != "stt_winner":
+            continue
+        duration = payload.get("stt_overall_duration_ms")
+        try:
+            duration_ms = int(duration)
+        except Exception:
+            continue
+        rows.append(
+            {
+                "timestamp": entry.get("timestamp"),
+                "revision": (entry.get("resource") or {}).get("labels", {}).get("revision_name"),
+                "winner": payload.get("stt_winner") or payload.get("provider") or "unknown",
+                "provider": payload.get("provider") or "unknown",
+                "duration_ms": duration_ms,
+                "success": payload.get("success"),
+                "qwen_error_type": payload.get("qwen_error_type") or "",
+            }
+        )
+    return rows
 
 
 def percentile(values: list[int], pct: float) -> int | None:
@@ -139,17 +161,39 @@ def percentile(values: list[int], pct: float) -> int | None:
     return values[index]
 
 
-durations = [row["duration_ms"] for row in rows]
-winner_counts = Counter(str(row["winner"]) for row in rows)
-provider_counts = Counter(str(row["provider"]) for row in rows)
-revision_counts = Counter(str(row["revision"]) for row in rows)
-timeout_rows = [row for row in rows if row["qwen_error_type"] == "TimeoutError"]
-over_10s = [row for row in rows if row["duration_ms"] > 10_000]
+def summarize(rows: list[dict[str, Any]]) -> dict[str, Any]:
+    durations = [row["duration_ms"] for row in rows]
+    timeout_rows = [row for row in rows if row["qwen_error_type"] == "TimeoutError"]
+    over_10s = [row for row in rows if row["duration_ms"] > 10_000]
+    p95 = percentile(durations, 0.95) or 0
+    over_10s_ratio = (len(over_10s) / len(rows)) if rows else 1.0
+    passed = bool(rows) and not timeout_rows and (
+        p95 <= 10_000 or (p95 <= 12_000 and over_10s_ratio <= 0.10)
+    )
+    return {
+        "durations": durations,
+        "winner_counts": Counter(str(row["winner"]) for row in rows),
+        "provider_counts": Counter(str(row["provider"]) for row in rows),
+        "revision_counts": Counter(str(row["revision"]) for row in rows),
+        "timeout_rows": timeout_rows,
+        "over_10s": over_10s,
+        "over_30s": [row for row in rows if row["duration_ms"] > 30_000],
+        "p95": p95,
+        "over_10s_ratio": over_10s_ratio,
+        "passed": passed,
+    }
+
+
+gate_rows = load_rows(gate_path)
+history_rows = load_rows(history_path)
+gate = summarize(gate_rows)
+history = summarize(history_rows)
+durations = gate["durations"]
+passed = bool(gate["passed"])
+timeout_rows = gate["timeout_rows"]
+over_10s = gate["over_10s"]
 p95 = percentile(durations, 0.95) or 0
-over_10s_ratio = (len(over_10s) / len(rows)) if rows else 1.0
-passed = bool(rows) and not timeout_rows and (
-    p95 <= 10_000 or (p95 <= 12_000 and over_10s_ratio <= 0.10)
-)
+over_10s_ratio = gate["over_10s_ratio"]
 
 lines = [
     "# STT Live Preflight",
@@ -158,12 +202,14 @@ lines = [
     f"- Project: {project}",
     f"- Service: {service}",
     f"- Region: {region}",
+    f"- Gate revision: {gate_revision or 'all revisions'}",
     f"- Lookback minutes: {minutes}",
     f"- Log limit: {limit}",
-    f"- Samples: {len(rows)}",
+    f"- Gate samples: {len(gate_rows)}",
+    f"- Historical samples: {len(history_rows)}",
     f"- Overall passed: {'yes' if passed else 'no'}",
     "",
-    "## Latency",
+    "## Gate Latency",
     "",
     "| Metric | Value ms |",
     "| --- | ---: |",
@@ -177,13 +223,13 @@ lines = [
     "| Winner | Count |",
     "| --- | ---: |",
 ]
-for key, value in winner_counts.most_common():
+for key, value in gate["winner_counts"].most_common():
     lines.append(f"| {key} | {value} |")
 lines.extend(["", "## Provider Distribution", "", "| Provider | Count |", "| --- | ---: |"])
-for key, value in provider_counts.most_common():
+for key, value in gate["provider_counts"].most_common():
     lines.append(f"| {key} | {value} |")
 lines.extend(["", "## Revision Distribution", "", "| Revision | Count |", "| --- | ---: |"])
-for key, value in revision_counts.most_common():
+for key, value in gate["revision_counts"].most_common():
     lines.append(f"| {key} | {value} |")
 
 lines.extend(
@@ -193,10 +239,35 @@ lines.extend(
     "",
     f"- Qwen TimeoutError samples: {len(timeout_rows)}",
     f"- Samples over 10s: {len(over_10s)}",
+    f"- Samples over 30s: {len(gate['over_30s'])}",
     f"- Samples over 10s ratio: {over_10s_ratio:.1%}",
     "- Pass rule: p95 <= 10s, or p95 <= 12s with <= 10% samples over 10s and no TimeoutError",
     ]
 )
+if gate_revision:
+    lines.extend(
+        [
+            "",
+            "## Historical Risk Report",
+            "",
+            "Historical rows are reported for operator awareness only; they do not decide the release gate when a gate revision is set.",
+            "",
+            "| Metric | Value |",
+            "| --- | ---: |",
+            f"| samples | {len(history_rows)} |",
+            f"| p95 ms | {percentile(history['durations'], 0.95) if history['durations'] else 'n/a'} |",
+            f"| max ms | {max(history['durations']) if history['durations'] else 'n/a'} |",
+            f"| TimeoutError samples | {len(history['timeout_rows'])} |",
+            f"| samples over 10s | {len(history['over_10s'])} |",
+            f"| samples over 30s | {len(history['over_30s'])} |",
+            f"| samples over 10s ratio | {history['over_10s_ratio']:.1%} |",
+            "",
+            "| Revision | Count |",
+            "| --- | ---: |",
+        ]
+    )
+    for key, value in history["revision_counts"].most_common():
+        lines.append(f"| {key} | {value} |")
 if timeout_rows or over_10s:
     lines.extend(["", "| Timestamp | Revision | Winner | Provider | Duration ms | Error |", "| --- | --- | --- | --- | ---: | --- |"])
     risk_rows = {

--- a/scripts/welcome-live-preflight.sh
+++ b/scripts/welcome-live-preflight.sh
@@ -115,7 +115,7 @@ set -e
   echo
   echo "## Scope"
   echo
-  echo "- H-1: Welcome 起動 → greeting TTS → OCR sidecar → STT warmup"
+  echo "- H-1: Welcome 起動 → greeting TTS → STT warmup（voice-first; OCR overlay は開かない）"
   echo "- H-2/H-3: Welcome 後 0秒/5秒/10秒の初回発話"
   echo "- H-6/H-7: frontend cleanup / stale warmup の回帰は mocked E2E と合わせて確認"
   echo


### PR DESCRIPTION
## Summary
- scope STT live preflight release gating to the deployed Cloud Run revision while keeping historical outliers visible in the report
- align Welcome live smoke with the current voice-first UI contract
- add alpha routing coverage for final reception/business-hours questions
- suppress non-UUID Supabase primary-key lookups in reception/session helpers
- split compact alpha reports from heavy browser artifacts and add RAGAS progress/model telemetry

## Validation
- git diff --check
- bash -n scripts/stt-live-preflight.sh scripts/welcome-live-preflight.sh
- ALPHA_SMOKE_CLOUD_RUN_REVISION=engineer-cafe-backend-test scripts/stt-live-preflight.sh --dry-run --timestamp DRYRUN --minutes 5 --limit 10
- scripts/welcome-live-preflight.sh --dry-run --timestamp DRYRUN --delays 0
- pnpm --dir frontend exec playwright test --config=playwright.config.ts e2e/welcome-live.spec.ts --project=chromium-voice-live --workers=1 --list
- pnpm --dir frontend exec playwright test --config=playwright.config.ts e2e/welcome-voice-first.spec.ts --project=chromium --workers=1
- pytest backend/tests/agents/test_orchestrator_fast_routing.py backend/tests/config/test_routing_constants.py backend/tests/infrastructure/test_reception_repository.py backend/tests/utils/test_memory_helper_unit.py::TestIsSessionActive -q
- pytest backend/tests/evaluation/test_ragas_pipeline_timeout_guard.py -q

## Notes
- A real scoped STT preflight against revision engineer-cafe-backend-00144-q85 still found a true qwen-primary 34.076s outlier, so #658 still needs product-side latency/fallback policy work after this gate/reporting fix.
- backend/tests/api/test_reception_persistence.py could not be collected locally because this environment is missing slowapi, which backend.main requires for rate limiting.
