### PR TITLE
docs: sync alpha ADR and remediation status

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,10 +6,11 @@
 
 ## 現在の要約
 
-- 2026-05-02 時点で、alpha live verification の full-suite workflow は Cloud Run SHA match 付きで実行できます。
-- Cloud Run staging は develop SHA `fa7745b7420c0709fcff950ed3bf4c090f0dfc55` の revision `engineer-cafe-backend-00144-q85` で検証済みです。
-- RAGAS evaluator は GitHub Actions secret 修正後、direct OpenAI で動くことを確認済みです。
-- ただし alpha はまだ **NO-GO** です。STT latency、B routing、Welcome UI、Q/C answer quality、RAGAS 127-case coverage、Cloud Run log hygiene が残っています。
+- 2026-05-03 時点で、alpha live verification の workflow は Cloud Run SHA match 付きで targeted suite を安定実行できます。
+- Cloud Run staging は develop SHA `d789a2cd899779423947c40a3d65e19382f52d30` の revision `engineer-cafe-backend-00148-82c` で検証済みです。
+- B routing / slide live smoke は targeted run `25254789937` で `64 passed, 0 warned, 0 failed` まで復旧しました。
+- Welcome UI, compact artifact, Cloud Run Supabase UUID/log hygiene は resolved として issue close 済みです。
+- ただし alpha はまだ **NO-GO** です。STT long-tail latency、Q/C answer quality、RAGAS 127-case coverage reconciliation が残っています。
 
 詳細は [docs/STATUS.md](docs/STATUS.md) を参照してください。
 
@@ -36,11 +37,11 @@ Browser
 
 ## 現時点の主要リスク
 
-- alpha gate は end-to-end で回るが、最新 full run は failure です。
+- alpha gate は end-to-end で回るが、latest `suites=all` の green proof はまだありません。
 - `continue-on-error` のため、GitHub step が success に見えても suite outcome が failure の場合があります。
-- STT preflight は現行 revision と過去24h履歴が混ざり、release 判定として過敏/不透明です。
+- STT preflight は current revision gate に分離済みですが、Qwen STT long-tail がまだ alpha P0 です。
 - RAGAS は direct OpenAI に修正済みですが、JA answer_correctness と 29-vs-127 coverage が未解決です。
-- Welcome UI live scenario は `kiosk-welcome-ocr-overlay` が見つからず失敗します。
+- B routing / slide live smoke と Cloud Run UUID log hygiene は 2026-05-03 時点の deployed staging で解消確認済みです。
 
 この README は現況の入口だけを扱います。監査結果と production readiness の論点は [docs/STATUS.md](docs/STATUS.md) に集約しています。
 
@@ -91,11 +92,11 @@ make dev
 
 ## GitHub の現況
 
-2026-05-02 時点で把握した主要な alpha open items:
+2026-05-03 時点で把握した主要な alpha open items:
 
-- P0: `#658`, `#659`, `#660`, `#657`, `#643`, `#623`, `#612`, `#611`, `#585`, `#584`, `#583`
-- P1: `#672`, `#670`, `#669`, `#663`, `#662`, `#661`, `#655`, `#653`
-- `#671` は GitHub Actions RAGAS provider secret 問題として作成し、direct OpenAI 確認後に close 済みです。
+- P0: `#658`, `#657`, `#643`, `#612`, `#611`, `#585`, `#583`
+- P1: `#672`, `#670`, `#669`, `#663`, `#655`, `#653`
+- Resolved in the latest remediation pass: `#659`, `#660`, `#661`, `#662`, `#671`
 
 ## 注意
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,6 +1,6 @@
 # Documentation Map
 
-> 2026-05-02 時点での現役ドキュメント案内です。まずこのページから参照してください。
+> 2026-05-03 時点での現役ドキュメント案内です。まずこのページから参照してください。
 
 ## まず読む文書
 
@@ -77,11 +77,30 @@
 - `archive/migration/`: Mastra -> LangGraph 移行期の詳細資料
 - `archive/frontend-docs-old/`: 旧 frontend 文書群
 
