### PR TITLE
test: summarize C-127 live collection coverage

### DIFF
--- a/.github/workflows/alpha-live-verification.yml
+++ b/.github/workflows/alpha-live-verification.yml
@@ -173,6 +173,7 @@ jobs:
           if [[ ",${{ inputs.suites }}," == *",c-127," ]]; then
             c_suite="alpha-127"
           fi
+          echo "ALPHA_C_RAGAS_SUITE=$c_suite" >> "$GITHUB_ENV"
           scripts/rag-api-live-test.sh --timestamp "${ALPHA_TIMESTAMP}-c" --case-suite "$c_suite" --languages ja,en,zh,ko
 
       - name: D memory and state durability smoke
@@ -295,6 +296,7 @@ jobs:
 
           - suites: ${{ inputs.suites }}
           - c_ragas_suite_input: ${{ inputs.c_ragas_suite }}
+          - c_ragas_suite_resolved: ${ALPHA_C_RAGAS_SUITE:-not-run}
           - timestamp: ${ALPHA_TIMESTAMP:-unknown}
           - backend: ${ALPHA_SMOKE_BASE_URL:-unknown}
           - revision: ${ALPHA_SMOKE_CLOUD_RUN_REVISION:-unknown}
@@ -317,6 +319,61 @@ jobs:
           | quality_t | ${{ steps.quality_t.outcome }} |
           | welcome_live | ${{ steps.welcome_live.outcome }} |
           EOF
+
+          ragas_report_ts="$(python - "${ALPHA_TIMESTAMP:-unknown}-c" <<'PY'
+          import sys
+
+          raw = sys.argv[1].strip()
+          safe = "".join(ch if ch.isalnum() or ch in {"-", "_", "."} else "_" for ch in raw)
+          print(safe or "unknown-c")
+          PY
+          )"
+          ragas_json="backend/tests/evaluation/reports/live_api_eval_${ragas_report_ts}.json"
+          if [[ -f "$ragas_json" ]]; then
+            python - "$ragas_json" >> "$GITHUB_STEP_SUMMARY" <<'PY'
+          import json
+          import sys
+
+          path = sys.argv[1]
+          with open(path, encoding="utf-8") as f:
+              data = json.load(f)
+
+          summary = data.get("evaluation_summary", {})
+          coverage = data.get("suite_coverage", {})
+          print("")
+          print("## C/RAGAS coverage")
+          print("")
+          print(f"- artifact: `{path}`")
+          print(f"- case_suite: {data.get('case_suite', 'unknown')}")
+          print(
+              "- suite_cases: "
+              f"requested={coverage.get('requested_total_cases', 'unknown')} "
+              f"expected={coverage.get('expected_total_cases', 'unknown')} "
+              f"passed={coverage.get('passed', 'unknown')}"
+          )
+          print(
+              "- totals: "
+              f"requested={summary.get('requested_total_cases', 0)} "
+              f"collected={summary.get('collected_total_cases', 0)} "
+              f"evaluated={summary.get('evaluated_total_cases', 0)} "
+              f"collection_errors={summary.get('collection_error_total', 0)} "
+              f"api_failed={summary.get('api_failed_total', 0)} "
+              f"ragas_errors={summary.get('ragas_error_total', 0)}"
+          )
+          requested = summary.get("requested_by_language", {})
+          collected = summary.get("collected_by_language", {})
+          evaluated = summary.get("evaluated_by_language", {})
+          errors = summary.get("collection_errors_by_language", {})
+          print("")
+          print("| Language | Requested | Collected | Evaluated | Collection errors |")
+          print("| --- | ---: | ---: | ---: | ---: |")
+          for lang in data.get("languages", []):
+              print(
+                  f"| {lang} | {requested.get(lang, 0)} | {collected.get(lang, 0)} | "
+                  f"{evaluated.get(lang, 0)} | {errors.get(lang, 0)} |"
+              )
+          PY
+          fi
 
       - name: Fail when any selected suite failed
         if: always()

