### PR TITLE
fix: add alpha 127 ragas gate selection

### DIFF
--- a/.github/workflows/alpha-live-verification.yml
+++ b/.github/workflows/alpha-live-verification.yml
@@ -4,9 +4,16 @@ on:
   workflow_dispatch:
     inputs:
       suites:
-        description: 'Comma-separated suites: stt,v,a,b,c,d,e,h-ui,h,q,m,t,all (h is a compatibility alias for h-ui)'
+        description: 'Comma-separated suites: stt,v,a,b,c,c-diag,c-127,d,e,h-ui,h,q,m,t,all (h is a compatibility alias for h-ui; c is c-diag)'
         default: 'stt,v,b,c,q,h-ui'
         type: string
+      c_ragas_suite:
+        description: 'C/RAGAS case suite when suites contains c or all: diagnostic-29 or alpha-127. Explicit c-diag/c-127 suite aliases override this input.'
+        default: 'diagnostic-29'
+        type: choice
+        options:
+          - diagnostic-29
+          - alpha-127
       timestamp:
         description: 'Stable timestamp marker. Empty uses current UTC time.'
         default: ''
@@ -129,7 +136,7 @@ jobs:
 
       - name: C live API RAGAS
         id: rag_api_live
-        if: contains(format(',{0},', inputs.suites), ',c,') || contains(format(',{0},', inputs.suites), ',all,')
+        if: contains(format(',{0},', inputs.suites), ',c,') || contains(format(',{0},', inputs.suites), ',c-diag,') || contains(format(',{0},', inputs.suites), ',c-127,') || contains(format(',{0},', inputs.suites), ',all,')
         continue-on-error: true
         env:
           API_SECRET_KEY: ${{ secrets.BACKEND_API_KEY }}
@@ -138,7 +145,17 @@ jobs:
           RAG_API_LIVE_OPENAI_SECRET_NAMES: OPENAI_API_KEY,openai-api-key
           SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
           SUPABASE_KEY: ${{ secrets.SUPABASE_KEY }}
-        run: scripts/rag-api-live-test.sh --timestamp "${ALPHA_TIMESTAMP}-c" --languages ja,en,zh,ko
+        shell: bash
+        run: |
+          set -euo pipefail
+          c_suite="${{ inputs.c_ragas_suite }}"
+          if [[ ",${{ inputs.suites }}," == *",c-diag," ]]; then
+            c_suite="diagnostic-29"
+          fi
+          if [[ ",${{ inputs.suites }}," == *",c-127," ]]; then
+            c_suite="alpha-127"
+          fi
+          scripts/rag-api-live-test.sh --timestamp "${ALPHA_TIMESTAMP}-c" --case-suite "$c_suite" --languages ja,en,zh,ko
 
       - name: D memory and state durability smoke
         id: alpha_d
@@ -258,6 +275,7 @@ jobs:
           # Alpha Live Verification
 
           - suites: ${{ inputs.suites }}
+          - c_ragas_suite_input: ${{ inputs.c_ragas_suite }}
           - timestamp: ${ALPHA_TIMESTAMP:-unknown}
           - backend: ${ALPHA_SMOKE_BASE_URL:-unknown}
           - revision: ${ALPHA_SMOKE_CLOUD_RUN_REVISION:-unknown}

--- a/backend/evaluation/run_live_api_eval.py
+++ b/backend/evaluation/run_live_api_eval.py
@@ -27,9 +27,19 @@ logger = logging.getLogger(__name__)
 
 DATASETS_DIR = Path(__file__).parent / "datasets"
 MULTILINGUAL_QUERIES_PATH = DATASETS_DIR / "multilingual_queries.json"
+GROUND_TRUTH_PATH = (
+    Path(__file__).parent.parent / "tests" / "fixtures" / "golden_datasets" / "ground_truth.json"
+)
 DEFAULT_REPORTS_DIR = Path(__file__).parent.parent / "tests" / "evaluation" / "reports"
 
 ALL_LANGUAGES = ("ja", "en", "zh", "ko")