+## 2026-05-03 Alpha Remediation Snapshot
+
+PR #674, #675, #676 を develop に merge し、Cloud Run staging
+`engineer-cafe-backend-00148-82c` / `d789a2cd899779423947c40a3d65e19382f52d30`
+で検証済みです。
+
+Resolved:
+
+- #659 B routing / slide live smoke: targeted B run `25254789937` が `64 passed, 0 warned, 0 failed`
+- #660 H-UI Welcome UI live scenario
+- #661 compact artifact visibility
+- #662 Supabase UUID / Cloud Run log hygiene
+- #671 RAGAS direct OpenAI provider secret
+
+Still active:
+
+- #658 STT long-tail latency
+- #657 / #583 RAGAS 29-case vs 127-case coverage reconciliation
+- #653 / #672 Q/C answer quality
+- #670 RAGAS full-run speed / telemetry closeout
+
 ## 直近の次アクション
 
-- #658 STT preflight latency を current revision 観点で修正する
-- #660 H-UI Welcome OCR overlay / wait condition を修正する
-- #659 `B1-BIZ-002` routing を修正する
-- #653 / #672 の Q/C answer quality failure を修正する
-- #662 の Supabase UUID/log hygiene を修正する
-- #661 / #670 で artifact size と RAGAS progress telemetry を改善する
+- #658 STT long-tail latency の fallback threshold / warmup / timeout 前 mitigation を実装する
+- #657 / #583 の alpha gate coverage を launch gate と diagnostic/soak に分けて文書化・実装する
+- #653 / #672 の Q/C answer quality failure を case-level telemetry で修正する
+- #670 は full C/Q run の artifact で provider/model/progress が十分に残ることを確認して close 判断する

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -1,11 +1,12 @@
 # 現在の状態
 
-Last updated: 2026-05-02
+Last updated: 2026-05-03
 
 ## 概要
 
 このページは、`develop` 上の現行コード、2026-04-19 の live audit、2026-04-29 の実機音声 UX 確認、
-2026-05-02 の alpha-live-verification full run / targeted C run をもとに更新しています。
+2026-05-02 の alpha-live-verification full run / targeted C run、2026-05-03 の PR #674/#675/#676
+deploy verification をもとに更新しています。
 
 確認元:
 
@@ -13,6 +14,7 @@ Last updated: 2026-05-02
 - 2026-04-19 UTC の直近 Vercel production deploy
 - 2026-04-29 JST の mobile / kiosk 実地確認 screenshot と Cloud Run structured logs
 - 2026-05-02 JST の `alpha-live-verification` run `25244933308` / `25247945549`
+- 2026-05-03 JST の targeted B run `25254789937` と Cloud Run revision `engineer-cafe-backend-00148-82c`
 - 現在 open の GitHub Issue
 
 Supabase については、CLI で linked project の確認まではできましたが、このセッションでは recent runtime log
@@ -23,20 +25,49 @@ Supabase については、CLI で linked project の確認まではできまし
 - キオスクのコアフロー自体は実装済み
 - alpha live verification workflow は Cloud Run SHA match 付きで end-to-end 実行できる
 - RAGAS evaluator は direct OpenAI で動くことを確認済み
-- ただし 2026-05-02 の full run は failure で、alpha release はまだ GO できない
+- PR #674/#675/#676 により、B routing / slide live smoke、Welcome UI、compact artifacts、Supabase UUID log hygiene は解消済み
+- ただし latest `suites=all` の green proof はまだなく、alpha release はまだ GO できない
 - 現在の主リスクは「未実装の基本機能」ではなく「会話 UX の基本品質、実測 latency、route 整合性、評価 gate の透明性」
 
-特に優先度が高いのは次の 6 点です。
+特に優先度が高いのは次の 4 点です。
 
