### PR TITLE
fix: improve alpha c127 answer routing

### DIFF
--- a/backend/agents/business_info_agent.py
+++ b/backend/agents/business_info_agent.py
@@ -125,7 +125,7 @@ class BusinessInfoAgent:
         )
 
         canonical = self._get_canonical_response(query, request_type, language)
-        if canonical and state_context is None:
+        if canonical:
             return canonical
 
         # requestTypeをcategoryにマッピング
@@ -155,9 +155,6 @@ class BusinessInfoAgent:
 
         if not context:
             return self._get_default_response(language, request_type)
-
-        if canonical:
-            return canonical
 
         # プロンプト構築
         prompt = self._build_prompt(query, context, request_type, language)
@@ -442,6 +439,82 @@ Information: {context}
     ) -> Optional[Dict]:
         """Return complete answers for common visitor-critical business questions."""
         normalized = query.lower()
+        if self._asks_closed_days(normalized):
+            answers = {
+                "ja": (
+                    "[relaxed]エンジニアカフェの休館日は毎月最終月曜日です。"
+                    "その日が祝休日の場合は翌平日が休館日になり、年末年始は"
+                    "12月29日から1月3日まで休館です。"
+                ),
+                "en": (
+                    "[relaxed]Engineer Cafe is closed on the last Monday of each month. "
+                    "If that day is a public holiday, the next weekday is closed instead. "
+                    "It is also closed from December 29 to January 3."
+                ),
+                "zh": (
+                    "[relaxed]工程师咖啡每月最后一个星期一闭馆。"
+                    "如果当天是节假日，则顺延到下一个工作日闭馆；"
+                    "年末年初12月29日至1月3日也闭馆。"
+                ),
+                "ko": (
+                    "[relaxed]엔지니어 카페는 매월 마지막 월요일에 휴관합니다. "
+                    "그날이 공휴일이면 다음 평일이 휴관일이며, 연말연시에는 "
+                    "12월 29일부터 1월 3일까지 휴관합니다."
+                ),
+            }
+            return self._canonical_result(answers.get(language, answers["ja"]), request_type)
+
+        if self._asks_community_program(normalized, request_type):
+            if "devday" in normalized:
+                answers = {
+                    "ja": (
+                        "[relaxed]DevDayはENGINEER IGNITION CAMP（EIC）の"
+                        "最終展示会で、2026年2月23日18:00から開催されます。"
+                        "ピッチではなく展示形式で実施されます。"
+                    ),
+                    "en": (
+                        "[relaxed]DevDay is the final exhibition for ENGINEER IGNITION "
+                        "CAMP (EIC). It is scheduled for February 23, 2026 at 18:00, "
+                        "and is held as an exhibition rather than a pitch event."
+                    ),
+                    "zh": (
+                        "[relaxed]DevDay是ENGINEER IGNITION CAMP（EIC）的最终展示会，"
+                        "预定于2026年2月23日18:00举行。形式是展示，不是路演。"
+                    ),
+                    "ko": (
+                        "[relaxed]DevDay는 ENGINEER IGNITION CAMP(EIC)의 최종 전시회로, "
+                        "2026년 2월 23일 18:00에 열릴 예정입니다. 피치가 아니라 "
+                        "전시 형식으로 진행됩니다."
+                    ),
+                }
+                return self._canonical_result(answers.get(language, answers["ja"]), request_type)
+
+            answers = {
+                "ja": (
+                    "[relaxed]ENGINEER IGNITION CAMP（EIC）は、エンジニアカフェが"
+                    "主催する短期集中・実践型プログラムです。参加費は無料で、"
+                    "「つくりたい物をつくる」をコンセプトに、事業化や対価を得ることを"
+                    "目指します。"
+                ),
+                "en": (
+                    "[relaxed]ENGINEER IGNITION CAMP (EIC) is a short, intensive, "
+                    "hands-on program hosted by Engineer Cafe. Participation is free, "
+                    "and the concept is to build what you want to build while aiming "
+                    "toward commercialization or earning value from it."
+                ),
+                "zh": (
+                    "[relaxed]ENGINEER IGNITION CAMP（EIC）是工程师咖啡主办的"
+                    "短期集中实践型项目，参加免费。理念是“制作自己想做的东西”，"
+                    "并以事业化或获得对价为目标。"
+                ),
+                "ko": (
+                    "[relaxed]ENGINEER IGNITION CAMP(EIC)는 엔지니어 카페가 주최하는 "
+                    "단기 집중 실천형 프로그램입니다. 참가비는 무료이며, "
+                    "'만들고 싶은 것을 만든다'는 콘셉트로 사업화나 가치 창출을 목표로 합니다."
+                ),
+            }
+            return self._canonical_result(answers.get(language, answers["ja"]), request_type)
+
         if self._asks_opening_hours(normalized, request_type):
             answers = {
                 "ja": (
@@ -646,6 +719,36 @@ Information: {context}
             "운영 시간",
             "이용 시간",
         )
+        return any(keyword in query for keyword in keywords)
+
+    @staticmethod
+    def _asks_closed_days(query: str) -> bool:
+        keywords = (
+            "休館日",
+            "休業日",
+            "定休日",
+            "休みの日",
+            "お休みの日",
+            "閉まっている日",
+            "閉まってる日",
+            "closed day",
+            "closed days",
+            "holiday",
+            "holidays",
+            "闭馆",
+            "休馆",
+            "闭馆日",
+            "休馆日",
+            "휴관일",
+            "쉬는 날",
+        )
+        return any(keyword in query for keyword in keywords)
+
+    @staticmethod
+    def _asks_community_program(query: str, request_type: Optional[str]) -> bool:
+        if request_type != "community":
+            return False
+        keywords = ("engineer ignition camp", "eic", "devday")
         return any(keyword in query for keyword in keywords)
 
     @staticmethod

--- a/backend/agents/facility_agent.py
+++ b/backend/agents/facility_agent.py
@@ -333,6 +333,161 @@ class FacilityAgent:
     ) -> Optional[Dict]:
         """Return complete answers for common visitor-critical facility questions."""
         normalized = query.lower()
