### PR TITLE
docs: sync alpha status after C-127 fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,8 @@
 - Cloud Run staging は develop SHA `d789a2cd899779423947c40a3d65e19382f52d30` の revision `engineer-cafe-backend-00148-82c` で検証済みです。
 - B routing / slide live smoke は targeted run `25254789937` で `64 passed, 0 warned, 0 failed` まで復旧しました。
 - Welcome UI, compact artifact, Cloud Run Supabase UUID/log hygiene は resolved として issue close 済みです。
-- ただし alpha はまだ **NO-GO** です。STT long-tail latency、Q/C answer quality、RAGAS 127-case coverage reconciliation が残っています。
+- ただし alpha はまだ **NO-GO** です。C-127 live collection completion、Q/C answer quality、live-only proof が残っています。
+- PR #692/#693/#695 は merge 済みですが、#693 後 Q rerun と #695 後 C-127 rerun が未完了です。
 
 詳細は [docs/STATUS.md](docs/STATUS.md) を参照してください。
 
@@ -39,8 +40,10 @@ Browser
 
 - alpha gate は end-to-end で回るが、latest `suites=all` の green proof はまだありません。
 - `continue-on-error` のため、GitHub step が success に見えても suite outcome が failure の場合があります。
-- STT preflight は current revision gate に分離済みですが、Qwen STT long-tail がまだ alpha P0 です。
-- RAGAS は direct OpenAI に修正済みですが、JA answer_correctness と 29-vs-127 coverage が未解決です。
+- STT / voice preflight は run `25258764528` で PASS し、#658 は close 済みです。
+- RAGAS は direct OpenAI と C-127 manifest accounting まで修正済みですが、post-#692 run `25270459825`
+  は `/api/chat` 429 により `35/127` evaluated でした。PR #695 後の C-127 rerun が必要です。
+- Q suite は PR #693 merge 後の targeted rerun 待ちです。
 - B routing / slide live smoke と Cloud Run UUID log hygiene は 2026-05-03 時点の deployed staging で解消確認済みです。
 
 この README は現況の入口だけを扱います。監査結果と production readiness の論点は [docs/STATUS.md](docs/STATUS.md) に集約しています。
@@ -94,9 +97,10 @@ make dev
 
 2026-05-03 時点で把握した主要な alpha open items:
 
-- P0: `#658`, `#657`, `#643`, `#612`, `#611`, `#585`, `#583`
-- P1: `#672`, `#670`, `#669`, `#663`, `#655`, `#653`
-- Resolved in the latest remediation pass: `#659`, `#660`, `#661`, `#662`, `#671`
+- P0 / alpha-scope: `#583`, `#584`, `#585`, `#611`, `#612`, `#643`
+- P1 / alpha-scope: `#653`, `#670`, `#672`
+- Resolved in the latest remediation pass: `#658`, `#659`, `#660`, `#661`, `#662`, `#671`, `#691`, `#694`
+- Merged and awaiting live proof: PR `#693` for Q quality, PR `#695` for C-127 `/api/chat` pacing / 429 retry
 
 ## 注意
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -79,28 +79,33 @@
 
 ## 2026-05-03 Alpha Remediation Snapshot
 
-PR #674, #675, #676 を develop に merge し、Cloud Run staging
-`engineer-cafe-backend-00148-82c` / `d789a2cd899779423947c40a3d65e19382f52d30`
-で検証済みです。
+PR #674, #675, #676 に加えて、#692, #693, #695 を develop に merge 済みです。
+#692 は C-127 accounting を修正し、run `25270459825` で `requested=127` を確認しました。
+ただし同 run は live `/api/chat` 429 により `evaluated=35`, `collection_errors=92`
+で、C-127 completion proof にはなっていません。#695 は 429 pacing / retry 修正として merge 済みで、
+post-#695 C-127 rerun 待ちです。#693 は Q suite 残 failure 修正として merge 済みで、post-deploy Q rerun 待ちです。
 
 Resolved:
 