-1. STT preflight latency が alpha gate を落としている問題
-2. H-UI Welcome OCR overlay が live scenario で見つからない問題
-3. B routing の `B1-BIZ-002` 誤判定
-4. Q/C answer quality と RAGAS JA target miss
-5. RAGAS 29-case gate と 127-case requirement の不一致
-6. Cloud Run / Supabase log hygiene と artifact size / progress telemetry
+1. STT long-tail latency が alpha gate を落としている問題
+2. Q/C answer quality と RAGAS JA target miss
+3. RAGAS 29-case gate と 127-case requirement の不一致
+4. RAGAS full-run speed / telemetry の operational closeout
 
 現行の実装判断は [ADR 018](adr/018-alpha-fast-response-and-assistant-profile-routing.md) と
 [Alpha Remediation Plan 2026-05-02](plans/alpha-remediation-plan-2026-05-02.md) を優先する。
+
+## 2026-05-03 Alpha Remediation Snapshot
+
+最新の deployed staging:
+
+- develop SHA: `d789a2cd899779423947c40a3d65e19382f52d30`
+- Cloud Run revision: `engineer-cafe-backend-00148-82c`
+- Traffic: latest revision 100%
+- Health: `/health` OK
+- develop CI: `25253946681`, success including backend-test, backend-test-ragas, backend-deploy-staging smoke
+- Targeted B run: `25254789937`
+- B result: `64 passed, 0 warned, 0 failed`
+- B1-BIZ-003: `土日祝日も利用できますか。` -> `business_info`, `1258ms`
+- Cloud Logging UUID / reception persistence errors during B run window: 0 rows
+
+Resolved in PR #674/#675/#676:
+
+- #659: B routing / slide live smoke
+- #660: Welcome UI live scenario
+- #661: compact artifact visibility
+- #662: Supabase UUID / Cloud Run log hygiene
+- #671: RAGAS provider secret issue
+
+Still blocking or important:
+
+- #658: STT long-tail latency remains P0. Latest STT-only gate after #674 deploy had 7 samples,
+  p50 `5180ms`, p95/max `29217ms`, and 14.3% over 10s.
+- #657 / #583: RAGAS 29 vs 127 coverage reconciliation remains P0.
+- #653 / #672: Q/C answer quality remains P1 and may become launch-blocking depending on case analysis.
+- #670: RAGAS telemetry is implemented, but a full C/Q run still needs operational proof before close.
 
 ## 2026-05-02 Alpha Live Verification Snapshot
 
@@ -50,19 +81,20 @@ Supabase については、CLI で linked project の確認まではできまし
 - Full run conclusion: failure
 - Direct OpenAI RAGAS: confirmed after GitHub Secret `OPENAI_API_KEY` sync
 
-Resolved in this session:
+Resolved in the 2026-05-02 / 2026-05-03 remediation pass:
 
 - #671: RAGAS provider secret issue. `OPENAI_API_KEY` is now available to the workflow, and C uses direct OpenAI.
+- #659: B routing / slide live smoke.
+- #660: H-UI Welcome UI live scenario.
+- #661: compact artifact visibility.
+- #662: Supabase UUID/log hygiene.
 
 Still blocking:
 
 - #658: STT preflight latency
-- #659: B routing `B1-BIZ-002`
-- #660: H-UI Welcome OCR overlay
 - #657 / #583: RAGAS 29 vs 127 coverage
 - #653 / #672: Q/C answer quality
-- #662: Supabase UUID/log errors
-- #661 / #670: artifact size and RAGAS telemetry
+- #670: full-run RAGAS speed / telemetry closeout
 
 ## 実装済みとして確認できたこと
 
@@ -214,26 +246,20 @@ current turn の high-confidence intent なしに route を固定してはいけ
 ## いま重要な Open Issues
 
 - `#658`: STT preflight latency
-- `#660`: Welcome UI live scenario
-- `#659`: B routing / slide live smoke
 - `#657`: RAGAS gate 29 vs 127
 - `#653`: Q-content quality
 - `#672`: Direct OpenAI C/RAGAS JA target miss
-- `#662`: Supabase UUID/log hygiene
-- `#661`: alpha artifact size
 - `#669`: deployed tRAG translation model missing
 - `#670`: C/RAGAS runtime and telemetry
 - `#611`: Cerebras dynamic filler / fast first-response path
 
 ## 推奨する実装順
 
