### PR TITLE
fix: pace C-127 live RAGAS collection

### DIFF
--- a/.github/workflows/alpha-live-verification.yml
+++ b/.github/workflows/alpha-live-verification.yml
@@ -258,6 +258,7 @@ jobs:
             backend/tests/evaluation/reports/*.md
             backend/tests/evaluation/reports/*.csv
             backend/tests/evaluation/reports/*.json
+            backend/tests/evaluation/reports/*.txt
           if-no-files-found: warn
           retention-days: 30
 

--- a/backend/evaluation/run_live_api_eval.py
+++ b/backend/evaluation/run_live_api_eval.py
@@ -31,6 +31,9 @@ GROUND_TRUTH_PATH = (
     Path(__file__).parent.parent / "tests" / "fixtures" / "golden_datasets" / "ground_truth.json"
 )
 DEFAULT_REPORTS_DIR = Path(__file__).parent.parent / "tests" / "evaluation" / "reports"
+DEFAULT_CHAT_INTERVAL_SECONDS = 2.2
+DEFAULT_CHAT_RETRY_ATTEMPTS = 4
+DEFAULT_CHAT_RETRY_BACKOFF_SECONDS = 2.0
 
 ALL_LANGUAGES = ("ja", "en", "zh", "ko")
 CASE_SUITE_DIAGNOSTIC_29 = "diagnostic-29"
@@ -202,6 +205,25 @@ def _collection_error_record(
     }
 
 
+def _report_file_timestamp(value: Optional[str] = None) -> str:
+    """Return a filesystem-safe timestamp marker for report artifact names."""
+    raw = (value or "").strip()
+    if not raw:
+        raw = datetime.now(timezone.utc).strftime("%Y%m%d_%H%M%S")
+    safe = "".join(ch if ch.isalnum() or ch in {"-", "_", "."} else "_" for ch in raw)
+    return safe or datetime.now(timezone.utc).strftime("%Y%m%d_%H%M%S")
+
+
+def _retry_after_seconds(response: httpx.Response, fallback: float) -> float:
+    retry_after = response.headers.get("Retry-After")
+    if retry_after:
+        try:
+            return max(0.0, float(retry_after))
+        except ValueError:
+            pass
+    return fallback
+
+
 async def _call_chat_api(
     client: httpx.AsyncClient,
     *,
@@ -209,6 +231,8 @@ async def _call_chat_api(
     question: str,
     language: str,
     api_key: Optional[str] = None,
+    retry_attempts: int = DEFAULT_CHAT_RETRY_ATTEMPTS,
+    retry_backoff_seconds: float = DEFAULT_CHAT_RETRY_BACKOFF_SECONDS,
 ) -> Dict[str, Any]:
     """Call the /api/chat endpoint and return the response."""
     headers: Dict[str, str] = {"Content-Type": "application/json"}
@@ -221,9 +245,26 @@ async def _call_chat_api(
     }
 
     url = f"{base_url.rstrip('/')}/api/chat"
-    response = await client.post(url, json=payload, headers=headers, timeout=60.0)
-    response.raise_for_status()
-    return response.json()
+    attempts = max(1, retry_attempts)
+    for attempt in range(attempts):
+        response = await client.post(url, json=payload, headers=headers, timeout=60.0)
+        try:
+            response.raise_for_status()
+            return response.json()
+        except httpx.HTTPStatusError as exc:
+            if response.status_code != 429 or attempt >= attempts - 1:
+                raise exc
+            fallback = retry_backoff_seconds * (2**attempt)
+            sleep_for = _retry_after_seconds(response, fallback)
+            logger.warning(
+                "  /api/chat returned 429; retrying in %.1fs (attempt %d/%d)",
+                sleep_for,
+                attempt + 2,
+                attempts,
+            )
+            await asyncio.sleep(sleep_for)
+
+    raise RuntimeError("unreachable chat retry loop")
 
 
 async def run_live_api_evaluation(
@@ -235,6 +276,10 @@ async def run_live_api_evaluation(
     check_live_sources: bool = True,
     metrics: Optional[Sequence[str]] = None,
     case_suite: str = CASE_SUITE_DIAGNOSTIC_29,
+    report_timestamp: Optional[str] = None,
+    chat_interval_seconds: float = 0.0,
+    chat_retry_attempts: int = DEFAULT_CHAT_RETRY_ATTEMPTS,
+    chat_retry_backoff_seconds: float = DEFAULT_CHAT_RETRY_BACKOFF_SECONDS,
 ) -> Dict[str, Any]:
     """Run RAGAS evaluation against the live API.
 
@@ -243,6 +288,10 @@ async def run_live_api_evaluation(
         api_key: Optional API key for authentication.
         languages: Languages to evaluate (default: all).
         output_dir: Directory for report output.
+        report_timestamp: Optional stable artifact filename marker.
+        chat_interval_seconds: Minimum seconds between live /api/chat request starts.
+        chat_retry_attempts: Total /api/chat attempts for retryable 429 responses.
+        chat_retry_backoff_seconds: Base exponential backoff for 429 responses.
 
     Returns:
         Evaluation result dictionary with per-language metrics.
@@ -256,6 +305,7 @@ async def run_live_api_evaluation(
     all_eval_cases: Dict[str, List[Dict[str, Any]]] = {}
     requested_case_counts: Dict[str, int] = {}
     collection_errors: Dict[str, List[Dict[str, Any]]] = {}
+    last_chat_started: Optional[float] = None
 
     # Phase 1: Collect live API responses
     async with httpx.AsyncClient() as client:
@@ -286,13 +336,21 @@ async def run_live_api_evaluation(
                     continue
 
                 try:
+                    if chat_interval_seconds > 0 and last_chat_started is not None:
+                        since_last_start = time.monotonic() - last_chat_started
+                        sleep_for = chat_interval_seconds - since_last_start
+                        if sleep_for > 0:
+                            await asyncio.sleep(sleep_for)
                     start = time.monotonic()
+                    last_chat_started = start
                     api_response = await _call_chat_api(
                         client,
                         base_url=base_url,
                         question=query["question"],
                         language=lang,
                         api_key=api_key,
+                        retry_attempts=chat_retry_attempts,
+                        retry_backoff_seconds=chat_retry_backoff_seconds,
                     )
                     elapsed = time.monotonic() - start
 
@@ -477,6 +535,9 @@ async def run_live_api_evaluation(
         check_live_sources=check_live_sources,
         case_suite=case_suite,
     )
+    report_file_ts = _report_file_timestamp(report_timestamp)
+    json_report_filename = f"live_api_eval_{report_file_ts}.json"
+    text_report_filename = f"live_api_eval_{report_file_ts}.txt"
 
     result = {
         "timestamp": datetime.now(timezone.utc).isoformat(),
@@ -488,6 +549,14 @@ async def run_live_api_evaluation(
         "metrics": list(selected_metrics),
         "ragas_context_source": "golden_dataset",
         "live_source_gate_enabled": check_live_sources,
+        "artifact_metadata": {
+            "report_timestamp": report_file_ts,
+            "json_report_filename": json_report_filename,
+            "text_report_filename": text_report_filename,
+            "chat_interval_seconds": chat_interval_seconds,
+            "chat_retry_attempts": chat_retry_attempts,
+            "chat_retry_backoff_seconds": chat_retry_backoff_seconds,
+        },
         "per_language": per_language_results,
         "comparison": comparison,
         "report": report_text,
@@ -496,9 +565,8 @@ async def run_live_api_evaluation(
     # Save reports
     dest_dir = output_dir or DEFAULT_REPORTS_DIR
     dest_dir.mkdir(parents=True, exist_ok=True)
-    ts = datetime.now(timezone.utc).strftime("%Y%m%d_%H%M%S")
-    json_path = dest_dir / f"live_api_eval_{ts}.json"
-    txt_path = dest_dir / f"live_api_eval_{ts}.txt"
+    json_path = dest_dir / json_report_filename
+    txt_path = dest_dir / text_report_filename
     json_path.write_text(json.dumps(result, ensure_ascii=False, indent=2), encoding="utf-8")
     txt_path.write_text(report_text, encoding="utf-8")
 
@@ -782,6 +850,12 @@ def main() -> None:
         help="Report output directory.",
     )
     parser.add_argument(
+        "--report-timestamp",
+        type=str,
+        default=None,
+        help="Stable timestamp marker for report artifact filenames.",
+    )
+    parser.add_argument(
         "--check-targets",
         action="store_true",
         help="Exit with status 1 when targets are missed.",
@@ -813,6 +887,24 @@ def main() -> None:
             "RAG/event sources. Diagnostic use only."
         ),
     )
+    parser.add_argument(
+        "--chat-interval-seconds",
+        type=float,
+        default=0.0,
+        help="Minimum seconds between live /api/chat request starts.",
+    )
+    parser.add_argument(
+        "--chat-retry-attempts",
+        type=int,
+        default=DEFAULT_CHAT_RETRY_ATTEMPTS,
+        help="Total /api/chat attempts for retryable 429 responses.",
+    )
+    parser.add_argument(
+        "--chat-retry-backoff-seconds",
+        type=float,
+        default=DEFAULT_CHAT_RETRY_BACKOFF_SECONDS,
+        help="Base exponential backoff seconds for retryable 429 responses.",
+    )
     parser.add_argument("--verbose", action="store_true", help="Enable debug logging.")
     args = parser.parse_args()
 
@@ -831,6 +923,10 @@ def main() -> None:
             check_live_sources=not args.no_check_live_sources,
             metrics=args.metrics,
             case_suite=args.case_suite,
+            report_timestamp=args.report_timestamp,
+            chat_interval_seconds=args.chat_interval_seconds,
+            chat_retry_attempts=args.chat_retry_attempts,
+            chat_retry_backoff_seconds=args.chat_retry_backoff_seconds,
         )
     )
 

--- a/backend/tests/evaluation/test_ragas_live_case_suites.py
+++ b/backend/tests/evaluation/test_ragas_live_case_suites.py
@@ -3,6 +3,7 @@
 from collections import Counter
 from types import SimpleNamespace
 
+import httpx
 import pytest
 
 from backend.evaluation.run_live_api_eval import (
@@ -11,6 +12,7 @@ from backend.evaluation.run_live_api_eval import (
     CASE_SUITE_DIAGNOSTIC_29,
     EVENT_SOURCE_REQUIREMENT,
     LOCAL_KNOWLEDGE_SOURCE_REQUIREMENT,
+    _call_chat_api,
     _load_case_suite_config,
     _required_live_sources,
     _source_requirement_ok,
@@ -112,7 +114,7 @@ async def test_live_eval_keeps_alpha_127_manifest_count_when_api_collection_fail
 ):
     calls = []
 
-    async def fake_call_chat_api(client, *, base_url, question, language, api_key=None):
+    async def fake_call_chat_api(client, *, base_url, question, language, api_key=None, **kwargs):
         calls.append((question, language))
         if len(calls) == 1:
             raise TimeoutError("synthetic timeout")
@@ -173,6 +175,7 @@ async def test_live_eval_keeps_alpha_127_manifest_count_when_api_collection_fail
         output_dir=tmp_path,
         case_suite=CASE_SUITE_ALPHA_127,
         metrics=("answer_correctness",),
+        report_timestamp="alpha-live-test-c",
     )
 
     assert result["suite_coverage"]["requested_total_cases"] == 127
@@ -189,6 +192,53 @@ async def test_live_eval_keeps_alpha_127_manifest_count_when_api_collection_fail
         "passed": False,
     }
     assert result["comparison"]["alpha_release_gate_met"] is False
+    assert result["artifact_metadata"] == {
+        "report_timestamp": "alpha-live-test-c",
+        "json_report_filename": "live_api_eval_alpha-live-test-c.json",
+        "text_report_filename": "live_api_eval_alpha-live-test-c.txt",
+        "chat_interval_seconds": 0.0,
+        "chat_retry_attempts": 4,
+        "chat_retry_backoff_seconds": 2.0,
+    }
+    assert (tmp_path / "live_api_eval_alpha-live-test-c.json").is_file()
+    assert (tmp_path / "live_api_eval_alpha-live-test-c.txt").is_file()
     assert "collection_errors: 1 (api_failed=1)" in result["report"]
     assert "evaluation_complete: evaluated=79/80 collection_errors=1 [FAIL]" in result["report"]
     assert "Alpha release gate met: NO" in result["report"]
+
+
+@pytest.mark.asyncio
+async def test_call_chat_api_retries_429_with_retry_after(monkeypatch):
+    sleeps: list[float] = []
+
+    async def fake_sleep(seconds: float) -> None:
+        sleeps.append(seconds)
+
+    attempts = 0
+
+    async def handler(request: httpx.Request) -> httpx.Response:
+        nonlocal attempts
+        attempts += 1
+        if attempts == 1:
+            return httpx.Response(429, headers={"Retry-After": "0.01"}, request=request)
+        return httpx.Response(
+            200,
+            json={"answer": "ok", "metadata": {"agent": "GeneralKnowledgeAgent"}},
+            request=request,
+        )
+
+    monkeypatch.setattr("backend.evaluation.run_live_api_eval.asyncio.sleep", fake_sleep)
+
+    async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as client:
+        result = await _call_chat_api(
+            client,
+            base_url="http://example.test",
+            question="少し雑談して",
+            language="ja",
+            retry_attempts=2,
+            retry_backoff_seconds=2.0,
+        )
+
+    assert result["answer"] == "ok"
+    assert attempts == 2
+    assert sleeps == [0.01]

--- a/scripts/rag-api-live-test.sh
+++ b/scripts/rag-api-live-test.sh
@@ -13,6 +13,8 @@ set -euo pipefail
 #   RAG_API_LIVE_BASE_URL          Overrides default Cloud Run URL.
 #   RAG_API_LIVE_SECRET_PROJECT    Overrides Secret Manager project.
 #   RAG_API_LIVE_METRICS           Comma-separated RAGAS metrics.
+#   RAG_API_LIVE_CHAT_INTERVAL_SECONDS
+#                                   Minimum seconds between /api/chat starts (default: 2.2).
 #   OPENAI_API_KEY / OPENROUTER_API_KEY are required by the RAGAS evaluator.
 #   If neither is set, this script tries Secret Manager. Direct OpenAI is preferred.
 
@@ -30,6 +32,9 @@ LANGUAGES="ja,en,zh,ko"
 METRICS="${RAG_API_LIVE_METRICS:-answer_correctness}"
 CASE_SUITE="${RAG_API_LIVE_CASE_SUITE:-diagnostic-29}"
 TIMESTAMP="$(date +%Y%m%d_%H%M%S)"
+CHAT_INTERVAL_SECONDS="${RAG_API_LIVE_CHAT_INTERVAL_SECONDS:-2.2}"
+CHAT_RETRY_ATTEMPTS="${RAG_API_LIVE_CHAT_RETRY_ATTEMPTS:-4}"
+CHAT_RETRY_BACKOFF_SECONDS="${RAG_API_LIVE_CHAT_RETRY_BACKOFF_SECONDS:-2.0}"
 DRY_RUN=0
 CHECK_TARGETS=1
 
@@ -49,14 +54,20 @@ Options:
   --metrics LIST         Comma-separated RAGAS metrics (default: answer_correctness)
   --case-suite NAME      diagnostic-29 (fast path) or alpha-127 (release gate)
   --output-dir DIR       Report directory (default: backend/tests/evaluation/reports)
-  --timestamp VALUE      Stable timestamp marker printed for operator correlation
+  --timestamp VALUE      Stable timestamp marker for logs and report names
+  --chat-interval-seconds VALUE
+                         Minimum seconds between live /api/chat request starts (default: 2.2)
+  --chat-retry-attempts VALUE
+                         Total /api/chat attempts for retryable 429 responses (default: 4)
+  --chat-retry-backoff-seconds VALUE
+                         Base exponential backoff seconds for retryable 429 responses (default: 2.0)
   --no-check-targets     Do not fail when configured answer_correctness targets are missed
   --dry-run              Validate local prerequisites and print planned command only
   -h, --help             Show this usage
 
 Outputs:
-  backend/tests/evaluation/reports/live_api_ragas_<timestamp>.json
-  backend/tests/evaluation/reports/live_api_ragas_<timestamp>.md
+  backend/tests/evaluation/reports/live_api_eval_<timestamp>.json
+  backend/tests/evaluation/reports/live_api_eval_<timestamp>.txt
 EOF
   exit "${1:-0}"
 }
@@ -74,6 +85,9 @@ while [ "$#" -gt 0 ]; do
     --case-suite) CASE_SUITE="$2"; shift 2 ;;
     --output-dir) OUTPUT_DIR="$2"; shift 2 ;;
     --timestamp) TIMESTAMP="$2"; shift 2 ;;
+    --chat-interval-seconds) CHAT_INTERVAL_SECONDS="$2"; shift 2 ;;
+    --chat-retry-attempts) CHAT_RETRY_ATTEMPTS="$2"; shift 2 ;;
+    --chat-retry-backoff-seconds) CHAT_RETRY_BACKOFF_SECONDS="$2"; shift 2 ;;
     --no-check-targets) CHECK_TARGETS=0; shift ;;
     --dry-run) DRY_RUN=1; shift ;;
     -h|--help) usage 0 ;;
@@ -207,6 +221,9 @@ main() {
     echo "Case suite: $CASE_SUITE"
     echo "Languages: ${LANG_ARGS[*]}"
     echo "Metrics: ${METRIC_ARGS[*]}"
+    echo "Chat interval seconds: $CHAT_INTERVAL_SECONDS"
+    echo "Chat retry attempts: $CHAT_RETRY_ATTEMPTS"
+    echo "Chat retry backoff seconds: $CHAT_RETRY_BACKOFF_SECONDS"
     if [ "$CHECK_TARGETS" = "1" ]; then
       echo "Target check: enabled"
       echo "Live source metadata gate: enabled"
@@ -233,10 +250,13 @@ main() {
   echo "Case suite: $CASE_SUITE"
   echo "Languages: ${LANG_ARGS[*]}"
   echo "Metrics: ${METRIC_ARGS[*]}"
+  echo "Chat interval seconds: $CHAT_INTERVAL_SECONDS"
+  echo "Chat retry attempts: $CHAT_RETRY_ATTEMPTS"
+  echo "Chat retry backoff seconds: $CHAT_RETRY_BACKOFF_SECONDS"
   echo "RAGAS batch strategy: ${RAGAS_BATCH_STRATEGY:-single}"
   echo "RAGAS per-case timeout: ${RAGAS_OUTER_SINGLE_TIMEOUT:-300}s"
 
-  cmd=(python evaluation/run_live_api_eval.py --base-url "$BASE_URL" --case-suite "$CASE_SUITE" --languages "${LANG_ARGS[@]}" --metrics "${METRIC_ARGS[@]}" --output-dir "$OUTPUT_DIR")
+  cmd=(python evaluation/run_live_api_eval.py --base-url "$BASE_URL" --case-suite "$CASE_SUITE" --languages "${LANG_ARGS[@]}" --metrics "${METRIC_ARGS[@]}" --output-dir "$OUTPUT_DIR" --report-timestamp "$TIMESTAMP" --chat-interval-seconds "$CHAT_INTERVAL_SECONDS" --chat-retry-attempts "$CHAT_RETRY_ATTEMPTS" --chat-retry-backoff-seconds "$CHAT_RETRY_BACKOFF_SECONDS")
   if [ "$CHECK_TARGETS" = "1" ]; then
     cmd+=(--check-targets)
   fi


### PR DESCRIPTION
## Summary

Fixes #694, the C-127 live gate failure where the full alpha RAGAS collection hit `/api/chat` rate limiting and evaluated only `35/127` cases.

## Changes

- Adds `/api/chat` request pacing to the live RAGAS runner.
- Defaults the wrapper to `2.2s` between request starts, keeping C-127 below the current `30/minute` `/api/chat` limit.
- Retries retryable `429` responses with `Retry-After` support and exponential fallback backoff.
- Preserves #692 collection accounting and exposes pacing/retry settings in artifact metadata.
- Passes workflow timestamp into report filenames and includes `.txt` reports in compact artifacts for easier triage.

## Validation

```bash
python -m py_compile backend/evaluation/run_live_api_eval.py
pytest backend/tests/evaluation/test_ragas_live_case_suites.py -q
# 7 passed

scripts/rag-api-live-test.sh --dry-run --timestamp alpha-live-test-c --case-suite alpha-127 --languages ja,en,zh,ko
# Shows chat interval seconds: 2.2, retry attempts: 4, retry backoff seconds: 2.0

git diff --check
```

## Post-Merge Live Check

After merge, rerun C-127 against the current deployed backend SHA:

```bash
gh workflow run alpha-live-verification.yml \
  --ref develop \
  -f suites=c-127 \
  -f require_deployed_sha_match=true \
  -f expected_backend_sha=<deployed-backend-sha>
```