+CASE_SUITE_DIAGNOSTIC_29 = "diagnostic-29"
+CASE_SUITE_ALPHA_127 = "alpha-127"
+CASE_SUITES = (CASE_SUITE_DIAGNOSTIC_29, CASE_SUITE_ALPHA_127)
+CASE_SUITE_EXPECTED_TOTALS = {
+    CASE_SUITE_DIAGNOSTIC_29: 29,
+    CASE_SUITE_ALPHA_127: 127,
+}
 TRACKED_METRICS = (
     "context_precision",
     "answer_correctness",
@@ -86,16 +96,73 @@ def _load_multilingual_config() -> Dict[str, Any]:
 
 def _load_ground_truth_lookup() -> Dict[str, Dict[str, Any]]:
     """Load ground truth cases indexed by id."""
-    gt_path = (
-        Path(__file__).parent.parent
-        / "tests"
-        / "fixtures"
-        / "golden_datasets"
-        / "ground_truth.json"
-    )
-    with open(gt_path, "r", encoding="utf-8") as f:
+    with open(GROUND_TRUTH_PATH, "r", encoding="utf-8") as f:
         data = json.load(f)
     return {case["id"]: case for case in data.get("test_cases", [])}
+
+
+def _load_ground_truth_cases() -> List[Dict[str, Any]]:
+    """Load ground truth cases in file order."""
+    with open(GROUND_TRUTH_PATH, "r", encoding="utf-8") as f:
+        data = json.load(f)
+    return list(data.get("test_cases", []))
+
+
+def _query_from_ground_truth(case: Dict[str, Any]) -> Dict[str, Any]:
+    """Convert a ground-truth entry to the live API query manifest shape."""
+    category = case.get("category", "")
+    return {
+        "id": case["id"],
+        "language": case.get("language", "ja"),
+        "question": case["question"],
+        "category": category,
+        "ground_truth_id": case["id"],
+        "metadata": {
+            "difficulty": "release",
+            "intent": category,
+            "source": "ground_truth_127",
+        },
+    }
+
+
+def _load_case_suite_config(case_suite: str) -> Dict[str, Any]:
+    """Load query manifest for a named C/RAGAS live suite."""
+    if case_suite == CASE_SUITE_DIAGNOSTIC_29:
+        config = _load_multilingual_config()
+        config["case_suite"] = CASE_SUITE_DIAGNOSTIC_29
+        config["expected_total_cases"] = CASE_SUITE_EXPECTED_TOTALS[CASE_SUITE_DIAGNOSTIC_29]
+        return config
+    if case_suite == CASE_SUITE_ALPHA_127:
+        cases = _load_ground_truth_cases()
+        return {
+            "version": "1.0.0",
+            "description": "Alpha release-blocking 127-case live API RAGAS suite.",
+            "case_suite": CASE_SUITE_ALPHA_127,
+            "expected_total_cases": CASE_SUITE_EXPECTED_TOTALS[CASE_SUITE_ALPHA_127],
+            "queries": [_query_from_ground_truth(case) for case in cases],
+        }
+    raise ValueError(f"Unknown case suite: {case_suite}")
+
+
+def _suite_coverage(
+    *,
+    case_suite: str,
+    selected_languages: Sequence[str],
+    requested_total: int,
+) -> Dict[str, Any]:
+    """Return artifact metadata that prevents partial suites from looking release-complete."""
+    expected_total = CASE_SUITE_EXPECTED_TOTALS[case_suite]
+    all_languages_selected = tuple(selected_languages) == ALL_LANGUAGES
+    release_blocking = case_suite == CASE_SUITE_ALPHA_127
+    passed = requested_total == expected_total and (not release_blocking or all_languages_selected)
+    return {
+        "case_suite": case_suite,
+        "release_blocking": release_blocking,
+        "expected_total_cases": expected_total,
+        "requested_total_cases": requested_total,
+        "all_languages_selected": all_languages_selected,
+        "passed": passed,
+    }
 
 
 async def _call_chat_api(
@@ -130,6 +197,7 @@ async def run_live_api_evaluation(
     output_dir: Optional[Path] = None,
     check_live_sources: bool = True,
     metrics: Optional[Sequence[str]] = None,
+    case_suite: str = CASE_SUITE_DIAGNOSTIC_29,
 ) -> Dict[str, Any]:
     """Run RAGAS evaluation against the live API.
 
@@ -142,7 +210,7 @@ async def run_live_api_evaluation(
     Returns:
         Evaluation result dictionary with per-language metrics.
     """
-    config = _load_multilingual_config()
+    config = _load_case_suite_config(case_suite)
     gt_lookup = _load_ground_truth_lookup()
     selected_languages = list(languages or ALL_LANGUAGES)
     selected_metrics = tuple(metrics or TRACKED_METRICS)
@@ -309,19 +377,36 @@ async def run_live_api_evaluation(
         }
 
     # Phase 3: Compare with targets
+    requested_total = sum(
+        int(result.get("requested_case_count", 0) or 0) for result in per_language_results.values()
+    )
+    suite_coverage = _suite_coverage(
+        case_suite=case_suite,
+        selected_languages=selected_languages,
+        requested_total=requested_total,
+    )
     comparison = _compare_targets(
         per_language_results, selected_languages, check_live_sources=check_live_sources
+    )
+    comparison["suite_coverage"] = suite_coverage
+    comparison["alpha_release_gate_met"] = (
+        comparison["all_targets_met"]
+        and suite_coverage["release_blocking"]
+        and suite_coverage["passed"]
     )
     report_text = _format_report(
         per_language_results,
         comparison,
         selected_languages,
         check_live_sources=check_live_sources,
+        case_suite=case_suite,
     )
 
     result = {
         "timestamp": datetime.now(timezone.utc).isoformat(),
         "mode": "live-api",
+        "case_suite": case_suite,
+        "suite_coverage": suite_coverage,
         "base_url": base_url,
         "languages": selected_languages,
         "metrics": list(selected_metrics),
@@ -440,6 +525,7 @@ def _format_report(
     languages: Sequence[str],
     *,
     check_live_sources: bool,
+    case_suite: str,
 ) -> str:
     """Format a human-readable report."""
     lines = [
@@ -448,11 +534,25 @@ def _format_report(
         f"Generated: {datetime.now(timezone.utc).isoformat()}",
         "=" * 60,
         "",
+        f"Case suite: {case_suite}",
         "Targets: ja >= 0.85, en >= 0.75, zh >= 0.65, ko >= 0.65",
         "RAGAS contexts: golden_dataset references, not live retrieved chunks",
         f"Live source metadata gate: {'enabled' if check_live_sources else 'disabled'}",
         "",
     ]
+    suite_coverage = comparison.get("suite_coverage", {})
+    if suite_coverage:
+        status = "PASS" if suite_coverage.get("passed") else "FAIL"
+        lines.extend(
+            [
+                "Suite coverage:",
+                f"  release_blocking: {suite_coverage.get('release_blocking')}",
+                "  cases: "
+                f"requested={suite_coverage.get('requested_total_cases')} "
+                f"expected={suite_coverage.get('expected_total_cases')} [{status}]",
+                "",
+            ]
+        )
 
     for lang in languages:
         result = lang_results.get(lang, {})
@@ -527,6 +627,18 @@ def _format_report(
     lines.append("=" * 60)
     all_met = comparison.get("all_targets_met", False)
     lines.append(f"All targets met: {'YES' if all_met else 'NO'}")
+    lines.append(
+        "Alpha release gate met: "
+        f"{'YES' if comparison.get('alpha_release_gate_met', False) else 'NO'}"
+    )
+    if suite_coverage and not suite_coverage.get("passed"):
+        lines.append(
+            "Suite coverage failed: "
+            f"case_suite={suite_coverage.get('case_suite')} "
+            f"requested={suite_coverage.get('requested_total_cases')} "
+            f"expected={suite_coverage.get('expected_total_cases')} "
+            f"all_languages_selected={suite_coverage.get('all_languages_selected')}"
+        )
 
     if not all_met:
         lines.append("Failed targets:")
@@ -595,6 +707,15 @@ def main() -> None:
         ),
     )
     parser.add_argument(
+        "--case-suite",
+        choices=CASE_SUITES,
+        default=CASE_SUITE_DIAGNOSTIC_29,
+        help=(
+            "C/RAGAS live case suite. diagnostic-29 is the existing fast diagnostic path; "
+            "alpha-127 is the release-blocking full dataset."
+        ),
+    )
+    parser.add_argument(
         "--no-check-live-sources",
         action="store_true",
         help=(
@@ -619,10 +740,14 @@ def main() -> None:
             output_dir=output_dir,
             check_live_sources=not args.no_check_live_sources,
             metrics=args.metrics,
+            case_suite=args.case_suite,
         )
     )
 
-    if args.check_targets and not result["comparison"]["all_targets_met"]:
+    target_key = (
+        "alpha_release_gate_met" if args.case_suite == CASE_SUITE_ALPHA_127 else "all_targets_met"
+    )
+    if args.check_targets and not result["comparison"][target_key]:
         logger.error("One or more evaluation targets were missed.")
         sys.exit(1)
 

--- a/backend/tests/evaluation/test_ragas_live_case_suites.py
+++ b/backend/tests/evaluation/test_ragas_live_case_suites.py
@@ -1,0 +1,64 @@
+"""C/RAGAS live API case-suite selection tests."""
+
+from collections import Counter
+
+from backend.evaluation.run_live_api_eval import (
+    ALL_LANGUAGES,
+    CASE_SUITE_ALPHA_127,
+    CASE_SUITE_DIAGNOSTIC_29,
+    _load_case_suite_config,
+    _suite_coverage,
+)
+
+
+def test_diagnostic_case_suite_preserves_29_case_manifest():
+    config = _load_case_suite_config(CASE_SUITE_DIAGNOSTIC_29)
+    queries = config["queries"]
+
+    assert config["case_suite"] == CASE_SUITE_DIAGNOSTIC_29
+    assert config["expected_total_cases"] == 29
+    assert len(queries) == 29
+    assert Counter(query["language"] for query in queries) == {
+        "ja": 5,
+        "en": 10,
+        "zh": 7,
+        "ko": 7,
+    }
+
+
+def test_alpha_case_suite_loads_full_127_case_ground_truth_dataset():
+    config = _load_case_suite_config(CASE_SUITE_ALPHA_127)
+    queries = config["queries"]
+
+    assert config["case_suite"] == CASE_SUITE_ALPHA_127
+    assert config["expected_total_cases"] == 127
+    assert len(queries) == 127
+    assert Counter(query["language"] for query in queries) == {
+        "ja": 80,
+        "en": 23,
+        "zh": 12,
+        "ko": 12,
+    }
+    assert all(query["ground_truth_id"] == query["id"] for query in queries)
+
+
+def test_alpha_127_coverage_requires_all_languages_and_all_cases():
+    full = _suite_coverage(
+        case_suite=CASE_SUITE_ALPHA_127,
+        selected_languages=ALL_LANGUAGES,
+        requested_total=127,
+    )
+    partial_languages = _suite_coverage(
+        case_suite=CASE_SUITE_ALPHA_127,
+        selected_languages=("ja",),
+        requested_total=80,
+    )
+    short_count = _suite_coverage(
+        case_suite=CASE_SUITE_ALPHA_127,
+        selected_languages=ALL_LANGUAGES,
+        requested_total=126,
+    )
+
+    assert full["passed"] is True
+    assert partial_languages["passed"] is False
+    assert short_count["passed"] is False

--- a/docs/plans/alpha-remediation-plan-2026-05-02.md
+++ b/docs/plans/alpha-remediation-plan-2026-05-02.md
@@ -57,7 +57,12 @@ Tasks:
 
 - Define release-blocking cases versus diagnostic/soak cases.
 - Add explicit workflow inputs for diagnostic C and full C-127.
+  - Implemented harness selection: `c` / `c-diag` run `diagnostic-29`; `c-127` runs
+    `alpha-127`; the `c_ragas_suite` workflow input can also select either suite for `c` or
+    `all`.
 - Ensure reports cannot imply that 29 cases satisfy the 127-case requirement.
+  - `live_api_eval` reports now include `case_suite` and `suite_coverage` metadata. Only
+    `alpha-127` with all four languages and 127 requested cases is release-blocking coverage.
 
 ### 3. #653 / #672 answer quality
 

--- a/docs/testing/alpha-final-scenarios.md
+++ b/docs/testing/alpha-final-scenarios.md
@@ -29,6 +29,10 @@ Current confirmed target:
 - RAGAS は direct RAG 評価と `/api/chat` live API 評価を分離します。`scripts/rag-live-test.sh` は `EnhancedRAGSearch` 直評価、`scripts/rag-api-live-test.sh` は `/api/chat` 経由評価です。
 - A 系の音声本実行前に `scripts/stt-live-preflight.sh` で直近の `stt_winner` latency / timeout 分布を確認します。
 - Alpha GO proof の C/RAGAS は direct OpenAI を必須にします。`RAGAS judge provider: direct OpenAI` が出ない run は diagnostic として扱い、GO 証跡にしません。
+- C/RAGAS の 29-case path は diagnostic only です。Alpha GO proof では
+  `scripts/rag-api-live-test.sh --case-suite alpha-127 --languages ja,en,zh,ko`、または
+  `alpha-live-verification.yml` の `suites=c-127` / `c_ragas_suite=alpha-127` を使います。
+  Report の `case_suite=alpha-127` と `suite_coverage` が 127/127 PASS になっていることを確認してください。
 - GitHub step conclusion だけで suite の成否を判断しないでください。`continue-on-error` のため、summary / artifact の suite outcome を正本にします。
 
 ## A-1 Japanese Realistic Utterances

--- a/scripts/rag-api-live-test.sh
+++ b/scripts/rag-api-live-test.sh
@@ -6,6 +6,7 @@ set -euo pipefail
 # Usage:
 #   scripts/rag-api-live-test.sh
 #   scripts/rag-api-live-test.sh --languages ja,en --dry-run
+#   scripts/rag-api-live-test.sh --case-suite alpha-127
 #
 # Env:
 #   API_SECRET_KEY                 Required unless --key is provided or gcloud can read it.
@@ -27,6 +28,7 @@ OPENROUTER_SECRET_NAMES="${RAG_API_LIVE_OPENROUTER_SECRET_NAMES:-OPENROUTER_API_
 OUTPUT_DIR="$ROOT_DIR/backend/tests/evaluation/reports"
 LANGUAGES="ja,en,zh,ko"
 METRICS="${RAG_API_LIVE_METRICS:-answer_correctness}"
+CASE_SUITE="${RAG_API_LIVE_CASE_SUITE:-diagnostic-29}"
 TIMESTAMP="$(date +%Y%m%d_%H%M%S)"
 DRY_RUN=0
 CHECK_TARGETS=1
@@ -45,6 +47,7 @@ Options:
                          Comma-separated OpenRouter fallback secret names (default: OPENROUTER_API_KEY)
   --languages LIST       Comma-separated languages (default: ja,en,zh,ko)
   --metrics LIST         Comma-separated RAGAS metrics (default: answer_correctness)
+  --case-suite NAME      diagnostic-29 (fast path) or alpha-127 (release gate)
   --output-dir DIR       Report directory (default: backend/tests/evaluation/reports)
   --timestamp VALUE      Stable timestamp marker printed for operator correlation
   --no-check-targets     Do not fail when configured answer_correctness targets are missed
@@ -68,6 +71,7 @@ while [ "$#" -gt 0 ]; do
     --openrouter-secret-names) OPENROUTER_SECRET_NAMES="$2"; shift 2 ;;
     --languages) LANGUAGES="$2"; shift 2 ;;
     --metrics) METRICS="$2"; shift 2 ;;
