### PR TITLE
fix: tighten C RAGAS source routing

### DIFF
--- a/backend/agents/facility_agent.py
+++ b/backend/agents/facility_agent.py
@@ -139,9 +139,11 @@ class FacilityAgent:
 
         # Check cached RAG results
         cached = state_context if state_context else None
-        if cached and cached.get("success") and cached.get("category") == "facility-info":
+        rag_category = self._map_request_type_to_rag_category(request_type)
+
+        if cached and cached.get("success") and cached.get("category") == rag_category:
             context = cached.get("context_string", "")
-            logger.info("Using cached RAG results for facility-info")
+            logger.info("Using cached RAG results for %s", rag_category)
         else:
             # クエリ拡張（requestTypeに応じて）
             enhanced_query = self._enhance_query(query, request_type, language)
@@ -149,7 +151,7 @@ class FacilityAgent:
             # Enhanced RAG検索
             rag_result = await self.enhanced_rag.search(
                 query=enhanced_query,
-                category="facility-info",
+                category=rag_category,
                 language=language,
                 include_advice=True,
                 max_results=10,
@@ -188,7 +190,7 @@ class FacilityAgent:
                 "metadata": {
                     "agent": "FacilityAgent",
                     "confidence": 0.85,
-                    "category": "facility-info",
+                    "category": rag_category,
                     "request_type": request_type,
                     "sources": ["enhanced_rag"],
                 },
@@ -206,6 +208,17 @@ class FacilityAgent:
             )
             return f"{query} {keywords}"
         return query
