### PR TITLE
test: warm up STT before voice live

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -67,6 +67,10 @@ APP_URL=http://localhost:3000
 # STT_POSTPROCESS_MODEL=google/gemini-3.1-flash-lite-preview
 # VISION_MODEL=openai/gpt-4.1-nano
 
+# STT latency hedge (Optional, qwen-primary only)
+# QWEN_STT_HEDGE_DELAY_SECONDS=4
+# QWEN_STT_HEDGE_GRACE_SECONDS=6
+
 # Embedding Configuration (Optional)
 # Must match the dimension of knowledge_base.content_embedding column
 # EMBEDDING_MODEL=text-embedding-3-small

--- a/backend/tests/agents/test_stt_agent.py
+++ b/backend/tests/agents/test_stt_agent.py
@@ -2247,6 +2247,45 @@ class TestQwenPrimaryFallback:
         assert winner.stt_overall_duration_ms - qwen_complete.stt_qwen_duration_ms < 100
 
     @pytest.mark.asyncio
+    async def test_qwen_fast_path_does_not_start_hedge(self, caplog):
+        """Fast Qwen completes before hedge delay, so Vosk fallback never starts."""
+        caplog.set_level(logging.INFO, logger="backend.observability.stt")
+
+        mock_qwen = MagicMock()
+        mock_qwen.transcribe = AsyncMock(
+            return_value=TranscriptionResult(
+                text="qwen fast",
+                confidence=0.95,
+                language="ja",
+            )
+        )
+        mock_vosk = MagicMock(spec=LocalSTTClient)
+        mock_vosk.transcribe = AsyncMock(
+            return_value=TranscriptionResult(
+                text="fallback should not run",
+                confidence=0.7,
+                language="ja",
+            )
+        )
+
+        agent = self._make_agent(mock_qwen, mock_vosk)
+        agent._qwen_hedge_delay = 0.5
+        result = await agent.speech_to_text(b"audio", language="ja")
+
+        assert result["success"] is True
+        assert result["provider"] == "qwen-primary"
+        assert result["transcript"] == "qwen fast"
+        mock_vosk.transcribe.assert_not_called()
+
+        events = [
+            getattr(record, "event", None)
+            for record in caplog.records
+            if record.name == "backend.observability.stt"
+        ]
+        assert "stt_qwen_hedge_start" not in events
+        assert "stt_vosk_start" not in events
+
+    @pytest.mark.asyncio
     async def test_qwen_timeout_vosk_fallback(self):
         """Qwen times out -> Vosk fallback with provider='vosk-fallback'"""
         import asyncio
@@ -2521,6 +2560,39 @@ class TestQwenPrimaryFallback:
         assert result["success"] is True
         assert result["provider"] == "vosk-fallback"
         assert result["transcript"] == "fallback ok"
+
+    @pytest.mark.asyncio
+    async def test_qwen_immediate_error_falls_back_with_hedge_enabled(self, caplog):
+        """Immediate Qwen error still starts Vosk fallback when hedge is configured."""
+        caplog.set_level(logging.INFO, logger="backend.observability.stt")
+
+        mock_qwen = MagicMock()
+        mock_qwen.transcribe = AsyncMock(side_effect=RuntimeError("Model OOM"))
+        mock_vosk = MagicMock(spec=LocalSTTClient)
+        mock_vosk.transcribe = AsyncMock(
+            return_value=TranscriptionResult(
+                text="fallback ok",
+                confidence=0.75,
+                language="en",
+            )
+        )
+
+        agent = self._make_agent(mock_qwen, mock_vosk)
+        agent._qwen_hedge_delay = 0.5
+        result = await agent.speech_to_text(b"audio", language="en")
+
+        assert result["success"] is True
+        assert result["provider"] == "vosk-fallback"
+        assert result["transcript"] == "fallback ok"
+        mock_qwen.transcribe.assert_called_once_with(b"audio", language="en")
+        mock_vosk.transcribe.assert_called_once_with(b"audio", "en")
+
+        stt_records = [
+            record for record in caplog.records if record.name == "backend.observability.stt"
+        ]
+        events = [getattr(record, "event", None) for record in stt_records]
+        assert "stt_qwen_hedge_start" not in events
+        assert events.index("stt_qwen_complete") < events.index("stt_vosk_start")
 
     @pytest.mark.asyncio
     async def test_qwen_failure_starts_vosk_after_qwen_and_returns_vosk(self, caplog):

--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -67,3 +67,6 @@ NEXT_PUBLIC_USE_WEB_SPEECH_API=false
 
 # Kiosk slide guide: default = PDF (public/reception/engineer-cafe-ja.pdf). Use Marp + /api/marp with:
 # NEXT_PUBLIC_RECEPTION_SLIDE_RENDERER=marp
