### PR TITLE
fix: ship tRAG translation models in backend image

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -76,6 +76,13 @@ RUN bash scripts/download_vosk_models.sh models
 # Download Qwen3-ASR 0.6B model (~1.2GB) — primary STT provider (ADR-007)
 RUN bash scripts/download_qwen_model.sh
 
+# Download translation models for tRAG EN<->JA on Cloud Run. Without these
+# assets, live alpha runs retry and fall back before answering EN queries.
+RUN pip install --no-cache-dir torch transformers \
+    && bash scripts/download_translation_models.sh models/translation \
+    && pip uninstall -y torch transformers \
+    && pip cache purge
+
 # Pre-warm numba JIT cache for librosa resample used by qwen-asr audio preprocessing.
 RUN python -c "import librosa; import numpy as np; librosa.resample(np.zeros(16000, dtype=np.float32), orig_sr=16000, target_sr=8000); print('numba warm complete')" || echo 'numba warm failed (non-fatal)'
 

--- a/backend/tests/test_dockerfile_assets.py
+++ b/backend/tests/test_dockerfile_assets.py
@@ -1,0 +1,10 @@
+from pathlib import Path
+
+
+def test_production_image_downloads_translation_models():
+    dockerfile = Path(__file__).resolve().parents[1] / "Dockerfile"
+    text = dockerfile.read_text(encoding="utf-8")
+    production_stage = text.split("FROM base AS production", maxsplit=1)[1]
+
+    assert "scripts/download_translation_models.sh models/translation" in production_stage
+    assert "scripts/download_qwen_model.sh" in production_stage


### PR DESCRIPTION
## Summary\n- download existing EN<->JA CTranslate2 translation models in the production Docker image\n- add a Dockerfile asset guard so production packaging cannot drop translation models again\n\nCloses #669.\n\n## Verification\n- git diff --check\n- cd backend && uv run --extra evaluation pytest tests/test_dockerfile_assets.py tests/test_translation_service.py tests/utils/test_translation_retry.py tests/workflows/test_trag_translation.py -q\n  - 50 passed, 18 warnings\n\n## Notes\n- Plain local pytest outside backend/.venv failed collection because that interpreter lacks langgraph.store.postgres; the backend uv environment passed.