### PR TITLE
fix: allow harness-only alpha SHA gate

### DIFF
--- a/.github/workflows/alpha-live-verification.yml
+++ b/.github/workflows/alpha-live-verification.yml
@@ -19,9 +19,13 @@ on:
         default: ''
         type: string
       require_deployed_sha_match:
-        description: 'Fail unless the live Cloud Run image tag contains this workflow SHA. Keep true for GO proof.'
+        description: 'Fail unless the live Cloud Run image tag contains the expected backend SHA. Keep true for GO proof.'
         default: true
         type: boolean
+      expected_backend_sha:
+        description: 'Optional deployed backend SHA to require in the live Cloud Run image. Empty defaults to workflow SHA.'
+        default: ''
+        type: string
 
 permissions:
   contents: read
@@ -66,35 +70,49 @@ jobs:
 
       - name: Resolve live target
         shell: bash
+        env:
+          INPUT_EXPECTED_BACKEND_SHA: ${{ inputs.expected_backend_sha }}
+          INPUT_REQUIRE_DEPLOYED_SHA_MATCH: ${{ inputs.require_deployed_sha_match }}
+          INPUT_TIMESTAMP: ${{ inputs.timestamp }}
         run: |
           set -euo pipefail
-          ts="${{ inputs.timestamp }}"
+          ts="$INPUT_TIMESTAMP"
           if [[ -z "$ts" ]]; then
             ts="$(date -u +%Y%m%d_%H%M%S)"
           fi
           service_url="$(gcloud run services describe "$SERVICE_NAME" --project "$PROJECT_ID" --region "$REGION" --format='value(status.url)')"
           revision="$(gcloud run services describe "$SERVICE_NAME" --project "$PROJECT_ID" --region "$REGION" --format='value(status.latestReadyRevisionName)')"
           image="$(gcloud run services describe "$SERVICE_NAME" --project "$PROJECT_ID" --region "$REGION" --format='value(spec.template.spec.containers[0].image)')"
+          expected_backend_sha="$INPUT_EXPECTED_BACKEND_SHA"
+          if [[ -z "$expected_backend_sha" ]]; then
+            expected_backend_sha="$GITHUB_SHA"
+          fi
+          if [[ ! "$expected_backend_sha" =~ ^[0-9a-fA-F]{40}$ ]]; then
+            echo "Error: expected_backend_sha must be a full 40-character commit SHA, got: $expected_backend_sha" >&2
+            exit 2
+          fi
           sha_match=false
-          if [[ "$image" == *"${GITHUB_SHA}"* ]]; then
+          if [[ "$image" == *"$expected_backend_sha"* ]]; then
             sha_match=true
           fi
           echo "ALPHA_TIMESTAMP=$ts" >> "$GITHUB_ENV"
           echo "ALPHA_SMOKE_BASE_URL=${service_url:-$DEFAULT_BACKEND_URL}" >> "$GITHUB_ENV"
           echo "RAG_API_LIVE_BASE_URL=${service_url:-$DEFAULT_BACKEND_URL}" >> "$GITHUB_ENV"
           echo "ALPHA_SMOKE_CLOUD_RUN_REVISION=$revision" >> "$GITHUB_ENV"
-          echo "ALPHA_SMOKE_BACKEND_SHA=${GITHUB_SHA}" >> "$GITHUB_ENV"
+          echo "ALPHA_SMOKE_BACKEND_SHA=$expected_backend_sha" >> "$GITHUB_ENV"
+          echo "ALPHA_SMOKE_WORKFLOW_SHA=${GITHUB_SHA}" >> "$GITHUB_ENV"
           echo "ALPHA_SMOKE_BACKEND_IMAGE=$image" >> "$GITHUB_ENV"
           echo "ALPHA_SMOKE_BACKEND_SHA_MATCH=$sha_match" >> "$GITHUB_ENV"
           echo "Live target: ${service_url:-$DEFAULT_BACKEND_URL}"
           echo "Revision: $revision"
-          echo "SHA: ${GITHUB_SHA}"
+          echo "Workflow SHA: ${GITHUB_SHA}"
+          echo "Expected backend SHA: $expected_backend_sha"
           echo "Image: $image"
-          echo "Image contains workflow SHA: $sha_match"
+          echo "Image contains expected backend SHA: $sha_match"
 