+    --case-suite) CASE_SUITE="$2"; shift 2 ;;
     --output-dir) OUTPUT_DIR="$2"; shift 2 ;;
     --timestamp) TIMESTAMP="$2"; shift 2 ;;
     --no-check-targets) CHECK_TARGETS=0; shift ;;
@@ -141,6 +145,16 @@ require_ragas_judge_key() {
   exit 2
 }
 
+validate_case_suite() {
+  case "$CASE_SUITE" in
+    diagnostic-29|alpha-127) ;;
+    *)
+      echo "Error: --case-suite must be diagnostic-29 or alpha-127, got: $CASE_SUITE" >&2
+      exit 2
+      ;;
+  esac
+}
+
 language_args() {
   python3 - "$LANGUAGES" <<'PY'
 import sys
@@ -161,6 +175,7 @@ PY
 
 main() {
   require_cmd python3
+  validate_case_suite
   if [ ! -f "$RUNNER" ]; then
     echo "Error: live API RAGAS runner not found: $RUNNER" >&2
     exit 2
@@ -189,6 +204,7 @@ main() {
     echo "Runner: $RUNNER"
     echo "Base URL: $BASE_URL"
     echo "Output dir: $OUTPUT_DIR"
+    echo "Case suite: $CASE_SUITE"
     echo "Languages: ${LANG_ARGS[*]}"
     echo "Metrics: ${METRIC_ARGS[*]}"
     if [ "$CHECK_TARGETS" = "1" ]; then
@@ -214,12 +230,13 @@ main() {
   echo "Running /api/chat live RAGAS"
   echo "Timestamp: $TIMESTAMP"
   echo "Base URL: $BASE_URL"
+  echo "Case suite: $CASE_SUITE"
   echo "Languages: ${LANG_ARGS[*]}"
   echo "Metrics: ${METRIC_ARGS[*]}"
   echo "RAGAS batch strategy: ${RAGAS_BATCH_STRATEGY:-single}"
   echo "RAGAS per-case timeout: ${RAGAS_OUTER_SINGLE_TIMEOUT:-300}s"
 
-  cmd=(python evaluation/run_live_api_eval.py --base-url "$BASE_URL" --languages "${LANG_ARGS[@]}" --metrics "${METRIC_ARGS[@]}" --output-dir "$OUTPUT_DIR")
+  cmd=(python evaluation/run_live_api_eval.py --base-url "$BASE_URL" --case-suite "$CASE_SUITE" --languages "${LANG_ARGS[@]}" --metrics "${METRIC_ARGS[@]}" --output-dir "$OUTPUT_DIR")
   if [ "$CHECK_TARGETS" = "1" ]; then
     cmd+=(--check-targets)
   fi


### PR DESCRIPTION
## Summary
- add explicit C/RAGAS case suite selection for diagnostic-29 versus alpha-127
- expose workflow aliases c-diag and c-127, plus c_ragas_suite input for c/all
- add suite coverage metadata so 29-case diagnostic reports cannot satisfy the 127-case alpha gate
- document alpha GO usage for c-127

## Validation
- pytest backend/tests/evaluation/test_ragas_live_case_suites.py -q
- pytest backend/tests/evaluation/test_multilingual_ragas.py::TestMultilingualQueryManifest -q
- python -m py_compile backend/evaluation/run_live_api_eval.py
- scripts/rag-api-live-test.sh --dry-run --timestamp drydiag --case-suite diagnostic-29 --languages ja,en,zh,ko
- scripts/rag-api-live-test.sh --dry-run --timestamp dryalpha --case-suite alpha-127 --languages ja,en,zh,ko
- git diff --check

Refs #657
Refs #583