+- #658 STT / voice preflight: run `25258764528` が `suites=stt,v` PASS
 - #659 B routing / slide live smoke: targeted B run `25254789937` が `64 passed, 0 warned, 0 failed`
 - #660 H-UI Welcome UI live scenario
 - #661 compact artifact visibility
 - #662 Supabase UUID / Cloud Run log hygiene
 - #671 RAGAS direct OpenAI provider secret
+- #691 C-127 manifest accounting: PR #692
+- #694 C-127 `/api/chat` 429 collection blocker: PR #695 merged, live proof pending
 
 Still active:
 
-- #658 STT long-tail latency
-- #657 / #583 RAGAS 29-case vs 127-case coverage reconciliation
+- #583 C-127 completion proof: post-#695 rerun must collect/evaluate `127/127`
 - #653 / #672 Q/C answer quality
 - #670 RAGAS full-run speed / telemetry closeout
+- #611 / #584 / #585 live-only proof / issue-scope decisions
 
 ## 直近の次アクション
 
-- #658 STT long-tail latency の fallback threshold / warmup / timeout 前 mitigation を実装する
-- #657 / #583 の alpha gate coverage を launch gate と diagnostic/soak に分けて文書化・実装する
-- #653 / #672 の Q/C answer quality failure を case-level telemetry で修正する
-- #670 は full C/Q run の artifact で provider/model/progress が十分に残ることを確認して close 判断する
+- #695 後に `suites=c-127` を rerun し、`requested=127`, `evaluated=127`, `collection_errors=0` を確認する
+- #693 後に `suites=q` を rerun し、#653 の残 failure が 0 になったか確認する
+- C-127 が完走してから #672 の answer/source quality を case-level telemetry で修正する
+- #670 は post-#695 C-127 artifact で provider/model/progress と compact report が十分に残ることを確認して close 判断する

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -6,7 +6,7 @@ Last updated: 2026-05-03
 
 このページは、`develop` 上の現行コード、2026-04-19 の live audit、2026-04-29 の実機音声 UX 確認、
 2026-05-02 の alpha-live-verification full run / targeted C run、2026-05-03 の PR #674/#675/#676
-deploy verification をもとに更新しています。
+deploy verification、PR #692/#693/#695 merge 後の alpha issue 状態をもとに更新しています。
 
 確認元:
 
@@ -15,6 +15,7 @@ deploy verification をもとに更新しています。
 - 2026-04-29 JST の mobile / kiosk 実地確認 screenshot と Cloud Run structured logs
 - 2026-05-02 JST の `alpha-live-verification` run `25244933308` / `25247945549`
 - 2026-05-03 JST の targeted B run `25254789937` と Cloud Run revision `engineer-cafe-backend-00148-82c`
+- 2026-05-03 JST の post-#692 C-127 run `25270459825`
 - 現在 open の GitHub Issue
 
 Supabase については、CLI で linked project の確認まではできましたが、このセッションでは recent runtime log
@@ -26,14 +27,17 @@ Supabase については、CLI で linked project の確認まではできまし
 - alpha live verification workflow は Cloud Run SHA match 付きで end-to-end 実行できる
 - RAGAS evaluator は direct OpenAI で動くことを確認済み
 - PR #674/#675/#676 により、B routing / slide live smoke、Welcome UI、compact artifacts、Supabase UUID log hygiene は解消済み
+- PR #692 により C-127 manifest accounting は解消済み。run `25270459825` で `requested=127` になったが、
+  live `/api/chat` 429 により `evaluated=35`, `collection_errors=92` だった
+- PR #693 は Q quality 修正、PR #695 は C-127 pacing / retry 修正として merge 済み。どちらも post-deploy live rerun 待ち
 - ただし latest `suites=all` の green proof はまだなく、alpha release はまだ GO できない
 - 現在の主リスクは「未実装の基本機能」ではなく「会話 UX の基本品質、実測 latency、route 整合性、評価 gate の透明性」
 
 特に優先度が高いのは次の 4 点です。
 
-1. STT long-tail latency が alpha gate を落としている問題
-2. Q/C answer quality と RAGAS JA target miss
-3. RAGAS 29-case gate と 127-case requirement の不一致
+1. C-127 が live `/api/chat` 429 なしで `127/127` collect/evaluate できることの証明
+2. Q suite の残 failure が #693 後に解消されたことの証明
+3. C-127 完走後の answer/source quality 判断
 4. RAGAS full-run speed / telemetry の operational closeout
 
 現行の実装判断は [ADR 018](adr/018-alpha-fast-response-and-assistant-profile-routing.md) と
