### PR TITLE
fix: keep qwen runtime deps in backend image

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -41,10 +41,9 @@ COPY . .
 RUN bash scripts/download_vosk_models.sh models
 
 # Download translation models (Helsinki-NLP/opus-mt, CTranslate2 int8: ~300MB total)
-# Requires build-time deps: pip install torch transformers
+# Qwen3-ASR uses torch/transformers at runtime, so keep them installed.
 RUN pip install --no-cache-dir torch transformers \
     && bash scripts/download_translation_models.sh models/translation \
-    && pip uninstall -y torch transformers \
     && pip cache purge
 
 # Set ownership and switch to non-root user
@@ -78,10 +77,13 @@ RUN bash scripts/download_qwen_model.sh
 
 # Download translation models for tRAG EN<->JA on Cloud Run. Without these
 # assets, live alpha runs retry and fall back before answering EN queries.
+# Qwen3-ASR uses torch/transformers at runtime, so keep them installed.
 RUN pip install --no-cache-dir torch transformers \
     && bash scripts/download_translation_models.sh models/translation \
-    && pip uninstall -y torch transformers \
     && pip cache purge
+
+# Fail Docker build before deploy if the production image loses Qwen runtime deps.
+RUN python -c "import torch; from qwen_asr import Qwen3ASRModel; print('qwen runtime import ok')"
 
 # Pre-warm numba JIT cache for librosa resample used by qwen-asr audio preprocessing.
 RUN python -c "import librosa; import numpy as np; librosa.resample(np.zeros(16000, dtype=np.float32), orig_sr=16000, target_sr=8000); print('numba warm complete')" || echo 'numba warm failed (non-fatal)'

--- a/backend/tests/test_dockerfile_assets.py
+++ b/backend/tests/test_dockerfile_assets.py
@@ -8,3 +8,12 @@ def test_production_image_downloads_translation_models():
 
     assert "scripts/download_translation_models.sh models/translation" in production_stage
     assert "scripts/download_qwen_model.sh" in production_stage
+
+
+def test_image_keeps_qwen_runtime_dependencies_after_translation_download():
+    dockerfile = Path(__file__).resolve().parents[1] / "Dockerfile"
+    text = dockerfile.read_text(encoding="utf-8")
+    production_stage = text.split("FROM base AS production", maxsplit=1)[1]
+
+    assert "pip uninstall -y torch transformers" not in text
+    assert "from qwen_asr import Qwen3ASRModel" in production_stage


### PR DESCRIPTION
## Summary
- keep torch/transformers installed after translation model download because Qwen3-ASR imports them at runtime
- add Dockerfile regression test so the backend image does not uninstall Qwen runtime dependencies again

## Verification
- git diff --check
- cd backend && uv run --extra evaluation pytest tests/test_dockerfile_assets.py -q

Fixes follow-up deploy failure from #688 / #669.