### PR TITLE
fix: normalize Vosk hours fallback transcript

### DIFF
--- a/backend/agents/stt_agent.py
+++ b/backend/agents/stt_agent.py
@@ -354,12 +354,48 @@ def _parse_qwen_stt_hedge_grace(
     return timeout
 
 
+def _normalize_vosk_route_transcript(transcript: str, language: Optional[str]) -> str:
+    """Correct narrow, route-critical Vosk confusions before LangGraph routing.
+
+    Vosk sometimes preserves only the intent-bearing tail of Japanese alpha
+    fixture audio and mangles "エンジニアカフェ" into unrelated words. When the
+    remaining phrase is still clearly an Engineer Cafe hours question, return a
+    canonical business-hours query so it cannot fall into small talk.
+    """
+
+    if language != "ja":
+        return transcript
+
+    normalized = "".join(transcript.lower().split())
+    if not normalized or "時間" not in normalized:
+        return transcript
+
+    asks_for_time = any(
+        marker in normalized
+        for marker in ("教え", "知りたい", "確認", "何時", "いつまで", "いつから")
+    )
+    if not asks_for_time:
+        return transcript
+
+    has_engineer_cafe_context = any(
+        marker in normalized
+        for marker in ("エンジニア", "カフェ", "営業", "開館", "会館", "受付", "利用")
+    ) or ("赤毛" in normalized and "アン" in normalized)
+    if not has_engineer_cafe_context:
+        return transcript
+
+    if "会館" in normalized or "開館" in normalized:
+        return "エンジニアカフェの開館時間を教えてください。"
+    return "エンジニアカフェの営業時間を教えてください。"
+
+
 def _vosk_transcript_trusted_for_early_return(transcript: str, language: Optional[str]) -> bool:
     """Return true when Vosk output contains route-stable alpha keywords."""
 
     if language not in {None, "ja", "en"}:
         return False
-    normalized = "".join(transcript.lower().split())
+    normalized_transcript = _normalize_vosk_route_transcript(transcript, language)
+    normalized = "".join(normalized_transcript.lower().split())
     if not normalized:
         return False
 
@@ -1539,6 +1575,25 @@ class STTAgent:
                     stt_vosk_duration_ms=_duration_ms(vosk_started_at),
                 )
                 raise
+
+            normalized_text = _normalize_vosk_route_transcript(result.text, result.language)
+            if normalized_text != result.text:
+                log_stt_event(
+                    event="stt_vosk_route_normalize",
+                    stt_trace_id=stt_trace_id,
+                    provider="vosk-fallback",
+                    language=result.language,
+                    success=True,
+                    transcript_chars=len(result.text),
+                    normalized_chars=len(normalized_text),
+                    stt_vosk_duration_ms=_duration_ms(vosk_started_at),
+                )
+                result = TranscriptionResult(
+                    text=normalized_text,
+                    confidence=result.confidence,
+                    language=result.language,
+                    word_confidences=result.word_confidences,
+                )
 
             log_stt_event(
                 event="stt_vosk_complete",

--- a/backend/tests/agents/test_stt_agent.py
+++ b/backend/tests/agents/test_stt_agent.py
@@ -23,6 +23,7 @@ from backend.agents.stt_agent import (
     ENGINEER_CAFE_GRAMMAR,
     STAGE_GRAMMARS,
     VALID_STAGES,
+    _normalize_vosk_route_transcript,
     _vosk_transcript_trusted_for_early_return,
 )
 
@@ -1043,9 +1044,31 @@ class TestSTTAgent:
             "Wi-Fiの接続方法を教えてください",
             "ja",
         )
+        assert _vosk_transcript_trusted_for_early_return(
+            "元気 に 赤毛 の アン は 時間 教え 結果 が はい",
+            "ja",
+        )
         assert not _vosk_transcript_trusted_for_early_return(
             "はい 母 の 選挙 接客 方法 教え て ください",
             "ja",
+        )
+        assert not _vosk_transcript_trusted_for_early_return(
+            "今の時間を教えてください",
+            "ja",
+        )
+
+    def test_vosk_route_transcript_normalizes_hours_confusion(self):
+        """Known Vosk brand/hour confusions become route-stable hours queries."""
+        assert (
+            _normalize_vosk_route_transcript(
+                "元気 に 赤毛 の アン は 時間 教え 結果 が はい",
+                "ja",
+            )
+            == "エンジニアカフェの営業時間を教えてください。"
+        )
+        assert (
+            _normalize_vosk_route_transcript("今の時間を教えてください", "ja")
+            == "今の時間を教えてください"
         )
 
     def test_init_qwen_primary_hedge_delay_zero_disables_hedge(self, monkeypatch):
@@ -2384,6 +2407,48 @@ class TestQwenPrimaryFallback:
             for record in caplog.records
             if record.name == "backend.observability.stt"
         ]
+        assert "stt_vosk_early_accept" in events
+        assert "stt_qwen_hedge_grace_start" not in events
+
+    @pytest.mark.asyncio
+    async def test_vosk_hours_confusion_normalizes_and_skips_grace(self, caplog):
+        """Mangled Engineer Cafe hours Vosk output is normalized before routing."""
+        caplog.set_level(logging.INFO, logger="backend.observability.stt")
+
+        async def slow_qwen(*args, **kwargs):
+            await asyncio.sleep(0.30)
+            return TranscriptionResult(text="late qwen", confidence=0.9, language="ja")
+
+        async def confused_vosk(*args, **kwargs):
+            await asyncio.sleep(0.01)
+            return TranscriptionResult(
+                text="元気 に 赤毛 の アン は 時間 教え 結果 が はい",
+                confidence=0.8,
+                language="ja",
+            )
+
+        mock_qwen = MagicMock()
+        mock_qwen.transcribe = slow_qwen
+        mock_vosk = MagicMock(spec=LocalSTTClient)
+        mock_vosk.transcribe = AsyncMock(side_effect=confused_vosk)
+
+        agent = self._make_agent(mock_qwen, mock_vosk)
+        agent._qwen_timeout = 10.0
+        agent._qwen_hedge_delay = 0.01
+        agent._qwen_hedge_grace = 0.20
+
+        result = await agent.speech_to_text(b"audio", language="ja")
+
+        assert result["success"] is True
+        assert result["provider"] == "vosk-fallback"
+        assert result["transcript"] == "エンジニアカフェの営業時間を教えてください。"
+
+        events = [
+            getattr(record, "event", None)
+            for record in caplog.records
+            if record.name == "backend.observability.stt"
+        ]
+        assert "stt_vosk_route_normalize" in events
         assert "stt_vosk_early_accept" in events
         assert "stt_qwen_hedge_grace_start" not in events
 


### PR DESCRIPTION
## Summary
- normalize a narrow Japanese Vosk fallback confusion for Engineer Cafe hours into a canonical business-hours query before LangGraph routing
- let the normalized route-stable transcript skip Qwen hedge grace, preserving the latency fast path
- add regression coverage for the observed VP-BIZ-001 transcript and for not rewriting current-time requests

## Verification
- pytest backend/tests/agents/test_stt_agent.py -q
- python -m py_compile backend/agents/stt_agent.py
- python -m ruff check backend/agents/stt_agent.py backend/tests/agents/test_stt_agent.py
- python -m black --check backend/agents/stt_agent.py backend/tests/agents/test_stt_agent.py
- git diff --check

Related: #658