-1. STT preflight latency と current revision scoping を直す (`#658`)
-2. H-UI Welcome OCR overlay / wait condition を直す (`#660`)
-3. B routing `B1-BIZ-002` を直す (`#659`)
-4. Q/C answer quality を直す (`#653`, `#672`)
-5. Supabase UUID/log hygiene を直す (`#662`)
-6. artifact size と RAGAS progress telemetry を直す (`#661`, `#670`)
-7. RAGAS 127-case gate を定義・実装する (`#657`, `#583`)
+1. STT long-tail latency mitigation を実装する (`#658`)
+2. RAGAS 127-case gate を定義・実装する (`#657`, `#583`)
+3. Q/C answer quality を直す (`#653`, `#672`)
+4. RAGAS full-run telemetry / runtime を close 判断する (`#670`)
+5. tRAG translation model fallback の alpha 影響を判断する (`#669`)
 
 ## 参照
 

--- a/docs/adr/008-operational-verification-and-deployment-guardrails.md
+++ b/docs/adr/008-operational-verification-and-deployment-guardrails.md
@@ -92,3 +92,14 @@ Alpha live verification の運用結果を踏まえ、以下をガードレー�
 - Alpha RAGAS は direct OpenAI を必須にする。`OPENAI_API_KEY` が空で OpenRouter fallback になった run は diagnostic として扱う。
 - Artifact は compact failure summary と heavy trace/video を分ける。932MB 級 artifact は triage 阻害として扱う。
 - STT preflight は historical 24h risk と current revision release gate を分ける。過去 revision の outlier だけで現行 release gate を落とさない。
+
+## 2026-05-03 追記
+
+PR #674, #675, #676 の remediation と deployed staging 検証を踏まえ、以下を運用ルールに追加する。
+
+- Alpha issue を close するには、実装 PR の merge だけでなく、Cloud Run staging の deployed SHA match と targeted live suite の artifact を紐づける。
+- Synthetic alpha session ID は test isolation のため維持してよいが、UUID 型 DB column へ直接渡してはならない。UUID column に保存する値は UUID に正規化し、元の synthetic ID は JSON payload / metadata に保持する。
+- Cloud Run log hygiene の issue は、対象 revision と run window を指定した Logging query で再発 0 件を確認してから close する。
+- B routing / slide smoke の GO 証跡は targeted B run `25254789937` とする。この run は Cloud Run revision `engineer-cafe-backend-00148-82c`、image tag `d789a2cd899779423947c40a3d65e19382f52d30` で `64 passed, 0 warned, 0 failed`。
+- Compact artifact split は release gate の一部とする。成功時も compact reports が残り、heavy browser artifacts は failure-oriented にする。
+- Current-revision STT gate が失敗している限り、B/H/log hygiene が green でも alpha GO とはしない。

--- a/docs/adr/018-alpha-fast-response-and-assistant-profile-routing.md
+++ b/docs/adr/018-alpha-fast-response-and-assistant-profile-routing.md
@@ -162,7 +162,7 @@ fast path は env flag と route condition で無効化できる構成にする�
 `alpha-live-verification` full run `25244933308` で、Cerebras fast path は live log 上で
 `gpt-oss-120b` を使っていることを確認した。ただし alpha GO はまだ不可。
 
-残る優先課題:
+この時点で残っていた優先課題:
 
 - #658: STT preflight latency
 - #660: H-UI Welcome OCR overlay
@@ -173,6 +173,35 @@ fast path は env flag と route condition で無効化できる構成にする�
 また、RAGAS は fast response の product path ではなく evaluation path だが、alpha gate の信頼性に直結する。
 2026-05-02 に GitHub Actions `OPENAI_API_KEY` を更新し、run `25247945549` で direct OpenAI
 `gpt-5.2-2025-12-11` が使われることを確認した。OpenRouter fallback は GO 証跡として使わない。