+
+    @staticmethod
+    def _map_request_type_to_rag_category(request_type: Optional[str]) -> str:
+        """Map facility request types to the narrowest RAG category available."""
+        category_by_request_type = {
+            "smoking": "smoking",
+            "food_drink": "food_drink",
+            "parking": "parking",
+            "bicycle": "bicycle",
+        }
+        return category_by_request_type.get(request_type or "", "facility-info")
 
     def _filter_basement_context(self, context: str, query: str, language: str) -> str:
         """地下施設に関連するコンテキストのみに絞り込む

--- a/backend/agents/general_knowledge_agent.py
+++ b/backend/agents/general_knowledge_agent.py
@@ -111,6 +111,7 @@ class GeneralKnowledgeAgent:
             state_context,
             context_signals,
             long_term_memory=long_term_memory,
+            query_type=query_type,
         )
 
     async def answer_general_query(
@@ -151,16 +152,17 @@ class GeneralKnowledgeAgent:
             # 2. ナレッジベース検索（キャッシュチェック付き）
             context = ""
             sources: List[str] = []
+            rag_category = self._rag_category_for_query_type(query_type)
 
             cached = state_context if state_context else None
-            if cached and cached.get("success") and cached.get("category") == "general":
+            if cached and cached.get("success") and cached.get("category") == rag_category:
                 context = cached.get("context_string", "")
                 sources.append("knowledge_base_cached")
                 logger.info("Using cached RAG results: %d chars", len(context))
             else:
                 kb_result = await self.rag_search.search(
                     query=query,
-                    category="general",
+                    category=rag_category,
                     language=language,
                     max_results=5,
                     context_signals=context_signals,
@@ -244,6 +246,15 @@ class GeneralKnowledgeAgent:
         except Exception as e:
             logger.exception("GeneralKnowledgeAgent処理エラー: %s", e)
             return self._handle_error(language)
+
+    @staticmethod
+    def _rag_category_for_query_type(query_type: str) -> str:
+        """Keep general-knowledge routes on specific local KB slices when known."""
+        category_by_query_type = {
+            "consultation": "consultation",
+            "community": "community",
+        }
+        return category_by_query_type.get(query_type, "general")
 
     # =========================================================================
     # メモリクエリ処理

--- a/backend/config/routing_constants.py
+++ b/backend/config/routing_constants.py
@@ -483,6 +483,9 @@ SMOKING_KEYWORDS = [
     "smoking",
     "cigarette",
     "smoke",
+    "흡연",
+    "금연",
+    "담배",
 ]
 
 FOOD_DRINK_KEYWORDS = [
@@ -532,6 +535,8 @@ FACILITY_EQUIPMENT_KEYWORDS = [
     "equipment",
     "facility",
     "facilities",
+    "available spaces",
+    "what spaces",
     "outlet",
     "printer",
     "monitor",

--- a/backend/tests/agents/test_facility_agent.py
+++ b/backend/tests/agents/test_facility_agent.py
@@ -318,6 +318,36 @@ class TestFacilityAgent:
 
         assert response is None
 
+    @pytest.mark.asyncio
+    async def test_smoking_query_uses_smoking_rag_category(self):
+        """喫煙ポリシーはfacility-infoではなくsmokingカテゴリで検索する"""
+        agent = FacilityAgent()
+
+        with (
+            patch.object(agent.enhanced_rag, "search", new_callable=AsyncMock) as mock_rag,
+            patch.object(agent.llm_provider, "generate", new_callable=AsyncMock) as mock_llm,
+        ):
+            mock_rag.return_value = {
+                "success": True,
+                "data": {
+                    "context": "エンジニアカフェは全館禁煙です。",
+                    "results": [],
+                    "totalResults": 1,
+                },
+            }
+            mock_llm.return_value = "[relaxed]실내에서는 흡연할 수 없습니다."
+
+            result = await agent.answer_facility_query(
+                query="실내에서 흡연할 수 있나요?",
+                request_type="smoking",
+                language="ko",
+            )
+
+        assert result["metadata"]["sources"] == ["enhanced_rag"]
+        assert result["metadata"]["category"] == "smoking"
+        mock_rag.assert_awaited_once()
+        assert mock_rag.await_args.kwargs["category"] == "smoking"
+
     def test_determine_emotion_default(self):
         """デフォルト感情タグ"""
         agent = FacilityAgent()

--- a/backend/tests/agents/test_general_knowledge_agent.py
+++ b/backend/tests/agents/test_general_knowledge_agent.py
@@ -324,6 +324,19 @@ class TestGeneralKnowledgeAgentIntegration:
         self.mock_provider.generate.assert_awaited_once()
 
     @pytest.mark.asyncio
+    async def test_consultation_query_type_uses_consultation_rag_category(self):
+        result = await self.agent.answer_query(
+            query="コミュニティマネージャーに相談できることは？",
+            language="ja",
+            session_id="test_session",
+            query_type="consultation",
+        )
+
+        assert result["metadata"]["sources"] == ["knowledge_base"]
+        self.mock_rag_search.search.assert_awaited_once()
+        assert self.mock_rag_search.search.await_args.kwargs["category"] == "consultation"
+
+    @pytest.mark.asyncio
     async def test_deep_reasoning_uses_explicit_model_case(self):
         result = await self.agent.answer_query(
             query="弁証法的に比較分析してください",

--- a/backend/tests/agents/test_gka_memory.py
+++ b/backend/tests/agents/test_gka_memory.py
@@ -90,6 +90,7 @@ class TestGKAAnswerQueryDispatch:
             None,
             None,
             long_term_memory=long_term_memory,
+            query_type="general",
         )
         assert result["answer"] == "一般回答"
 

--- a/backend/tests/agents/test_identity_routing.py
+++ b/backend/tests/agents/test_identity_routing.py
@@ -34,6 +34,7 @@ IDENTITY_QUERIES = {
         "あなたは誰ですか",
         "何者ですか",
         "自己紹介してください",
+        "あなたに相談できることは？",
         "どんなAIなの？",
         "どのモデルを使ってる？",
     ],
@@ -78,6 +79,8 @@ VISITOR_NAME_QUERIES = [
 NON_IDENTITY_AMBIGUOUS_QUERIES = [
     # 貴方 used as 2nd-person pronoun in a Wi-Fi question (not asking about bot)
     "貴方にWi-Fiの設定を聞きたい",
+    # "できること" as a consultation domain phrase, not assistant capability.
+    "コミュニティマネージャーに相談できることは？",
     # "AI" as topic of an event lookup, not asking which AI the bot is
     "which AI events are held here?",
     # Chinese capability marker without self-referential identity token

--- a/backend/tests/agents/test_orchestrator_fast_routing.py
+++ b/backend/tests/agents/test_orchestrator_fast_routing.py
@@ -234,6 +234,35 @@ class TestOrchestratorFastRouting:
             assert result is not None, f"Query '{query}' should match fast-path"
             assert result["agent"] == "facility", f"Query '{query}' should route to facility"
 
+    def test_english_available_spaces_routes_to_facility(self, orchestrator):
+        result = orchestrator._try_fast_routing("What spaces are available at Engineer Cafe?")
+
+        assert result is not None
+        assert result["agent"] == "facility"
+        assert result["category"] == "facility-info"
+        assert result["request_type"] == "facility"
+
+    def test_namespace_does_not_route_to_facility_space_keyword(self, orchestrator):
+        result = orchestrator._try_fast_routing("What is namespace in Python?")
+
+        assert result is None
+
+    def test_gt_019_consultation_not_assistant_profile(self, orchestrator):
+        result = orchestrator._try_fast_routing("コミュニティマネージャーに相談できることは？")
+
+        assert result is not None
+        assert result["request_type"] != "assistant_profile"
+        assert result["category"] == "consultation"
+        assert result["request_type"] == "consultation"
+
+    def test_korean_smoking_routes_to_facility(self, orchestrator):
+        result = orchestrator._try_fast_routing("실내에서 흡연할 수 있나요?")
+
+        assert result is not None
+        assert result["agent"] == "facility"
+        assert result["category"] == "facility-info"
+        assert result["request_type"] == "smoking"
+
     def test_greeting_konnichiwa(self, orchestrator):
         """こんにちは が greeting にルーティングされること"""
         result = orchestrator._try_fast_routing("こんにちは")

--- a/backend/tests/config/test_routing_constants.py
+++ b/backend/tests/config/test_routing_constants.py
@@ -43,10 +43,22 @@ class TestNewRoutingKeywords:
             ("喫煙所はありますか？", "smoking"),
             ("タバコは吸えますか？", "smoking"),
             ("Is smoking allowed?", "smoking"),
+            ("실내에서 흡연할 수 있나요?", "smoking"),
         ],
     )
     def test_smoking_keywords(self, query, expected):
         """喫煙キーワードがsmokingにルーティングされることを確認"""
+        assert extract_request_type(query) == expected
+
+    @pytest.mark.parametrize(
+        "query,expected",
+        [
+            ("What spaces are available at Engineer Cafe?", "facility"),
+            ("Tell me about available spaces.", "facility"),
+        ],
+    )
+    def test_available_spaces_keywords(self, query, expected):
+        """英語のスペース一覧質問がfacilityにルーティングされることを確認"""
         assert extract_request_type(query) == expected
 
     @pytest.mark.parametrize(

--- a/backend/tests/tools/test_enhanced_rag.py
+++ b/backend/tests/tools/test_enhanced_rag.py
@@ -671,6 +671,58 @@ class TestTextFallbackSearch:
         assert results
         assert "SSID" in results[0]["content"] or "engnecf" in results[0]["content"]
 
+    def test_local_yaml_fallback_returns_consultation_for_gt_019(self, rag_search):
+        """gt-019の相談サービス質問が公式相談KBに当たる"""
+        results = rag_search._local_knowledge_fallback_search(
+            query="コミュニティマネージャーに相談できることは？",
+            category="consultation",
+            language="ja",
+            max_results=3,
+        )
+
+        assert results
+        assert results[0]["id"] == "community-manager"
+        assert "スキルチェンジ" in results[0]["content"]
+
+    def test_local_yaml_fallback_returns_spaces_for_gt_065(self, rag_search):
+        """gt-065の英語スペース一覧質問が主要スペースKBに当たる"""
+        results = rag_search._local_knowledge_fallback_search(
+            query="What spaces are available at Engineer Cafe?",
+            category="facility-info",
+            language="en",
+            max_results=10,
+        )
+
+        result_ids = {row["id"] for row in results}
+        assert "facility-main-hall" in result_ids
+        assert "facility-focus-space" in result_ids
+        assert "facility-makers-space" in result_ids
+
+    def test_expand_query_adds_space_terms_for_gt_065(self, rag_search):
+        """gt-065の英語スペース質問はスペース系KB語彙へ拡張される"""
+        expanded = rag_search._expand_query(
+            "What spaces are available at Engineer Cafe?",
+            category="facility-info",
+            language="en",
+        )
+
+        assert "spaces" in expanded
+        assert "スペース" in expanded
+        assert "メインホール" in expanded or "集中スペース" in expanded
+
+    def test_local_yaml_fallback_returns_smoking_for_gt_115_korean(self, rag_search):
+        """gt-115の韓国語喫煙質問が喫煙ポリシーKBに当たる"""
+        results = rag_search._local_knowledge_fallback_search(
+            query="실내에서 흡연할 수 있나요?",
+            category="smoking",
+            language="ko",
+            max_results=3,
+        )
+
+        assert results
+        assert results[0]["id"] == "policy-smoking"
+        assert "禁煙" in results[0]["content"]
+
     def test_local_yaml_fallback_keeps_reception_queries_on_general_guides(self, rag_search):
         """受付・予約なし質問ではイベント予約ではなく一般受付案内を優先する"""
         results = rag_search._local_knowledge_fallback_search(

--- a/backend/tools/enhanced_rag.py
+++ b/backend/tools/enhanced_rag.py
@@ -35,6 +35,10 @@ RPC_SIMILARITY_THRESHOLDS: Dict[str, float] = {
     "general": 0.30,
     "consultation": 0.30,
     "community": 0.30,
+    "smoking": 0.30,
+    "food_drink": 0.30,
+    "parking": 0.30,
+    "bicycle": 0.30,
 }
 DEFAULT_RPC_SIMILARITY_THRESHOLD = 0.30
 RPC_TIMEOUT_SECONDS = 10.0
@@ -49,6 +53,10 @@ CATEGORY_THRESHOLDS = {
     "general": {"high": 0.72, "medium": 0.52, "term_match": 0.20},
     "consultation": {"high": 0.65, "medium": 0.45, "term_match": 0.18},
     "community": {"high": 0.73, "medium": 0.53, "term_match": 0.20},
+    "smoking": {"high": 0.65, "medium": 0.45, "term_match": 0.18},
+    "food_drink": {"high": 0.70, "medium": 0.50, "term_match": 0.20},
+    "parking": {"high": 0.70, "medium": 0.50, "term_match": 0.20},
+    "bicycle": {"high": 0.70, "medium": 0.50, "term_match": 0.20},
 }
 DEFAULT_THRESHOLDS = {"high": 0.78, "medium": 0.58, "term_match": 0.25}
 
@@ -153,6 +161,14 @@ QUERY_EXPANSION_MAP: Dict[str, List[str]] = {
     "位置": ["場所", "アクセス", "住所"],
     "设施": ["設備", "施設", "facility"],
     "登记": ["利用方法", "登録", "初回"],
+    # Policy / space queries
+    "spaces": ["スペース", "施設", "設備", "メインホール", "集中スペース"],
+    "available spaces": ["スペース", "施設", "設備", "メインホール", "集中スペース"],
+    "what spaces": ["スペース", "施設", "設備", "メインホール", "集中スペース"],
+    "smoking": ["喫煙", "禁煙", "喫煙所"],
+    "흡연": ["喫煙", "禁煙", "喫煙所"],
+    "금연": ["禁煙", "喫煙"],
+    "담배": ["喫煙", "禁煙", "喫煙所"],
 }
 
 
@@ -518,22 +534,35 @@ class EnhancedRAGSearch:
         if category != "general" and len(query) < 15 and "エンジニアカフェ" not in query:
             query = f"エンジニアカフェ {query}"
 
-        # カテゴリベースの拡張キーワード
-        category_keywords: Dict[str, List[str]] = {
-            "hours": ["営業時間", "opening hours", "business hours", "開館時間"],
-            "pricing": ["料金", "price", "pricing", "cost", "利用料金"],
-            "location": ["場所", "アクセス", "location", "access", "住所", "address"],
-            "facility-info": ["設備", "facility", "施設", "equipment"],
-        }
-
-        if category in category_keywords:
-            expansions.extend(category_keywords[category])
-
         # クエリ内のキーワードに基づく拡張
         query_lower = query.lower()
         for key, synonyms in QUERY_EXPANSION_MAP.items():
             if key.lower() in query_lower:
                 expansions.extend(synonyms)
+
+        # カテゴリベースの拡張キーワード
+        category_keywords: Dict[str, List[str]] = {
+            "hours": ["営業時間", "opening hours", "business hours", "開館時間"],
+            "pricing": ["料金", "price", "pricing", "cost", "利用料金"],
+            "location": ["場所", "アクセス", "location", "access", "住所", "address"],
+            "facility-info": [
+                "設備",
+                "facility",
+                "facilities",
+                "space",
+                "spaces",
+                "施設",
+                "equipment",
+            ],
+            "consultation": ["相談", "コミュニティマネージャー", "career", "consultation"],
+            "smoking": ["喫煙", "禁煙", "smoking", "흡연", "금연"],
+            "food_drink": ["飲食", "食べ物", "drink", "food"],
+            "parking": ["駐車場", "parking"],
+            "bicycle": ["駐輪場", "bicycle parking"],
+        }
+
+        if category in category_keywords:
+            expansions.extend(category_keywords[category])
 
         # 重複除去して元クエリと結合
         seen: set[str] = set()
@@ -815,7 +844,12 @@ class EnhancedRAGSearch:
 
     def _extract_text_query_terms(self, query: str, category: str, language: str) -> list[str]:
         text = self._expand_query(query, category, language).lower()
-        terms = set(re.findall(r"[a-z0-9][a-z0-9_.+-]*|[\u3040-\u30ff\u4e00-\u9fff]{2,}", text))
+        terms = set(
+            re.findall(
+                r"[a-z0-9][a-z0-9_.+-]*|[\u3040-\u30ff\u4e00-\u9fff\uac00-\ud7af]{2,}",
+                text,
+            )
+        )
 
         domain_terms = (
             "wi-fi",
@@ -833,6 +867,11 @@ class EnhancedRAGSearch:
             "開館",
             "駐車",
             "電源",
+            "喫煙",
+            "禁煙",
+            "흡연",
+            "금연",
+            "담배",
         )
         query_lower = query.lower()
         for term in domain_terms:
@@ -869,7 +908,10 @@ class EnhancedRAGSearch:
 
     @staticmethod
     def _contains_cjk(text: str) -> bool:
-        return any("\u3040" <= c <= "\u30ff" or "\u4e00" <= c <= "\u9fff" for c in text)
+        return any(
+            "\u3040" <= c <= "\u30ff" or "\u4e00" <= c <= "\u9fff" or "\uac00" <= c <= "\ud7af"
+            for c in text
+        )
 
     async def _generate_embedding(self, text: str) -> List[float]:
         """OpenRouter API経由でエンベディングを生成。

