### PR TITLE
fix: classify alpha c127 live source gate

### DIFF
--- a/backend/evaluation/run_live_api_eval.py
+++ b/backend/evaluation/run_live_api_eval.py
@@ -40,6 +40,20 @@ CASE_SUITE_EXPECTED_TOTALS = {
     CASE_SUITE_DIAGNOSTIC_29: 29,
     CASE_SUITE_ALPHA_127: 127,
 }
+LOCAL_KNOWLEDGE_SOURCE_REQUIREMENT = "enhanced_rag|knowledge_base|knowledge_base_cached"
+EVENT_SOURCE_REQUIREMENT = f"google_calendar|connpass|{LOCAL_KNOWLEDGE_SOURCE_REQUIREMENT}"
+NO_SOURCE_REQUIRED_CATEGORIES = {"emergency", "farewell", "reception"}
+EVENT_LIKE_CATEGORIES = {"event", "community", "clarification"}
+EMERGENCY_TERMS = (
+    "緊急",
+    "避難",
+    "地震",
+    "火事",
+    "aed",
+    "earthquake",
+    "fire",
+    "evacuate",
+)
 TRACKED_METRICS = (
     "context_precision",
     "answer_correctness",
@@ -71,9 +85,14 @@ def _flatten_metadata_sources(value: Any) -> set[str]:
 
 def _required_live_sources(query: Dict[str, Any]) -> List[str]:
     category = str(query.get("category") or "").strip().lower().replace("-", "_")
-    if category == "event":
-        return ["google_calendar|connpass"]
-    return ["enhanced_rag"]
+    question = str(query.get("question") or "").strip().lower()
+    if category in NO_SOURCE_REQUIRED_CATEGORIES or any(
+        term in question for term in EMERGENCY_TERMS
+    ):
+        return []
+    if category in EVENT_LIKE_CATEGORIES:
+        return [EVENT_SOURCE_REQUIREMENT]
+    return [LOCAL_KNOWLEDGE_SOURCE_REQUIREMENT]
 
 
 def _source_requirement_ok(

--- a/backend/tests/evaluation/test_ragas_live_case_suites.py
+++ b/backend/tests/evaluation/test_ragas_live_case_suites.py
@@ -6,7 +6,11 @@ from backend.evaluation.run_live_api_eval import (
     ALL_LANGUAGES,
     CASE_SUITE_ALPHA_127,
     CASE_SUITE_DIAGNOSTIC_29,
+    EVENT_SOURCE_REQUIREMENT,
+    LOCAL_KNOWLEDGE_SOURCE_REQUIREMENT,
     _load_case_suite_config,
+    _required_live_sources,
+    _source_requirement_ok,
     _suite_coverage,
 )
 
@@ -62,3 +66,36 @@ def test_alpha_127_coverage_requires_all_languages_and_all_cases():
     assert full["passed"] is True
     assert partial_languages["passed"] is False
     assert short_count["passed"] is False
+
+
+def test_alpha_source_requirements_allow_live_metadata_aliases():
+    assert _required_live_sources({"category": "access", "question": "雨の日の行き方は？"}) == [
+        LOCAL_KNOWLEDGE_SOURCE_REQUIREMENT
+    ]
+    assert _required_live_sources({"category": "community", "question": "DevDayはいつ？"}) == [
+        EVENT_SOURCE_REQUIREMENT
+    ]
+    assert _required_live_sources({"category": "emergency", "question": "火事だ！"}) == []
+    assert _required_live_sources({"category": "policy", "question": "緊急時の避難経路は？"}) == []
+
+
+def test_source_requirement_accepts_knowledge_and_event_alternatives():
+    assert _source_requirement_ok(
+        {"sources": ["knowledge_base_cached"]}, [LOCAL_KNOWLEDGE_SOURCE_REQUIREMENT]
+    ) == (
+        True,
+        [],
+        ["knowledge_base_cached"],
+    )
+    assert _source_requirement_ok({"sources": ["google_calendar"]}, [EVENT_SOURCE_REQUIREMENT]) == (
+        True,
+        [],
+        ["google_calendar"],
+    )
+    assert _source_requirement_ok(
+        {"sources": ["fallback"]}, [LOCAL_KNOWLEDGE_SOURCE_REQUIREMENT]
+    ) == (
+        False,
+        [LOCAL_KNOWLEDGE_SOURCE_REQUIREMENT],
+        ["fallback"],
+    )

--- a/docs/testing/alpha-final-scenarios.md
+++ b/docs/testing/alpha-final-scenarios.md
@@ -33,6 +33,10 @@ Current confirmed target:
   `scripts/rag-api-live-test.sh --case-suite alpha-127 --languages ja,en,zh,ko`、または
   `alpha-live-verification.yml` の `suites=c-127` / `c_ragas_suite=alpha-127` を使います。
   Report の `case_suite=alpha-127` と `suite_coverage` が 127/127 PASS になっていることを確認してください。
+- C/RAGAS live source gate は intent ごとの source policy で判定します。施設・料金・連絡先などの local knowledge は
+  `enhanced_rag` / `knowledge_base` / `knowledge_base_cached` を同等に扱い、event-like case は
+  `google_calendar` / `connpass` も許容します。緊急・受付・farewell の即時応答は source なしでも source gate 上は許容し、
+  回答品質は `answer_correctness` 側で判定します。
 - GitHub step conclusion だけで suite の成否を判断しないでください。`continue-on-error` のため、summary / artifact の suite outcome を正本にします。
 
 ## A-1 Japanese Realistic Utterances


### PR DESCRIPTION
## Summary

- classify C-127 live source requirements by intent instead of requiring `enhanced_rag` for every ground-truth case
- accept `knowledge_base` / `knowledge_base_cached` as local-knowledge source aliases
- allow calendar/Connpass/event-like sources for event/community/clarification cases
- allow no source metadata for immediate emergency/reception/farewell responses, leaving answer quality to `answer_correctness`
- document the source-gate policy in alpha final scenarios

## Verification

- `pytest backend/tests/evaluation/test_ragas_live_case_suites.py -q`
- `python -m py_compile backend/evaluation/run_live_api_eval.py`
- `python -m black --check backend/evaluation/run_live_api_eval.py backend/tests/evaluation/test_ragas_live_case_suites.py`
- `python -m ruff check backend/evaluation/run_live_api_eval.py backend/tests/evaluation/test_ragas_live_case_suites.py`
- `git diff --check -- backend/evaluation/run_live_api_eval.py backend/tests/evaluation/test_ragas_live_case_suites.py docs/testing/alpha-final-scenarios.md`

## C-127 Reclassification

Using run `25259243955`, this policy narrows source failures from 20 cases to 6 remaining true product/source issues:

- `gt-019` JA consultation: no source
- `gt-038` JA facility-info: fallback
- `gt-100` ZH pricing: fallback
- `gt-103` ZH food_drink: fallback
- `gt-107` ZH general: fallback
- `gt-115` KO smoking: fallback

Closes #684.