+
+## 2026-05-03 検証結果
+
+PR #674, #675, #676 を develop に merge し、Cloud Run staging に `d789a2cd899779423947c40a3d65e19382f52d30`
+を deploy した。
+
+検証済み:
+
+- Cloud Run revision: `engineer-cafe-backend-00148-82c`
+- Targeted B run: `25254789937`
+- B routing / slide result: `64 passed, 0 warned, 0 failed`
+- `B1-BIZ-003` (`土日祝日も利用できますか。`): `business_info`, `1258ms`
+- slide narration B5-1..B5-5: PASS
+- Cloud Logging UUID / reception persistence errors during the B run window: 0 rows
+
+この結果により、ADR 018 の「identity / business-info / slide route は unnecessary heavyweight fallback
+に流さない」という方針のうち、B routing と slide smoke の live proof は成立した。
+
+一方、voice turn 全体の alpha GO はまだ不可。STT-only current-revision gate では p50 `5180ms`,
+p95/max `29217ms`, over-10s ratio `14.3%` が残っている。したがって、次の実装優先度は
+fast LLM / routing ではなく #658 の STT long-tail mitigation とする。
+
+ADR 018 の release gate を以下に更新する。
+
+- identity / assistant profile: deterministic response, provider self-disclosure 0 件を維持
+- business-info fast routing: B targeted suite green を維持
+- slide narration: B5 smoke green を維持
+- Cloud Run log hygiene: synthetic session ID による UUID 400 を 0 件に維持
+- full voice turn: STT p95 が current-revision gate を満たすまで alpha GO 不可
 
 ## 参照
 

--- a/docs/plans/alpha-remediation-plan-2026-05-02.md
+++ b/docs/plans/alpha-remediation-plan-2026-05-02.md
@@ -1,57 +1,65 @@
 # Alpha Remediation Plan 2026-05-02
 
-This is the execution plan for the next implementation session after the 2026-05-02 alpha live
-verification run.
+This is the execution plan for the implementation sessions after the 2026-05-02 alpha live
+verification run. It includes the 2026-05-03 remediation status after PR #674, #675, and #676.
 
 ## Current State
 
-The workflow infrastructure is now complete enough to run the alpha gate end to end:
+The workflow infrastructure is now complete enough to run targeted alpha gates end to end:
 
 - Cloud Run SHA match gate works.
 - Full suite dispatch works.
 - C/RAGAS can run with direct OpenAI after syncing `OPENAI_API_KEY`.
-- Reports and artifacts are uploaded.
+- Compact reports and failure-oriented heavy artifacts are split.
+- RAGAS provider/model/case progress telemetry is emitted.
+- B routing / slide live smoke is green on deployed staging.
 
-The product is still **NO-GO** for alpha because the latest full suite ended in failure.
+The product is still **NO-GO** for alpha because there is no latest `suites=all` green proof and
+the STT current-revision gate still fails.
+
+Latest deployed verification:
+
+- develop SHA: `d789a2cd899779423947c40a3d65e19382f52d30`
+- Cloud Run revision: `engineer-cafe-backend-00148-82c`
+- Targeted B run: `25254789937`
+- B result: `64 passed, 0 warned, 0 failed`
+- UUID / reception persistence log errors during the B run window: 0 rows
 
 ## Implementation Order
 
-### 1. #658 STT preflight latency
+### 1. #658 STT long-tail latency
 
-Goal: make the preflight evaluate the current deployed revision and remove avoidable long-tail
-latency before relying on voice gates.
+Goal: reduce the current deployed revision STT long-tail before relying on voice gates.
 
-Tasks:
+Status:
 
-- Scope `scripts/stt-live-preflight.sh` to the current Cloud Run revision when
-  `ALPHA_SMOKE_CLOUD_RUN_REVISION` is present.
-- Separate historical 24h risk reporting from the release gate for the current revision.
-- Investigate current revision outliers above 30s.
+- Current-revision scoping is implemented.
+- Historical risk reporting is separated from release gate reporting.
+- The latest STT-only current-revision gate still failed: 7 samples, p50 `5180ms`,
+  p95/max `29217ms`, 14.3% over 10s.
+
+Next tasks:
+
+- Implement Qwen STT long-tail mitigation: fallback threshold, warmup policy, and timeout-before-failure behavior.
 - Re-run `stt` and `v` suites.
 