--- a/backend/utils/intent_classifier.py
+++ b/backend/utils/intent_classifier.py
@@ -135,6 +135,17 @@ def is_assistant_profile_question(lower_query: str) -> bool:
     if any(marker in lower_query for marker in visitor_name_markers):
         return False
 
+    domain_service_markers = (
+        "コミュニティマネージャー",
+        "community manager",
+        "キャリア相談",
+        "技術相談",
+        "スキルチェンジ",
+        "転職",
+    )
+    if any(marker in lower_query for marker in domain_service_markers):
+        return False
+
     # Substring identity markers that are unambiguous on their own.
     identity_markers = (
         # Japanese


### PR DESCRIPTION
## Summary
- route consultation/community general queries to narrower RAG categories
- route smoking/food/parking/bicycle facility queries to narrower RAG categories
- add Korean smoking, English available-spaces, gt-019 consultation, and namespace regression coverage

## Validation
- pytest backend/tests/config/test_routing_constants.py backend/tests/agents/test_identity_routing.py backend/tests/agents/test_orchestrator_fast_routing.py backend/tests/tools/test_enhanced_rag.py backend/tests/agents/test_facility_agent.py backend/tests/agents/test_general_knowledge_agent.py -q
- git diff --cached --check

Closes #672 follow-up source-gate fixes after C-127 collection is proven.
