### PR TITLE
feat: add M5Stack device integration with ToF sensor and PIR detection

### DIFF
--- a/backend/engineercafe-device/.gitignore
+++ b/backend/engineercafe-device/.gitignore
@@ -1,0 +1,1 @@
+secrets.h

--- a/backend/engineercafe-device/README.md
+++ b/backend/engineercafe-device/README.md
@@ -1,0 +1,82 @@
+# Engineer Cafe — M5Stack Core2 センサーデバイス
+
+PIR と VL53L0X（ToF）で来訪を検知し、バックエンドの reception Webhook に POST する Arduino スケッチです。
+
+## ハードウェア
+
+| 要素 | 接続・備考 |
+|------|------------|
+| M5Stack Core2 | 本体 |
+| VL53L0X | Core2 PORT-A（I2C **SDA 32 / SCL 33**、`Wire.begin(32, 33)`） |
+| PIR（例: HC-SR501） | **GPIO 35**（`INPUT`） |
+
+## Arduino IDE での準備
+
+1. ボードマネージャで **ESP32** 系パッケージをインストールし、ボードに **M5Stack-Core2**（または同等）を選択する。
+2. ライブラリマネージャから以下をインストールする。
+   - **M5Core2**
+   - **Adafruit VL53L0X**
+
+本リポジトリではスケッチを [`engineercafe-device.ino`](engineercafe-device.ino) と同じフォルダで開いてビルドする。
+
+## シークレット（必須）
+
+1. このディレクトリでテンプレをコピーする。
+
+   ```bash
+   cp secrets.example.h secrets.h
+   ```
+
+2. `secrets.h` を編集し、`SSID` / `PASSWORD` / `WEBHOOK_URL_BACKEND` / `API_SECRET_KEY` / `DEVICE_ID` を実環境の値に置き換える。
+3. **`secrets.h` はコミットしない。** `.gitignore` で無視されていることを確認する。
+
+   ```bash
+   git check-ignore -v backend/engineercafe-device/secrets.h
+   ```
+
+4. `git ls-files backend/engineercafe-device | rg secrets` で **`secrets.h` が一覧に含まれない**ことをマージ前に確認する。
+
+## API（バックエンド契約）
+
+- **エンドポイント:** `POST {BASE_URL}/api/reception/sensor-trigger`
+  - `BASE_URL` はデプロイ先（例: Cloud Run の HTTPS オリジン）。パスは **`sensor-trigger`**（`/api/reception/sensor` ではない）。
+- **ヘッダ**
+  - `Content-Type: application/json`
+  - `Authorization: Bearer <API_SECRET_KEY>`（バックエンドの API キーと一致させる）
+- **JSON ボディ**（[`SensorTriggerRequest`](../api/reception.py) と一致）
+
+  | フィールド | 型・制約 |
+  |-----------|-----------|
+  | `sensor_type` | 文字列（最大 50）。スケッチでは `pir_tof` |
+  | `distance_mm` | 整数 ≥ 0（ToF の mm） |
+  | `device_id` | 文字列（最大 100） |
+
+成功時は HTTP 200 と `success: true` / `action: trigger_received` が返る。
+
+### レートリミットとデバイス側の扱い
+
+サーバ側では **デバイス ID ごとに 5 秒間のクールダウン**があり、短時間に続けて送ると HTTP 200 で `success: false` / `action: rate_limited` が返ることがあります。
+
+ファームウェアでは **`rate_limited` を成功扱い**にしています。理由は次のとおりです。
+
+- 直前の POST がサーバで受理済みなのに、クライアント側だけタイムアウトや切断で失敗と判定した場合などにリトライすると、`rate_limited` が返りやすい。
+- キオスク用途では「サーバが既にイベントを抑えている」状態とみなし、画面を歓迎状態へ進めてよいと判断できる。
+
+ネットワークエラーや非 200 で **`rate_limited` でも `trigger_received` でもない**応答のときは Webhook 失敗とし、歓迎画面には進みません。
+
+## フラッシュ・シリアル
+
+- USB 経由で書き込み、シリアルモニタは **115200 baud**。
+- 初回起動後、PIR の安定のため約 **30 秒**のウォームアップカウントダウンがある。
+
+## セキュリティ（TLS）
+
+現状スケッチでは **`WiFiClientSecure::setInsecure()`** を使用しており、サーバ証明書の検証を行っていません。半公開 Wi-Fi 環境では MITM のリスクがあります。**ルート CA をバンドルして `setCACert()` に渡す**対応は別 Issue / PR（HIGH-2 follow-up）として扱う想定です。
+
+## トラブルシュート
+
+| 現象 | 確認 |
+|------|------|
+| WiFi に繋がらない | `secrets.h` の SSID/パスワード、タイムアウト後は自動再起動 |
+| ToF 初期化失敗 | 配線・PORT-A、再起動ループまたはメッセージ後に再起動 |
+| Webhook NG と表示 | URL・Bearer・ネットワーク、バックエンドログ |

