### PR TITLE
fix: harden mobile audio playback

### DIFF
--- a/frontend/src/__tests__/mobile-audio-service.test.ts
+++ b/frontend/src/__tests__/mobile-audio-service.test.ts
@@ -1,0 +1,53 @@
+import assert from "node:assert/strict";
+import { after, test } from "node:test";
+
+import {
+  estimateAudioDataByteLength,
+  shouldUseHtmlAudioFirstForPlayback,
+} from "../lib/audio/mobile-audio-service";
+
+const originalNavigator = globalThis.navigator;
+
+const setUserAgent = (userAgent: string): void => {
+  Object.defineProperty(globalThis, "navigator", {
+    configurable: true,
+    value: { userAgent },
+  });
+};
+
+after(() => {
+  Object.defineProperty(globalThis, "navigator", {
+    configurable: true,
+    value: originalNavigator,
+  });
+});
+
+test("estimateAudioDataByteLength handles raw and data URL base64", () => {
+  assert.equal(estimateAudioDataByteLength("AQIDBA=="), 4);
+  assert.equal(estimateAudioDataByteLength("data:audio/wav;base64,AQIDBA=="), 4);
+  assert.equal(estimateAudioDataByteLength(""), 0);
+});
+
+test("estimateAudioDataByteLength handles Blob and ArrayBuffer inputs", () => {
+  assert.equal(estimateAudioDataByteLength(new Blob([new Uint8Array(7)])), 7);
+  assert.equal(estimateAudioDataByteLength(new ArrayBuffer(9)), 9);
+});
+
+test("Android large audio uses HTML audio before Web Audio decode", () => {
+  setUserAgent("Mozilla/5.0 (Linux; Android 14; Pixel 8) AppleWebKit/537.36");
+
+  const largeBase64 = "A".repeat(1_333_340);
+  assert.equal(estimateAudioDataByteLength(largeBase64), 1_000_005);
+  assert.equal(shouldUseHtmlAudioFirstForPlayback(largeBase64), true);
+});
+
+test("non-Android and small Android audio stay on Web Audio first", () => {
+  const largeBase64 = "A".repeat(1_333_340);
+  const smallBase64 = "A".repeat(400);
+
+  setUserAgent("Mozilla/5.0 (iPhone; CPU iPhone OS 17_0 like Mac OS X) AppleWebKit/605.1.15");
+  assert.equal(shouldUseHtmlAudioFirstForPlayback(largeBase64), false);
+
+  setUserAgent("Mozilla/5.0 (Linux; Android 14; Pixel 8) AppleWebKit/537.36");
+  assert.equal(shouldUseHtmlAudioFirstForPlayback(smallBase64), false);
+});

--- a/frontend/src/__tests__/web-audio-player.test.ts
+++ b/frontend/src/__tests__/web-audio-player.test.ts
@@ -1,0 +1,28 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import { WebAudioPlayer } from "../lib/audio/web-audio-player";
+
+test("WebAudioPlayer reuses the gesture-unlocked AudioContext", async () => {
+  let closeCalled = false;
+  const sharedContext = {
+    state: "running",
+    destination: {},
+    createGain: () => ({
+      connect: () => undefined,
+      gain: { value: 1 },
+    }),
+    close: () => {
+      closeCalled = true;
+      return Promise.resolve();
+    },
+  } as unknown as AudioContext;
+
+  const player = new WebAudioPlayer({}, sharedContext);
+  await player.initializeContext();
+
+  assert.equal(player.getAudioContextState(), "running");
+
+  player.dispose();
+  assert.equal(closeCalled, false);
+});

--- a/frontend/src/lib/audio/mobile-audio-service.ts
+++ b/frontend/src/lib/audio/mobile-audio-service.ts
@@ -19,8 +19,45 @@ export interface MobileAudioOptions extends MobileAudioPlayerOptions {
   retryDelay?: number;
 }
 
+const ANDROID_WEB_AUDIO_DECODE_LIMIT_BYTES = 1_000_000;
+
 // Legacy type alias for backward compatibility
 export type AudioPlaybackResult = AudioOperationResult;
