### PR TITLE
fix: sanitize reception persistence UUID fields

### DIFF
--- a/backend/tests/api/test_reception_persistence.py
+++ b/backend/tests/api/test_reception_persistence.py
@@ -7,6 +7,7 @@ from dataclasses import dataclass
 from datetime import datetime, timedelta, timezone
 from typing import Any, Iterator, Optional
 from unittest.mock import AsyncMock, Mock, patch
+import uuid
 
 import pytest
 from fastapi.testclient import TestClient
@@ -242,6 +243,26 @@ async def test_repository_non_uuid_conversation_session_id_skips_lookup() -> Non
     assert await repo.get_session_by_conversation_id("alpha-b-20260502-B1-BIZ-003") is None
 
     mock_client.table.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_repository_store_session_coerces_non_uuid_values_for_uuid_columns() -> None:
+    fake_client = _FakeSupabaseClient()
+    repo = ReceptionRepository(fake_client)  # type: ignore[arg-type]
+
+    synthetic_id = "alpha-b-fast-20260502-B2-GREET-001"
+    await repo.store_session(
+        synthetic_id,
+        _sample_session_data() | {"id": synthetic_id, "session_id": synthetic_id},
+    )
+
+    rows = fake_client.storage["reception_sessions"]
+    assert len(rows) == 1
+    stored_id, stored = next(iter(rows.items()))
+    assert uuid.UUID(stored_id)
+    assert stored_id != synthetic_id
+    assert stored["session_id"] is None
+    assert stored["session_data"]["session_id"] == synthetic_id
 
 
 @pytest.mark.asyncio

--- a/backend/utils/reception_repository.py
+++ b/backend/utils/reception_repository.py
@@ -34,6 +34,18 @@ def _is_uuid(value: str) -> bool:
     return True
 
 
+def _db_uuid_or_none(value: Any) -> str | None:
+    if not isinstance(value, str) or not _is_uuid(value):
+        return None
+    return str(uuid.UUID(value))
+
+
+def _stable_reception_id(value: str) -> str:
+    if _is_uuid(value):
+        return str(uuid.UUID(value))
+    return str(uuid.uuid5(uuid.NAMESPACE_URL, f"engineer-cafe-navigator:reception:{value}"))
+
+
 async def _run_db_call(call: Callable[[], _T]) -> _T:
     """Run the synchronous Supabase client without blocking the event loop."""
     return await asyncio.wait_for(asyncio.to_thread(call), timeout=_db_timeout_seconds())
@@ -59,8 +71,8 @@ class ReceptionRepository:
         metadata = data.get("metadata") or {}
 
         payload = {
-            "id": session_id,
-            "session_id": data.get("session_id"),
+            "id": _stable_reception_id(session_id),
+            "session_id": _db_uuid_or_none(data.get("session_id")),
             "user_id": visitor_identity.get("user_id"),
             "stage": data.get("stage", "initiated"),
             "purpose": purpose.get("category") if isinstance(purpose, dict) else purpose,


### PR DESCRIPTION
## Summary
- coerce reception persistence primary keys to valid UUIDs for synthetic alpha session IDs
- store non-UUID conversation session IDs as NULL in the UUID column while preserving the original value in session_data
- add regression coverage for synthetic alpha IDs so Cloud Run logs do not emit Supabase UUID 400s

## Validation
- cd backend && uv run pytest tests/api/test_reception_persistence.py -q
- black --check backend/utils/reception_repository.py backend/tests/api/test_reception_persistence.py
- git diff --check

## Alpha context
Follow-up to #662 after B suite passed on PR #675 but Cloud Logging still showed reception persistence UUID 400s for synthetic alpha session IDs.