### PR TITLE
test: guard Welcome camera flow

### DIFF
--- a/frontend/e2e/welcome-voice-first.spec.ts
+++ b/frontend/e2e/welcome-voice-first.spec.ts
@@ -2,6 +2,11 @@ import { expect, test } from '@playwright/test';
 
 const RECEPTION_START_URL = '/api/reception/start';
 
+interface MediaRequestCounts {
+  audio: number;
+  video: number;
+}
+
 async function dismissInitialModal(page: import('@playwright/test').Page) {
   const modal = page.getByRole('dialog');
   const closeButton = page.getByTestId('initial-settings-close');
@@ -10,6 +15,61 @@ async function dismissInitialModal(page: import('@playwright/test').Page) {
     await expect(modal).toBeHidden({ timeout: 10_000 });
   }
   await expect(page.getByRole('button', { name: 'Welcome' })).toBeVisible({ timeout: 5_000 });
+}
+
+async function installMediaRequestProbe(page: import('@playwright/test').Page) {
+  await page.addInitScript(() => {
+    const counts = { audio: 0, video: 0 };
+    const existingMediaDevices = navigator.mediaDevices ?? {};
+
+    Object.defineProperty(window, '__welcomeMediaRequestCounts', {
+      configurable: true,
+      value: counts,
+    });
+
+    Object.defineProperty(navigator, 'mediaDevices', {
+      configurable: true,
+      value: {
+        ...existingMediaDevices,
+        getUserMedia: async (constraints?: MediaStreamConstraints) => {
+          const wantsVideo = Boolean(
+            constraints &&
+              typeof constraints === 'object' &&
+              'video' in constraints &&
+              constraints.video,
+          );
+          const wantsAudio = Boolean(
+            constraints &&
+              typeof constraints === 'object' &&
+              'audio' in constraints &&
+              constraints.audio,
+          );
+
+          if (wantsVideo) {
+            counts.video += 1;
+            return new Promise<MediaStream>(() => {
+              // Keep OCR mounted without requiring real camera access.
+            });
+          }
+          if (wantsAudio) {
+            counts.audio += 1;
+          }
+          return new MediaStream();
+        },
+      },
+    });
+  });
+}
+
+async function getMediaRequestCounts(
+  page: import('@playwright/test').Page,
+): Promise<MediaRequestCounts> {
+  return page.evaluate(() => {
+    const windowWithCounts = window as Window & {
+      __welcomeMediaRequestCounts?: MediaRequestCounts;
+    };
+    return windowWithCounts.__welcomeMediaRequestCounts ?? { audio: 0, video: 0 };
+  });
 }
 
 function mockReceptionStart(page: import('@playwright/test').Page) {
@@ -28,6 +88,7 @@ function mockReceptionStart(page: import('@playwright/test').Page) {
 
 test.describe('Welcome voice-first (#616)', () => {
   test.beforeEach(async ({ page }) => {
+    await installMediaRequestProbe(page);
     await mockReceptionStart(page);
     await page.route('**/api/qa', async (route) => {
       await route.fulfill({
@@ -58,5 +119,23 @@ test.describe('Welcome voice-first (#616)', () => {
     await expect(page.getByTestId('response-text')).toContainText('エンジニアカフェへようこそ', {
       timeout: 8_000,
     });
+  });
+
+  test('Welcome does not request camera; member card button does', async ({ page }) => {
+    expect((await getMediaRequestCounts(page)).video).toBe(0);
+
+    await page.getByRole('button', { name: 'Welcome' }).click();
+    await expect(page.getByTestId('kiosk-welcome-ocr-overlay')).toBeHidden({ timeout: 5_000 });
+    await expect
+      .poll(async () => (await getMediaRequestCounts(page)).video, { timeout: 2_000 })
+      .toBe(0);
+
+    await page.reload({ waitUntil: 'domcontentloaded' });
+    await dismissInitialModal(page);
+
+    await page.getByRole('button', { name: /会員証|Member card/ }).click();
+    await expect
+      .poll(async () => (await getMediaRequestCounts(page)).video, { timeout: 5_000 })
+      .toBeGreaterThanOrEqual(1);
   });
 });


### PR DESCRIPTION
## Summary
- add a Playwright media probe for Welcome voice-first flow
- assert Welcome does not request camera/video
- assert the dedicated member card action is the only path that requests camera/video

## Validation
- pnpm --dir frontend test:e2e -- welcome-voice-first.spec.ts --project=chromium
- pnpm --dir frontend test:e2e -- reception-flow.spec.ts --project=chromium
- pnpm --dir frontend typecheck
- git diff --check -- frontend/e2e/welcome-voice-first.spec.ts

Follow-up guard for #660.
