### PR TITLE
fix: reduce alpha Cloud Run log noise

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -50,6 +50,21 @@ _VALID_REQUEST_ID = re.compile(r"^[a-zA-Z0-9\-]{1,64}$")
 _ENVIRONMENT = os.getenv("ENVIRONMENT", "development")
 
 
+def _float_env(name: str, default: float) -> float:
+    raw = os.getenv(name)
+    if raw is None:
+        return default
+    try:
+        value = float(raw)
+    except (TypeError, ValueError):
+        logger.warning("Invalid %s=%r; using %.0f", name, raw, default)
+        return default
+    return value if value >= 0 else default
+
+
+_REQUEST_TIMING_LOG_THRESHOLD_MS = _float_env("REQUEST_TIMING_LOG_THRESHOLD_MS", 10000)
+
+
 class RequestIDMiddleware(BaseHTTPMiddleware):
     """X-Request-ID ヘッダーの生成/伝播"""
 
@@ -78,20 +93,33 @@ class RequestTimingMiddleware(BaseHTTPMiddleware):
         except Exception:
             duration_ms = (time.perf_counter() - start) * 1000
             logger.warning(
-                "Request %s %s failed after %.2fms",
-                request.method,
-                request.url.path,
-                duration_ms,
+                "request_failed",
+                extra={
+                    "event": "request_failed",
+                    "method": request.method,
+                    "path": request.url.path,
+                    "duration_ms": round(duration_ms, 2),
+                },
             )
             raise
         duration_ms = (time.perf_counter() - start) * 1000
         response.headers["X-Response-Time-Ms"] = f"{duration_ms:.2f}"