@@ -41,7 +45,7 @@ Supabase については、CLI で linked project の確認まではできまし
 
 ## 2026-05-03 Alpha Remediation Snapshot
 
-最新の deployed staging:
+最新の deployed staging / harness 状態:
 
 - develop SHA: `d789a2cd899779423947c40a3d65e19382f52d30`
 - Cloud Run revision: `engineer-cafe-backend-00148-82c`
@@ -52,6 +56,10 @@ Supabase については、CLI で linked project の確認まではできまし
 - B result: `64 passed, 0 warned, 0 failed`
 - B1-BIZ-003: `土日祝日も利用できますか。` -> `business_info`, `1258ms`
 - Cloud Logging UUID / reception persistence errors during B run window: 0 rows
+- PR #692 merge SHA: `d74264e808e9b2a0244d3a1a9e5dfe12671530ea`
+- Post-#692 C-127 run: `25270459825`, `requested=127`, `evaluated=35`, `collection_errors=92`
+- PR #693 merge SHA: `14cb8e5b3c4f9711a77c634d3db80f8bf4f80efd`; Q rerun pending
+- PR #695 merge SHA: `ed25199e4c7104ac0f6e2f027c4fdadd72280182`; post-#695 C-127 rerun pending
 
 Resolved in PR #674/#675/#676:
 
@@ -60,14 +68,15 @@ Resolved in PR #674/#675/#676:
 - #661: compact artifact visibility
 - #662: Supabase UUID / Cloud Run log hygiene
 - #671: RAGAS provider secret issue
+- #691: C-127 manifest accounting
+- #694: C-127 `/api/chat` 429 collection blocker implementation merged in PR #695; live proof pending
 
 Still blocking or important:
 
-- #658: STT long-tail latency remains P0. Latest STT-only gate after #674 deploy had 7 samples,
-  p50 `5180ms`, p95/max `29217ms`, and 14.3% over 10s.
-- #657 / #583: RAGAS 29 vs 127 coverage reconciliation remains P0.
-- #653 / #672: Q/C answer quality remains P1 and may become launch-blocking depending on case analysis.
-- #670: RAGAS telemetry is implemented, but a full C/Q run still needs operational proof before close.
+- #583: C-127 completion remains P0 until post-#695 run collects/evaluates `127/127` with `collection_errors=0`.
+- #653: Q quality remains P1 until post-#693 `suites=q` rerun has 0 failures.
+- #672: C answer/source quality remains P1, but current C metrics are not release-proof until C-127 collection completes.
+- #670: RAGAS telemetry is implemented, but post-#695 C-127 artifact still needs operational proof before close.
 
 ## 2026-05-02 Alpha Live Verification Snapshot
 
@@ -91,8 +100,7 @@ Resolved in the 2026-05-02 / 2026-05-03 remediation pass:
 
 Still blocking:
 
-- #658: STT preflight latency
-- #657 / #583: RAGAS 29 vs 127 coverage
+- #583: C-127 completion proof after #695
 - #653 / #672: Q/C answer quality
 - #670: full-run RAGAS speed / telemetry closeout
 
@@ -245,21 +253,19 @@ current turn の high-confidence intent なしに route を固定してはいけ
 
 ## いま重要な Open Issues
 
-- `#658`: STT preflight latency
-- `#657`: RAGAS gate 29 vs 127
+- `#583`: C-127 completion proof
 - `#653`: Q-content quality
 - `#672`: Direct OpenAI C/RAGAS JA target miss
-- `#669`: deployed tRAG translation model missing
 - `#670`: C/RAGAS runtime and telemetry
 - `#611`: Cerebras dynamic filler / fast first-response path
 
 ## 推奨する実装順
 