-### 2. #660 H-UI Welcome OCR overlay
+### 2. #657 / #583 RAGAS coverage
 
-Goal: make the live welcome scenario assert the real UI state without depending on a missing or
-renamed test id.
+Goal: reconcile the 29-case diagnostic gate with the 127-case alpha requirement.
 
-Tasks:
+Status:
 
-- Inspect `frontend/e2e/welcome-live.spec.ts` around the `kiosk-welcome-ocr-overlay` assertion.
-- Confirm whether the overlay is intentionally absent, hidden behind a timing transition, or renamed.
-- Fix the UI/test contract, then run the H-UI suite.
-
-### 3. #659 B routing
-
-Goal: make `B1-BIZ-002` route to `business_info`.
+- Direct OpenAI provider path is confirmed.
+- RAGAS progress telemetry is implemented.
+- Coverage semantics are still unresolved.
 
 Tasks:
 
-- Reproduce the single query locally or with a targeted live request.
-- Inspect route metadata and classifier decision path for `今日の最終受付は何時ですか。`.
-- Add a focused regression test.
-- Re-run suite `b`.
+- Define release-blocking cases versus diagnostic/soak cases.
+- Add explicit workflow inputs for diagnostic C and full C-127.
+- Ensure reports cannot imply that 29 cases satisfy the 127-case requirement.
 
-### 4. #653 / #672 answer quality
+### 3. #653 / #672 answer quality
 
 Goal: remove current Q/C answer-quality failures without masking real product issues.
 
@@ -73,36 +81,62 @@ Tasks:
 - Fix the smallest product-side issue first; only adjust tests when the expected answer is wrong.
 - Re-run `q` and `c`.
 
-### 5. #662 Supabase UUID/log hygiene
+### 4. #670 RAGAS operational closeout
+
+Goal: make slow or failing C/Q gates diagnosable in GitHub Actions artifacts.
+
+Status:
+
+- Provider/model/case progress telemetry is implemented.
+- Compact report artifact upload is implemented.
+
+Tasks:
+
+- Run full C/Q after #658 or in a diagnostic window.
+- Confirm provider/model/case progress is present in logs and compact artifacts.
+- Close #670 only after one full C/Q operational proof.
+
+## Completed Items
+
+### #660 H-UI Welcome OCR overlay
+
+Goal: make the live welcome scenario assert the real UI state without depending on a missing or
+renamed test id.
+
+Status: completed in PR #674.
+
+- H-UI targeted run passed after the contract was updated to the current voice-first UI.
+- Issue #660 is closed.
+
+### #659 B routing
+
+Goal: make `B1-BIZ-002` and `B1-BIZ-003` route to `business_info`.
+
+Status: completed in PR #675 and verified again after PR #676.
+
+- Targeted B run `25254789937`: `64 passed, 0 warned, 0 failed`.
+- Issue #659 is closed.
+
+### #662 Supabase UUID/log hygiene
 
 Goal: stop synthetic alpha session IDs from causing 400 UUID lookup noise.
 
-Tasks:
+Status: completed in PR #675 and PR #676.
 
-- Guard UUID-only Supabase queries before hitting `reception_sessions` and `conversation_sessions`.
-- Keep synthetic session IDs valid for test isolation without logging avoidable errors.
-- Add tests around non-UUID session IDs.
-- Re-run the suites that exercise A/B/D.
+- UUID-only lookups are guarded.
+- Reception persistence now stores non-UUID conversation session IDs outside UUID columns.
+- Cloud Logging queries for UUID parsing and reception persistence failures returned 0 rows for targeted B run `25254789937`.
+- Issue #662 is closed.
 
-### 6. #661 / #670 test infrastructure
+### #661 artifact size
 
 Goal: make failures obvious and keep artifacts usable.
 
-Tasks:
+Status: completed in PR #674.
 
