### PR TITLE
[codex] Fix iOS TTS audio unlock silent failures

### DIFF
--- a/frontend/src/app/components/VoiceInterface.tsx
+++ b/frontend/src/app/components/VoiceInterface.tsx
@@ -3,7 +3,11 @@
 import { AudioQueue } from '@/lib/audio-queue';
 import { AudioDataProcessor } from '@/lib/audio/audio-data-processor';
 import { unlockAudioForUserGesture } from '@/lib/audio/audio-interaction-manager';
-import { markAudioUserInteraction } from '@/lib/audio/audio-user-interaction-gate';
+import {
+  getTapToEnableAudioMessage,
+  isIOSWebKitAudio,
+  markAudioUserInteraction,
+} from '@/lib/audio/audio-user-interaction-gate';
 import { MobileAudioService } from '@/lib/audio/mobile-audio-service';
 import { audioStateManager } from '@/lib/audio-state-manager';
 import { cn } from '@/lib/cn';
@@ -496,9 +500,16 @@ export default function VoiceInterface({
       }
       const detectedFormat = AudioDataProcessor.detectAudioFormat(audioBytes.buffer as ArrayBuffer);
       const audioBlob = new Blob([audioBytes], { type: detectedFormat });
-      const audioUrl = URL.createObjectURL(audioBlob);
       const audioService = ensureAudioService();
 
+      if (isIOSWebKitAudio() && !audioService.isAudioContextReady()) {
+        const message = getTapToEnableAudioMessage(currentLanguage);
+        setError(message);
+        voiceController.notifySpeakingComplete(true);
+        throw new Error(message);
+      }
+
+      const audioUrl = URL.createObjectURL(audioBlob);
       revokeAudioUrl();
       audioUrlRef.current = audioUrl;
 
@@ -1386,6 +1397,7 @@ export default function VoiceInterface({
       <div className="mt-6 flex items-center justify-center gap-3">
         <button
           type="button"
+          onPointerDown={!isListening ? unlockAudioForUserGesture : undefined}
           onClick={isListening ? stopListening : startListening}
           disabled={isBusy && !isListening}
           aria-label={isListening ? '録音を停止' : '録音を開始'}
@@ -1415,6 +1427,7 @@ export default function VoiceInterface({
 
         <button
           type="button"
+          onPointerDown={unlockAudioForUserGesture}
           onClick={() => setMuted(!isMuted)}
           aria-label={isMuted ? 'ミュートを解除' : 'ミュートにする'}
           className="flex size-12 items-center justify-center rounded-full border border-slate-200 bg-white text-slate-700 shadow-sm transition-colors duration-200 hover:bg-slate-50"

--- a/frontend/src/lib/audio/audio-interaction-manager.ts
+++ b/frontend/src/lib/audio/audio-interaction-manager.ts
@@ -83,7 +83,7 @@ export class AudioInteractionManager {
    */
   private setupInteractionListeners(): void {
     registerAudioInteractionCallback(async () => {
-      this.hasUserInteracted = true;
+      this.unlockFromUserGesture();
       this.hideInteractionPrompt();
 
       try {
@@ -292,7 +292,9 @@ export class AudioInteractionManager {
    * Check if audio context is ready
    */
   public isAudioContextReady(): boolean {
-    return this.isContextInitialized && this.globalAudioManager.isContextInitialized();
+    return this.isContextInitialized &&
+      this.globalAudioManager.isContextInitialized() &&
+      this.globalAudioManager.hasPlaybackUnlock();
   }
 
   /**
@@ -332,7 +334,9 @@ export class AudioInteractionManager {
   public unlockFromUserGesture(): AudioContext {
     markAudioUserInteraction();
     this.hasUserInteracted = true;
-    return this.globalAudioManager.initializeFromUserGesture();
+    const context = this.globalAudioManager.initializeFromUserGesture();
+    this.isContextInitialized = true;
+    return context;
   }
 
   /**
@@ -412,9 +416,6 @@ export const unlockAudioForUserGesture = (): void => {
     markAudioUserInteraction();
     const manager = AudioInteractionManager.getInstance();
     manager.unlockFromUserGesture();
-    void manager.forceInitialize().catch((error) => {
-      console.warn('[AudioInteractionManager] Failed to unlock audio from user gesture:', error);
-    });
   } catch (error) {
     console.warn('[AudioInteractionManager] Failed to start audio unlock:', error);
   }

--- a/frontend/src/lib/audio/audio-user-interaction-gate.ts
+++ b/frontend/src/lib/audio/audio-user-interaction-gate.ts
@@ -101,6 +101,22 @@ export const markAudioUserInteraction = (): void => {
 
 export const hasAudioUserInteraction = (): boolean => hasUserInteracted;
 
+export const isIOSWebKitAudio = (): boolean => {
+  if (!isBrowser()) {
+    return false;
+  }
+
+  const userAgent = navigator.userAgent;
+  const vendor = navigator.vendor;
+  return /iPad|iPhone|iPod/.test(userAgent) || (/Safari/.test(userAgent) && /Apple/.test(vendor));
+};
+
+export const getTapToEnableAudioMessage = (language: string = 'ja'): string => {
+  return language === 'ja'
+    ? '音声を有効にするには、もう一度画面をタップしてください'
+    : 'Tap once more to enable audio playback';
+};
+
 export const registerAudioContextResumeOnInteraction = (audioContext: AudioContext): void => {
   registerAudioInteractionCallback(async () => {
     if (audioContext.state === 'suspended') {

--- a/frontend/src/lib/audio/web-audio-player.ts
+++ b/frontend/src/lib/audio/web-audio-player.ts
@@ -20,6 +20,7 @@ import {
 } from './audio-user-interaction-gate';
 
 export class WebAudioPlayer {
+  private ownsAudioContext = false;
   private audioContext: AudioContext | null = null;
   private audioBuffer: AudioBuffer | null = null;
   private source: AudioBufferSourceNode | null = null;
@@ -56,10 +57,17 @@ export class WebAudioPlayer {
     }
 
     try {
-      // Use webkitAudioContext for Safari compatibility
-      const AudioContextClass = window.AudioContext || (window as any).webkitAudioContext;
-      this.audioContext = new AudioContextClass();
-      registerAudioContextResumeOnInteraction(this.audioContext);
+      const globalAudioManager = GlobalAudioManager.getInstance();
+      const sharedContext = globalAudioManager.getContext();
+
+      if (sharedContext && sharedContext.state !== 'closed') {
+        this.audioContext = sharedContext;
+        this.ownsAudioContext = false;
+      } else {
+        this.audioContext = await globalAudioManager.initialize();
+        this.ownsAudioContext = false;
+      }
+
       await this.resumeContextIfNeeded();
 
       // Create gain node for volume control
@@ -354,10 +362,11 @@ export class WebAudioPlayer {
   public dispose(): void {
     this.stop();
     
-    if (this.audioContext && this.audioContext.state !== 'closed') {
+    if (this.ownsAudioContext && this.audioContext && this.audioContext.state !== 'closed') {
       this.audioContext.close();
     }
     this.audioContext = null;
+    this.ownsAudioContext = false;
     this.audioBuffer = null;
     this.gainNode = null;
     this.state = 'idle';
@@ -403,6 +412,7 @@ export class GlobalAudioManager {
   private static instance: GlobalAudioManager;
   private audioContext: AudioContext | null = null;
   private isInitialized = false;
+  private playbackUnlocked = false;
 
   private constructor() {}
 
@@ -448,6 +458,7 @@ export class GlobalAudioManager {
 
     this.playSilentWarmupBuffer(context);
     this.isInitialized = true;
+    this.playbackUnlocked = true;
 
     return context;
   }
@@ -503,11 +514,16 @@ export class GlobalAudioManager {
     return this.isInitialized && this.audioContext !== null;
   }
 
+  public hasPlaybackUnlock(): boolean {
+    return this.playbackUnlocked && this.audioContext !== null && this.audioContext.state !== 'closed';
+  }
+
   public dispose(): void {
     if (this.audioContext && this.audioContext.state !== 'closed') {
       this.audioContext.close();
     }
     this.audioContext = null;
     this.isInitialized = false;
+    this.playbackUnlocked = false;
   }
 }


### PR DESCRIPTION
## Summary
- Reuses the shared GlobalAudioManager AudioContext in WebAudioPlayer instead of creating a fresh delayed context.
- Marks playback as ready only after a gesture-time silent warmup has run.
- Primes audio on pointerdown for mic and volume controls and shows a tap-to-enable message instead of silent failure when iOS/WebKit playback is blocked.

## Root Cause
- iOS Safari transient user activation can expire before delayed TTS playback reaches AudioContext.resume(). The unlock must begin synchronously inside the user gesture.

## Validation
- pnpm typecheck
- git diff --check

## Stacking
- Android large-audio fallback PR is stacked on this branch to avoid conflicts in frontend/src/lib/audio/web-audio-player.ts.

Fixes #697