-1. STT long-tail latency mitigation を実装する (`#658`)
-2. RAGAS 127-case gate を定義・実装する (`#657`, `#583`)
-3. Q/C answer quality を直す (`#653`, `#672`)
+1. PR #695 後の `suites=c-127` rerun で #583 / #670 / #672 の判断材料を取る
+2. PR #693 後の `suites=q` rerun で #653 を close できるか判断する
+3. C-127 が `127/127` 完走してから C answer/source quality を直す (`#672`)
 4. RAGAS full-run telemetry / runtime を close 判断する (`#670`)
-5. tRAG translation model fallback の alpha 影響を判断する (`#669`)
+5. #611 / #584 / #585 の live-only proof を収集するか、alpha GO から demote / waive する
 
 ## 参照
 

--- a/docs/adr/019-alpha-live-ragas-case-accounting.md
+++ b/docs/adr/019-alpha-live-ragas-case-accounting.md
@@ -2,7 +2,7 @@
 
 ## ステータス
 
-提案
+Accepted / implemented by PR #692
 
 ## 日付
 
@@ -28,6 +28,12 @@
 127 ケースを保持しており、`alpha-127` manifest も `ja=80, en=23, zh=12, ko=12`
 をロードしている。したがって、これは dataset selection の問題ではなく live API
 評価ハーネスの accounting 問題である。
+
+PR #692 でこの accounting defect は修正済み。post-#692 validation run `25270459825`
+では `suite_coverage.requested_total_cases=127` を保持し、live `/api/chat` 失敗は
+`collection_errors` として artifact に残った。ただし同 run は `/api/chat` `429 Too Many Requests`
+により `evaluated=35`, `collection_errors=92` であり、C-127 completion / alpha GO proof ではない。
+429 collection blocker は #694 / PR #695 で別途対応し、post-#695 rerun 待ち。
 
 現在の `backend/evaluation/run_live_api_eval.py` は `/api/chat` collection phase で
 例外が出たケースをログに出すだけで report から落とす。その後
@@ -109,6 +115,24 @@ Alpha gate では manifest 件数を primary accounting とする必要がある
    `suite_coverage.requested_total_cases=127` であること、collection failure があれば
    `collection_errors` と `evaluation_complete=false` に出ることを確認する。
 
+## 実装・検証結果
+
+- PR: <https://github.com/EngineerCafeJP/engineercafe-navigator/pull/692>
+- Merge SHA: `d74264e808e9b2a0244d3a1a9e5dfe12671530ea`
+- Live validation run: <https://github.com/EngineerCafeJP/engineercafe-navigator/actions/runs/25270459825>
+- Result:
+  - `case_suite`: `alpha-127`
+  - `suite_coverage.expected_total_cases`: `127`
+  - `suite_coverage.requested_total_cases`: `127`
+  - evaluated cases: `35`
+  - collection errors: `92`
+  - API failed cases: `92`
+  - main failure mode: live `/api/chat` `429 Too Many Requests`
+
+This validates the ADR decision: manifest/request accounting now remains `127` even when live API
+collection fails. It also separates the next blocker cleanly: collection reliability / rate-limit
+pacing, not manifest accounting.
+
 ## ロールバック
 
 この変更は evaluation harness artifact schema の追加であり、product runtime には影響しない。
@@ -118,13 +142,17 @@ collection-success-only report に戻せる。ただし、その状態の C-127 
 
 ## 現在の実装メモ
 
-2026-05-03 時点で `codex/alpha-c127-live-harness-accounting` に未コミットの draft patch がある。
-次セッションではこの ADR と GitHub Issue #691 を起点に、draft patch を見直して test / PR / merge へ進める。
+ADR 019 itself is implemented and #691 is closed. Remaining C-127 proof depends on #694 / PR #695
+and a post-#695 `suites=c-127` rerun that reaches `evaluated=127` and `collection_errors=0`.
 
 ## 参照
 
 - Run: <https://github.com/EngineerCafeJP/engineercafe-navigator/actions/runs/25268597241>
+- Validation run: <https://github.com/EngineerCafeJP/engineercafe-navigator/actions/runs/25270459825>
 - Issue: <https://github.com/EngineerCafeJP/engineercafe-navigator/issues/691>