-- Upload compact Markdown/JSON failure summaries separately from Playwright videos and traces.
-- Keep video/trace upload opt-in or failure-only.
-- Emit RAGAS provider/model/case progress while the C gate runs.
-
-### 7. #657 / #583 RAGAS coverage
-
-Goal: reconcile the 29-case diagnostic gate with the 127-case alpha requirement.
-
-Tasks:
-
-- Define which cases are release-blocking versus diagnostic/soak.
-- Add explicit workflow inputs for diagnostic C and full C-127.
-- Do not expand to 127 until #670 telemetry is in place.
+- Compact Markdown/JSON reports are uploaded separately.
+- Heavy browser artifacts are failure-oriented.
+- Issue #661 is closed.
 
 ## Re-run Strategy
 
@@ -110,10 +144,7 @@ Use targeted suites until the relevant blocker is fixed:
 
 ```bash
 gh workflow run alpha-live-verification.yml --ref develop -f suites=stt,v -f require_deployed_sha_match=true
-gh workflow run alpha-live-verification.yml --ref develop -f suites=h-ui -f require_deployed_sha_match=true
-gh workflow run alpha-live-verification.yml --ref develop -f suites=b -f require_deployed_sha_match=true
 gh workflow run alpha-live-verification.yml --ref develop -f suites=q,c -f require_deployed_sha_match=true
 ```
 
-Only run `suites=all` after the current P0 blockers have targeted green runs.
-
+Only run `suites=all` after #658 and the C/Q gate decision have targeted green runs.

--- a/docs/testing/alpha-live-verification-status-2026-05-02.md
+++ b/docs/testing/alpha-live-verification-status-2026-05-02.md
@@ -1,7 +1,8 @@
 # Alpha Live Verification Status 2026-05-02
 
-このドキュメントは、2026-05-02 JST 時点の alpha live verification 正本です。古い
-2026-04-25 status は履歴として残しますが、次の実装判断ではこのファイルを優先します。
+このドキュメントは、2026-05-02 JST 時点の alpha live verification 正本に、2026-05-03 JST
+の PR #674/#675/#676 remediation 結果を追記したものです。古い 2026-04-25 status は履歴として残しますが、
+次の実装判断ではこのファイルを優先します。
 
 ## 結論
 
@@ -10,7 +11,10 @@
 `develop` と Cloud Run staging の SHA 同期、full-suite workflow、C/RAGAS direct OpenAI
 実行経路は成立しました。一方で、alpha GO を止める blocker がまだ残っています。
 
-## Deploy / SHA Sync
+2026-05-03 時点で、B routing / slide live smoke、Welcome UI、artifact split、Supabase UUID
+log hygiene は解消済みです。残る P0 は STT long-tail latency と RAGAS coverage reconciliation です。
+
+## 2026-05-02 Baseline Deploy / SHA Sync
 
 - PR: #667
 - develop SHA: `fa7745b7420c0709fcff950ed3bf4c090f0dfc55`
@@ -21,6 +25,39 @@
 - `require_deployed_sha_match=true`: PASS
 
 ## Runs
+
+### 2026-05-03 Targeted B Verification After PR #674/#675/#676
+
+- Run: <https://github.com/EngineerCafeJP/engineercafe-navigator/actions/runs/25254789937>
+- Suites: `b`
+- Result: success
+- Cloud Run revision: `engineer-cafe-backend-00148-82c`
+- Image:
+  `asia-northeast1-docker.pkg.dev/aipartner-426616/cloud-run-source-deploy/engineer-cafe-backend:d789a2cd899779423947c40a3d65e19382f52d30`
+- Health: `/health` OK
+- `require_deployed_sha_match=true`: PASS
+- Summary: `64 passed, 0 warned, 0 failed`
+- B1-BIZ-003: `土日祝日も利用できますか。` -> `business_info`, `1258ms`
+- Slide narration B5-1..B5-5: PASS, `171ms` to `180ms`
+- Cloud Logging query for `invalid input syntax for type uuid`: 0 rows in the run window
+- Cloud Logging query for `Reception session persistence failed`: 0 rows in the run window
+
+Resolved by this remediation pass:
+
+- #659: B routing / slide live smoke
+- #660: H-UI Welcome UI live scenario
+- #661: compact artifact visibility
+- #662: Supabase UUID / Cloud Run log hygiene
+- #671: RAGAS provider secret issue
+
+Important STT follow-up:
+
+- STT-only run after PR #674 deploy still failed the current-revision gate.
+- Gate samples: 7
+- p50: `5180ms`
+- p95/max: `29217ms`
+- over-10s ratio: `14.3%`
+- #658 remains the highest-priority P0.
 
 ### Full Suite
 