-        logger.info(
-            "Request %s %s completed in %.2fms",
-            request.method,
-            request.url.path,
-            duration_ms,
+        should_log = response.status_code >= 500 or (
+            request.url.path != "/health" and duration_ms >= _REQUEST_TIMING_LOG_THRESHOLD_MS
         )
+        if should_log:
+            level = logging.WARNING if response.status_code >= 500 else logging.INFO
+            logger.log(
+                level,
+                "request_completed_slow",
+                extra={
+                    "event": "request_completed_slow",
+                    "method": request.method,
+                    "path": request.url.path,
+                    "status_code": response.status_code,
+                    "duration_ms": round(duration_ms, 2),
+                },
+            )
         return response
 
 
@@ -107,10 +135,13 @@ class TokenTrackerMiddleware(BaseHTTPMiddleware):
             # Log token summary for this request
             tracker = get_token_tracker()
             if tracker.total_tokens > 0:
-                logger.info(
-                    "Token usage: %d tokens, $%.6f estimated cost",
-                    tracker.total_tokens,
-                    tracker.total_cost_usd,
+                logger.debug(
+                    "token_usage",
+                    extra={
+                        "event": "token_usage",
+                        "total_tokens": tracker.total_tokens,
+                        "estimated_cost_usd": round(tracker.total_cost_usd, 6),
+                    },
                 )
             return response
         finally:

--- a/backend/observability/structured_logger.py
+++ b/backend/observability/structured_logger.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import json
 import logging
+import os
 import sys
 from typing import Any, Literal, cast
 
@@ -41,9 +42,17 @@ class _SttJsonFormatter(logging.Formatter):
         return json.dumps(payload, ensure_ascii=False, default=str)
 
 
+def _propagate_observability_logs() -> bool:
+    raw = os.getenv("OBSERVABILITY_LOG_PROPAGATE")
+    if raw is not None:
+        return raw.strip().lower() in {"1", "true", "yes", "on"}
+    return os.getenv("ENVIRONMENT") != "production"
+
+
 def _get_chat_response_logger() -> logging.Logger:
     logger = logging.getLogger(CHAT_RESPONSE_LOGGER_NAME)
     logger.setLevel(logging.INFO)
+    logger.propagate = _propagate_observability_logs()
 
     if not any(getattr(handler, _CHAT_LOG_HANDLER_MARKER, False) for handler in logger.handlers):
         handler = logging.StreamHandler(sys.stdout)
@@ -57,7 +66,7 @@ def _get_chat_response_logger() -> logging.Logger:
 def _get_stt_logger() -> logging.Logger:
     logger = logging.getLogger(STT_LOGGER_NAME)
     logger.setLevel(logging.INFO)
-    logger.propagate = True
+    logger.propagate = _propagate_observability_logs()
 
     if not any(getattr(handler, _STT_LOG_HANDLER_MARKER, False) for handler in logger.handlers):
         handler = logging.StreamHandler(sys.stdout)
@@ -87,7 +96,7 @@ def _get_tts_cache_logger() -> logging.Logger:
 def _get_tts_logger() -> logging.Logger:
     logger = logging.getLogger(TTS_LOGGER_NAME)
     logger.setLevel(logging.INFO)
-    logger.propagate = True
+    logger.propagate = _propagate_observability_logs()
 
     if not any(getattr(handler, _TTS_LOG_HANDLER_MARKER, False) for handler in logger.handlers):
         handler = logging.StreamHandler(sys.stdout)

--- a/backend/tests/observability/test_structured_logger_tts.py
+++ b/backend/tests/observability/test_structured_logger_tts.py
@@ -57,3 +57,25 @@ def test_log_tts_event_includes_request_id(capsys):
     assert payload["event"] == "tts_complete"
     assert payload["request_id"] == "req-tts-613"
     assert payload["tts_overall_duration_ms"] == 42
+
+
+def test_observability_loggers_do_not_propagate_in_production(monkeypatch):
+    monkeypatch.setenv("ENVIRONMENT", "production")
+    monkeypatch.delenv("OBSERVABILITY_LOG_PROPAGATE", raising=False)
+
+    chat_logger = structured_logger_module._get_chat_response_logger()
+    stt_logger = structured_logger_module._get_stt_logger()
+    tts_logger = structured_logger_module._get_tts_logger()
+
+    assert chat_logger.propagate is False
+    assert stt_logger.propagate is False
+    assert tts_logger.propagate is False
+
+
+def test_observability_log_propagation_can_be_enabled_for_tests(monkeypatch):
+    monkeypatch.setenv("ENVIRONMENT", "production")
+    monkeypatch.setenv("OBSERVABILITY_LOG_PROPAGATE", "true")
+
+    stt_logger = structured_logger_module._get_stt_logger()
+
+    assert stt_logger.propagate is True

--- a/backend/tests/test_main_endpoints.py
+++ b/backend/tests/test_main_endpoints.py
@@ -1,5 +1,7 @@
 """Tests for backend/main.py endpoint fixes (Sprint 5)"""
 
+import logging
+
 import pytest
 from httpx import ASGITransport, AsyncClient
 from unittest.mock import AsyncMock, MagicMock, patch
@@ -36,6 +38,47 @@ class TestHealthCheck:
         # CI環境ではSupabase/LLM未接続のため "degraded" になりうる
         assert data["status"] in ("ok", "degraded")
         assert data["service"] == "engineer-cafe-navigator-backend"
+
+
+class TestProductionLogHygiene:
+    def test_request_timing_threshold_env_falls_back_on_invalid_value(self, monkeypatch):
+        import backend.main as main_mod
+
+        monkeypatch.setenv("REQUEST_TIMING_LOG_THRESHOLD_MS", "not-a-number")
+
+        assert main_mod._float_env("REQUEST_TIMING_LOG_THRESHOLD_MS", 10000) == 10000
+
+    def test_health_request_does_not_emit_info_timing_log(self, caplog):
+        from backend.main import app
+
+        caplog.set_level(logging.INFO, logger="backend.main")
+        client = TestClient(app)
+        response = client.get("/health")
+
+        assert response.status_code == 200
+        assert response.headers.get("x-response-time-ms")
+        assert not any(record.getMessage() == "request_completed_slow" for record in caplog.records)
+
+    def test_slow_non_health_request_keeps_structured_timing_fields(self, caplog, monkeypatch):
+        import backend.main as main_mod
+        from backend.main import app
+
+        monkeypatch.setattr(main_mod, "_REQUEST_TIMING_LOG_THRESHOLD_MS", 0)
+        caplog.set_level(logging.INFO, logger="backend.main")
+        client = TestClient(app)
+        response = client.get("/api/voice")
+
+        assert response.status_code == 200
+        records = [
+            record for record in caplog.records if record.getMessage() == "request_completed_slow"
+        ]
+        assert records
+        record = records[-1]
+        assert record.event == "request_completed_slow"
+        assert record.method == "GET"
+        assert record.path == "/api/voice"
+        assert record.status_code == 200
+        assert record.duration_ms >= 0
 
 
 class TestVoiceWarmupEndpoint:

--- a/backend/tests/utils/test_structured_logging.py
+++ b/backend/tests/utils/test_structured_logging.py
@@ -13,6 +13,7 @@ from backend.utils.structured_logging import (
     StructuredFormatter,
     generate_request_id,
     request_id_var,
+    setup_structured_logging,
 )
 
 # ============================================
@@ -134,3 +135,26 @@ def test_generate_request_id():
     # 毎回異なる値を生成する
     rid2 = generate_request_id()
     assert rid != rid2
+
+
+def test_setup_structured_logging_quiets_access_and_http_client_loggers():
+    original_handlers = logging.getLogger().handlers[:]
+    original_level = logging.getLogger().level
+    access_level = logging.getLogger("uvicorn.access").level
+    httpx_level = logging.getLogger("httpx").level
+    httpcore_level = logging.getLogger("httpcore").level
+
+    try:
+        setup_structured_logging()
+
+        assert logging.getLogger("uvicorn.access").level == logging.WARNING
+        assert logging.getLogger("httpx").level == logging.WARNING
+        assert logging.getLogger("httpcore").level == logging.WARNING
+    finally:
+        root = logging.getLogger()
+        root.handlers.clear()
+        root.handlers.extend(original_handlers)
+        root.setLevel(original_level)
+        logging.getLogger("uvicorn.access").setLevel(access_level)
+        logging.getLogger("httpx").setLevel(httpx_level)
+        logging.getLogger("httpcore").setLevel(httpcore_level)

--- a/backend/utils/structured_logging.py
+++ b/backend/utils/structured_logging.py
@@ -6,6 +6,7 @@ JSON形式のログフォーマッターとリクエストID伝播のための�
 
 import json
 import logging
+import os
 import uuid
 from contextvars import ContextVar
 from datetime import datetime, timezone
@@ -108,3 +109,12 @@ def setup_structured_logging(level: int = logging.INFO) -> None:
     root_logger.handlers.clear()
     root_logger.addHandler(handler)
     root_logger.setLevel(level)
+
+    # Cloud Run already emits request/access logs. Keep application logs focused
+    # on structured diagnostics instead of duplicating every request line.
+    logging.getLogger("uvicorn.access").setLevel(logging.WARNING)
+    logging.getLogger("httpx").setLevel(logging.WARNING)
+    logging.getLogger("httpcore").setLevel(logging.WARNING)
+
+    if os.getenv("ENVIRONMENT") == "production":
+        logging.getLogger("slowapi").setLevel(logging.WARNING)

--- a/docs/observability-runbook.md
+++ b/docs/observability-runbook.md
@@ -83,6 +83,27 @@ Triage:
 3. Check Cloud Run request latency and 5xx logs for platform-level issues.
 4. Compare the current revision against the previous healthy revision.
 
+## Alpha Log Hygiene
+
+The alpha Cloud Logging gate treats the following as release-blocking noise because they obscure
+actual P0/P1 signal during live verification:
+
+- `invalid input syntax for type uuid`
+- `Reception session persistence failed`
+
+Useful Cloud Logging query:
+
+```text
+resource.type="cloud_run_revision"
+resource.labels.service_name="engineer-cafe-backend"
+("invalid input syntax for type uuid" OR "Reception session persistence failed")
+```
+
+Expected result during a targeted alpha run window is zero rows. If rows appear, first confirm
+whether synthetic alpha `session_id` values are being passed into UUID-only persistence lookups or
+whether Supabase reception persistence is genuinely unavailable. Keep structured request,
+`chat_response`, STT, and TTS logs intact; do not hide real persistence errors by lowering severity.
+
 ## Memory Errors
 
 There is no structured `memory_*` event today. Phase 1b monitors existing root structured

--- a/scripts/cloud-logging-verify.sh
+++ b/scripts/cloud-logging-verify.sh
@@ -103,6 +103,8 @@ event_filter() {
 
 chat_filter="$BASE_FILTER AND (jsonPayload.event=\"chat_response\" OR labels.event=\"chat_response\" OR textPayload:\"chat_response\")"
 memory_filter="$BASE_FILTER AND ((jsonPayload.logger=\"backend.utils.memory_helper\" AND jsonPayload.level=\"ERROR\") OR jsonPayload.event=\"memory_helper_error\" OR (jsonPayload.logger:\"memory_helper\" AND severity>=ERROR) OR (textPayload:\"memory_helper\" AND severity>=ERROR))"
+uuid_hygiene_filter="$BASE_FILTER AND (textPayload:\"invalid input syntax for type uuid\" OR jsonPayload.message:\"invalid input syntax for type uuid\" OR jsonPayload.exception.message:\"invalid input syntax for type uuid\")"
+reception_hygiene_filter="$BASE_FILTER AND (textPayload:\"Reception session persistence failed\" OR jsonPayload.message:\"Reception session persistence failed\")"
 
 if [ "$DRY_RUN" = "1" ]; then
   echo "Dry run: no gcloud logging read calls will be executed."
@@ -113,6 +115,8 @@ if [ "$DRY_RUN" = "1" ]; then
   done
   echo "Filter[chat_response]: $chat_filter"
   echo "Filter[memory_helper_error]: $memory_filter"
+  echo "Filter[uuid_hygiene]: $uuid_hygiene_filter"
+  echo "Filter[reception_hygiene]: $reception_hygiene_filter"
   exit 0
 fi
 
@@ -135,6 +139,8 @@ for event in stt_qwen_start stt_qwen_complete stt_winner; do
 done
 read_logs "$chat_filter" "$TMP_DIR/chat_response.json"
 read_logs "$memory_filter" "$TMP_DIR/memory_helper_errors.json"
+read_logs "$uuid_hygiene_filter" "$TMP_DIR/uuid_hygiene.json"
+read_logs "$reception_hygiene_filter" "$TMP_DIR/reception_hygiene.json"
 
 python3 - "$TIMESTAMP" "$PROJECT_ID" "$SERVICE_NAME" "$REGION" "$MINUTES" "$THRESHOLD" "$REPORT" "$TMP_DIR" <<'PY'
 from __future__ import annotations
@@ -238,6 +244,9 @@ for entry in load("memory_helper_errors"):
     ):
         memory_errors.append({**data, "_timestamp": entry.get("timestamp"), "_severity": entry.get("severity")})
 
+uuid_hygiene_entries = load("uuid_hygiene")
+reception_hygiene_entries = load("reception_hygiene")
+
 failures: list[str] = []
 if trace_count == 0:
     failures.append("No structured STT trace events found.")
@@ -250,6 +259,14 @@ if not chat_entries:
     failures.append("No structured chat_response logs found.")
 if chat_missing:
     failures.append(f"{len(chat_missing)} chat_response log(s) are missing required fields.")
+if uuid_hygiene_entries:
+    failures.append(
+        f"{len(uuid_hygiene_entries)} invalid UUID syntax log(s) found; synthetic alpha IDs are still leaking into UUID queries."
+    )
+if reception_hygiene_entries:
+    failures.append(
+        f"{len(reception_hygiene_entries)} reception persistence failure log(s) found."
+    )
 
 passed = not failures
 lines = [
@@ -282,6 +299,14 @@ lines.append(
 lines.append(
     f"| `memory_helper` ERROR samples | {'WARN' if memory_errors else 'PASS'} | "
     f"{len(memory_errors)} error log(s) found; samples listed below if present |"
+)
+lines.append(
+    f"| `invalid input syntax for type uuid` hygiene | {'FAIL' if uuid_hygiene_entries else 'PASS'} | "
+    f"{len(uuid_hygiene_entries)} matching log row(s) |"
+)
+lines.append(
+    f"| `Reception session persistence failed` hygiene | {'FAIL' if reception_hygiene_entries else 'PASS'} | "
+    f"{len(reception_hygiene_entries)} matching log row(s) |"
 )
 
 if failures:
@@ -328,6 +353,34 @@ if memory_errors:
         lines.append(f"| {md(item.get('_timestamp'))} | {md(item.get('_severity') or item.get('level'))} | {md(message)[:500]} |")
 else:
     lines.append("- No memory_helper error samples in the lookback window.")
+
+lines.extend([
+    "",
+    "## Alpha Log Hygiene",
+    "",
+    f"- `invalid input syntax for type uuid` rows: {len(uuid_hygiene_entries)}",
+    f"- `Reception session persistence failed` rows: {len(reception_hygiene_entries)}",
+])
+if uuid_hygiene_entries or reception_hygiene_entries:
+    lines.extend(["", "| Check | Timestamp | Severity | Message |", "| --- | --- | --- | --- |"])
+    for name, entries in (
+        ("uuid", uuid_hygiene_entries[:5]),
+        ("reception", reception_hygiene_entries[:5]),
+    ):
+        for entry in entries:
+            data = payload(entry)
+            message = (
+                data.get("message")
+                or data.get("error")
+                or entry.get("textPayload")
+                or data.get("event")
+                or ""
+            )
+            lines.append(
+                f"| {name} | {md(entry.get('timestamp'))} | {md(entry.get('severity'))} | {md(message)[:500]} |"
+            )
+else:
+    lines.append("- No alpha log hygiene matches in the lookback window.")
 
 pathlib.Path(report).write_text("\n".join(lines) + "\n", encoding="utf-8")
 print(report)


### PR DESCRIPTION
## Summary
- suppress per-request INFO timing logs for health/fast requests while preserving slow/5xx structured timing
- avoid duplicate observability JSON logs in production unless explicitly enabled
- add Cloud Logging hygiene checks for invalid UUID and reception persistence noise
- document alpha log hygiene triage in the observability runbook

## Validation
- python -m py_compile backend/main.py backend/utils/structured_logging.py backend/observability/structured_logger.py
- bash -n scripts/cloud-logging-verify.sh
- scripts/cloud-logging-verify.sh --dry-run --timestamp hygiene-test --minutes 5 --limit 10
- cd backend && .venv/bin/pytest tests/test_main_endpoints.py tests/utils/test_structured_logging.py tests/observability/test_structured_logger_tts.py tests/api/test_chat_api.py tests/api/test_reception_persistence.py tests/workflows/test_main_workflow.py -q

Follow-up for #662 log hygiene proof.