+- PR: <https://github.com/EngineerCafeJP/engineercafe-navigator/pull/692>
+- Follow-up rate-limit issue: <https://github.com/EngineerCafeJP/engineercafe-navigator/issues/694>
+- Follow-up rate-limit PR: <https://github.com/EngineerCafeJP/engineercafe-navigator/pull/695>
 - `backend/evaluation/run_live_api_eval.py`
 - `backend/tests/evaluation/test_ragas_live_case_suites.py`
 - `backend/tests/fixtures/golden_datasets/ground_truth.json`

--- a/docs/plans/alpha-remediation-plan-2026-05-02.md
+++ b/docs/plans/alpha-remediation-plan-2026-05-02.md
@@ -14,39 +14,43 @@ The workflow infrastructure is now complete enough to run targeted alpha gates e
 - RAGAS provider/model/case progress telemetry is emitted.
 - B routing / slide live smoke is green on deployed staging.
 
-The product is still **NO-GO** for alpha because there is no latest `suites=all` green proof, and
-the first C-127 run exposed a live RAGAS harness accounting defect.
+The product is still **NO-GO** for alpha because there is no latest `suites=all` green proof.
+The C-127 manifest accounting defect is fixed by PR #692, but post-#692 validation exposed a
+live `/api/chat` 429 collection blocker.
 
 Latest deployed verification:
 
 - backend deploy SHA: `d1280aa64643aae7b22df875ee22f13cbfe294a2`
 - Cloud Run revision: `engineer-cafe-backend-00157-b6c`
-- C-127 run: `25268597241`
-- C-127 result: failure, `alpha-127` expected `127` but artifact reported `85`
-- Q targeted run after C-127 dispatch: `25269072919` failed with `23 PASS / 0 WARN / 2 FAIL`
+- PR #692 merge SHA: `d74264e808e9b2a0244d3a1a9e5dfe12671530ea`
+- C-127 run after #692: `25270459825`
+- C-127 result after #692: failure, `alpha-127` requested `127`, evaluated `35`, collection errors `92`
+- PR #695 merge SHA: `ed25199e4c7104ac0f6e2f027c4fdadd72280182`; post-#695 C-127 rerun pending
+- Q targeted run before #693: `25269072919` failed with `23 PASS / 0 WARN / 2 FAIL`
+- PR #693 merge SHA: `14cb8e5b3c4f9711a77c634d3db80f8bf4f80efd`; post-#693 Q rerun pending
 
 ## Implementation Order
 
-### 1. ADR 019 / #691 / #657 / #583 RAGAS coverage and accounting
+### 1. #583 / #694 C-127 live collection completion
 
-Goal: make C-127 artifacts prove both selected manifest coverage and live API collection success.
+Goal: make C-127 collect and evaluate all 127 selected manifest cases through live `/api/chat`.
 
 Status:
 
 - Direct OpenAI provider path is confirmed.
 - RAGAS progress telemetry is implemented.
 - `c-127` workflow selection is implemented.
-- The first C-127 run selected `alpha-127`, but artifact accounting reported only 85 requested cases
-  because live API collection failures were dropped from the report.
+- PR #692 fixed manifest accounting: post-#692 run `25270459825` reports `requested=127`.
+- The same run evaluated only `35/127` because live `/api/chat` returned `92` `429 Too Many Requests`
+  collection errors.
+- PR #695 is merged with C-127 pacing / 429 retry and compact artifact polish, but live proof is pending.
 
 Tasks:
 
-- Implement ADR 019 in `backend/evaluation/run_live_api_eval.py`.
-- Keep `requested_case_count` tied to selected manifest cases, not collected successful responses.
-- Persist `/api/chat` collection failures as `collection_errors`.
-- Fail `evaluation_complete` and `alpha_release_gate_met` when collection errors exist.
-- Add regression coverage in `backend/tests/evaluation/test_ragas_live_case_suites.py`.
-- Re-run `suites=c-127` before interpreting C answer quality metrics.
+- Re-run `suites=c-127` after PR #695 is deployed or explicitly pass the current deployed backend SHA
+  if the merge is harness-only.
+- Require `suite_coverage.requested_total_cases=127`, `evaluated=127`, and `collection_errors=0`.
+- Only interpret #672 C answer/source metrics after collection completes.
 
 ### 2. #653 / #672 answer quality
 