+
+export function estimateAudioDataByteLength(audioData: AudioDataInput): number | null {
+  if (audioData instanceof Blob) {
+    return audioData.size;
+  }
+
+  if (audioData instanceof ArrayBuffer) {
+    return audioData.byteLength;
+  }
+
+  if (typeof audioData !== 'string') {
+    return null;
+  }
+
+  let cleanedBase64 = audioData;
+  if (cleanedBase64.includes(',')) {
+    cleanedBase64 = cleanedBase64.split(',')[1] ?? '';
+  }
+  cleanedBase64 = cleanedBase64.replace(/[^A-Za-z0-9+/=]/g, '');
+  if (!cleanedBase64) {
+    return 0;
+  }
+
+  const padding = cleanedBase64.endsWith('==') ? 2 : cleanedBase64.endsWith('=') ? 1 : 0;
+  return Math.max(0, Math.floor((cleanedBase64.length * 3) / 4) - padding);
+}
+
+export function shouldUseHtmlAudioFirstForPlayback(audioData: AudioDataInput): boolean {
+  if (!DeviceDetector.isAndroid()) {
+    return false;
+  }
+
+  const byteLength = estimateAudioDataByteLength(audioData);
+  return byteLength !== null && byteLength > ANDROID_WEB_AUDIO_DECODE_LIMIT_BYTES;
+}
 
 export class MobileAudioService {
   private static readonly PLAYBACK_START_TIMEOUT_MS = 8000;
@@ -54,13 +91,27 @@ export class MobileAudioService {
   public async playAudio(audioData: AudioDataInput): Promise<AudioOperationResult> {
     try {
       const result = await this.withPlaybackStartTimeout(async () => {
-        if (DeviceDetector.isIOS()) {
+        if (
+          this.options.preferredMethod === 'html-audio' ||
+          shouldUseHtmlAudioFirstForPlayback(audioData)
+        ) {
           const htmlAudioResult = await this.tryHtmlAudio(audioData);
           if (htmlAudioResult.success) {
             return htmlAudioResult;
           }
 
           console.warn('[MOBILE-AUDIO] HTML audio fallback failed, retrying Web Audio:', htmlAudioResult.error);
+        }
+
+        if (this.options.preferredMethod === 'html-audio') {
+          return {
+            success: false,
+            method: 'html-audio',
+            error: new AudioError(
+              AudioErrorType.PLAYBACK_FAILED,
+              'HTML audio playback failed and Web Audio fallback is disabled',
+            ),
+          };
         }
 
         return this.tryWebAudio(audioData);
@@ -100,8 +151,9 @@ export class MobileAudioService {
       
 
       // Ensure audio context is ready
+      let audioContext: AudioContext;
       try {
-        await this.interactionManager.ensureAudioContext();
+        audioContext = await this.interactionManager.ensureAudioContext();
       } catch (error) {
         // If user interaction is required, let the UI handle it
         if (error instanceof Error && error.message.includes('User interaction required')) {
@@ -118,7 +170,7 @@ export class MobileAudioService {
 
       // For tablets, always recreate the player to avoid state issues
       if (!this.webAudioPlayer) {
-        this.webAudioPlayer = new WebAudioPlayer(this.options);
+        this.webAudioPlayer = new WebAudioPlayer(this.options, audioContext);
       } else if (isTablet) {
         // Reset existing player for tablets to avoid state issues
         this.webAudioPlayer.reset();

--- a/frontend/src/lib/audio/web-audio-player.ts
+++ b/frontend/src/lib/audio/web-audio-player.ts
@@ -29,9 +29,11 @@ export class WebAudioPlayer {
   private pauseTime = 0;
   private duration = 0;
   private options: AudioPlayerOptions;
+  private readonly sharedAudioContext: AudioContext | null;
 
-  constructor(options: AudioPlayerOptions = {}) {
+  constructor(options: AudioPlayerOptions = {}, audioContext?: AudioContext | null) {
     this.options = options;
+    this.sharedAudioContext = audioContext ?? null;
   }
 
   /**
@@ -56,10 +58,14 @@ export class WebAudioPlayer {
     }
 
     try {
-      // Use webkitAudioContext for Safari compatibility
-      const AudioContextClass = window.AudioContext || (window as any).webkitAudioContext;
-      this.audioContext = new AudioContextClass();
-      registerAudioContextResumeOnInteraction(this.audioContext);
+      if (this.sharedAudioContext && this.sharedAudioContext.state !== 'closed') {
+        this.audioContext = this.sharedAudioContext;
+      } else {
+        // Use webkitAudioContext for Safari compatibility
+        const AudioContextClass = window.AudioContext || (window as any).webkitAudioContext;
+        this.audioContext = new AudioContextClass();
+        registerAudioContextResumeOnInteraction(this.audioContext);
+      }
       await this.resumeContextIfNeeded();
 
       // Create gain node for volume control
@@ -354,7 +360,11 @@ export class WebAudioPlayer {
   public dispose(): void {
     this.stop();
     
-    if (this.audioContext && this.audioContext.state !== 'closed') {
+    if (
+      this.audioContext &&
+      this.audioContext !== this.sharedAudioContext &&
+      this.audioContext.state !== 'closed'
+    ) {
       this.audioContext.close();
     }
     this.audioContext = null;


### PR DESCRIPTION
## Summary
- reuse the gesture-unlocked AudioContext for delayed Web Audio playback so iOS Safari does not create a fresh suspended context after TTS returns
- avoid closing shared gesture contexts from WebAudioPlayer.dispose
- route large Android audio payloads through HTML audio before Web Audio decode to avoid decodeAudioData hangs on >1MB responses
- add focused node tests for mobile audio payload sizing and shared context reuse

## Validation
- pnpm --dir frontend exec tsx src/__tests__/mobile-audio-service.test.ts
- pnpm --dir frontend exec tsx src/__tests__/web-audio-player.test.ts
- pnpm --dir frontend typecheck
- pnpm --dir frontend lint (passes with existing MarpViewer hook warnings)
- git diff --check

Refs #697
Refs #698