### PR TITLE
fix: surface voice backend warmup timeouts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -463,8 +463,9 @@ jobs:
             --memory 8Gi \
             --cpu 4 \
             --concurrency 1 \
-            --min-instances 1 \
-            --max-instances 3 \
+            --min-instances 3 \
+            --max-instances 10 \
+            --cpu-boost \
             --update-env-vars "ENVIRONMENT=production,TTS_PROVIDER=piper,STT_PROVIDER=qwen-primary,STT_LLM_POSTPROCESS=false,QWEN_STT_TIMEOUT=45,QWEN_STT_HEDGE_DELAY_SECONDS=4,QWEN_STT_HEDGE_GRACE_SECONDS=6,STT_PRELOAD_QWEN_PRIMARY=true,HF_HOME=/app/.hf_cache,FRONTEND_PRODUCTION_ORIGIN=${FRONTEND_PRODUCTION_ORIGIN},ALLOWED_ORIGINS=${FRONTEND_PRODUCTION_ORIGIN},FAST_LLM_ENABLED=true,FAST_LLM_PRIMARY_PROVIDER=cerebras,FAST_LLM_PRIMARY_MODEL=google/gemini-3.1-flash-lite-preview,FAST_LLM_FALLBACK_PROVIDER=gemini,FAST_LLM_FALLBACK_MODEL=google/gemini-2.5-flash-lite,FAST_LLM_TERTIARY_PROVIDER=cerebras,CEREBRAS_ENABLED=true,CEREBRAS_FAST_MODEL=gpt-oss-120b,CEREBRAS_REASONING_EFFORT=low,DEEP_REASONING_MODEL=google/gemini-3.1-pro-preview,DEEP_REASONING_FALLBACK_MODEL=google/gemini-2.5-pro" \
             --update-secrets "OPENROUTER_API_KEY=OPENROUTER_API_KEY:latest,CEREBRAS_API_KEY=CEREBRAS_API_KEY:latest,SUPABASE_URL=SUPABASE_URL:latest,SUPABASE_KEY=SUPABASE_KEY:latest,SUPABASE_DB_URI=SUPABASE_DB_URI:latest,API_SECRET_KEY=API_SECRET_KEY:latest,TAVILY_API_KEY=TAVILY_API_KEY:latest"
         env:

--- a/frontend/src/__tests__/api-proxy-contract.test.ts
+++ b/frontend/src/__tests__/api-proxy-contract.test.ts
@@ -172,3 +172,27 @@ test(
     });
   }
 );
+
+test(
+  'voice POST maps backend proxy timeout to a controlled 504 payload',
+  { concurrency: false },
+  async () => {
+    process.env.BACKEND_API_URL = 'https://backend.example.com';
+    (process.env as Record<string, string | undefined>).NODE_ENV = 'test';
+    global.fetch = (async () => {
+      throw new DOMException('The operation was aborted due to timeout', 'TimeoutError');
+    }) as typeof fetch;
+
+    const { POST } = await import('../app/api/voice/route');
+    const response = await POST(
+      new NextRequest('https://example.com/api/voice', {
+        method: 'POST',
+        body: JSON.stringify({ action: 'text_to_speech', text: 'hello', language: 'ja' }),
+        headers: { 'Content-Type': 'application/json' },
+      })
+    );
+
+    assert.equal(response.status, 504);
+    assert.deepEqual(await response.json(), { error: 'Backend request timed out' });
+  }
+);

--- a/frontend/src/__tests__/error-messages.test.ts
+++ b/frontend/src/__tests__/error-messages.test.ts
@@ -9,8 +9,8 @@ test("formatError preserves Safari microphone permission failures by DOMExceptio
     originalName: "NotAllowedError",
   });
 
-  assert.match(formatError(error, "ja"), /マイク.*拒否/);
-  assert.match(formatError(error, "en"), /Microphone access was denied/);
+  assert.match(formatError(error, "ja"), /マイク.*許可/);
+  assert.match(formatError(error, "en"), /Microphone permission is required/);
 });
 
 test("formatError maps microphone device and state failures to actionable messages", () => {
@@ -19,7 +19,7 @@ test("formatError maps microphone device and state failures to actionable messag
       Object.assign(new Error("missing"), { name: "NotFoundError" }),
       "ja",
     ),
-    /検出されません/,
+    /見つかりません/,
   );
   assert.match(
     formatError(
@@ -33,6 +33,17 @@ test("formatError maps microphone device and state failures to actionable messag
       Object.assign(new Error("state"), { name: "InvalidStateError" }),
       "ja",
     ),
-    /もう一度ボタン/,
+    /マイクボタン/,
+  );
+});
+
+test("formatError maps backend timeout to a voice warmup message", () => {
+  assert.match(
+    formatError(Object.assign(new Error("Backend request timed out"), { status: 504 }), "ja"),
+    /起動に時間/,
+  );
+  assert.match(
+    formatError(Object.assign(new Error("Backend request timed out"), { status: 504 }), "en"),
+    /warming up/,
   );
 });