--- a/backend/evaluation/run_live_api_eval.py
+++ b/backend/evaluation/run_live_api_eval.py
@@ -794,6 +794,10 @@ def _format_report(
     if evaluation_summary:
         collection_status = "PASS" if evaluation_summary.get("collection_complete") else "FAIL"
         evaluation_status = "PASS" if evaluation_summary.get("evaluation_complete") else "FAIL"
+        requested_by_language = evaluation_summary.get("requested_by_language", {})
+        collected_by_language = evaluation_summary.get("collected_by_language", {})
+        evaluated_by_language = evaluation_summary.get("evaluated_by_language", {})
+        errors_by_language = evaluation_summary.get("collection_errors_by_language", {})
         lines.extend(
             [
                 "Collection/evaluation summary:",
@@ -807,10 +811,10 @@ def _format_report(
                 f"  evaluation_complete: {evaluation_status}",
                 "  language_counts: "
                 + ", ".join(
-                    f"{lang}=requested:{evaluation_summary.get('requested_by_language', {}).get(lang, 0)}"
-                    f"/collected:{evaluation_summary.get('collected_by_language', {}).get(lang, 0)}"
-                    f"/evaluated:{evaluation_summary.get('evaluated_by_language', {}).get(lang, 0)}"
-                    f"/errors:{evaluation_summary.get('collection_errors_by_language', {}).get(lang, 0)}"
+                    f"{lang}=requested:{requested_by_language.get(lang, 0)}"
+                    f"/collected:{collected_by_language.get(lang, 0)}"
+                    f"/evaluated:{evaluated_by_language.get(lang, 0)}"
+                    f"/errors:{errors_by_language.get(lang, 0)}"
                     for lang in languages
                 ),
                 "",

--- a/backend/evaluation/run_live_api_eval.py
+++ b/backend/evaluation/run_live_api_eval.py
@@ -187,6 +187,66 @@ def _suite_coverage(
     }
 
 
+def _language_case_counts(config: Dict[str, Any]) -> Dict[str, int]:
+    """Return manifest case counts by language for coverage artifacts."""
+    counts = {lang: 0 for lang in ALL_LANGUAGES}
+    for query in config.get("queries", []):
+        language = str(query.get("language") or "")
+        if language:
+            counts[language] = counts.get(language, 0) + 1
+    return counts
+
+
+def _evaluation_summary(
+    lang_results: Dict[str, Dict[str, Any]],
+    languages: Sequence[str],
+) -> Dict[str, Any]:
+    """Aggregate collection/evaluation counts so partial 127 runs are obvious."""
+    requested_by_language: Dict[str, int] = {}
+    collected_by_language: Dict[str, int] = {}
+    evaluated_by_language: Dict[str, int] = {}
+    collection_errors_by_language: Dict[str, int] = {}
+    api_failed_by_language: Dict[str, int] = {}
+    ragas_errors_by_language: Dict[str, int] = {}
+
+    for lang in languages:
+        result = lang_results.get(lang, {})
+        requested_by_language[lang] = int(result.get("requested_case_count", 0) or 0)
+        collected_by_language[lang] = int(result.get("collected_case_count", 0) or 0)
+        evaluated_by_language[lang] = int(result.get("evaluated_case_count", 0) or 0)
+        collection_errors_by_language[lang] = int(result.get("collection_error_count", 0) or 0)
+        api_failed_by_language[lang] = int(result.get("api_failed_case_count", 0) or 0)
+        ragas_errors_by_language[lang] = int(result.get("ragas_error_count", 0) or 0)
+
+    requested_total = sum(requested_by_language.values())
+    collected_total = sum(collected_by_language.values())
+    evaluated_total = sum(evaluated_by_language.values())
+    collection_error_total = sum(collection_errors_by_language.values())
+    api_failed_total = sum(api_failed_by_language.values())
+    ragas_error_total = sum(ragas_errors_by_language.values())
+
+    return {
+        "requested_total_cases": requested_total,
+        "collected_total_cases": collected_total,
+        "evaluated_total_cases": evaluated_total,
+        "collection_error_total": collection_error_total,
+        "api_failed_total": api_failed_total,
+        "ragas_error_total": ragas_error_total,
+        "requested_by_language": requested_by_language,
+        "collected_by_language": collected_by_language,
+        "evaluated_by_language": evaluated_by_language,
+        "collection_errors_by_language": collection_errors_by_language,
+        "api_failed_by_language": api_failed_by_language,
+        "ragas_errors_by_language": ragas_errors_by_language,
+        "collection_complete": collected_total == requested_total and collection_error_total == 0,
+        "evaluation_complete": (
+            evaluated_total == requested_total
+            and collection_error_total == 0
+            and ragas_error_total == 0
+        ),
+    }
+
+
 def _collection_error_record(
     query: Dict[str, Any],
     *,
@@ -300,6 +360,7 @@ async def run_live_api_evaluation(
     gt_lookup = _load_ground_truth_lookup()
     selected_languages = list(languages or ALL_LANGUAGES)
     selected_metrics = tuple(metrics or TRACKED_METRICS)
+    manifest_language_counts = _language_case_counts(config)
 
     per_language_results: Dict[str, Dict[str, Any]] = {}
     all_eval_cases: Dict[str, List[Dict[str, Any]]] = {}
@@ -433,10 +494,12 @@ async def run_live_api_evaluation(
                 "language": lang,
                 "error": "no evaluable cases",
                 "requested_case_count": requested_count,
+                "collected_case_count": 0,
                 "evaluated_case_count": 0,
                 "skipped_case_count": requested_count,
                 "api_failed_case_count": api_failed_count,
                 "collection_error_count": len(lang_collection_errors),
+                "ragas_error_count": 0,
                 "collection_errors": lang_collection_errors,
                 "metrics": {},
                 "results": [],
@@ -454,10 +517,12 @@ async def run_live_api_evaluation(
                 "language": lang,
                 "error": "ragas not installed",
                 "requested_case_count": requested_count,
+                "collected_case_count": len(cases),
                 "evaluated_case_count": 0,
                 "skipped_case_count": requested_count,
                 "api_failed_case_count": api_failed_count,
                 "collection_error_count": len(lang_collection_errors),
+                "ragas_error_count": 0,
                 "collection_errors": lang_collection_errors,
                 "metrics": {},
                 "results": [
@@ -476,9 +541,15 @@ async def run_live_api_evaluation(
 
         logger.info("Running RAGAS evaluation for %s (%d cases)...", lang, len(cases))
         report = await evaluator.evaluate_batch(cases)
+        report_error_count = len(
+            [error for error in getattr(report, "errors", []) if str(error).strip()]
+        )
+        per_case_error_count = 0
 
         per_case_results: List[Dict[str, Any]] = []
         for case, result in zip(cases, report.results):
+            if result.error:
+                per_case_error_count += 1
             per_case_results.append(
                 {
                     "query_id": case["query_id"],
@@ -496,14 +567,17 @@ async def run_live_api_evaluation(
                     "live_source_check": case["live_source_check"],
                 }
             )
+        ragas_error_count = max(report_error_count, per_case_error_count)
 
         per_language_results[lang] = {
             "language": lang,
             "requested_case_count": requested_count,
+            "collected_case_count": len(cases),
             "evaluated_case_count": report.evaluated_cases,
             "skipped_case_count": report.skipped_cases + len(lang_collection_errors),
             "api_failed_case_count": api_failed_count,
             "collection_error_count": len(lang_collection_errors),
+            "ragas_error_count": ragas_error_count,
             "collection_errors": lang_collection_errors,
             "metrics": report.metrics,
             "errors": report.errors,
@@ -519,10 +593,12 @@ async def run_live_api_evaluation(
         selected_languages=selected_languages,
         requested_total=requested_total,
     )
+    evaluation_summary = _evaluation_summary(per_language_results, selected_languages)
     comparison = _compare_targets(
         per_language_results, selected_languages, check_live_sources=check_live_sources
     )
     comparison["suite_coverage"] = suite_coverage
+    comparison["evaluation_summary"] = evaluation_summary
     comparison["alpha_release_gate_met"] = (
         comparison["all_targets_met"]
         and suite_coverage["release_blocking"]
@@ -544,6 +620,7 @@ async def run_live_api_evaluation(
         "mode": "live-api",
         "case_suite": case_suite,
         "suite_coverage": suite_coverage,
+        "evaluation_summary": evaluation_summary,
         "base_url": base_url,
         "languages": selected_languages,
         "metrics": list(selected_metrics),
@@ -553,6 +630,11 @@ async def run_live_api_evaluation(
             "report_timestamp": report_file_ts,
             "json_report_filename": json_report_filename,
             "text_report_filename": text_report_filename,
+            "expected_total_cases": config.get("expected_total_cases"),
+            "manifest_language_counts": manifest_language_counts,
+            "selected_language_counts": {
+                lang: manifest_language_counts.get(lang, 0) for lang in selected_languages
+            },
             "chat_interval_seconds": chat_interval_seconds,
             "chat_retry_attempts": chat_retry_attempts,
             "chat_retry_backoff_seconds": chat_retry_backoff_seconds,
@@ -608,14 +690,18 @@ def _compare_targets(
 
         answer_target_passed = isinstance(actual, (int, float)) and actual >= target
         requested_count = int(result.get("requested_case_count", 0) or 0)
+        collected_count = int(result.get("collected_case_count", 0) or 0)
         evaluated_count = int(result.get("evaluated_case_count", 0) or 0)
         collection_error_count = int(result.get("collection_error_count", 0) or 0)
+        ragas_error_count = int(result.get("ragas_error_count", 0) or 0)
         evaluation_complete = (
             requested_count > 0
+            and collected_count == requested_count
             and evaluated_count == requested_count
             and not result.get("errors")
             and not result.get("error")
             and collection_error_count == 0
+            and ragas_error_count == 0
         )
         passed = answer_target_passed and not source_failures and evaluation_complete
         per_language[lang] = {
@@ -626,8 +712,10 @@ def _compare_targets(
             },
             "evaluation_complete": {
                 "requested": requested_count,
+                "collected": collected_count,
                 "evaluated": evaluated_count,
                 "collection_errors": collection_error_count,
+                "ragas_errors": ragas_error_count,
                 "passed": evaluation_complete,
             },
             "live_source_gate": {
@@ -654,6 +742,7 @@ def _compare_targets(
                     "answer_target_passed": answer_target_passed,
                     "evaluation_complete": evaluation_complete,
                     "collection_errors": collection_error_count,
+                    "ragas_errors": ragas_error_count,
                     "source_failures": len(source_failures),
                 }
             )
@@ -701,6 +790,32 @@ def _format_report(
                 "",
             ]
         )
+    evaluation_summary = comparison.get("evaluation_summary", {})
+    if evaluation_summary:
+        collection_status = "PASS" if evaluation_summary.get("collection_complete") else "FAIL"
+        evaluation_status = "PASS" if evaluation_summary.get("evaluation_complete") else "FAIL"
+        lines.extend(
+            [
+                "Collection/evaluation summary:",
+                "  totals: "
+                f"requested={evaluation_summary.get('requested_total_cases', 0)} "
+                f"collected={evaluation_summary.get('collected_total_cases', 0)} "
+                f"evaluated={evaluation_summary.get('evaluated_total_cases', 0)} "
+                f"collection_errors={evaluation_summary.get('collection_error_total', 0)} "
+                f"ragas_errors={evaluation_summary.get('ragas_error_total', 0)}",
+                f"  collection_complete: {collection_status}",
+                f"  evaluation_complete: {evaluation_status}",
+                "  language_counts: "
+                + ", ".join(
+                    f"{lang}=requested:{evaluation_summary.get('requested_by_language', {}).get(lang, 0)}"
+                    f"/collected:{evaluation_summary.get('collected_by_language', {}).get(lang, 0)}"
+                    f"/evaluated:{evaluation_summary.get('evaluated_by_language', {}).get(lang, 0)}"
+                    f"/errors:{evaluation_summary.get('collection_errors_by_language', {}).get(lang, 0)}"
+                    for lang in languages
+                ),
+                "",
+            ]
+        )
 
     for lang in languages:
         result = lang_results.get(lang, {})
@@ -710,6 +825,7 @@ def _format_report(
         lines.append(f"--- [{lang.upper()}] ---")
         lines.append(
             f"  Cases: requested={result.get('requested_case_count', 0)} "
+            f"collected={result.get('collected_case_count', 0)} "
             f"evaluated={result.get('evaluated_case_count', 0)} "
             f"skipped={result.get('skipped_case_count', 0)}"
         )
@@ -743,9 +859,12 @@ def _format_report(
         eval_status = "PASS" if eval_complete.get("passed") else "FAIL"
         lines.append(
             "  evaluation_complete: "
+            f"collected={eval_complete.get('collected', 0)}/"
+            f"{eval_complete.get('requested', 0)} "
             f"evaluated={eval_complete.get('evaluated', 0)}/"
             f"{eval_complete.get('requested', 0)} "
             f"collection_errors={eval_complete.get('collection_errors', 0)} "
+            f"ragas_errors={eval_complete.get('ragas_errors', 0)} "
             f"[{eval_status}]"
         )
         if source_gate.get("enabled"):
@@ -805,6 +924,7 @@ def _format_report(
                 f"answer_target_passed={f.get('answer_target_passed')} "
                 f"evaluation_complete={f.get('evaluation_complete')} "
                 f"collection_errors={f.get('collection_errors', 0)} "
+                f"ragas_errors={f.get('ragas_errors', 0)} "
                 f"source_failures={f.get('source_failures', 0)}"
             )
 

--- a/backend/tests/evaluation/test_ragas_live_case_suites.py
+++ b/backend/tests/evaluation/test_ragas_live_case_suites.py
@@ -181,21 +181,44 @@ async def test_live_eval_keeps_alpha_127_manifest_count_when_api_collection_fail
     assert result["suite_coverage"]["requested_total_cases"] == 127
     assert result["suite_coverage"]["passed"] is True
     assert result["per_language"]["ja"]["requested_case_count"] == 80
+    assert result["per_language"]["ja"]["collected_case_count"] == 79
     assert result["per_language"]["ja"]["evaluated_case_count"] == 79
     assert result["per_language"]["ja"]["api_failed_case_count"] == 1
     assert result["per_language"]["ja"]["collection_error_count"] == 1
+    assert result["per_language"]["ja"]["ragas_error_count"] == 0
     assert result["per_language"]["ja"]["collection_errors"][0]["error_type"] == "api_call_failed"
     assert result["comparison"]["per_language"]["ja"]["evaluation_complete"] == {
         "requested": 80,
+        "collected": 79,
         "evaluated": 79,
         "collection_errors": 1,
+        "ragas_errors": 0,
         "passed": False,
+    }
+    assert result["evaluation_summary"] == {
+        "requested_total_cases": 127,
+        "collected_total_cases": 126,
+        "evaluated_total_cases": 126,
+        "collection_error_total": 1,
+        "api_failed_total": 1,
+        "ragas_error_total": 0,
+        "requested_by_language": {"ja": 80, "en": 23, "zh": 12, "ko": 12},
+        "collected_by_language": {"ja": 79, "en": 23, "zh": 12, "ko": 12},
+        "evaluated_by_language": {"ja": 79, "en": 23, "zh": 12, "ko": 12},
+        "collection_errors_by_language": {"ja": 1, "en": 0, "zh": 0, "ko": 0},
+        "api_failed_by_language": {"ja": 1, "en": 0, "zh": 0, "ko": 0},
+        "ragas_errors_by_language": {"ja": 0, "en": 0, "zh": 0, "ko": 0},
+        "collection_complete": False,
+        "evaluation_complete": False,
     }
     assert result["comparison"]["alpha_release_gate_met"] is False
     assert result["artifact_metadata"] == {
         "report_timestamp": "alpha-live-test-c",
         "json_report_filename": "live_api_eval_alpha-live-test-c.json",
         "text_report_filename": "live_api_eval_alpha-live-test-c.txt",
+        "expected_total_cases": 127,
+        "manifest_language_counts": {"ja": 80, "en": 23, "zh": 12, "ko": 12},
+        "selected_language_counts": {"ja": 80, "en": 23, "zh": 12, "ko": 12},
         "chat_interval_seconds": 0.0,
         "chat_retry_attempts": 4,
         "chat_retry_backoff_seconds": 2.0,
@@ -203,7 +226,13 @@ async def test_live_eval_keeps_alpha_127_manifest_count_when_api_collection_fail
     assert (tmp_path / "live_api_eval_alpha-live-test-c.json").is_file()
     assert (tmp_path / "live_api_eval_alpha-live-test-c.txt").is_file()
     assert "collection_errors: 1 (api_failed=1)" in result["report"]
-    assert "evaluation_complete: evaluated=79/80 collection_errors=1 [FAIL]" in result["report"]
+    assert "Collection/evaluation summary:" in result["report"]
+    assert "totals: requested=127 collected=126 evaluated=126" in result["report"]
+    assert "ja=requested:80/collected:79/evaluated:79/errors:1" in result["report"]
+    assert (
+        "evaluation_complete: collected=79/80 evaluated=79/80 "
+        "collection_errors=1 ragas_errors=0 [FAIL]"
+    ) in result["report"]
     assert "Alpha release gate met: NO" in result["report"]
 
 

--- a/docs/testing/alpha-final-scenarios.md
+++ b/docs/testing/alpha-final-scenarios.md
@@ -4,7 +4,7 @@ Alpha 最終 Live 検証は Cloud Run live 環境で実施します。このド�
 
 ## Current Status
 
-2026-05-02 時点の live verification は **NO-GO** です。最新の実行結果、残 blocker、再開手順は [Alpha Live Verification Status 2026-05-02](alpha-live-verification-status-2026-05-02.md) を正本として参照してください。
+2026-05-03 時点の live verification は **NO-GO** です。最新の実行結果、残 blocker、再開手順は [Alpha Live Verification Status 2026-05-02](alpha-live-verification-status-2026-05-02.md) を正本として参照してください。
 
 Current confirmed target:
 
@@ -18,6 +18,7 @@ Current confirmed target:
 - Backend: `https://engineer-cafe-backend-639959525777.asia-northeast1.run.app`
 - Cloud Run revision: GO 判定時は workflow の `Resolve live target` 出力を正本にする
 - Backend SHA: `require_deployed_sha_match=true` で expected backend SHA と Cloud Run image tag の一致を必須にする。`expected_backend_sha` が空の場合は workflow SHA を expected backend SHA として使うため、backend 変更を含む GO proof の既定動作は変わらない。
+  Harness-only merge の後に backend deploy が意図的に変わっていない場合だけ、現行 Cloud Run image tag の 40-char SHA を `expected_backend_sha` に渡す。
 - Frontend: `https://frontend-delta-six-20.vercel.app`
 
 ## Usage Notes
@@ -32,7 +33,16 @@ Current confirmed target:
 - C/RAGAS の 29-case path は diagnostic only です。Alpha GO proof では
   `scripts/rag-api-live-test.sh --case-suite alpha-127 --languages ja,en,zh,ko`、または
   `alpha-live-verification.yml` の `suites=c-127` / `c_ragas_suite=alpha-127` を使います。
-  Report の `case_suite=alpha-127` と `suite_coverage` が 127/127 PASS になっていることを確認してください。
+  Report の `case_suite=alpha-127` と `suite_coverage.requested_total_cases=127` に加えて、
+  `evaluated=127`, `collection_errors=0`, `api_failed_case_count=0` を確認してください。
+  Post-#692 run `25270459825` は `requested=127` でしたが、`evaluated=35`, `collection_errors=92`
+  だったため GO proof ではありません。PR #695 後の C-127 rerun が必要です。
+- C/RAGAS の 127-case artifact では `evaluation_summary` を必ず確認してください。
+  `requested_total_cases=127` だけでは GO 証跡になりません。
+  `collected_total_cases=127`、`evaluated_total_cases=127`、`collection_error_total=0`、
+  `ragas_error_total=0`、および言語別 counts（ja=80/en=23/zh=12/ko=12）が揃って初めて
+  完全実行として扱います。collection error がある run は、RAGAS scores が高くても
+  incomplete として扱います。
 - C/RAGAS live source gate は intent ごとの source policy で判定します。施設・料金・連絡先などの local knowledge は
   `enhanced_rag` / `knowledge_base` / `knowledge_base_cached` を同等に扱い、event-like case は
   `google_calendar` / `connpass` も許容します。緊急・受付・farewell の即時応答は source なしでも source gate 上は許容し、

--- a/docs/testing/alpha-live-verification-status-2026-05-02.md
+++ b/docs/testing/alpha-live-verification-status-2026-05-02.md
@@ -12,8 +12,8 @@
 実行経路は成立しました。一方で、alpha GO を止める blocker がまだ残っています。
 
 2026-05-03 時点で、B routing / slide live smoke、Welcome UI、artifact split、Supabase UUID
-log hygiene、Cloud Run Qwen runtime dependency、STT/voice preflight は解消済みです。残る P0 は
-RAGAS coverage / accounting reconciliation と live-only proof 群です。
+log hygiene、Cloud Run Qwen runtime dependency、STT/voice preflight、C-127 manifest accounting は
+解消済みです。残る P0 は C-127 live collection completion と live-only proof 群です。
 
 ## 2026-05-02 Baseline Deploy / SHA Sync
 
@@ -68,14 +68,32 @@ collection failures from the report and then uses collected-success count as `re
 The missing 42 cases were all Japanese and were absent from the artifact instead of being reported as
 collection failures.
 
-Required next action is ADR 019 / #691:
+Resolved by ADR 019 / #691 / PR #692:
 
 - `requested_case_count` must mean selected manifest cases, not successfully collected responses.
 - API collection failures must be persisted as `collection_errors`.
 - `evaluation_complete` and `alpha_release_gate_met` must fail when collection errors exist.
+- Artifact review must compare `requested`, `collected`, and `evaluated` totals plus language counts.
+  For `alpha-127`, complete coverage means ja=80/en=23/zh=12/ko=12 with zero collection and
+  RAGAS errors.
 
-Until this is fixed and rerun, C-127 artifacts cannot be used as alpha GO proof even when
-`case_suite=alpha-127` is present.
+### 2026-05-03 Post-#692 C-127 Validation
+
+- Run: <https://github.com/EngineerCafeJP/engineercafe-navigator/actions/runs/25270459825>
+- Suites: `c-127`
+- Result: failure
+- Workflow head SHA / #692 merge SHA: `d74264e808e9b2a0244d3a1a9e5dfe12671530ea`
+- Case suite: `alpha-127`
+- Expected cases: `127`
+- Requested cases: `127`
+- Evaluated cases: `35`
+- Collection errors: `92`
+- Main failure mode: live `/api/chat` `429 Too Many Requests`
+
+This run proves that PR #692 fixed the manifest accounting defect: `suite_coverage.requested_total_cases`
+stays `127`. It does **not** prove C-127 completion because only `35/127` cases were collected/evaluated.
+PR #695 is merged to add C-127 pacing / 429 retry, and the next required proof is a post-#695
+`suites=c-127` rerun with `evaluated=127` and `collection_errors=0`.
 
 ### 2026-05-03 Targeted Q Verification After PR #690/#689
 
@@ -92,6 +110,9 @@ Remaining failures:
 - `Q-DAILY-JA-001`: route is `general_knowledge`, but latency is `2205ms`.
 
 Improvement from the previous Q baseline: `Q-EVT-EN-001` now passes.
+
+PR #693 is merged for the two remaining Q failures. Close proof for #653 is still pending and must
+come from a post-#693 targeted `suites=q` run with `0 FAIL`.
 
 Resolved STT follow-up:
 
@@ -111,9 +132,9 @@ Historical failing outcomes from that run:
 
 | Outcome | Status | Current issue |
 | --- | --- | --- |
-| `stt_preflight` | failure | #658 |
+| `stt_preflight` | failure | #658 (closed by run `25258764528`) |
 | `alpha_b` | failure | #659 |
-| `rag_api_live` | failure | #657, #583, #672 |
+| `rag_api_live` | failure | #583, #672 |
 | `cloud_logging` | failure | #662 |
 | `quality_q` | failure | #653 |
 | `welcome_live` | failure | #660 |
@@ -139,21 +160,23 @@ coverage, not provider configuration.
 
 ### P0
 
-- #691 / #657 / #583: C/RAGAS gate now has `c-127`, but the first full run exposed harness accounting
-  drift: `alpha-127` expected 127 while artifact reported only 85 requested/evaluated cases.
+- #583: C/RAGAS gate now has `c-127`, and PR #692 fixed manifest accounting. Post-#692 run
+  `25270459825` still evaluated only `35/127` because live `/api/chat` returned 92 `429` collection
+  errors. PR #695 is merged; post-#695 rerun is pending.
 - #643 / #612: umbrella issues remain open until the alpha gate is green.
 - #611 / #584 / #585: fast first-response, edge/failure tolerance, and 2h kiosk soak still need final proof.
 
 ### P1
 
-- #672: Direct OpenAI C/RAGAS still misses answer quality targets after C-127.
+- #672: Direct OpenAI C/RAGAS still misses answer quality targets, but the latest post-#692 C metrics
+  are not release-proof because C-127 collection failed.
   - JA: `0.585`, target `0.85`
   - EN: `0.7017`, target `0.75`
   - ZH: `0.7271`, target `0.65`
   - KO: `0.7151`, target `0.65`
   - JA/EN answer quality and live source fallback cases need product-side triage after harness
     accounting is fixed.
-- #653: Q content quality still fails.
+- #653: Q content quality still needs post-#693 live proof.
   - `Q-BIZ-EN-003`
   - `Q-DAILY-JA-001`
   - `Q-EVT-EN-001` now passes in run `25269072919`.
@@ -180,11 +203,11 @@ Observed impact:
 
 ## Next Implementation Order
 
-1. ADR 019 / #691 / #657 / #583: fix C-127 harness accounting so 127 manifest cases are always reported,
-   and collection failures are explicit.
-2. #653 and #672: Q/C answer quality for current failing cases.
-3. #670: verify full C/Q telemetry and runtime with the current artifact split.
-4. #611 / #584 / #585: collect or split the remaining live-only alpha proof.
+1. Post-#695 `suites=c-127`: prove `requested=127`, `evaluated=127`, `collection_errors=0`.
+2. Post-#693 `suites=q`: prove #653 has `0 FAIL`.
+3. #672: triage C answer/source quality only after C-127 collection completes.
+4. #670: verify full C/Q telemetry and runtime with the current artifact split.
+5. #611 / #584 / #585: collect or split the remaining live-only alpha proof.
 
 ## Useful Commands
 

--- a/scripts/rag-api-live-test.sh
+++ b/scripts/rag-api-live-test.sh
@@ -169,6 +169,13 @@ validate_case_suite() {
   esac
 }
 
+expected_suite_cases() {
+  case "$CASE_SUITE" in
+    diagnostic-29) printf '29' ;;
+    alpha-127) printf '127' ;;
+  esac
+}
+
 language_args() {
   python3 - "$LANGUAGES" <<'PY'
 import sys
@@ -219,6 +226,7 @@ main() {
     echo "Base URL: $BASE_URL"
     echo "Output dir: $OUTPUT_DIR"
     echo "Case suite: $CASE_SUITE"
+    echo "Expected suite cases: $(expected_suite_cases)"
     echo "Languages: ${LANG_ARGS[*]}"
     echo "Metrics: ${METRIC_ARGS[*]}"
     echo "Chat interval seconds: $CHAT_INTERVAL_SECONDS"
@@ -248,6 +256,7 @@ main() {
   echo "Timestamp: $TIMESTAMP"
   echo "Base URL: $BASE_URL"
   echo "Case suite: $CASE_SUITE"
+  echo "Expected suite cases: $(expected_suite_cases)"
   echo "Languages: ${LANG_ARGS[*]}"
   echo "Metrics: ${METRIC_ARGS[*]}"
   echo "Chat interval seconds: $CHAT_INTERVAL_SECONDS"


### PR DESCRIPTION
## Summary
- add explicit C/RAGAS evaluation_summary totals for requested, collected, evaluated, collection errors, API failures, and RAGAS errors
- surface per-language counts in JSON/TXT reports and GitHub workflow summary
- document that alpha-127 GO proof requires collected/evaluated=127 and collection/RAGAS errors=0

## Validation
- pytest backend/tests/evaluation/test_ragas_live_case_suites.py backend/tests/evaluation/test_live_quality_gates.py -q
- python -m py_compile backend/evaluation/run_live_api_eval.py
- bash -n scripts/rag-api-live-test.sh
- workflow YAML parse via PyYAML
- git diff --cached --check

Follow-up for #670 / #583 after #695 pacing.
