### PR TITLE
fix: skip STT grace for trusted Vosk routes

### DIFF
--- a/backend/agents/stt_agent.py
+++ b/backend/agents/stt_agent.py
@@ -354,6 +354,41 @@ def _parse_qwen_stt_hedge_grace(
     return timeout
 
 
+def _vosk_transcript_trusted_for_early_return(transcript: str, language: Optional[str]) -> bool:
+    """Return true when Vosk output contains route-stable alpha keywords."""
+
+    if language not in {None, "ja", "en"}:
+        return False
+    normalized = "".join(transcript.lower().split())
+    if not normalized:
+        return False
+
+    trusted_terms = (
+        "営業時間",
+        "開館時間",
+        "営業日",
+        "予約",
+        "料金",
+        "wi-fi",
+        "wifi",
+        "接続",
+        "パスワード",
+        "イベント",
+        "開催",
+        "python",
+        "パイソン",
+        "仮想環境",
+        "api",
+        "sdk",
+    )
+    if any(term in normalized for term in trusted_terms):
+        return True
+
+    return ("営業" in normalized and "時間" in normalized) or (
+        "開館" in normalized and "時間" in normalized
+    )
+
+
 def _env_flag(name: str, default: bool = False) -> bool:
     raw_value = os.getenv(name)
     if raw_value is None:
@@ -1587,10 +1622,29 @@ class STTAgent:
                             vosk_result = await vosk_task
                         except Exception as exc:
                             vosk_result = exc
+                        vosk_trusted = isinstance(
+                            vosk_result, TranscriptionResult
+                        ) and _vosk_transcript_trusted_for_early_return(
+                            vosk_result.text,
+                            vosk_result.language,
+                        )
+                        if vosk_trusted:
+                            log_stt_event(
+                                event="stt_vosk_early_accept",
+                                stt_trace_id=stt_trace_id,
+                                provider="vosk-fallback",
+                                language=vosk_result.language,
+                                success=True,
+                                transcript_chars=len(vosk_result.text),
+                                confidence=vosk_result.confidence,
+                                hedge_grace_s=self._qwen_hedge_grace,
+                                stt_overall_duration_ms=_duration_ms(overall_started_at),
+                            )
                         if (
                             isinstance(vosk_result, TranscriptionResult)
                             and self._qwen_hedge_grace > 0
                             and not qwen_task.done()
+                            and not vosk_trusted
                         ):
                             log_stt_event(
                                 event="stt_qwen_hedge_grace_start",

--- a/backend/tests/agents/test_stt_agent.py
+++ b/backend/tests/agents/test_stt_agent.py
@@ -23,6 +23,7 @@ from backend.agents.stt_agent import (
     ENGINEER_CAFE_GRAMMAR,
     STAGE_GRAMMARS,
     VALID_STAGES,
+    _vosk_transcript_trusted_for_early_return,
 )
 
 # ==============================================================================
@@ -1031,6 +1032,21 @@ class TestSTTAgent:
         assert agent._qwen_timeout == pytest.approx(24.0)
         assert agent._qwen_hedge_delay == pytest.approx(3.5)
         assert agent._qwen_hedge_grace == pytest.approx(2.5)
+
+    def test_vosk_transcript_trusted_for_alpha_route_keywords(self):
+        """Route-stable Vosk transcripts can skip the Qwen grace wait."""
+        assert _vosk_transcript_trusted_for_early_return(
+            "エンジニア カフェ の 営業 時間 教え て ください",
+            "ja",
+        )
+        assert _vosk_transcript_trusted_for_early_return(
+            "Wi-Fiの接続方法を教えてください",
+            "ja",
+        )
+        assert not _vosk_transcript_trusted_for_early_return(
+            "はい 母 の 選挙 接客 方法 教え て ください",
+            "ja",
+        )
 
     def test_init_qwen_primary_hedge_delay_zero_disables_hedge(self, monkeypatch):
         """QWEN_STT_HEDGE_DELAY_SECONDS=0 restores hard-timeout-only behavior."""
@@ -2325,6 +2341,51 @@ class TestQwenPrimaryFallback:
             if record.name == "backend.observability.stt"
         ]
         assert "stt_qwen_hedge_grace_start" in events
+
+    @pytest.mark.asyncio
+    async def test_trusted_vosk_skips_grace_wait(self, caplog):
+        """Trusted route keywords let Vosk return without waiting for Qwen grace."""
+        caplog.set_level(logging.INFO, logger="backend.observability.stt")
+
+        async def slow_qwen(*args, **kwargs):
+            await asyncio.sleep(0.30)
+            return TranscriptionResult(text="late qwen", confidence=0.9, language="ja")
+
+        async def trusted_vosk(*args, **kwargs):
+            await asyncio.sleep(0.01)
+            return TranscriptionResult(
+                text="エンジニア カフェ の 営業 時間 教え て ください",
+                confidence=0.8,
+                language="ja",
+            )
+
+        mock_qwen = MagicMock()
+        mock_qwen.transcribe = slow_qwen
+        mock_vosk = MagicMock(spec=LocalSTTClient)
+        mock_vosk.transcribe = AsyncMock(side_effect=trusted_vosk)
+
+        agent = self._make_agent(mock_qwen, mock_vosk)
+        agent._qwen_timeout = 10.0
+        agent._qwen_hedge_delay = 0.01
+        agent._qwen_hedge_grace = 0.20
+
+        loop = asyncio.get_running_loop()
+        started_at = loop.time()
+        result = await agent.speech_to_text(b"audio", language="ja")
+        elapsed = loop.time() - started_at
+
+        assert result["success"] is True
+        assert result["provider"] == "vosk-fallback"
+        assert "営業" in result["transcript"]
+        assert elapsed < 0.10
+
+        events = [
+            getattr(record, "event", None)
+            for record in caplog.records
+            if record.name == "backend.observability.stt"
+        ]
+        assert "stt_vosk_early_accept" in events
+        assert "stt_qwen_hedge_grace_start" not in events
 
     @pytest.mark.asyncio
     async def test_qwen_grace_expires_then_vosk_wins(self, caplog):

--- a/docs/adr/016-qwen-stt-phase2-profiling.md
+++ b/docs/adr/016-qwen-stt-phase2-profiling.md
@@ -141,6 +141,8 @@ Alpha voice pipeline の合成音声 round-trip で、Vosk fallback が先に完
 - Qwen を先行開始し、`QWEN_STT_HEDGE_DELAY_SECONDS` を超えたら Vosk fallback を開始する。
 - Vosk が先に完了しても `QWEN_STT_HEDGE_GRACE_SECONDS` の範囲で Qwen 完了を待つ。
 - Qwen が grace 内に成功すれば Qwen を返し、間に合わなければ Vosk を返す。
+- ただし Vosk transcript が `営業 時間`、`Wi-Fi 接続` など route-stable な alpha keyword を
+  含む場合は、grace を待たず早期採用して long-tail latency を抑える。
 
 Cloud Run deploy は `QWEN_STT_TIMEOUT=45`、`QWEN_STT_HEDGE_DELAY_SECONDS=4`、
 `QWEN_STT_HEDGE_GRACE_SECONDS=6` を明示する。


### PR DESCRIPTION
## Summary
- add a route-keyword trust check for hedged Vosk transcripts
- skip Qwen grace when Vosk already contains stable alpha routing keywords such as 営業 時間 or Wi-Fi 接続
- keep grace for suspicious transcripts so Qwen can still recover route correctness

## Verification
- pytest backend/tests/agents/test_stt_agent.py -q
- python -m ruff check backend/agents/stt_agent.py backend/tests/agents/test_stt_agent.py
- python -m py_compile backend/agents/stt_agent.py
- git diff --check

Refs #658 #643