### PR TITLE
fix: stabilize alpha Q reservation quality

### DIFF
--- a/backend/agents/business_info_agent.py
+++ b/backend/agents/business_info_agent.py
@@ -588,6 +588,27 @@ Information: {context}
             }
             return self._canonical_result(answers.get(language, answers["ja"]), request_type)
 
+        if self._asks_reservation_requirement(normalized):
+            answers = {
+                "ja": (
+                    "[relaxed]通常のコワーキング利用は予約なしで利用できます。"
+                    "来館したら1階受付でチェックインしてください。"
+                ),
+                "en": (
+                    "[relaxed]Yes. You can use the regular coworking space at "
+                    "Engineer Cafe without a reservation. Please check in at the "
+                    "1F reception when you arrive."
+                ),
+                "zh": (
+                    "[relaxed]普通共享办公空间无需预约即可使用。" "到馆后请先到一楼前台办理签到。"
+                ),
+                "ko": (
+                    "[relaxed]일반 코워킹 공간은 예약 없이 이용할 수 있습니다. "
+                    "방문하시면 1층 안내 데스크에서 체크인해 주세요."
+                ),
+            }
+            return self._canonical_result(answers.get(language, answers["ja"]), request_type)
+
         if self._asks_what_is_engineer_cafe(normalized, language):
             answers = {
                 "ja": (
@@ -770,6 +791,71 @@ Information: {context}
             "얼마",
         )
         return any(keyword in query for keyword in keywords)
+
+    @staticmethod
+    def _asks_reservation_requirement(query: str) -> bool:
+        excluded_targets = (
+            "event",
+            "events",
+            "event room",
+            "workshop",
+            "meetup",
+            "seminar",
+            "meeting room",
+            "conference room",
+            "room",
+            "イベント",
+            "イベントスペース",
+            "勉強会",
+            "セミナー",
+            "ミートアップ",
+            "会議室",
+            "ミーティングルーム",
+            "会议室",
+            "活动",
+            "이벤트",
+            "회의실",
+        )
+        if any(target in query for target in excluded_targets):
+            return False
+
+        reservation_markers = (
+            "without a reservation",
+            "no reservation",
+            "need a reservation",
+            "reservation needed",
+            "reservation required",
+            "予約なし",
+            "予約無し",
+            "予約不要",
+            "予約は必要",
+            "予約が必要",
+            "予約必要",
+            "无需预约",
+            "需要预约",
+            "예약 없이",
+            "예약 필요",
+        )
+        if not any(marker in query for marker in reservation_markers):
+            return False
+
+        regular_use_markers = (
+            "engineer cafe",
+            "coworking",
+            "regular",
+            "use",
+            "visit",
+            "利用",
+            "使え",
+            "コワーキング",
+            "普通",
+            "通常",
+            "使用",
+            "共享办公",
+            "이용",
+            "코워킹",
+        )
+        return any(marker in query for marker in regular_use_markers)
 
     @staticmethod
     def _asks_what_is_engineer_cafe(query: str, language: str) -> bool:

--- a/backend/main.py
+++ b/backend/main.py
@@ -36,7 +36,11 @@ from backend.utils.structured_logging import (
     setup_structured_logging,
 )
 from backend.utils.session_task_manager import get_session_task_manager
-from backend.utils.intent_classifier import FILLER_INTENTS, filler_intent_for_query
+from backend.utils.intent_classifier import (
+    FILLER_INTENTS,
+    classify_fast_intent,
+    filler_intent_for_query,
+)
 from backend.utils.filler_catalog import FILLER_TEXTS
 
 logger = logging.getLogger(__name__)
@@ -365,6 +369,127 @@ def _build_workflow_payload(body: ChatRequest, session_id: str) -> Dict[str, Any
     return payload
 
 
+def _general_fast_path_answer(query: str, language: str, request_type: str) -> tuple[str, str]:
+    lower_query = query.lower()
+    if request_type == "assistant_profile":
+        if language == "en":
+            return (
+                "I am Engineer Cafe Navigator, the reception kiosk for Engineer Cafe in "
+                "Fukuoka. I can help with facilities, events, membership check-in, Wi-Fi, "
+                "slide guidance, and everyday questions visitors commonly ask at reception.",
+                "helpful",
+            )
+        if language == "ko":
+            return (
+                "저는 Engineer Cafe Navigator 입니다. 후쿠오카의 엔지니어 카페 안내 키오스크로서, "
+                "시설 이용, 이벤트, 회원증, Wi-Fi, 슬라이드 안내와 함께 접수처에서 자주 받는 "
+                "일상적인 질문에도 답해 드립니다.",
+                "helpful",
+            )
+        if language == "zh":
+            return (
+                "我是 Engineer Cafe Navigator，福冈工程师咖啡馆的前台导览终端。我可以为您介绍"
+                "设施使用、活动信息、会员证、Wi-Fi、幻灯片导览，以及前台常见的日常问题。",
+                "helpful",
+            )
+        return (
+            "私は Engineer Cafe Navigator です。福岡市のエンジニアカフェの受付キオスク"
+            "として、施設利用、イベント、会員証、Wi-Fi、スライド案内に加えて、"
+            "受付でよくある日常的な質問にもお答えします。",
+            "helpful",
+        )
+
+    if any(marker in lower_query for marker in ("ありがとう", "サンキュー", "thanks", "thank you")):
+        return (
+            (
+                "どういたしまして。ほかにも気になることがあれば、気軽に聞いてください。"
+                if language == "ja"
+                else "You're welcome. Feel free to ask me anything else."
+            ),
+            "relaxed",
+        )
+    if any(marker in lower_query for marker in ("疲れた", "i am tired", "i'm tired")):
+        return (
+            (
+                "少し休憩しましょう。エンジニアカフェでは、落ち着いて作業したり一息ついたりできます。"
+                if language == "ja"
+                else "Take a short break. Engineer Cafe is a good place to settle in and recharge."
+            ),
+            "relaxed",
+        )
+    if any(marker in lower_query for marker in ("元気", "how are you")):
+        return (
+            (
+                "元気です。今日は受付として、施設案内でも雑談でもすぐお手伝いできます。"
+                if language == "ja"
+                else "I'm doing well. I can help with reception guidance or a quick casual chat."
+            ),
+            "relaxed",
+        )
+    return (
+        (
+            "もちろんです。短くお話ししましょう。施設のことでも、今日の過ごし方でも気軽に聞いてください。"
+            if language == "ja"
+            else (
+                "Of course. We can keep it light. Ask me about the facility "
+                "or anything practical for your visit."
+            )
+        ),
+        "relaxed",
+    )
+
+
+def _try_chat_general_fast_path(
+    body: ChatRequest,
+    *,
+    session_id: str,
+    request_id: str,
+    started_at: float,
+) -> ChatResponse | None:
+    if body.image_data or body.context or body.visitor_id:
+        return None
+
+    intent = classify_fast_intent(body.query)
+    if (
+        intent is None
+        or intent.agent != "general_knowledge"
+        or intent.request_type not in {"assistant_profile", "daily_conversation"}
+    ):
+        return None
+
+    language = body.language or "ja"
+    answer, emotion = _general_fast_path_answer(body.query, language, intent.request_type)
+    metadata = {
+        "query": body.query,
+        "session_id": session_id,
+        "agent": "GeneralKnowledgeAgent",
+        "category": "general_knowledge",
+        "route": "general_knowledge",
+        "request_type": intent.request_type,
+        "query_type": intent.request_type,
+        "sources": [],
+        "web_search_used": False,
+        "rag_used": False,
+        "provider_called": False,
+        "fast_path": "chat_endpoint",
+    }
+    latency_ms = int((time.perf_counter() - started_at) * 1000)
+    log_chat_response(
+        request_id=request_id,
+        language=language,
+        metadata=metadata,
+        latency_ms=latency_ms,
+    )
+    return ChatResponse(
+        answer=answer,
+        emotion=emotion,
+        metadata=metadata,
+        requestId=request_id,
+        phase="chat",
+        upstreamStatus=_upstream_status("chat_endpoint_fast_path", route="general_knowledge"),
+    )
+
+
 def _request_id_from_request(request: Request) -> str:
     return get_request_id() or request.headers.get("X-Request-ID") or generate_request_id()
 
@@ -464,6 +589,15 @@ async def chat(request: Request, body: ChatRequest):
             )
 
         body = body.copy(update={"query": sanitize_input(body.query)})
+        fast_response = _try_chat_general_fast_path(
+            body,
+            session_id=session_id,
+            request_id=request_id,
+            started_at=started_at,
+        )
+        if fast_response is not None:
+            return fast_response
+
         result = await _run_workflow_with_tracking(
             payload=_build_workflow_payload(body, session_id),
             session_id=session_id,

--- a/backend/tests/agents/test_business_info_agent.py
+++ b/backend/tests/agents/test_business_info_agent.py
@@ -3,6 +3,7 @@ BusinessInfoAgent のユニットテスト
 """
 
 import pytest
+from unittest.mock import AsyncMock
 
 from backend.agents.business_info_agent import BusinessInfoAgent
 
@@ -134,6 +135,74 @@ class TestBusinessInfoAgent:
         assert "cafe&bar saino" in response["answer"]
         assert "3Dプリンターのフィラメント代" in response["answer"]
         assert "2階" not in response["answer"]
+
+    def test_reservation_canonical_response_english_includes_expected_fact(self):
+        """Q-BIZ-EN-003: reservation questions must be deterministic."""
+        response = self.agent._get_canonical_response(
+            "Can I use Engineer Cafe without a reservation?",
+            "reception",
+            "en",
+        )
+
+        assert response is not None
+        assert "reservation" in response["answer"].lower()
+        assert "without a reservation" in response["answer"].lower()
+        assert "1F reception" in response["answer"]
+        assert response["metadata"]["sources"] == ["enhanced_rag"]
+
+    def test_reservation_canonical_does_not_capture_event_room_booking(self):
+        """Event-room reservation questions must stay out of generic coworking answers."""
+        response = self.agent._get_canonical_response(
+            "Do I need a reservation for an event room?",
+            "reception",
+            "en",
+        )
+
+        assert response is None
+
+    def test_reservation_canonical_does_not_capture_meeting_room_booking(self):
+        """Meeting-room reservation questions are facility-specific, not coworking use."""
+        response = self.agent._get_canonical_response(
+            "Do I need a reservation for a meeting room?",
+            "reception",
+            "en",
+        )
+
+        assert response is None
+
+    def test_first_visit_registration_precedes_reservation_canonical(self):
+        """First-visit registration questions should not become reservation-only answers."""
+        response = self.agent._get_canonical_response(
+            "For my first visit, do I need a reservation or should I register at reception?",
+            "reception",
+            "en",
+        )
+
+        assert response is not None
+        assert "5 to 10 minutes" in response["answer"]
+        assert "web form" in response["answer"].lower()
+        assert "regular coworking space" not in response["answer"].lower()
+
+    @pytest.mark.asyncio
+    async def test_answer_business_query_reservation_canonical_skips_rag_and_llm(self):
+        """Q-BIZ-EN-003: live path should not depend on RAG/LLM wording."""
+        self.agent.enhanced_rag.search = AsyncMock(
+            side_effect=AssertionError("reservation canonical must skip RAG")
+        )
+        self.agent.llm_provider.generate = AsyncMock(
+            side_effect=AssertionError("reservation canonical must skip LLM")
+        )
+
+        response = await self.agent.answer_business_query(
+            "Can I use Engineer Cafe without a reservation?",
+            "reception",
+            "en",
+            "q-biz-en-003",
+        )
+
+        assert "reservation" in response["answer"].lower()
+        self.agent.enhanced_rag.search.assert_not_called()
+        self.agent.llm_provider.generate.assert_not_called()
 
     def test_reception_request_type_alone_does_not_force_first_visit(self):
         """reception routingだけで初回登録回答へ倒さない"""

--- a/backend/tests/agents/test_general_knowledge_agent.py
+++ b/backend/tests/agents/test_general_knowledge_agent.py
@@ -3,6 +3,7 @@ GeneralKnowledgeAgent のユニットテスト
 """
 
 import os
+import time
 import pytest
 from unittest.mock import patch, MagicMock, AsyncMock
 from backend.agents.general_knowledge_agent import GeneralKnowledgeAgent
@@ -264,15 +265,20 @@ class TestGeneralKnowledgeAgentIntegration:
 
     @pytest.mark.asyncio
     async def test_answer_query_daily_conversation_does_not_call_provider_or_search(self):
+        started = time.perf_counter()
         result = await self.agent.answer_query(
             query="今日は少し疲れた",
             language="ja",
             session_id="test_session",
             query_type="daily_conversation",
         )
+        elapsed_ms = (time.perf_counter() - started) * 1000
 
         assert result["metadata"]["query_type"] == "daily_conversation"
         assert result["metadata"]["web_search_used"] is False
+        assert result["metadata"]["rag_used"] is False
+        assert result["metadata"]["provider_called"] is False
+        assert elapsed_ms < 100
         self.mock_provider.generate.assert_not_called()
         self.mock_web_search.search.assert_not_called()
         self.mock_rag_search.search.assert_not_called()

--- a/backend/tests/test_main_endpoints.py
+++ b/backend/tests/test_main_endpoints.py
@@ -196,6 +196,44 @@ class TestChatEndpoint:
             assert response.vrm_control == {"name": "idle", "duration": 1000, "keyframes": []}
 
     @pytest.mark.asyncio
+    async def test_chat_daily_conversation_uses_endpoint_fast_path(self):
+        from backend.main import ChatRequest, chat
+
+        with patch("backend.main._run_workflow_with_tracking", new_callable=AsyncMock) as workflow:
+            body = ChatRequest(
+                query="少し雑談して",
+                session_id="quality-q-daily",
+                language="ja",
+            )
+            response = await chat(_mock_request(), body)
+
+        workflow.assert_not_awaited()
+        assert response.metadata["route"] == "general_knowledge"
+        assert response.metadata["request_type"] == "daily_conversation"
+        assert response.metadata["fast_path"] == "chat_endpoint"
+        assert response.metadata["provider_called"] is False
+        assert response.metadata["web_search_used"] is False
+        assert "施設" in response.answer
+
+    @pytest.mark.asyncio
+    async def test_chat_assistant_profile_uses_endpoint_fast_path(self):
+        from backend.main import ChatRequest, chat
+
+        with patch("backend.main._run_workflow_with_tracking", new_callable=AsyncMock) as workflow:
+            body = ChatRequest(
+                query="あなたの名前は？",
+                session_id="quality-q-assistant",
+                language="ja",
+            )
+            response = await chat(_mock_request(), body)
+
+        workflow.assert_not_awaited()
+        assert response.metadata["route"] == "general_knowledge"
+        assert response.metadata["request_type"] == "assistant_profile"
+        assert response.metadata["sources"] == []
+        assert "Engineer Cafe Navigator" in response.answer
+
+    @pytest.mark.asyncio
     async def test_chat_error_no_leak(self):
         """Exception detail should NOT contain internal error message"""
         with patch(


### PR DESCRIPTION
## Summary

Addresses the remaining Q-suite failures from run `25269072919` for #653.

## Changes

- Adds a deterministic business-info answer for regular Engineer Cafe/coworking use without a reservation.
- Ensures the English answer includes the expected `reservation` fact and returns before RAG/LLM.
- Hardens the trigger so event-room, meeting-room, and first-visit registration reservation wording does not get captured by the generic coworking response.
- Adds an `/api/chat` endpoint-level deterministic fast path for `assistant_profile` and `daily_conversation`, avoiding workflow / memory / VRM overhead for the 1s Q latency gate.
- Keeps image/context/visitor-id requests on the normal workflow path.

## Validation

```bash
pytest backend/tests/agents/test_business_info_agent.py backend/tests/agents/test_general_knowledge_agent.py -q
# 50 passed

cd backend
uv run pytest tests/test_main_endpoints.py::TestChatEndpoint tests/agents/test_business_info_agent.py tests/agents/test_general_knowledge_agent.py tests/workflows/test_main_workflow.py::TestOrchestratorIntegration::test_keyword_router_fast_routes_assistant_profile_without_memory_loader tests/workflows/test_main_workflow.py::TestOrchestratorIntegration::test_keyword_router_fast_routes_current_weather -q
# 60 passed
```

Warnings are existing PyIceberg/Pydantic/SWIG deprecation warnings.

## Post-Merge Live Check

After deploy, rerun:

```bash
gh workflow run alpha-live-verification.yml \
  --ref develop \
  -f suites=q \
  -f require_deployed_sha_match=true \
  -f expected_backend_sha=<deployed-backend-sha>
```