+
+# Playwright voice-live STT preflight timeout (default: 60000)
+# PLAYWRIGHT_VOICE_LIVE_WARMUP_TIMEOUT_MS=60000

--- a/frontend/e2e/voice-live.spec.ts
+++ b/frontend/e2e/voice-live.spec.ts
@@ -11,6 +11,13 @@ interface ObservedCall {
   method: string;
 }
 
+interface SttWarmupPayload {
+  sttWarmupError?: unknown;
+  sttWarmupProvider?: unknown;
+  sttWarmupStatus?: unknown;
+  success?: unknown;
+}
+
 function normalizeText(value: string | null | undefined): string {
   return (value ?? '')
     .replace(/\[\/?[a-zA-Z_]+(?::\d*\.?\d+)?\]/g, '')
@@ -38,6 +45,61 @@ async function selectEnglishAndClose(page: Page, timeout = 15_000): Promise<void
   await expect(closeButton).toBeVisible({ timeout });
   await closeButton.click();
   await expect(dialog).toBeHidden({ timeout });
+}
+
+function parsePositiveInteger(value: string | undefined, fallback: number): number {
+  const parsed = Number(value);
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : fallback;
+}
+
+async function warmupSttForLiveVoice(
+  page: Page,
+  baseURL: string | undefined,
+  language: string,
+): Promise<void> {
+  const warmupTimeoutMs = parsePositiveInteger(
+    process.env.PLAYWRIGHT_VOICE_LIVE_WARMUP_TIMEOUT_MS,
+    60_000,
+  );
+  const requestTimeoutMs = Math.min(60_000, Math.max(10_000, warmupTimeoutMs));
+  const deadline = Date.now() + warmupTimeoutMs;
+  const voiceUrl = new URL('/api/voice', baseURL ?? 'http://127.0.0.1:3000').toString();
+  const sessionId = `voice-live-warmup-${Date.now()}`;
+  let lastStatus = 'not-started';
+  let lastProvider = 'unknown';
+  let lastError = '';
+
+  while (Date.now() < deadline) {
+    const response = await page.request.post(voiceUrl, {
+      data: { action: 'warmup', language, sessionId },
+      timeout: requestTimeoutMs,
+    });
+    expect(response.ok(), `STT warmup request failed with HTTP ${response.status()}`).toBeTruthy();
+
+    const payload = (await response.json().catch(() => null)) as SttWarmupPayload | null;
+    expect(payload, 'STT warmup response must be JSON').not.toBeNull();
+    lastStatus =
+      typeof payload?.sttWarmupStatus === 'string' ? payload.sttWarmupStatus : 'unknown';
+    lastProvider =
+      typeof payload?.sttWarmupProvider === 'string' ? payload.sttWarmupProvider : 'unknown';
+    lastError = typeof payload?.sttWarmupError === 'string' ? payload.sttWarmupError : '';
+
+    if (lastStatus === 'ready' || lastStatus === 'skipped') {
+      return;
+    }
+    if (lastStatus === 'failed') {
+      throw new Error(
+        `STT warmup failed before voice-live test (provider=${lastProvider}, error=${lastError})`,
+      );
+    }
+
+    await page.waitForTimeout(2_000);
+  }
+
+  throw new Error(
+    `STT warmup did not become ready before voice-live test ` +
+      `(lastStatus=${lastStatus}, provider=${lastProvider}, timeoutMs=${warmupTimeoutMs})`,
+  );
 }
 
 function parseAction(request: Request): string | undefined {
@@ -79,6 +141,7 @@ test.describe('Voice live (browser voice round-trip against live backend)', () =
       origin: baseURL ?? 'http://127.0.0.1:3000',
     });
     await installDeterministicVoiceRecorder(page);
+    await warmupSttForLiveVoice(page, baseURL, 'en');
 
     const apiCalls: ObservedCall[] = [];
     page.on('request', (request) => {


### PR DESCRIPTION
## Summary
- add Qwen STT hedge regression tests
- document STT hedge/warmup knobs in backend/frontend env examples
- add voice-live Playwright warmup polling before mic round-trip

## Validation
- pytest backend/tests/agents/test_stt_agent.py::TestQwenPrimaryFallback -q
- pnpm --dir frontend typecheck
- PLAYWRIGHT_VOICE_LIVE=0 pnpm --dir frontend exec playwright test e2e/voice-live.spec.ts --project=chromium-voice-live --reporter=line
- git diff --check -- backend/.env.example backend/tests/agents/test_stt_agent.py frontend/.env.example frontend/e2e/voice-live.spec.ts

Follow-up hardening for #658 voice-live stability.