@@ -62,21 +66,18 @@ Latest Q run `25269072919` improved from 3 failures to 2 failures:
 - `Q-BIZ-EN-003`: route OK, sources OK, missing expected fact `reservation`.
 - `Q-DAILY-JA-001`: route OK, answer OK, latency `2205ms`.
 - `Q-EVT-EN-001` now passes.
+- PR #693 is merged for the two remaining failures; post-deploy `suites=q` proof is pending.
 
-Current C/RAGAS direct OpenAI C-127 failure:
+Current C/RAGAS direct OpenAI C-127 status:
 
-- Run `25268597241`: `alpha-127` expected `127`, reported `85`; interpret answer quality only
-  after ADR 019 is merged and rerun.
-- Current reported metrics from the incomplete artifact:
-  - JA answer_correctness `0.585`, target `0.85`
-  - EN answer_correctness `0.7017`, target `0.75`
-  - ZH answer_correctness `0.7271`, target `0.65`
-  - KO answer_correctness `0.7151`, target `0.65`
-- Source gate failures: `gt-019` JA, `gt-065` EN, `gt-115` KO.
+- Run `25270459825`: `alpha-127` requested `127`, evaluated `35`, collection errors `92`.
+- Current answer/source metrics are not release-proof because most cases were not collected.
+- Known evaluated-subset source failure: `gt-019` JA consultation had actual sources `[]`.
 
 Tasks:
 
-- Read the report artifacts for exact expected facts and actual answers.
+- Re-run `q` after PR #693 and close #653 only if the Q suite has `0 FAIL`.
+- Re-run `c-127` after PR #695 and only then read the report artifacts for exact expected facts and actual answers.
 - Decide whether each failure is response generation, source retrieval, ground truth, or threshold drift.
 - Fix the smallest product-side issue first; only adjust tests when the expected answer is wrong.
 - Re-run `q` and `c`.
@@ -92,7 +93,7 @@ Status:
 
 Tasks:
 
-- Run full C/Q after #691 and the targeted Q/C fixes, or in a diagnostic window.
+- Run full C/Q after #695 and the targeted Q/C fixes, or in a diagnostic window.
 - Confirm provider/model/case progress is present in logs and compact artifacts.
 - Close #670 only after one full C/Q operational proof.
 
@@ -151,11 +152,10 @@ Status: completed in PR #674.
 Use targeted suites until the relevant blocker is fixed:
 
 ```bash
-gh workflow run alpha-live-verification.yml --ref develop -f suites=stt,v -f require_deployed_sha_match=true
 gh workflow run alpha-live-verification.yml --ref develop -f suites=c-127 -f require_deployed_sha_match=true -f expected_backend_sha=<current-backend-sha>
-gh workflow run alpha-live-verification.yml --ref develop -f suites=q,c -f require_deployed_sha_match=true
+gh workflow run alpha-live-verification.yml --ref develop -f suites=q -f require_deployed_sha_match=true -f expected_backend_sha=<current-backend-sha>
 ```
 
-Only run `suites=all` after #691 and the C/Q gate decision have targeted green runs. For C-127,
-do not treat an artifact as release proof unless `suite_coverage.requested_total_cases=127` and
-collection failures are explicitly represented.
+Only run `suites=all` after post-#695 C-127 and post-#693 Q have targeted green runs. For C-127,
+do not treat an artifact as release proof unless `suite_coverage.requested_total_cases=127`,
+`evaluated=127`, and `collection_errors=0`.


### PR DESCRIPTION
## Summary
- mark ADR 019 as accepted/implemented by PR #692
- update README/docs status after #692/#693/#695
- clarify that #695 C-127 and #693 Q live reruns are the next proof steps
- remove stale #658 / 29-vs-127 framing from active blockers

## Validation
- git diff --check -- README.md docs/README.md docs/STATUS.md docs/adr/019-alpha-live-ragas-case-accounting.md docs/plans/alpha-remediation-plan-2026-05-02.md

Docs-only follow-up for alpha issue/ADR hygiene.
