### PR TITLE
fix: preserve C-127 live collection failures

### DIFF
--- a/backend/evaluation/run_live_api_eval.py
+++ b/backend/evaluation/run_live_api_eval.py
@@ -184,6 +184,24 @@ def _suite_coverage(
     }
 
 
+def _collection_error_record(
+    query: Dict[str, Any],
+    *,
+    error_type: str,
+    message: str,
+) -> Dict[str, Any]:
+    """Return a reportable record for cases that never reached RAGAS evaluation."""
+    return {
+        "query_id": query.get("id"),
+        "ground_truth_id": query.get("ground_truth_id"),
+        "language": query.get("language"),
+        "category": query.get("category"),
+        "question": query.get("question"),
+        "error_type": error_type,
+        "error": message,
+    }
+
+
 async def _call_chat_api(
     client: httpx.AsyncClient,
     *,
@@ -236,12 +254,16 @@ async def run_live_api_evaluation(
 
     per_language_results: Dict[str, Dict[str, Any]] = {}
     all_eval_cases: Dict[str, List[Dict[str, Any]]] = {}
+    requested_case_counts: Dict[str, int] = {}
+    collection_errors: Dict[str, List[Dict[str, Any]]] = {}
 
     # Phase 1: Collect live API responses
     async with httpx.AsyncClient() as client:
         for lang in selected_languages:
             queries = [q for q in config["queries"] if q["language"] == lang]
             lang_cases: List[Dict[str, Any]] = []
+            lang_collection_errors: List[Dict[str, Any]] = []
+            requested_case_counts[lang] = len(queries)
 
             logger.info("Evaluating %d queries for language: %s", len(queries), lang)
 
@@ -253,6 +275,13 @@ async def run_live_api_evaluation(
                         "Skipping %s: ground truth %s not found",
                         query["id"],
                         gt_id,
+                    )
+                    lang_collection_errors.append(
+                        _collection_error_record(
+                            query,
+                            error_type="missing_ground_truth",
+                            message=f"ground truth {gt_id} not found",
+                        )
                     )
                     continue
 
@@ -312,8 +341,16 @@ async def run_live_api_evaluation(
                     )
                 except Exception as exc:
                     logger.error("  [%s] API call failed: %s", query["id"], exc)
+                    lang_collection_errors.append(
+                        _collection_error_record(
+                            query,
+                            error_type="api_call_failed",
+                            message=str(exc),
+                        )
+                    )
 
             all_eval_cases[lang] = lang_cases
+            collection_errors[lang] = lang_collection_errors
 
     # Phase 2: Run RAGAS evaluation
     try:
@@ -324,12 +361,25 @@ async def run_live_api_evaluation(
 
     for lang in selected_languages:
         cases = all_eval_cases.get(lang, [])
+        requested_count = requested_case_counts.get(lang, 0)
+        lang_collection_errors = collection_errors.get(lang, [])
+        api_failed_count = len(
+            [
+                error
+                for error in lang_collection_errors
+                if error.get("error_type") == "api_call_failed"
+            ]
+        )
         if not cases:
             per_language_results[lang] = {
                 "language": lang,
                 "error": "no evaluable cases",
-                "requested_case_count": 0,
+                "requested_case_count": requested_count,
                 "evaluated_case_count": 0,
+                "skipped_case_count": requested_count,
+                "api_failed_case_count": api_failed_count,
+                "collection_error_count": len(lang_collection_errors),
+                "collection_errors": lang_collection_errors,
                 "metrics": {},
                 "results": [],
             }
@@ -345,8 +395,12 @@ async def run_live_api_evaluation(
             per_language_results[lang] = {
                 "language": lang,
                 "error": "ragas not installed",
-                "requested_case_count": len(cases),
+                "requested_case_count": requested_count,
                 "evaluated_case_count": 0,
+                "skipped_case_count": requested_count,
+                "api_failed_case_count": api_failed_count,
+                "collection_error_count": len(lang_collection_errors),
+                "collection_errors": lang_collection_errors,
                 "metrics": {},
                 "results": [
                     {
@@ -387,9 +441,12 @@ async def run_live_api_evaluation(
 
         per_language_results[lang] = {
             "language": lang,
-            "requested_case_count": len(cases),
+            "requested_case_count": requested_count,
             "evaluated_case_count": report.evaluated_cases,
-            "skipped_case_count": report.skipped_cases,
+            "skipped_case_count": report.skipped_cases + len(lang_collection_errors),
+            "api_failed_case_count": api_failed_count,
+            "collection_error_count": len(lang_collection_errors),
+            "collection_errors": lang_collection_errors,
             "metrics": report.metrics,
             "errors": report.errors,
             "results": per_case_results,
@@ -484,11 +541,13 @@ def _compare_targets(
         answer_target_passed = isinstance(actual, (int, float)) and actual >= target
         requested_count = int(result.get("requested_case_count", 0) or 0)
         evaluated_count = int(result.get("evaluated_case_count", 0) or 0)
+        collection_error_count = int(result.get("collection_error_count", 0) or 0)
         evaluation_complete = (
             requested_count > 0
             and evaluated_count == requested_count
             and not result.get("errors")
             and not result.get("error")
+            and collection_error_count == 0
         )
         passed = answer_target_passed and not source_failures and evaluation_complete
         per_language[lang] = {
@@ -500,6 +559,7 @@ def _compare_targets(
             "evaluation_complete": {
                 "requested": requested_count,
                 "evaluated": evaluated_count,
+                "collection_errors": collection_error_count,
                 "passed": evaluation_complete,
             },
             "live_source_gate": {
@@ -525,6 +585,7 @@ def _compare_targets(
                     "target": target,
                     "answer_target_passed": answer_target_passed,
                     "evaluation_complete": evaluation_complete,
+                    "collection_errors": collection_error_count,
                     "source_failures": len(source_failures),
                 }
             )
@@ -584,6 +645,13 @@ def _format_report(
             f"evaluated={result.get('evaluated_case_count', 0)} "
             f"skipped={result.get('skipped_case_count', 0)}"
         )
+        collection_error_count = result.get("collection_error_count", 0)
+        if collection_error_count:
+            lines.append(
+                "  collection_errors: "
+                f"{collection_error_count} "
+                f"(api_failed={result.get('api_failed_case_count', 0)})"
+            )
 
         if result.get("error"):
             lines.append(f"  ERROR: {result['error']}")
@@ -608,7 +676,9 @@ def _format_report(
         lines.append(
             "  evaluation_complete: "
             f"evaluated={eval_complete.get('evaluated', 0)}/"
-            f"{eval_complete.get('requested', 0)} [{eval_status}]"
+            f"{eval_complete.get('requested', 0)} "
+            f"collection_errors={eval_complete.get('collection_errors', 0)} "
+            f"[{eval_status}]"
         )
         if source_gate.get("enabled"):
             sg_status = "PASS" if source_gate.get("passed") else "FAIL"
@@ -666,6 +736,7 @@ def _format_report(
                 f"  {f['language']}: actual={f['actual']} target={f['target']} "
                 f"answer_target_passed={f.get('answer_target_passed')} "
                 f"evaluation_complete={f.get('evaluation_complete')} "
+                f"collection_errors={f.get('collection_errors', 0)} "
                 f"source_failures={f.get('source_failures', 0)}"
             )
 

--- a/backend/tests/evaluation/test_ragas_live_case_suites.py
+++ b/backend/tests/evaluation/test_ragas_live_case_suites.py
@@ -1,6 +1,9 @@
 """C/RAGAS live API case-suite selection tests."""
 
 from collections import Counter
+from types import SimpleNamespace
+
+import pytest
 
 from backend.evaluation.run_live_api_eval import (
     ALL_LANGUAGES,
@@ -12,6 +15,7 @@ from backend.evaluation.run_live_api_eval import (
     _required_live_sources,
     _source_requirement_ok,
     _suite_coverage,
+    run_live_api_evaluation,
 )
 
 
@@ -99,3 +103,92 @@ def test_source_requirement_accepts_knowledge_and_event_alternatives():
         [LOCAL_KNOWLEDGE_SOURCE_REQUIREMENT],
         ["fallback"],
     )
+
+
+@pytest.mark.asyncio()
+async def test_live_eval_keeps_alpha_127_manifest_count_when_api_collection_fails(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path,
+):
+    calls = []
+
+    async def fake_call_chat_api(client, *, base_url, question, language, api_key=None):
+        calls.append((question, language))
+        if len(calls) == 1:
+            raise TimeoutError("synthetic timeout")
+        return {
+            "answer": "grounded answer",
+            "metadata": {
+                "agent": "FakeAgent",
+                "category": "test",
+                "route": "fake",
+                "sources": ["knowledge_base_cached", "google_calendar"],
+            },
+        }
+
+    class FakeRagasEvaluator:
+        is_available = True
+
+        def __init__(self, *, metrics, max_cases):
+            self.metrics = metrics
+            self.max_cases = max_cases
+
+        async def evaluate_batch(self, cases):
+            return SimpleNamespace(
+                evaluated_cases=len(cases),
+                skipped_cases=0,
+                metrics={
+                    "context_precision": 1.0,
+                    "answer_correctness": 1.0,
+                    "answer_relevancy": 1.0,
+                    "faithfulness": 1.0,
+                },
+                errors=[],
+                results=[
+                    SimpleNamespace(
+                        question=case["question"],
+                        answer_correctness=1.0,
+                        answer_relevancy=1.0,
+                        faithfulness=1.0,
+                        context_precision=1.0,
+                        error=None,
+                    )
+                    for case in cases
+                ],
+            )
+
+    monkeypatch.setattr(
+        "backend.evaluation.run_live_api_eval._call_chat_api",
+        fake_call_chat_api,
+    )
+    monkeypatch.setitem(
+        __import__("sys").modules,
+        "evaluation.ragas_pipeline",
+        SimpleNamespace(RagasEvaluator=FakeRagasEvaluator),
+    )
+
+    result = await run_live_api_evaluation(
+        base_url="http://example.test",
+        languages=ALL_LANGUAGES,
+        output_dir=tmp_path,
+        case_suite=CASE_SUITE_ALPHA_127,
+        metrics=("answer_correctness",),
+    )
+
+    assert result["suite_coverage"]["requested_total_cases"] == 127
+    assert result["suite_coverage"]["passed"] is True
+    assert result["per_language"]["ja"]["requested_case_count"] == 80
+    assert result["per_language"]["ja"]["evaluated_case_count"] == 79
+    assert result["per_language"]["ja"]["api_failed_case_count"] == 1
+    assert result["per_language"]["ja"]["collection_error_count"] == 1
+    assert result["per_language"]["ja"]["collection_errors"][0]["error_type"] == "api_call_failed"
+    assert result["comparison"]["per_language"]["ja"]["evaluation_complete"] == {
+        "requested": 80,
+        "evaluated": 79,
+        "collection_errors": 1,
+        "passed": False,
+    }
+    assert result["comparison"]["alpha_release_gate_met"] is False
+    assert "collection_errors: 1 (api_failed=1)" in result["report"]
+    assert "evaluation_complete: evaluated=79/80 collection_errors=1 [FAIL]" in result["report"]
+    assert "Alpha release gate met: NO" in result["report"]

--- a/docs/adr/019-alpha-live-ragas-case-accounting.md
+++ b/docs/adr/019-alpha-live-ragas-case-accounting.md
@@ -1,0 +1,130 @@
+# ADR 019: Alpha Live RAGAS Case Accounting
+
+## ステータス
+
+提案
+
+## 日付
+
+2026-05-03
+
+## 背景
+
+2026-05-03 の `alpha-live-verification` C-127 run `25268597241` で、`alpha-127`
+を指定したにもかかわらず artifact の `suite_coverage.requested_total_cases` が `85`
+になった。
+
+期待値と実績は次の通り。
+
+| Language | Expected | Reported requested/evaluated |
+| --- | ---: | ---: |
+| ja | 80 | 38 |
+| en | 23 | 23 |
+| zh | 12 | 12 |
+| ko | 12 | 12 |
+| total | 127 | 85 |
+
+ローカル dataset は `backend/tests/fixtures/golden_datasets/ground_truth.json` に
+127 ケースを保持しており、`alpha-127` manifest も `ja=80, en=23, zh=12, ko=12`
+をロードしている。したがって、これは dataset selection の問題ではなく live API
+評価ハーネスの accounting 問題である。
+
+現在の `backend/evaluation/run_live_api_eval.py` は `/api/chat` collection phase で
+例外が出たケースをログに出すだけで report から落とす。その後
+`requested_case_count = len(cases)` としており、ここでの `cases` は manifest 件数ではなく
+collection に成功した API response 件数である。このため、API call failure が
+「評価失敗」ではなく「存在しなかったケース」として扱われ、127-case gate の信頼性を失わせる。
+
+## 決定
+
+Alpha live RAGAS gate では、manifest/request accounting と RAGAS evaluable response
+accounting を分離する。
+
+- `requested_case_count` は manifest で選択されたケース数に固定する。
+- `/api/chat` collection に失敗したケースは report から落とさず、`collection_errors`
+  として case id / language / category / question / error type / message を保存する。
+- `api_failed_case_count` と `collection_error_count` を per-language result に追加する。
+- `suite_coverage.requested_total_cases` は manifest request count の合計にする。
+- `evaluation_complete` は `evaluated_case_count == requested_case_count` に加えて
+  `collection_error_count == 0` を要求する。
+- `alpha_release_gate_met` は collection error が 1 件でもあれば false にする。
+
+この変更により、`alpha-127` は API failure があっても `requested_total_cases=127`
+を保持し、失敗は `evaluation_complete` / `collection_errors` として見える。
+
+## 採用理由
+
+Alpha gate は「評価できたケースの平均品質」だけでなく「予定した release-blocking ケースを
+すべて実際に試したか」を証明する必要がある。
+
+API failure を report から落とすと、障害が少なく見えるだけでなく、言語別 coverage の欠損も
+見落とす。今回の run では欠損 42 件がすべて日本語であり、JA answer quality の判断にも影響する。
+
+manifest accounting を正にすることで、以後の triage は次の 3 種類に分離できる。
+
+- coverage failure: workflow / manifest / language selection が正しくない
+- collection failure: live `/api/chat` が timeout / HTTP error / auth error を返す
+- quality failure: API response は得られたが RAGAS / source gate が落ちる
+
+## 代替案
+
+### API failure を retry して成功したケースだけ評価する
+
+短期的には pass 率が上がる可能性があるが、long-tail timeout や backend instability を隠す。
+retry は別途導入してよいが、最終 report には初回失敗と retry 成否を残す必要がある。
+
+### `requested_case_count` の名前だけ `collected_case_count` に変える
+
+既存 artifact の意味は正確になるが、127-case gate の release proof にはならない。
+Alpha gate では manifest 件数を primary accounting とする必要があるため不採用。
+
+### Collection failure を skipped として扱う
+
+`skipped_case_count` だけでは、RAGAS evaluator の skip と live API collection failure が混ざる。
+原因別の修正ができなくなるため、`collection_errors` として別に保持する。
+
+## 実装影響
+
+- `backend/evaluation/run_live_api_eval.py`
+  - per-language manifest count を collection 前に保存する。
+  - API call exception と missing ground truth を `collection_errors` に保存する。
+  - per-language result に `api_failed_case_count`, `collection_error_count`,
+    `collection_errors` を追加する。
+  - `evaluation_complete` と text report に collection error を表示する。
+- `backend/tests/evaluation/test_ragas_live_case_suites.py`
+  - `alpha-127` で 1 件の API failure が起きても `suite_coverage.requested_total_cases`
+    が `127` のままになる regression test を追加する。
+  - 同時に `evaluation_complete=false` と `alpha_release_gate_met=false` を確認する。
+
+## 検証方針
+
+1. Unit:
+   `uv run --extra evaluation pytest tests/evaluation/test_ragas_live_case_suites.py -q`
+2. Harness dry proof:
+   `alpha-127` manifest が `127` / `80,23,12,12` を返すことを確認する。
+3. Live:
+   `alpha-live-verification.yml` を `suites=c-127`, `require_deployed_sha_match=true`,
+   `expected_backend_sha=<current Cloud Run backend SHA>` で再 dispatch する。
+4. Artifact:
+   `suite_coverage.requested_total_cases=127` であること、collection failure があれば
+   `collection_errors` と `evaluation_complete=false` に出ることを確認する。
+
+## ロールバック
+
+この変更は evaluation harness artifact schema の追加であり、product runtime には影響しない。
+問題が出た場合は `run_live_api_eval.py` の accounting change を revert すれば、既存の
+collection-success-only report に戻せる。ただし、その状態の C-127 result は alpha GO 証跡として
+採用しない。
+
+## 現在の実装メモ
+
+2026-05-03 時点で `codex/alpha-c127-live-harness-accounting` に未コミットの draft patch がある。
+次セッションではこの ADR と GitHub Issue #691 を起点に、draft patch を見直して test / PR / merge へ進める。
+
+## 参照
+
+- Run: <https://github.com/EngineerCafeJP/engineercafe-navigator/actions/runs/25268597241>
+- Issue: <https://github.com/EngineerCafeJP/engineercafe-navigator/issues/691>
+- `backend/evaluation/run_live_api_eval.py`
+- `backend/tests/evaluation/test_ragas_live_case_suites.py`
+- `backend/tests/fixtures/golden_datasets/ground_truth.json`

--- a/docs/plans/alpha-remediation-plan-2026-05-02.md
+++ b/docs/plans/alpha-remediation-plan-2026-05-02.md
@@ -14,70 +14,65 @@ The workflow infrastructure is now complete enough to run targeted alpha gates e
 - RAGAS provider/model/case progress telemetry is emitted.
 - B routing / slide live smoke is green on deployed staging.
 
-The product is still **NO-GO** for alpha because there is no latest `suites=all` green proof and
-the STT current-revision gate still fails.
+The product is still **NO-GO** for alpha because there is no latest `suites=all` green proof, and
+the first C-127 run exposed a live RAGAS harness accounting defect.
 
 Latest deployed verification:
 
-- develop SHA: `d789a2cd899779423947c40a3d65e19382f52d30`
-- Cloud Run revision: `engineer-cafe-backend-00148-82c`
-- Targeted B run: `25254789937`
-- B result: `64 passed, 0 warned, 0 failed`
-- UUID / reception persistence log errors during the B run window: 0 rows
+- backend deploy SHA: `d1280aa64643aae7b22df875ee22f13cbfe294a2`
+- Cloud Run revision: `engineer-cafe-backend-00157-b6c`
+- C-127 run: `25268597241`
+- C-127 result: failure, `alpha-127` expected `127` but artifact reported `85`
+- Q targeted run after C-127 dispatch: `25269072919` failed with `23 PASS / 0 WARN / 2 FAIL`
 
 ## Implementation Order
 
-### 1. #658 STT long-tail latency
+### 1. ADR 019 / #691 / #657 / #583 RAGAS coverage and accounting
 
-Goal: reduce the current deployed revision STT long-tail before relying on voice gates.
-
-Status:
-
-- Current-revision scoping is implemented.
-- Historical risk reporting is separated from release gate reporting.
-- The latest STT-only current-revision gate still failed: 7 samples, p50 `5180ms`,
-  p95/max `29217ms`, 14.3% over 10s.
-
-Next tasks:
-
-- Implement Qwen STT long-tail mitigation: fallback threshold, warmup policy, and timeout-before-failure behavior.
-- Re-run `stt` and `v` suites.
-
-### 2. #657 / #583 RAGAS coverage
-
-Goal: reconcile the 29-case diagnostic gate with the 127-case alpha requirement.
+Goal: make C-127 artifacts prove both selected manifest coverage and live API collection success.
 
 Status:
 
 - Direct OpenAI provider path is confirmed.
 - RAGAS progress telemetry is implemented.
-- Coverage semantics are still unresolved.
+- `c-127` workflow selection is implemented.
+- The first C-127 run selected `alpha-127`, but artifact accounting reported only 85 requested cases
+  because live API collection failures were dropped from the report.
 
 Tasks:
 
-- Define release-blocking cases versus diagnostic/soak cases.
-- Add explicit workflow inputs for diagnostic C and full C-127.
-  - Implemented harness selection: `c` / `c-diag` run `diagnostic-29`; `c-127` runs
-    `alpha-127`; the `c_ragas_suite` workflow input can also select either suite for `c` or
-    `all`.
-- Ensure reports cannot imply that 29 cases satisfy the 127-case requirement.
-  - `live_api_eval` reports now include `case_suite` and `suite_coverage` metadata. Only
-    `alpha-127` with all four languages and 127 requested cases is release-blocking coverage.
+- Implement ADR 019 in `backend/evaluation/run_live_api_eval.py`.
+- Keep `requested_case_count` tied to selected manifest cases, not collected successful responses.
+- Persist `/api/chat` collection failures as `collection_errors`.
+- Fail `evaluation_complete` and `alpha_release_gate_met` when collection errors exist.
+- Add regression coverage in `backend/tests/evaluation/test_ragas_live_case_suites.py`.
+- Re-run `suites=c-127` before interpreting C answer quality metrics.
 
-### 3. #653 / #672 answer quality
+### 2. #653 / #672 answer quality
 
 Goal: remove current Q/C answer-quality failures without masking real product issues.
 
 Current Q failures:
 
 - `Q-BIZ-EN-003`
-- `Q-EVT-EN-001`
 - `Q-DAILY-JA-001`
 
-Current C/RAGAS direct OpenAI failure:
+Latest Q run `25269072919` improved from 3 failures to 2 failures:
 
-- JA answer_correctness `0.8295`, target `0.85`
-- weak cases: `ml-ja-003`, `ml-ja-004`
+- `Q-BIZ-EN-003`: route OK, sources OK, missing expected fact `reservation`.
+- `Q-DAILY-JA-001`: route OK, answer OK, latency `2205ms`.
+- `Q-EVT-EN-001` now passes.
+
+Current C/RAGAS direct OpenAI C-127 failure:
+
+- Run `25268597241`: `alpha-127` expected `127`, reported `85`; interpret answer quality only
+  after ADR 019 is merged and rerun.
+- Current reported metrics from the incomplete artifact:
+  - JA answer_correctness `0.585`, target `0.85`
+  - EN answer_correctness `0.7017`, target `0.75`
+  - ZH answer_correctness `0.7271`, target `0.65`
+  - KO answer_correctness `0.7151`, target `0.65`
+- Source gate failures: `gt-019` JA, `gt-065` EN, `gt-115` KO.
 
 Tasks:
 
@@ -86,7 +81,7 @@ Tasks:
 - Fix the smallest product-side issue first; only adjust tests when the expected answer is wrong.
 - Re-run `q` and `c`.
 
-### 4. #670 RAGAS operational closeout
+### 3. #670 RAGAS operational closeout
 
 Goal: make slow or failing C/Q gates diagnosable in GitHub Actions artifacts.
 
@@ -97,11 +92,19 @@ Status:
 
 Tasks:
 
-- Run full C/Q after #658 or in a diagnostic window.
+- Run full C/Q after #691 and the targeted Q/C fixes, or in a diagnostic window.
 - Confirm provider/model/case progress is present in logs and compact artifacts.
 - Close #670 only after one full C/Q operational proof.
 
 ## Completed Items
+
+### #658 STT long-tail latency
+
+Status: completed and closed.
+
+- Current-revision scoping is implemented.
+- Historical risk reporting is separated from release gate reporting.
+- GitHub issue #658 is closed after run `25258764528` passed `suites=stt,v`.
 
 ### #660 H-UI Welcome OCR overlay
 
@@ -149,7 +152,10 @@ Use targeted suites until the relevant blocker is fixed:
 
 ```bash
 gh workflow run alpha-live-verification.yml --ref develop -f suites=stt,v -f require_deployed_sha_match=true
+gh workflow run alpha-live-verification.yml --ref develop -f suites=c-127 -f require_deployed_sha_match=true -f expected_backend_sha=<current-backend-sha>
 gh workflow run alpha-live-verification.yml --ref develop -f suites=q,c -f require_deployed_sha_match=true
 ```
 
-Only run `suites=all` after #658 and the C/Q gate decision have targeted green runs.
+Only run `suites=all` after #691 and the C/Q gate decision have targeted green runs. For C-127,
+do not treat an artifact as release proof unless `suite_coverage.requested_total_cases=127` and
+collection failures are explicitly represented.

--- a/docs/testing/alpha-live-verification-status-2026-05-02.md
+++ b/docs/testing/alpha-live-verification-status-2026-05-02.md
@@ -12,7 +12,8 @@
 実行経路は成立しました。一方で、alpha GO を止める blocker がまだ残っています。
 
 2026-05-03 時点で、B routing / slide live smoke、Welcome UI、artifact split、Supabase UUID
-log hygiene は解消済みです。残る P0 は STT long-tail latency と RAGAS coverage reconciliation です。
+log hygiene、Cloud Run Qwen runtime dependency、STT/voice preflight は解消済みです。残る P0 は
+RAGAS coverage / accounting reconciliation と live-only proof 群です。
 
 ## 2026-05-02 Baseline Deploy / SHA Sync
 
@@ -50,14 +51,53 @@ Resolved by this remediation pass:
 - #662: Supabase UUID / Cloud Run log hygiene
 - #671: RAGAS provider secret issue
 
-Important STT follow-up:
+### 2026-05-03 C-127 Harness Accounting Finding
 
-- STT-only run after PR #674 deploy still failed the current-revision gate.
-- Gate samples: 7
-- p50: `5180ms`
-- p95/max: `29217ms`
-- over-10s ratio: `14.3%`
-- #658 remains the highest-priority P0.
+- Run: <https://github.com/EngineerCafeJP/engineercafe-navigator/actions/runs/25268597241>
+- Suites: `c-127`
+- Result: failure
+- Backend SHA match: `d1280aa64643aae7b22df875ee22f13cbfe294a2`
+- Case suite: `alpha-127`
+- Expected cases: `127`
+- Reported requested/evaluated cases: `85`
+- Reported language counts: `ja=38`, `en=23`, `zh=12`, `ko=12`
+
+This run confirmed a harness accounting bug. The `alpha-127` dataset still contains 127 cases
+(`ja=80`, `en=23`, `zh=12`, `ko=12`), but `run_live_api_eval.py` currently drops `/api/chat`
+collection failures from the report and then uses collected-success count as `requested_case_count`.
+The missing 42 cases were all Japanese and were absent from the artifact instead of being reported as
+collection failures.
+
+Required next action is ADR 019 / #691:
+
+- `requested_case_count` must mean selected manifest cases, not successfully collected responses.
+- API collection failures must be persisted as `collection_errors`.
+- `evaluation_complete` and `alpha_release_gate_met` must fail when collection errors exist.
+
+Until this is fixed and rerun, C-127 artifacts cannot be used as alpha GO proof even when
+`case_suite=alpha-127` is present.
+
+### 2026-05-03 Targeted Q Verification After PR #690/#689
+
+- Run: <https://github.com/EngineerCafeJP/engineercafe-navigator/actions/runs/25269072919>
+- Suites: `q`
+- Result: failure
+- Backend SHA match: `d1280aa64643aae7b22df875ee22f13cbfe294a2`
+- Summary: `23 PASS / 0 WARN / 2 FAIL`
+
+Remaining failures:
+
+- `Q-BIZ-EN-003`: route is `business_info` and source is `enhanced_rag`, but expected fact
+  `reservation` is missing.
+- `Q-DAILY-JA-001`: route is `general_knowledge`, but latency is `2205ms`.
+
+Improvement from the previous Q baseline: `Q-EVT-EN-001` now passes.
+
+Resolved STT follow-up:
+
+- Earlier STT-only run after PR #674 deploy failed with p95/max `29217ms`.
+- A later `suites=stt,v` run `25258764528` passed on Cloud Run `engineer-cafe-backend-00153-r9r`.
+- #658 is closed.
 
 ### Full Suite
 
@@ -67,7 +107,7 @@ Important STT follow-up:
 - Artifact: `alpha-live-verification-25244933308`, artifact ID `6761318600`
 - Artifact size: `932,009,663` bytes
 
-Final failing outcomes:
+Historical failing outcomes from that run:
 
 | Outcome | Status | Current issue |
 | --- | --- | --- |
@@ -99,27 +139,27 @@ coverage, not provider configuration.
 
 ### P0
 
-- #658: STT preflight latency still fails. The current-revision gate after PR #674 had p95/max
-  `29217ms` and 14.3% samples over 10s.
-- #657 / #583: C/RAGAS gate still runs 29 cases while #583 requires 127.
+- #691 / #657 / #583: C/RAGAS gate now has `c-127`, but the first full run exposed harness accounting
+  drift: `alpha-127` expected 127 while artifact reported only 85 requested/evaluated cases.
 - #643 / #612: umbrella issues remain open until the alpha gate is green.
-- #623: slide narration endpoint smoke is covered by B, but full 5-page ingestion proof remains open.
 - #611 / #584 / #585: fast first-response, edge/failure tolerance, and 2h kiosk soak still need final proof.
 
 ### P1
 
-- #672: Direct OpenAI C/RAGAS still misses JA answer_correctness target.
-  - JA: `0.8295`, target `0.85`
-  - weakest cases: `ml-ja-003` access guidance and `ml-ja-004` Connpass/event check
+- #672: Direct OpenAI C/RAGAS still misses answer quality targets after C-127.
+  - JA: `0.585`, target `0.85`
+  - EN: `0.7017`, target `0.75`
+  - ZH: `0.7271`, target `0.65`
+  - KO: `0.7151`, target `0.65`
+  - JA/EN answer quality and live source fallback cases need product-side triage after harness
+    accounting is fixed.
 - #653: Q content quality still fails.
   - `Q-BIZ-EN-003`
-  - `Q-EVT-EN-001`
   - `Q-DAILY-JA-001`
-- #669: deployed tRAG translation model assets are missing, causing retry/fallback logs.
+  - `Q-EVT-EN-001` now passes in run `25269072919`.
 - #670: C/RAGAS runtime improved after direct OpenAI, and telemetry is now present, but full-run
   operational proof is still needed.
 - #655: memory WARNs remain; TTS long Japanese case passed in the latest run.
-- #663: SHA-match gate still blocks harness-only commits without backend deploy.
 - #668: GitHub Actions Node.js 20 deprecation warnings need post-alpha cleanup.
 
 ## RAGAS Provider Decision
@@ -140,11 +180,11 @@ Observed impact:
 
 ## Next Implementation Order
 
-1. #658: STT long-tail latency mitigation.
-2. #657/#583: expand or correctly define the 127-case alpha RAGAS gate.
-3. #653 and #672: Q/C answer quality for current failing cases.
-4. #670: verify full C/Q telemetry and runtime with the current artifact split.
-5. #669: decide whether deployed tRAG translation model fallback is launch-blocking.
+1. ADR 019 / #691 / #657 / #583: fix C-127 harness accounting so 127 manifest cases are always reported,
+   and collection failures are explicit.
+2. #653 and #672: Q/C answer quality for current failing cases.
+3. #670: verify full C/Q telemetry and runtime with the current artifact split.
+4. #611 / #584 / #585: collect or split the remaining live-only alpha proof.
 
 ## Useful Commands
 


### PR DESCRIPTION
## Summary

Fixes #691.

This PR changes the C-127 live RAGAS harness accounting so `requested_case_count` means selected manifest cases, not successfully collected `/api/chat` responses.

## Changes

- Preserve API collection failures in `collection_errors` instead of dropping them from the report.
- Add `api_failed_case_count` and `collection_error_count` to per-language results.
- Keep `suite_coverage.requested_total_cases=127` for `alpha-127` even when a live API call fails.
- Fail `evaluation_complete` and `alpha_release_gate_met` when collection errors exist.
- Surface collection errors in the text report.
- Add ADR 019 and update alpha status/remediation docs with run `25268597241` and Q run `25269072919`.

## Validation

- `python -m py_compile backend/evaluation/run_live_api_eval.py`
- `uv run --extra evaluation pytest tests/evaluation/test_ragas_live_case_suites.py -q`
- `uv run --extra evaluation pytest tests/evaluation/test_multilingual_ragas.py::TestMultilingualQueryManifest -q`
- `git diff --check`

## Notes

This is a harness/docs PR only. It does not change production answer behavior. The next proof after merge is a `suites=c-127` dispatch against the current Cloud Run backend SHA.