--- a/backend/engineercafe-device/engineercafe-device.ino
+++ b/backend/engineercafe-device/engineercafe-device.ino
@@ -338,7 +338,8 @@ void loop() {
 
   } else if (currentState == GREETING) {
     int  tofMM     = measureToF_MM();
-    bool personGone = (tofMM != 9999 && tofMM > LEAVE_THRESHOLD_MM);
+    // 9999 = VL53L0X out-of-range, treat as visitor left.
+    bool personGone = (tofMM == 9999 || tofMM > LEAVE_THRESHOLD_MM);
 
     if (personGone) {
       leaveCount++;

--- a/backend/engineercafe-device/engineercafe-device.ino
+++ b/backend/engineercafe-device/engineercafe-device.ino
@@ -4,32 +4,33 @@
 #include <WiFiClientSecure.h>
 #include <Wire.h>
 #include <Adafruit_VL53L0X.h>
+#include "secrets.h"  // SSID, PASSWORD, WEBHOOK_URL_BACKEND, API_SECRET_KEY, DEVICE_ID
 
-// ─── WiFi / API設定 ─────────────────────────────────────────
-const char* SSID        = "";
-const char* PASSWORD    = "";
-
-// ─── Webhook URL設定 ────────────────────────────────────────
-const char* WEBHOOK_URL_BACKEND   = "";
-
-const char* API_SECRET_KEY = "";
-const char* DEVICE_ID      = "";
 const char* SENSOR_TYPE    = "pir_tof";  // ← 変更
 
 // ─── ピン設定 ───────────────────────────────────────────────
 #define PIR_PIN   35
 
 // ─── ToF設定 ────────────────────────────────────────────────
+// Near-field kiosk line: trigger inside ~30cm, release hysteresis ~40cm (VL53L0X noise).
 #define TOF_TRIGGER_MM       300   // 確定閾値: 30cm
-#define CONFIRM_COUNT          3   // 連続N回でWebhook発火
+#define CONFIRM_COUNT          3   // loop ~300ms: debounce ghost triggers before firing webhook
 #define LEAVE_THRESHOLD_MM   400   // 離脱判定: 40cm以上
 #define LEAVE_CONFIRM_COUNT    3   // 離脱連続N回で確定
 
 // ─── PIR保持設定 ────────────────────────────────────────────
+// Hold PIR-high context across slow ToF sampling (~10s typical walk-by window).
 #define PIR_HOLD_MS          10000
 
 // ─── 画面更新間隔 ────────────────────────────────────────────
 #define DISPLAY_INTERVAL_MS   1000
+
+// ─── WiFi / ToF ブート ───────────────────────────────────────
+#define WIFI_CONNECT_TIMEOUT_MS 30000
+#define TOF_INIT_MAX_ATTEMPTS    5
+
+// PIR: typical HC-SR501 warm-up after power (~30–60s); kiosk fixed boot delay.
+#define PIR_WARMUP_SECONDS      30
 
 // ─── ToFインスタンス ────────────────────────────────────────
 Adafruit_VL53L0X tof;
@@ -52,7 +53,8 @@ int measureToF_MM() {
 }
 
 // ─── バックエンドへ送信 ──────────────────────────────────────
-void sendToBackend(int tofMM) {
+// HTTP 200 + success/trigger_received, or rate_limited (see README) => true.
+bool sendToBackend(int tofMM) {
   char payload[256];
   snprintf(
     payload, sizeof(payload),
@@ -76,16 +78,39 @@ void sendToBackend(int tofMM) {
     Serial.printf("[Backend] response=%s\n", responseBody.c_str());
   }
   http.end();
+
+  if (code <= 0 || code != 200) {
+    return false;
+  }
+  if (responseBody.indexOf("\"success\":true") >= 0 ||
+      responseBody.indexOf("\"success\": true") >= 0) {
+    return true;
+  }
+  if (responseBody.indexOf("trigger_received") >= 0) {
+    return true;
+  }
+  if (responseBody.indexOf("rate_limited") >= 0) {
+    return true;
+  }
+  return false;
 }
 
-// ─── 両方へ送信 ──────────────────────────────────────────────
-void sendSensorTrigger(int tofMM) {
+// ─── Webhook（本体 + 最大2回リトライ） ────────────────────────
+bool sendSensorTrigger(int tofMM) {
   if (WiFi.status() != WL_CONNECTED) {
     Serial.println("[Webhook] WiFi未接続のためスキップ");
-    return;
+    return false;
   }
 
-  sendToBackend(tofMM);
+  if (sendToBackend(tofMM)) {
+    return true;
+  }
+  delay(500);
+  if (sendToBackend(tofMM)) {
+    return true;
+  }
+  delay(1500);
+  return sendToBackend(tofMM);
 }
 
 // ─── 画面表示 ────────────────────────────────────────────────
@@ -106,6 +131,15 @@ void showStandby() {
   M5.Lcd.setTextSize(2);
   M5.Lcd.setCursor(75, 135);
   M5.Lcd.println("Engineer Cafe");
+}
+
+void showWebhookFailure() {
+  M5.Lcd.fillScreen(TFT_BLACK);
+  M5.Lcd.setTextColor(TFT_RED);
+  M5.Lcd.setTextSize(3);
+  M5.Lcd.setCursor(40, 100);
+  M5.Lcd.println("Webhook NG");
+  delay(2000);
 }
 
 void showDebug(bool pirOn, int tofMM, bool measuring) {
@@ -184,34 +218,64 @@ void setup() {
   M5.Lcd.setCursor(10, 80);
   M5.Lcd.println("Init ToF...");
 
-  if (!tof.begin(0x29, false, &Wire)) {
-    Serial.println("[ToF] 初期化失敗！");
+  bool tofOk = false;
+  for (int attempt = 1; attempt <= TOF_INIT_MAX_ATTEMPTS; attempt++) {
+    if (attempt > 1) {
+      delay(300);
+    }
+    if (tof.begin(0x29, false, &Wire)) {
+      tofOk = true;
+      break;
+    }
+    Serial.printf("[ToF] init retry %d/%d\n", attempt, TOF_INIT_MAX_ATTEMPTS);
+    delay(400);
+  }
+  if (!tofOk) {
+    Serial.println("[ToF] 初期化失敗 — 再起動");
     M5.Lcd.setTextColor(TFT_RED);
     M5.Lcd.setCursor(10, 110);
-    M5.Lcd.println("ToF INIT FAILED");
-    while (1) delay(100);
+    M5.Lcd.println("ToF FAILED");
+    M5.Lcd.setCursor(10, 135);
+    M5.Lcd.setTextSize(2);
+    M5.Lcd.println("Rebooting...");
+    delay(3000);
+    ESP.restart();
   }
   Serial.println("[ToF] 初期化完了");
 
   // WiFi接続
-  M5.Lcd.setCursor(10, 110);
+  M5.Lcd.fillScreen(TFT_BLACK);
   M5.Lcd.setTextColor(TFT_WHITE);
+  M5.Lcd.setTextSize(2);
+  M5.Lcd.setCursor(10, 80);
   M5.Lcd.println("WiFi connecting...");
   WiFi.begin(SSID, PASSWORD);
+  unsigned long wifiStarted = millis();
   while (WiFi.status() != WL_CONNECTED) {
+    if (millis() - wifiStarted > WIFI_CONNECT_TIMEOUT_MS) {
+      Serial.println("[WiFi] timeout -> restart");
+      M5.Lcd.fillScreen(TFT_BLACK);
+      M5.Lcd.setTextColor(TFT_RED);
+      M5.Lcd.setCursor(10, 90);
+      M5.Lcd.println("WiFi timeout");
+      M5.Lcd.setCursor(10, 120);
+      M5.Lcd.println("Restarting...");
+      delay(2000);
+      ESP.restart();
+    }
     delay(250);
     Serial.print(".");
   }
   Serial.printf("\n[WiFi] 接続完了: %s\n", WiFi.localIP().toString().c_str());
 
   // PIR安定待ち
-  Serial.println("[PIR] 安定待ち中... 30秒");
+  Serial.printf("[PIR] 安定待ち中... %d秒\n", PIR_WARMUP_SECONDS);
   M5.Lcd.fillScreen(TFT_BLACK);
   M5.Lcd.setTextColor(TFT_WHITE);
   M5.Lcd.setTextSize(2);
   M5.Lcd.setCursor(10, 80);
   M5.Lcd.println("PIR Warming up...");
-  for (int i = 30; i > 0; i--) {
+  for (int i = PIR_WARMUP_SECONDS; i > 0; i--) {
     M5.Lcd.fillRect(10, 110, 300, 30, TFT_BLACK);
     M5.Lcd.setCursor(10, 110);
     M5.Lcd.printf("Wait: %d sec", i);
@@ -248,12 +312,18 @@ void loop() {
         confirmCount++;
         if (confirmCount >= CONFIRM_COUNT) {
           Serial.println("[System] >>> 来訪者検知！Webhook送信 <<<");
-          showWelcome();
-          sendSensorTrigger(tofMM);
-          currentState = GREETING;
-          confirmCount = 0;
-          leaveCount   = 0;
-          Serial.println("[System] GREETING状態へ。人が離れるまでPIR無効。");
+          if (sendSensorTrigger(tofMM)) {
+            showWelcome();
+            currentState = GREETING;
+            confirmCount = 0;
+            leaveCount   = 0;
+            Serial.println("[System] GREETING状態へ。人が離れるまでPIR無効。");
+          } else {
+            Serial.println("[System] Webhook失敗のためWAITING維持");
+            confirmCount = 0;
+            showWebhookFailure();
+            lastDisplayUpdate = 0;
+          }
         }
       } else {
         confirmCount = 0;

--- a/backend/engineercafe-device/secrets.example.h
+++ b/backend/engineercafe-device/secrets.example.h
@@ -1,0 +1,7 @@
+#pragma once
+
+#define SSID "YOUR_WIFI_SSID"
+#define PASSWORD "YOUR_WIFI_PASSWORD"
+#define WEBHOOK_URL_BACKEND "https://YOUR_SERVICE.run.app/api/reception/sensor-trigger"
+#define API_SECRET_KEY "YOUR_API_SECRET_KEY"
+#define DEVICE_ID "m5stack-001"

--- a/backend/m5stack/engineercafe-device.ino
+++ b/backend/m5stack/engineercafe-device.ino
@@ -1,0 +1,296 @@
+#include <M5Core2.h>
+#include <WiFi.h>
+#include <HTTPClient.h>
+#include <WiFiClientSecure.h>
+#include <Wire.h>
+#include <Adafruit_VL53L0X.h>
+
+// ─── WiFi / API設定 ─────────────────────────────────────────
+const char* SSID        = "";
+const char* PASSWORD    = "";
+
+// ─── Webhook URL設定 ────────────────────────────────────────
+const char* WEBHOOK_URL_BACKEND   = "";
+
+const char* API_SECRET_KEY = "";
+const char* DEVICE_ID      = "";
+const char* SENSOR_TYPE    = "pir_tof";  // ← 変更
+
+// ─── ピン設定 ───────────────────────────────────────────────
+#define PIR_PIN   35
+
+// ─── ToF設定 ────────────────────────────────────────────────
+#define TOF_TRIGGER_MM       300   // 確定閾値: 30cm
+#define CONFIRM_COUNT          3   // 連続N回でWebhook発火
+#define LEAVE_THRESHOLD_MM   400   // 離脱判定: 40cm以上
+#define LEAVE_CONFIRM_COUNT    3   // 離脱連続N回で確定
+
+// ─── PIR保持設定 ────────────────────────────────────────────
+#define PIR_HOLD_MS          10000
+
+// ─── 画面更新間隔 ────────────────────────────────────────────
+#define DISPLAY_INTERVAL_MS   1000
+
+// ─── ToFインスタンス ────────────────────────────────────────
+Adafruit_VL53L0X tof;
+
+// ─── 状態管理 ───────────────────────────────────────────────
+enum State { WAITING, GREETING };
+State currentState = WAITING;
+
+int           confirmCount      = 0;
+int           leaveCount        = 0;
+unsigned long lastPirOnTime     = 0;
+unsigned long lastDisplayUpdate = 0;
+
+// ─── ToF距離測定 ─────────────────────────────────────────────
+int measureToF_MM() {
+  VL53L0X_RangingMeasurementData_t measure;
+  tof.rangingTest(&measure, false);
+  if (measure.RangeStatus == 4) return 9999;
+  return measure.RangeMilliMeter;
+}
+
+// ─── バックエンドへ送信 ──────────────────────────────────────
+void sendToBackend(int tofMM) {
+  char payload[256];
+  snprintf(
+    payload, sizeof(payload),
+    "{\"sensor_type\":\"%s\",\"distance_mm\":%d,\"device_id\":\"%s\"}",
+    SENSOR_TYPE, tofMM, DEVICE_ID
+  );
+
+  WiFiClientSecure client;
+  client.setInsecure();
+
+  HTTPClient http;
+  http.begin(client, WEBHOOK_URL_BACKEND);
+  http.setTimeout(10000);
+  http.addHeader("Content-Type", "application/json");
+  http.addHeader("Authorization", String("Bearer ") + API_SECRET_KEY);
+  int code = http.POST((uint8_t*)payload, strlen(payload));
+  String responseBody = http.getString();
+
+  Serial.printf("[Backend] HTTP %d payload=%s\n", code, payload);
+  if (responseBody.length() > 0) {
+    Serial.printf("[Backend] response=%s\n", responseBody.c_str());
+  }
+  http.end();
+}
+
+// ─── 両方へ送信 ──────────────────────────────────────────────
+void sendSensorTrigger(int tofMM) {
+  if (WiFi.status() != WL_CONNECTED) {
+    Serial.println("[Webhook] WiFi未接続のためスキップ");
+    return;
+  }
+
+  sendToBackend(tofMM);
+}
+
+// ─── 画面表示 ────────────────────────────────────────────────
+void showWelcome() {
+  M5.Lcd.fillScreen(TFT_YELLOW);
+  M5.Lcd.setTextColor(TFT_BLACK);
+  M5.Lcd.setTextSize(4);
+  M5.Lcd.setCursor(60, 100);
+  M5.Lcd.println("WELCOME!!");
+}
+
+void showStandby() {
+  M5.Lcd.fillScreen(TFT_BLACK);
+  M5.Lcd.setTextColor(TFT_DARKGREY);
+  M5.Lcd.setTextSize(3);
+  M5.Lcd.setCursor(60, 80);
+  M5.Lcd.println("Waiting...");
+  M5.Lcd.setTextSize(2);
+  M5.Lcd.setCursor(75, 135);
+  M5.Lcd.println("Engineer Cafe");
+}
+
+void showDebug(bool pirOn, int tofMM, bool measuring) {
+  M5.Lcd.fillScreen(TFT_BLACK);
+  M5.Lcd.setTextSize(2);
+
+  // PIR
+  M5.Lcd.setCursor(10, 10);
+  M5.Lcd.setTextColor(TFT_WHITE);
+  M5.Lcd.print("PIR:    ");
+  M5.Lcd.setTextColor(pirOn ? TFT_GREEN : TFT_RED);
+  M5.Lcd.println(pirOn ? "ON " : "OFF");
+
+  // ToF
+  M5.Lcd.setCursor(10, 55);
+  M5.Lcd.setTextColor(TFT_WHITE);
+  M5.Lcd.print("ToF:  ");
+  if (measuring) {
+    bool near = (tofMM != 9999 && tofMM < TOF_TRIGGER_MM);
+    M5.Lcd.setTextColor(near ? TFT_YELLOW : TFT_WHITE);
+    if (tofMM == 9999) {
+      M5.Lcd.println("--- mm");
+    } else {
+      M5.Lcd.print(tofMM);
+      M5.Lcd.println(" mm");
+    }
+  } else {
+    M5.Lcd.setTextColor(TFT_DARKGREY);
+    M5.Lcd.println("--- mm");
+  }
+
+  // 状態
+  M5.Lcd.setCursor(10, 100);
+  M5.Lcd.setTextColor(TFT_WHITE);
+  M5.Lcd.print("State: ");
+  M5.Lcd.setTextColor(currentState == GREETING ? TFT_YELLOW : TFT_GREEN);
+  M5.Lcd.println(currentState == GREETING ? "GREETING" : "WAITING ");
+
+  // 確定カウント
+  M5.Lcd.setCursor(10, 145);
+  M5.Lcd.setTextColor(TFT_WHITE);
+  M5.Lcd.print("Count: ");
+  M5.Lcd.print(currentState == WAITING ? confirmCount : leaveCount);
+  M5.Lcd.print(" / ");
+  M5.Lcd.println(currentState == WAITING ? CONFIRM_COUNT : LEAVE_CONFIRM_COUNT);
+
+  // プログレスバー
+  int total    = (currentState == WAITING) ? CONFIRM_COUNT     : LEAVE_CONFIRM_COUNT;
+  int count    = (currentState == WAITING) ? confirmCount      : leaveCount;
+  int barWidth = map(count, 0, total, 0, 300);
+  M5.Lcd.fillRect(10, 178, barWidth, 14,
+    currentState == WAITING ? TFT_GREEN : TFT_CYAN);
+  M5.Lcd.drawRect(10, 178, 300, 14, TFT_DARKGREY);
+
+  // WiFi状態
+  M5.Lcd.setTextSize(1);
+  M5.Lcd.setCursor(230, 225);
+  M5.Lcd.setTextColor(WiFi.status() == WL_CONNECTED ? TFT_GREEN : TFT_RED);
+  M5.Lcd.println(WiFi.status() == WL_CONNECTED ? "WiFi:OK" : "WiFi:NG");
+}
+
+// ─── 初期化 ─────────────────────────────────────────────────
+void setup() {
+  M5.begin(true, true, true, false);
+  M5.Lcd.setRotation(1);
+  Serial.begin(115200);
+
+  pinMode(PIR_PIN, INPUT);
+
+  // I2C + ToF初期化
+  // 変更後（Core2: PORT-A）
+  Wire.begin(32, 33);
+  M5.Lcd.fillScreen(TFT_BLACK);
+  M5.Lcd.setTextColor(TFT_WHITE);
+  M5.Lcd.setTextSize(2);
+  M5.Lcd.setCursor(10, 80);
+  M5.Lcd.println("Init ToF...");
+
+  if (!tof.begin(0x29, false, &Wire)) {
+    Serial.println("[ToF] 初期化失敗！");
+    M5.Lcd.setTextColor(TFT_RED);
+    M5.Lcd.setCursor(10, 110);
+    M5.Lcd.println("ToF INIT FAILED");
+    while (1) delay(100);
+  }
+  Serial.println("[ToF] 初期化完了");
+
+  // WiFi接続
+  M5.Lcd.setCursor(10, 110);
+  M5.Lcd.setTextColor(TFT_WHITE);
+  M5.Lcd.println("WiFi connecting...");
+  WiFi.begin(SSID, PASSWORD);
+  while (WiFi.status() != WL_CONNECTED) {
+    delay(250);
+    Serial.print(".");
+  }
+  Serial.printf("\n[WiFi] 接続完了: %s\n", WiFi.localIP().toString().c_str());
+
+  // PIR安定待ち
+  Serial.println("[PIR] 安定待ち中... 30秒");
+  M5.Lcd.fillScreen(TFT_BLACK);
+  M5.Lcd.setTextColor(TFT_WHITE);
+  M5.Lcd.setTextSize(2);
+  M5.Lcd.setCursor(10, 80);
+  M5.Lcd.println("PIR Warming up...");
+  for (int i = 30; i > 0; i--) {
+    M5.Lcd.fillRect(10, 110, 300, 30, TFT_BLACK);
+    M5.Lcd.setCursor(10, 110);
+    M5.Lcd.printf("Wait: %d sec", i);
+    delay(1000);
+  }
+
+  lastPirOnTime = 0;
+  showStandby();
+  Serial.println("[PIR] 安定完了。検知開始。");
+}
+
+// ─── メインループ ────────────────────────────────────────────
+void loop() {
+  M5.update();
+  unsigned long now = millis();
+
+  bool pirRaw = digitalRead(PIR_PIN) == HIGH;
+  if (pirRaw) lastPirOnTime = now;
+
+  if (currentState == WAITING) {
+    bool pirDetected = (lastPirOnTime > 0) &&
+                       ((now - lastPirOnTime) < PIR_HOLD_MS);
+
+    if (pirDetected) {
+      int tofMM = measureToF_MM();
+      Serial.printf("[Sensor] PIR=ON ToF=%dmm count=%d\n", tofMM, confirmCount);
+
+      if (now - lastDisplayUpdate >= DISPLAY_INTERVAL_MS) {
+        showDebug(true, tofMM, true);
+        lastDisplayUpdate = now;
+      }
+
+      if (tofMM != 9999 && tofMM < TOF_TRIGGER_MM) {
+        confirmCount++;
+        if (confirmCount >= CONFIRM_COUNT) {
+          Serial.println("[System] >>> 来訪者検知！Webhook送信 <<<");
+          showWelcome();
+          sendSensorTrigger(tofMM);
+          currentState = GREETING;
+          confirmCount = 0;
+          leaveCount   = 0;
+          Serial.println("[System] GREETING状態へ。人が離れるまでPIR無効。");
+        }
+      } else {
+        confirmCount = 0;
+      }
+    } else {
+      confirmCount = 0;
+      if (now - lastDisplayUpdate >= DISPLAY_INTERVAL_MS) {
+        showDebug(false, 0, false);
+        lastDisplayUpdate = now;
+      }
+    }
+
+  } else if (currentState == GREETING) {
+    int  tofMM     = measureToF_MM();
+    bool personGone = (tofMM != 9999 && tofMM > LEAVE_THRESHOLD_MM);
+
+    if (personGone) {
+      leaveCount++;
+      Serial.printf("[System] 離脱確認中... %d / %d (ToF=%dmm)\n",
+        leaveCount, LEAVE_CONFIRM_COUNT, tofMM);
+    } else {
+      leaveCount = 0;
+    }
+
+    if (leaveCount >= LEAVE_CONFIRM_COUNT) {
+      currentState  = WAITING;
+      leaveCount    = 0;
+      lastPirOnTime = 0;
+      showStandby();
+      Serial.println("[System] 人が離れた。WAITING状態へ戻る。");
+    }
+
+    if (now - lastDisplayUpdate >= DISPLAY_INTERVAL_MS) {
+      showDebug(false, tofMM, true);
+      lastDisplayUpdate = now;
+    }
+  }
+
+  delay(300);
+}


### PR DESCRIPTION
# feat(m5stack): M5Stack 来訪センサー用スケッチ（PIR + ToF）を追加

## 概要

M5Stack Core2 と PIR・VL53L0X（ToF）による来訪検知スケッチを `backend/m5stack/` に追加する。検知確定時にバックエンドの reception センサー Webhook へ JSON を POST する。WiFi 認証情報・Webhook URL・API キー・デバイス ID はリポジトリ上では空のプレースホルダとし、実機ビルド時にローカルで設定する。

## 変更内容

- `backend/m5stack/engineercafe-device.ino` を追加（PIR + ToF、状態機械 WAITING / GREETING）
- ToF 連続閾値超過で来訪確定 → `sensor_type` / `distance_mm` / `device_id` を含む JSON で Webhook 送信（Bearer 認証）
- 離脱判定（ToF 閾値）後に待機状態へ復帰
- 機密値はコミットに含めない（定数は空文字のまま）

## 関連 Issue

なし

<!-- Closes #123 / Fixes #123 / Resolves #123 -->

## テスト計画

- [ ] M5Stack 実機で ToF 初期化・画面表示（Waiting / Welcome・デバッグ表示）を確認
- [ ] WiFi 接続後、検知条件成立時に Webhook が送信されバックエンド側で受け付けられることを確認
- [ ] 離脱後に WAITING に戻ることを確認
- [ ] ローカルで動作確認済み
- [ ] 既存機能への影響がないことを確認済み（本変更は Arduino ファームのみのため、アプリ本体の挙動は変更なし）

## チェックリスト

- [ ] コードが目的を達成している
- [ ] 不要なコード・コメントを削除した
- [ ] 必要に応じてドキュメントを更新した（例: `backend/m5stack/` に README を追加する場合）
- [ ] `pnpm lint` が通る（フロント未変更のため CI で問題なければスキップ可）
- [ ] `pnpm typecheck` が通る（同上）