@@ -62,10 +99,8 @@ coverage, not provider configuration.
 
 ### P0
 
-- #658: STT preflight latency still fails. Reconstructed 1440-minute report showed p95 `11067ms`,
-  max `34076ms`, and 11.6% samples over 10s.
-- #659: B routing still fails at `B1-BIZ-002` (`今日の最終受付は何時ですか。`).
-- #660: H-UI Welcome live scenario still fails because `kiosk-welcome-ocr-overlay` is not found.
+- #658: STT preflight latency still fails. The current-revision gate after PR #674 had p95/max
+  `29217ms` and 14.3% samples over 10s.
 - #657 / #583: C/RAGAS gate still runs 29 cases while #583 requires 127.
 - #643 / #612: umbrella issues remain open until the alpha gate is green.
 - #623: slide narration endpoint smoke is covered by B, but full 5-page ingestion proof remains open.
@@ -80,10 +115,9 @@ coverage, not provider configuration.
   - `Q-BIZ-EN-003`
   - `Q-EVT-EN-001`
   - `Q-DAILY-JA-001`
-- #662: Cloud Run still logs Supabase UUID parsing errors for synthetic alpha session IDs.
-- #661: alpha artifact remains too large and hides compact failure details.
 - #669: deployed tRAG translation model assets are missing, causing retry/fallback logs.
-- #670: C/RAGAS runtime improved after direct OpenAI, but progress telemetry and gate splitting remain weak.
+- #670: C/RAGAS runtime improved after direct OpenAI, and telemetry is now present, but full-run
+  operational proof is still needed.
 - #655: memory WARNs remain; TTS long Japanese case passed in the latest run.
 - #663: SHA-match gate still blocks harness-only commits without backend deploy.
 - #668: GitHub Actions Node.js 20 deprecation warnings need post-alpha cleanup.
@@ -106,13 +140,11 @@ Observed impact:
 
 ## Next Implementation Order
 
-1. #658: STT preflight latency and report scoping.
-2. #660: H-UI Welcome OCR overlay / wait condition.
-3. #659: `B1-BIZ-002` routing.
-4. #653 and #672: Q/C answer quality for current failing cases.
-5. #662: Supabase UUID/log hygiene.
-6. #661 and #670: artifact size and live progress telemetry.
-7. #657/#583: expand or correctly define the 127-case alpha RAGAS gate.
+1. #658: STT long-tail latency mitigation.
+2. #657/#583: expand or correctly define the 127-case alpha RAGAS gate.
+3. #653 and #672: Q/C answer quality for current failing cases.
+4. #670: verify full C/Q telemetry and runtime with the current artifact split.
+5. #669: decide whether deployed tRAG translation model fallback is launch-blocking.
 
 ## Useful Commands
 
@@ -132,4 +164,3 @@ gcloud run services describe engineer-cafe-backend \
   --region asia-northeast1 \
   --format='value(status.latestReadyRevisionName,spec.template.spec.containers[0].image,status.url)'
 ```
-


### PR DESCRIPTION
## Summary
- sync README/docs status with the deployed PR #674/#675/#676 alpha remediation state
- update ADR-008 and ADR-018 with the 2026-05-03 Cloud Run verification guardrails
- revise the alpha remediation plan so resolved issues (#659/#660/#661/#662/#671) are separated from remaining P0/P1 work

## Validation
- git diff --check
- searched the updated docs for stale unresolved references to #659/#660/#661/#662

## Current alpha state captured
- Cloud Run revision: engineer-cafe-backend-00148-82c
- develop SHA: d789a2cd899779423947c40a3d65e19382f52d30
- B targeted run: https://github.com/EngineerCafeJP/engineercafe-navigator/actions/runs/25254789937
- Remaining priority: #658, #657/#583, #653/#672, #670