--- a/frontend/src/lib/api/backend-proxy.ts
+++ b/frontend/src/lib/api/backend-proxy.ts
@@ -34,6 +34,17 @@ export interface BackendProxyResult<T = unknown> {
   readonly data: T;
 }
 
+const BACKEND_TIMEOUT_STATUS = 504;
+const BACKEND_TIMEOUT_ERROR = "Backend request timed out";
+
+function isAbortLikeError(error: unknown): boolean {
+  if (!(error instanceof Error || error instanceof DOMException)) {
+    return false;
+  }
+
+  return error.name === "TimeoutError" || error.name === "AbortError";
+}
+
 /**
  * Send a request to the backend, automatically attaching X-API-Key.
  *
@@ -74,7 +85,24 @@ export async function backendFetch<T = unknown>(
     fetchInit.body = JSON.stringify(body);
   }
 
-  const response = await fetch(url, fetchInit);
+  let response: Response;
+  try {
+    response = await fetch(url, fetchInit);
+  } catch (error) {
+    if (timeoutMs !== undefined && signal === undefined && isAbortLikeError(error)) {
+      return {
+        ok: false,
+        status: BACKEND_TIMEOUT_STATUS,
+        data: {
+          error: BACKEND_TIMEOUT_ERROR,
+          details:
+            "The backend did not respond before the Vercel proxy timeout. Try again after the voice service finishes warming up.",
+        } as T,
+      };
+    }
+    throw error;
+  }
+
   let data: T;
   try {
     data = (await response.json()) as T;

--- a/frontend/src/lib/error-messages.ts
+++ b/frontend/src/lib/error-messages.ts
@@ -71,6 +71,12 @@ export const ERROR_MESSAGES: Record<string, ErrorMessage> = {
     ja: 'サービスが一時的に利用できません。しばらくしてからもう一度お試しください。',
     en: 'Service is temporarily unavailable. Please try again later.',
   },
+  BACKEND_TIMEOUT: {
+    ja:
+      '音声サービスの起動に時間がかかっています。少し待ってからもう一度お試しください。',
+    en:
+      'The voice service is still warming up. Please wait a moment and try again.',
+  },
   
   // Session Errors
   SESSION_EXPIRED: {
@@ -208,6 +214,13 @@ export function formatError(
     ) {
       return getErrorMessage('TTS_ERROR', language);
     }
+    if (
+      message.includes('timed out') ||
+      message.includes('timeout') ||
+      message.includes('504')
+    ) {
+      return getErrorMessage('BACKEND_TIMEOUT', language);
+    }
   }
 
   // Check for 422 validation error
@@ -256,6 +269,9 @@ export function formatError(
   
   // Check for HTTP status codes
   if (error.status) {
+    if (error.status === 504) {
+      return getErrorMessage('BACKEND_TIMEOUT', language);
+    }
     if (error.status >= 500) {
       return getErrorMessage('SERVER_ERROR', language);
     }


### PR DESCRIPTION
## Summary
- keep Cloud Run staging deploy config aligned with the current higher-capacity voice service settings: min-instances=3, max-instances=10, CPU boost
- convert frontend backend proxy timeout/abort into a controlled 504 payload instead of a generic 500/silent failure path
- map voice backend timeout errors to an actionable warmup message for kiosk users

## Validation
- pnpm --dir frontend exec tsx src/__tests__/api-proxy-contract.test.ts
- pnpm --dir frontend exec tsx src/__tests__/api-voice-filler-route.test.ts
- pnpm --dir frontend exec tsx src/__tests__/error-messages.test.ts
- pnpm --dir frontend exec tsx src/__tests__/vercel-timeout-hierarchy.test.ts
- pnpm --dir frontend typecheck
- python YAML parse for .github/workflows/ci.yml
- git diff --check

Fixes #696