-          if [[ "${{ inputs.require_deployed_sha_match }}" == "true" && "$sha_match" != "true" ]]; then
-            echo "Error: live Cloud Run image does not contain workflow SHA ${GITHUB_SHA}." >&2
-            echo "For #571 GO proof, dispatch this workflow from the deployed commit or set require_deployed_sha_match=false only for harness debugging." >&2
+          if [[ "$INPUT_REQUIRE_DEPLOYED_SHA_MATCH" == "true" && "$sha_match" != "true" ]]; then
+            echo "Error: live Cloud Run image does not contain expected backend SHA $expected_backend_sha." >&2
+            echo "For #571 GO proof, dispatch this workflow from the deployed backend commit, pass expected_backend_sha for harness-only reruns, or set require_deployed_sha_match=false only for harness debugging." >&2
             exit 2
           fi
 
@@ -279,9 +297,10 @@ jobs:
           - timestamp: ${ALPHA_TIMESTAMP:-unknown}
           - backend: ${ALPHA_SMOKE_BASE_URL:-unknown}
           - revision: ${ALPHA_SMOKE_CLOUD_RUN_REVISION:-unknown}
-          - sha: ${ALPHA_SMOKE_BACKEND_SHA:-unknown}
+          - workflow_sha: ${ALPHA_SMOKE_WORKFLOW_SHA:-unknown}
+          - expected_backend_sha: ${ALPHA_SMOKE_BACKEND_SHA:-unknown}
           - image: ${ALPHA_SMOKE_BACKEND_IMAGE:-unknown}
-          - image_sha_match: ${ALPHA_SMOKE_BACKEND_SHA_MATCH:-unknown}
+          - image_expected_backend_sha_match: ${ALPHA_SMOKE_BACKEND_SHA_MATCH:-unknown}
 
           | Step | Outcome |
           | --- | --- |

--- a/docs/testing/alpha-final-scenarios.md
+++ b/docs/testing/alpha-final-scenarios.md
@@ -17,7 +17,7 @@ Current confirmed target:
 
 - Backend: `https://engineer-cafe-backend-639959525777.asia-northeast1.run.app`
 - Cloud Run revision: GO 判定時は workflow の `Resolve live target` 出力を正本にする
-- Backend SHA: `require_deployed_sha_match=true` で workflow SHA と Cloud Run image tag の一致を必須にする
+- Backend SHA: `require_deployed_sha_match=true` で expected backend SHA と Cloud Run image tag の一致を必須にする。`expected_backend_sha` が空の場合は workflow SHA を expected backend SHA として使うため、backend 変更を含む GO proof の既定動作は変わらない。
 - Frontend: `https://frontend-delta-six-20.vercel.app`
 
 ## Usage Notes
@@ -38,6 +38,17 @@ Current confirmed target:
   `google_calendar` / `connpass` も許容します。緊急・受付・farewell の即時応答は source なしでも source gate 上は許容し、
   回答品質は `answer_correctness` 側で判定します。
 - GitHub step conclusion だけで suite の成否を判断しないでください。`continue-on-error` のため、summary / artifact の suite outcome を正本にします。
+- Harness-only workflow/script rerun では、backend deploy が意図的に変わっていない場合だけ
+  `require_deployed_sha_match=true` のまま `expected_backend_sha=<Cloud Run image tag の 40-char commit SHA>` を渡します。
+  `expected_backend_sha` は full SHA のみ許容されます。
+
+```bash
+gh workflow run alpha-live-verification.yml \
+  --ref develop \
+  -f suites=all \
+  -f require_deployed_sha_match=true \
+  -f expected_backend_sha=19623d5534c409856344215b3062900f35ff2816
+```
 
 ## A-1 Japanese Realistic Utterances
 

--- a/docs/testing/alpha-live-verification-status-2026-05-02.md
+++ b/docs/testing/alpha-live-verification-status-2026-05-02.md
@@ -159,6 +159,13 @@ gh workflow run alpha-live-verification.yml \
   -f suites=c \
   -f require_deployed_sha_match=true
 
+# Harness-only rerun when the workflow/scripts changed but Cloud Run backend did not:
+gh workflow run alpha-live-verification.yml \
+  --ref develop \
+  -f suites=all \
+  -f require_deployed_sha_match=true \
+  -f expected_backend_sha=<40-char-deployed-backend-sha>
+
 gcloud run services describe engineer-cafe-backend \
   --project aipartner-426616 \
   --region asia-northeast1 \


### PR DESCRIPTION
## Summary\n- add expected_backend_sha to alpha-live-verification dispatch\n- keep strict default behavior by falling back to the workflow SHA\n- document harness-only reruns that validate the deployed backend SHA without an ad hoc backend redeploy\n\nCloses #663.\n\n## Verification\n- git diff --check