+        if self._asks_3d_printer_filament_price(normalized):
+            answers = {
+                "ja": (
+                    "[relaxed]MAKER'sスペースの3Dプリンター用フィラメントは"
+                    "使用分を買い取り方式で精算します。Bambu Lab P1S用の"
+                    "PLA白・黒とABS白・黒は2円/gで、使用量に単価をかけて"
+                    "10円未満は切り捨てです。福岡市在住の学生は無料です。"
+                ),
+                "en": (
+                    "[relaxed]3D printer filament in MAKER's Space is charged by "
+                    "the amount used. Standard PLA and ABS for the Bambu Lab P1S are "
+                    "2 yen per gram, with amounts under 10 yen rounded down. Students "
+                    "living in Fukuoka City can use filament for free."
+                ),
+                "zh": (
+                    "[relaxed]MAKER's Space的3D打印机耗材按实际使用量结算。"
+                    "Bambu Lab P1S用的PLA白色、黑色和ABS白色、黑色都是2日元/g，"
+                    "不足10日元会舍去。福冈市在住学生免费。"
+                ),
+                "ko": (
+                    "[relaxed]MAKER's Space의 3D 프린터 필라멘트는 사용량만큼 "
+                    "정산합니다. Bambu Lab P1S용 PLA 흰색・검정색과 ABS 흰색・검정색은 "
+                    "2엔/g이며, 10엔 미만은 절사됩니다. 후쿠오카시 거주 학생은 무료입니다."
+                ),
+            }
+            return self._canonical_result(answers.get(language, answers["ja"]), request_type)
+
+        if self._asks_3d_printer_use(normalized):
+            answers = {
+                "ja": (
+                    "[relaxed]3Dプリンターは地下1階のMAKER'sスペースで利用できます。"
+                    "初回は約1時間の無料講習が必要で、講習後はWeb予約優先制です。"
+                    "予約は前日まで受け付けています。"
+                ),
+                "en": (
+                    "[relaxed]You can use 3D printers in MAKER's Space on B1F. "
+                    "First-time users need a free training session of about one hour; "
+                    "after that, use is prioritized by web reservation, accepted until "
+                    "the day before."
+                ),
+                "zh": (
+                    "[relaxed]3D打印机可在地下一层MAKER's Space使用。"
+                    "首次使用需要参加约1小时的免费讲习；讲习后采用网页预约优先制，"
+                    "预约受理到前一天为止。"
+                ),
+                "ko": (
+                    "[relaxed]3D 프린터는 지하 1층 MAKER's Space에서 이용할 수 있습니다. "
+                    "처음 이용할 때는 약 1시간의 무료 강습이 필요하며, 이후에는 "
+                    "웹 예약 우선제로 전날까지 예약할 수 있습니다."
+                ),
+            }
+            return self._canonical_result(answers.get(language, answers["ja"]), request_type)
+
+        if request_type == "toilet" or self._asks_toilet(normalized):
+            answers = {
+                "ja": (
+                    "[relaxed]トイレは1階テラスの奥にあります。館内から直接は"
+                    "行けないため、受付奥の通路からテラスに出て、テラス奥へ"
+                    "進んでください。"
+                ),
+                "en": (
+                    "[relaxed]The restroom is at the back of the 1F terrace. "
+                    "You cannot access it directly from inside the building, so go "
+                    "through the passage behind reception to the terrace, then continue "
+                    "to the back."
+                ),
+                "zh": (
+                    "[relaxed]洗手间在一楼露台深处。馆内不能直接过去，"
+                    "请从前台后方通道到露台，再往露台里面走。"
+                ),
+                "ko": (
+                    "[relaxed]화장실은 1층 테라스 안쪽에 있습니다. 건물 안에서는 "
+                    "바로 갈 수 없으니, 접수대 안쪽 통로로 테라스에 나간 뒤 "
+                    "안쪽으로 이동해 주세요."
+                ),
+            }
+            return self._canonical_result(answers.get(language, answers["ja"]), request_type)
+
+        if self._asks_online_meeting_place(normalized):
+            answers = {
+                "ja": (
+                    "[relaxed]電話やオンラインミーティングは、1階メインホール、"
+                    "談話室、テラス、cafe&bar sainoで可能です。地下1階には"
+                    "1回1時間まで使える防音室が1室あり、オンラインミーティングや"
+                    "電話に向いています。集中スペースは会話・電話禁止です。"
+                ),
+                "en": (
+                    "[relaxed]For calls or online meetings, you can use the 1F main "
+                    "hall, lounge, terrace, or cafe&bar saino. There is also one "
+                    "soundproof room on B1F for up to one hour at a time. The B1F "
+                    "Focus Space does not allow talking or phone calls."
+                ),
+                "zh": (
+                    "[relaxed]电话或线上会议可以在一楼主厅、谈话室、露台或"
+                    "cafe&bar saino进行。地下一层有一间防音室，每次最多可用1小时，"
+                    "适合线上会议和电话。集中空间禁止交谈和通话。"
+                ),
+                "ko": (
+                    "[relaxed]전화나 온라인 미팅은 1층 메인 홀, 담화실, 테라스, "
+                    "cafe&bar saino에서 가능합니다. 지하 1층에는 1회 1시간까지 "
+                    "쓸 수 있는 방음실이 1개 있으며, 집중 스페이스에서는 대화와 전화가 금지됩니다."
+                ),
+            }
+            return self._canonical_result(answers.get(language, answers["ja"]), request_type)
+
+        if self._asks_focus_space(normalized):
+            answers = {
+                "ja": (
+                    "[relaxed]集中スペースは地下1階にある静かなブース型スペースです。"
+                    "6席あり、座席指定制・先着順で予約はできません。会話や電話は"
+                    "できないので、静かに作業したい方向けです。"
+                ),
+                "en": (
+                    "[relaxed]The Focus Space is a quiet booth-style work area on B1F. "
+                    "It has six seats, is first-come first-served with assigned seating, "
+                    "and cannot be reserved. Talking and phone calls are not allowed."
+                ),
+                "zh": (
+                    "[relaxed]集中空间位于地下一层，是安静的隔间式工作区。"
+                    "共有6个座位，指定座位、先到先用，不能预约。这里禁止交谈和通话。"
+                ),
+                "ko": (
+                    "[relaxed]집중 스페이스는 지하 1층의 조용한 부스형 작업 공간입니다. "
+                    "6석이 있으며 좌석 지정제와 선착순으로 운영되고 예약은 불가합니다. "
+                    "대화와 전화는 할 수 없습니다."
+                ),
+            }
+            return self._canonical_result(answers.get(language, answers["ja"]), request_type)
+
+        if request_type == "lost_found" or self._asks_lost_found(normalized):
+            answers = {
+                "ja": (
+                    "[relaxed]忘れ物や落とし物は、まず1階のエンジニアカフェ受付に"
+                    "お声がけください。2階会議室やトイレなど共用部の忘れ物は、"
+                    "赤煉瓦文化館受付で保管される場合もあります。電話は080-6742-7231です。"
+                ),
+                "en": (
+                    "[relaxed]For lost items, please ask the 1F Engineer Cafe reception "
+                    "first. Items found in shared areas such as the 2F meeting rooms or "
+                    "restrooms may be kept at the Red Brick Culture Hall reception. "
+                    "You can also call 080-6742-7231."
+                ),
+                "zh": (
+                    "[relaxed]遗失物请先询问一楼工程师咖啡前台。"
+                    "二楼会议室或洗手间等公共区域的遗失物，也可能由赤炼瓦文化馆前台保管。"
+                    "电话是080-6742-7231。"
+                ),
+                "ko": (
+                    "[relaxed]분실물은 먼저 1층 엔지니어 카페 접수에 문의해 주세요. "
+                    "2층 회의실이나 화장실 같은 공용부의 분실물은 아카렌가 문화관 접수에서 "
+                    "보관하는 경우도 있습니다. 전화번호는 080-6742-7231입니다."
+                ),
+            }
+            return self._canonical_result(answers.get(language, answers["ja"]), request_type)
+
         if self._asks_power_outlet(normalized):
             answers = {
                 "ja": (
@@ -520,9 +675,130 @@ class FacilityAgent:
             "飲み物",
             "飲食",
             "食物",
+            "自带食物",
+            "带食物",
+            "带吃的",
+            "外带食物",
             "饮料",
+            "餐饮",
             "음식",
             "음료",
+        )
+        return any(keyword in query for keyword in keywords)
+
+    @staticmethod
+    def _asks_3d_printer_filament_price(query: str) -> bool:
+        printer_markers = ("3dプリンター", "3d printer", "3d打印", "3d 프린터")
+        material_markers = ("フィラメント", "filament", "材料", "素材", "耗材")
+        price_markers = (
+            "料金",
+            "価格",
+            "費用",
+            "値段",
+            "いくら",
+            "price",
+            "fee",
+            "cost",
+            "收费",
+            "费用",
+        )
+        has_printer_or_material = any(marker in query for marker in printer_markers) or any(
+            marker in query for marker in material_markers
+        )
+        return has_printer_or_material and any(marker in query for marker in price_markers)
+
+    @staticmethod
+    def _asks_3d_printer_use(query: str) -> bool:
+        printer_markers = ("3dプリンター", "3d printer", "3d打印", "3d 프린터")
+        use_markers = (
+            "使い方",
+            "使いたい",
+            "使えますか",
+            "利用",
+            "予約",
+            "講習",
+            "use",
+            "reservation",
+            "reserve",
+            "training",
+            "使用",
+            "预约",
+            "사용",
+            "예약",
+        )
+        return any(marker in query for marker in printer_markers) and any(
+            marker in query for marker in use_markers
+        )
+
+    @staticmethod
+    def _asks_toilet(query: str) -> bool:
+        keywords = (
+            "トイレ",
+            "お手洗い",
+            "おてあらい",
+            "化粧室",
+            "toilet",
+            "restroom",
+            "bathroom",
+            "洗手间",
+            "厕所",
+            "화장실",
+        )
+        return any(keyword in query for keyword in keywords)
+
+    @staticmethod
+    def _asks_online_meeting_place(query: str) -> bool:
+        keywords = (
+            "オンライン会議",
+            "オンラインミーティング",
+            "web会議",
+            "通話",
+            "電話できる場所",
+            "電話したい",
+            "防音室",
+            "phone booth",
+            "online meeting",
+            "video call",
+            "take a call",
+            "线上会议",
+            "在线会议",
+            "通话",
+            "화상 회의",
+            "온라인 미팅",
+            "통화",
+        )
+        return any(keyword in query for keyword in keywords)
+
+    @staticmethod
+    def _asks_focus_space(query: str) -> bool:
+        keywords = (
+            "集中スペース",
+            "focus space",
+            "静かに作業",
+            "静かな作業",
+            "集中できる",
+            "集中空间",
+            "집중 스페이스",
+        )
+        return any(keyword in query for keyword in keywords)
+
+    @staticmethod
+    def _asks_lost_found(query: str) -> bool:
+        keywords = (
+            "忘れ物",
+            "落とし物",
+            "なくした",
+            "失くした",
+            "置き忘れ",
+            "紛失",
+            "lost",
+            "missing",
+            "left behind",
+            "left my",
+            "forgot",
+            "遗失",
+            "丢失",
+            "분실",
         )
         return any(keyword in query for keyword in keywords)
 

--- a/backend/config/routing_constants.py
+++ b/backend/config/routing_constants.py
@@ -219,6 +219,12 @@ ACCESS_DIRECTION_KEYWORDS = [
     "nearest station from here",
     "way to the station",
     "exit",
+    "空港",
+    "福岡空港",
+    "博多駅",
+    "airport",
+    "fukuoka airport",
+    "hakata station",
 ]
 
 BUILDING_KEYWORDS = [
@@ -241,7 +247,9 @@ COMMUNITY_KEYWORDS = [
     "engineer cafe lab",
     "エンジニアカフェlab",
     "エンジニアカフェラボ",
+    "engineer ignition camp",
     "eic",
+    "devday",
     "会員制コミュニティ",
 ]
 
@@ -493,6 +501,13 @@ FOOD_DRINK_KEYWORDS = [
     "bring food",
     "menu",
     "saino",
+    "食物",
+    "自带食物",
+    "带食物",
+    "带吃的",
+    "外带食物",
+    "饮料",
+    "餐饮",
 ]
 
 BOOKING_KEYWORDS = [
@@ -520,6 +535,17 @@ FACILITY_EQUIPMENT_KEYWORDS = [
     "outlet",
     "printer",
     "monitor",
+    "オンライン会議",
+    "オンラインミーティング",
+    "web会議",
+    "通話",
+    "電話できる場所",
+    "電話したい",
+    "防音室",
+    "phone booth",
+    "online meeting",
+    "video call",
+    "take a call",
 ]
 
 EXCLUSIVE_RENTAL_KEYWORDS = [

--- a/backend/tests/agents/test_business_info_agent.py
+++ b/backend/tests/agents/test_business_info_agent.py
@@ -2,6 +2,8 @@
 BusinessInfoAgent のユニットテスト
 """
 
+import pytest
+
 from backend.agents.business_info_agent import BusinessInfoAgent
 
 
@@ -162,3 +164,41 @@ class TestBusinessInfoAgent:
         assert response is not None
         assert "080-6742-7231" in response["answer"]
         assert "13時から21時" in response["answer"]
+
+    def test_closed_days_canonical_precedes_hours(self):
+        """休館日は営業時間の広い回答に倒さない"""
+        response = self.agent._get_canonical_response(
+            "エンジニアカフェの休館日はいつですか？",
+            "hours",
+            "ja",
+        )
+
+        assert response is not None
+        assert "毎月最終月曜日" in response["answer"]
+        assert "12月29日から1月3日" in response["answer"]
+        assert "朝9時から夜22時" not in response["answer"]
+
+    def test_community_program_canonical_static_devday(self):
+        """DevDayはlive eventではなくEICの静的情報として回答する"""
+        response = self.agent._get_canonical_response(
+            "DevDayはいつ開催されますか？",
+            "community",
+            "ja",
+        )
+
+        assert response is not None
+        assert "2026年2月23日18:00" in response["answer"]
+        assert "展示形式" in response["answer"]
+
+    @pytest.mark.asyncio
+    async def test_chinese_canonical_ignores_stale_state_context(self):
+        """ZH canonical は stale cache があっても fallback/RAG に進まない"""
+        response = await self.agent.answer_business_query(
+            query="工程师咖啡是什么？",
+            request_type="general",
+            language="zh",
+            state_context={"success": True, "category": "general", "context_string": ""},
+        )
+
+        assert "免费共享办公" in response["answer"]
+        assert response["metadata"]["sources"] == ["enhanced_rag"]

--- a/backend/tests/agents/test_facility_agent.py
+++ b/backend/tests/agents/test_facility_agent.py
@@ -230,6 +230,38 @@ class TestFacilityAgent:
         assert "akarenga-112years" in response["answer"]
         assert "테라스" in response["answer"]
 
+    def test_3d_printer_filament_price_canonical_precedes_general_printer(self):
+        """3Dプリンターのフィラメント料金は一般プリンター回答に倒さない"""
+        agent = FacilityAgent()
+        response = agent._get_canonical_response(
+            "3Dプリンターのフィラメント料金を教えてください",
+            "facility",
+            "ja",
+        )
+
+        assert response is not None
+        assert "2円/g" in response["answer"]
+        assert "福岡市在住の学生は無料" in response["answer"]
+        assert "紙の印刷" not in response["answer"]
+
+    def test_lost_found_canonical_response(self):
+        """忘れ物は受付・電話番号案内に固定する"""
+        agent = FacilityAgent()
+        response = agent._get_canonical_response("忘れ物をしたのですが", "lost_found", "ja")
+
+        assert response is not None
+        assert "1階のエンジニアカフェ受付" in response["answer"]
+        assert "080-6742-7231" in response["answer"]
+
+    def test_chinese_food_policy_canonical(self):
+        """中国語の持ち込み食物質問を food policy として扱う"""
+        agent = FacilityAgent()
+        response = agent._get_canonical_response("可以自己带食物进去吗？", "food_drink", "zh")
+
+        assert response is not None
+        assert "外带食物原则上不允许" in response["answer"]
+        assert "cafe&bar saino" in response["answer"]
+
     def test_access_canonical_response_english(self):
         """アクセス案内は施設名と最寄り駅を含める"""
         agent = FacilityAgent()

--- a/backend/tests/evaluation/test_fast_path_accuracy.py
+++ b/backend/tests/evaluation/test_fast_path_accuracy.py
@@ -134,6 +134,30 @@ class TestFastPathAccuracy:
         assert result["agent"] == "facility"
         assert result["request_type"] == "meeting_room"
 
+    def test_alpha_lost_found_routes_to_facility(self, orchestrator):
+        """gt-047: 忘れ物は一般応答ではなく facility/lost_found に固定する"""
+        result = orchestrator._try_fast_routing("忘れ物をしたのですが")
+
+        assert result is not None
+        assert result["agent"] == "facility"
+        assert result["request_type"] == "lost_found"
+
+    def test_alpha_devday_routes_to_static_community(self, orchestrator):
+        """gt-024: DevDay は live EventAgent ではなく静的 community 情報へ送る"""
+        result = orchestrator._try_fast_routing("DevDayはいつ開催されますか？")
+
+        assert result is not None
+        assert result["agent"] == "business_info"
+        assert result["request_type"] == "community"
+
+    def test_alpha_chinese_food_policy_routes_to_facility(self, orchestrator):
+        """gt-103: 中国語の自带食物は food_drink として扱う"""
+        result = orchestrator._try_fast_routing("可以自己带食物进去吗？")
+
+        assert result is not None
+        assert result["agent"] == "facility"
+        assert result["request_type"] == "food_drink"
+
     def test_memory_cases_detected(self, orchestrator, golden_cases):
         """日本語メモリケース(rt-002, rt-010, rt-015)がすべて検出される
 

--- a/backend/tests/workflows/test_rag_cache.py
+++ b/backend/tests/workflows/test_rag_cache.py
@@ -256,7 +256,7 @@ class TestAgentCacheUsage:
             agent = BusinessInfoAgent()
 
             mock_provider = AsyncMock()
-            mock_provider.generate = AsyncMock(return_value="[relaxed]料金は無料です")
+            mock_provider.generate = AsyncMock(return_value="[relaxed]相談できます")
             agent.llm_provider = mock_provider
 
             agent.enhanced_rag.search = AsyncMock(
@@ -266,7 +266,7 @@ class TestAgentCacheUsage:
                 }
             )
 
-            # カテゴリ不一致: キャッシュはgeneral、実際はpricing
+            # カテゴリ不一致: キャッシュはgeneral、実際はconsultation
             state_context = {
                 "success": True,
                 "category": "general",
@@ -276,8 +276,8 @@ class TestAgentCacheUsage:
             }
 
             await agent.answer_business_query(
-                query="料金は？",
-                request_type="price",
+                query="コミュニティマネージャーに相談できることは？",
+                request_type="consultation",
                 language="ja",
                 state_context=state_context,
             )
@@ -310,15 +310,15 @@ class TestAgentCacheUsage:
             # キャッシュが失敗状態
             state_context = {
                 "success": False,
-                "category": "hours",
+                "category": "consultation",
                 "context_string": "",
                 "results": [],
                 "query": "テスト",
             }
 
             await agent.answer_business_query(
-                query="営業時間は？",
-                request_type="hours",
+                query="コミュニティマネージャーに相談できることは？",
+                request_type="consultation",
                 language="ja",
                 state_context=state_context,
             )

--- a/backend/utils/intent_classifier.py
+++ b/backend/utils/intent_classifier.py
@@ -26,6 +26,7 @@ from backend.config.routing_constants import (
     FOOD_DRINK_KEYWORDS,
     FOOD_DRINK_VERBS,
     GREETING_KEYWORDS,
+    LOST_FOUND_KEYWORDS,
     MEETING_ROOM_KEYWORDS,
     PARKING_KEYWORDS,
     PHOTOGRAPHY_KEYWORDS,
@@ -319,6 +320,11 @@ def classify_fast_intent(query: str) -> Optional[FastIntent]:
     if has_emergency:
         return FastIntent("facility", "emergency", "emergency", "Emergency keyword detected")
 
+    if match_keywords(lower_query, LOST_FOUND_KEYWORDS):
+        return FastIntent(
+            "facility", "facility-info", "lost_found", "Lost-and-found keyword detected"
+        )
+
     if match_keywords(lower_query, GREETING_KEYWORDS):
         stripped = lower_query.strip()
         remaining = stripped
@@ -349,6 +355,8 @@ def classify_fast_intent(query: str) -> Optional[FastIntent]:
         return FastIntent(
             "business_info", "business-hours", "hours", "Business hours keyword detected"
         )
+    if self_or_static_community := _static_community_program_route(lower_query):
+        return self_or_static_community
     if any(kw in lower_query for kw in MEETING_ROOM_KEYWORDS) and match_keywords(
         lower_query, PRICING_KEYWORDS
     ):
@@ -357,6 +365,13 @@ def classify_fast_intent(query: str) -> Optional[FastIntent]:
             "facility-info",
             "meeting_room",
             "Meeting room pricing query detected",
+        )
+    if _is_3d_printer_price_query(lower_query):
+        return FastIntent(
+            "facility",
+            "facility-info",
+            "facility",
+            "3D printer filament pricing query detected",
         )
     if match_keywords(lower_query, PRICING_KEYWORDS):
         return FastIntent("business_info", "pricing", "price", "Pricing keyword detected")
@@ -454,6 +469,55 @@ def classify_fast_intent(query: str) -> Optional[FastIntent]:
         )
 
     return None
+
+
+def _static_community_program_route(lower_query: str) -> Optional[FastIntent]:
+    """Keep EIC/DevDay ground-truth questions on static community knowledge."""
+    program_markers = ("engineer ignition camp", "eic", "devday")
+    if not any(marker in lower_query for marker in program_markers):
+        return None
+
+    static_question_markers = (
+        "とは",
+        "何",
+        "なに",
+        "いつ",
+        "when",
+        "what",
+        "修了",
+        "条件",
+        "開催",
+        "about",
+    )
+    if any(marker in lower_query for marker in static_question_markers):
+        return FastIntent(
+            "business_info",
+            "community",
+            "community",
+            "Static community/program keyword detected",
+        )
+    return None
+
+
+def _is_3d_printer_price_query(lower_query: str) -> bool:
+    printer_markers = ("3dプリンター", "3d printer", "3d打印", "3d 프린터")
+    material_markers = ("フィラメント", "filament", "材料", "素材", "耗材")
+    price_markers = (
+        "料金",
+        "価格",
+        "費用",
+        "値段",
+        "いくら",
+        "price",
+        "fee",
+        "cost",
+        "收费",
+        "费用",
+    )
+    has_printer_or_material = any(marker in lower_query for marker in printer_markers) or any(
+        marker in lower_query for marker in material_markers
+    )
+    return has_printer_or_material and any(marker in lower_query for marker in price_markers)
 
 
 def filler_intent_for_query(query: str) -> str:


### PR DESCRIPTION
## Summary

- let BusinessInfo canonical answers run before stale cached RAG context, avoiding ZH fallback for first-visit and "what is Engineer Cafe" cases
- add specific canonical answers before broad branches for closed days, EIC/DevDay, 3D printer filament pricing/use, toilets, online meetings, focus space, and lost-and-found
- route lost-and-found, EIC/DevDay static program questions, 3D printer filament price, airport/Hakata access, online meeting places, and Chinese food-policy queries through the intended fast paths
- add focused regression tests for the C-127 low-scoring/fallback clusters

## Verification

- `pytest backend/tests/agents/test_business_info_agent.py backend/tests/agents/test_facility_agent.py backend/tests/evaluation/test_fast_path_accuracy.py -q`
- `python -m py_compile backend/agents/business_info_agent.py backend/agents/facility_agent.py backend/utils/intent_classifier.py backend/config/routing_constants.py`
- `python -m black --check backend/agents/business_info_agent.py backend/agents/facility_agent.py backend/config/routing_constants.py backend/utils/intent_classifier.py backend/tests/agents/test_business_info_agent.py backend/tests/agents/test_facility_agent.py backend/tests/evaluation/test_fast_path_accuracy.py`
- `python -m ruff check backend/agents/business_info_agent.py backend/agents/facility_agent.py backend/config/routing_constants.py backend/utils/intent_classifier.py backend/tests/agents/test_business_info_agent.py backend/tests/agents/test_facility_agent.py backend/tests/evaluation/test_fast_path_accuracy.py`
- `git diff --check -- backend/agents/business_info_agent.py backend/agents/facility_agent.py backend/config/routing_constants.py backend/utils/intent_classifier.py backend/tests/agents/test_business_info_agent.py backend/tests/agents/test_facility_agent.py backend/tests/evaluation/test_fast_path_accuracy.py`

## Notes

Targets issue #672. This is the first answer-quality pass after #683/#685 and focuses on deterministic routing/canonical fixes rather than changing RAGAS ground truth.
