### PR TITLE
[codex] Fix P0 Cloud Run/Vercel voice timeout budget

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,6 +32,7 @@ jobs:
           filters: |
             frontend:
               - 'frontend/**'
+              - 'scripts/validate-p0-cloudrun-vercel-timeouts.mjs'
               - 'pnpm-lock.yaml'
               - '.github/workflows/ci.yml'
               - '.github/workflows/voice-e2e-nightly.yml'
@@ -94,9 +95,40 @@ jobs:
         run: pnpm typecheck
         working-directory: frontend
 
+  # Frontend/Infra: P0 timeout guard
+  frontend-timeout-guard:
+    needs: changes
+    if: needs.changes.outputs.frontend == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v2
+        with:
+          version: ${{ env.PNPM_VERSION }}
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+          cache: 'pnpm'
+          cache-dependency-path: frontend/pnpm-lock.yaml
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+        working-directory: frontend
+
+      - name: Validate Vercel timeout hierarchy
+        run: pnpm exec tsx src/__tests__/vercel-timeout-hierarchy.test.ts
+        working-directory: frontend
+
+      - name: Validate P0 Cloud Run/Vercel settings
+        run: node scripts/validate-p0-cloudrun-vercel-timeouts.mjs
+
   # Frontend: Build
   frontend-build:
-    needs: [changes, frontend-lint, frontend-typecheck]
+    needs: [changes, frontend-lint, frontend-typecheck, frontend-timeout-guard]
     if: needs.changes.outputs.frontend == 'true'
     runs-on: ubuntu-latest
     steps:
@@ -463,9 +495,10 @@ jobs:
             --memory 8Gi \
             --cpu 4 \
             --concurrency 1 \
-            --min-instances 3 \
-            --max-instances 10 \
+            --min-instances 5 \
+            --max-instances 15 \
             --cpu-boost \
+            --no-cpu-throttling \
             --update-env-vars "ENVIRONMENT=production,TTS_PROVIDER=piper,STT_PROVIDER=qwen-primary,STT_LLM_POSTPROCESS=false,QWEN_STT_TIMEOUT=45,QWEN_STT_HEDGE_DELAY_SECONDS=4,QWEN_STT_HEDGE_GRACE_SECONDS=6,STT_PRELOAD_QWEN_PRIMARY=true,HF_HOME=/app/.hf_cache,FRONTEND_PRODUCTION_ORIGIN=${FRONTEND_PRODUCTION_ORIGIN},ALLOWED_ORIGINS=${FRONTEND_PRODUCTION_ORIGIN},FAST_LLM_ENABLED=true,FAST_LLM_PRIMARY_PROVIDER=cerebras,FAST_LLM_PRIMARY_MODEL=google/gemini-3.1-flash-lite-preview,FAST_LLM_FALLBACK_PROVIDER=gemini,FAST_LLM_FALLBACK_MODEL=google/gemini-2.5-flash-lite,FAST_LLM_TERTIARY_PROVIDER=cerebras,CEREBRAS_ENABLED=true,CEREBRAS_FAST_MODEL=gpt-oss-120b,CEREBRAS_REASONING_EFFORT=low,DEEP_REASONING_MODEL=google/gemini-3.1-pro-preview,DEEP_REASONING_FALLBACK_MODEL=google/gemini-2.5-pro" \
             --update-secrets "OPENROUTER_API_KEY=OPENROUTER_API_KEY:latest,CEREBRAS_API_KEY=CEREBRAS_API_KEY:latest,SUPABASE_URL=SUPABASE_URL:latest,SUPABASE_KEY=SUPABASE_KEY:latest,SUPABASE_DB_URI=SUPABASE_DB_URI:latest,API_SECRET_KEY=API_SECRET_KEY:latest,TAVILY_API_KEY=TAVILY_API_KEY:latest"
         env:
@@ -492,6 +525,7 @@ jobs:
     needs:
       - frontend-lint
       - frontend-typecheck
+      - frontend-timeout-guard
       - frontend-build
       - frontend-playwright-e2e
       - frontend-playwright-voice-live
@@ -510,6 +544,7 @@ jobs:
           for job_result in \
             "${{ needs.frontend-lint.result }}" \
             "${{ needs.frontend-typecheck.result }}" \
+            "${{ needs.frontend-timeout-guard.result }}" \
             "${{ needs.frontend-build.result }}" \
             "${{ needs.frontend-playwright-e2e.result }}" \
             "${{ needs.frontend-playwright-voice-live.result }}" \

--- a/frontend/src/__tests__/api-proxy-contract.test.ts
+++ b/frontend/src/__tests__/api-proxy-contract.test.ts
@@ -196,3 +196,27 @@ test(
     assert.deepEqual(await response.json(), { error: 'Backend request timed out' });
   }
 );
+
+test(
+  'voice filler POST maps backend proxy timeout to a controlled 504 payload',
+  { concurrency: false },
+  async () => {
+    process.env.BACKEND_API_URL = 'https://backend.example.com';
+    (process.env as Record<string, string | undefined>).NODE_ENV = 'test';
+    global.fetch = (async () => {
+      throw new DOMException('The operation was aborted due to timeout', 'TimeoutError');
+    }) as typeof fetch;
+
+    const { POST } = await import('../app/api/voice/filler/route');
+    const response = await POST(
+      new NextRequest('https://example.com/api/voice/filler', {
+        method: 'POST',
+        body: JSON.stringify({ query: 'こんにちは', language: 'ja' }),
+        headers: { 'Content-Type': 'application/json' },
+      })
+    );
+
+    assert.equal(response.status, 504);
+    assert.deepEqual(await response.json(), { error: 'Backend request timed out' });
+  }
+);

--- a/frontend/src/__tests__/vercel-timeout-hierarchy.test.ts
+++ b/frontend/src/__tests__/vercel-timeout-hierarchy.test.ts
@@ -56,3 +56,29 @@ test('frontend API proxy timeouts stay below their Vercel maxDuration', async ()
     }
   }
 });
+
+test('voice proxy timeout covers observed Cloud Run cold starts without exceeding Vercel', async () => {
+  const config = JSON.parse(await readText('vercel.json')) as VercelConfig;
+  const proxySource = await readText('src/lib/api/backend-proxy.ts');
+  const constants = new Map(
+    Array.from(proxySource.matchAll(/export const\s+([A-Z0-9_]+)\s*=\s*([0-9][0-9_]*)/g)).map(
+      (match) => [match[1], Number(match[2].replaceAll('_', ''))] as const,
+    ),
+  );
+
+  const voiceMaxDurationMs =
+    (config.functions?.['src/app/api/voice/route.ts']?.maxDuration ?? 0) * 1000;
+  const fillerMaxDurationMs =
+    (config.functions?.['src/app/api/voice/filler/route.ts']?.maxDuration ?? 0) * 1000;
+  const proxyTimeoutMs = constants.get('BACKEND_PROXY_TIMEOUT_MS');
+  const worstObservedLatencyMs = constants.get('ISSUE_696_WORST_OBSERVED_LATENCY_MS');
+  const cloudRunTimeoutMs = constants.get('CLOUD_RUN_TIMEOUT_MS');
+
+  assert.equal(proxyTimeoutMs, 110_000);
+  assert.equal(worstObservedLatencyMs, 97_630);
+  assert.equal(cloudRunTimeoutMs, 300_000);
+  assert.ok(proxyTimeoutMs > worstObservedLatencyMs);
+  assert.ok(proxyTimeoutMs < voiceMaxDurationMs);
+  assert.ok(proxyTimeoutMs < fillerMaxDurationMs);
+  assert.ok(voiceMaxDurationMs < cloudRunTimeoutMs);
+});

--- a/frontend/src/app/api/voice/filler/route.ts
+++ b/frontend/src/app/api/voice/filler/route.ts
@@ -7,7 +7,7 @@ import {
 import { backendFetch } from '@/lib/api/backend-proxy';
 import { fillerRequestSchema } from '@/lib/schemas/voice-filler';
 
-const FILLER_PROXY_TIMEOUT_MS = 15_000;
+const FILLER_PROXY_TIMEOUT_MS = 110_000;
 
 export async function POST(request: NextRequest) {
   try {

--- a/frontend/src/app/api/voice/route.ts
+++ b/frontend/src/app/api/voice/route.ts
@@ -6,7 +6,7 @@ import {
 } from '@/app/api/_shared/backend-error-response';
 import { backendFetch } from '@/lib/api/backend-proxy';
 
-const VOICE_PROXY_TIMEOUT_MS = 55_000;
+const VOICE_PROXY_TIMEOUT_MS = 110_000;
 
 export async function POST(request: NextRequest) {
   try {

--- a/frontend/src/lib/api/backend-proxy.ts
+++ b/frontend/src/lib/api/backend-proxy.ts
@@ -6,6 +6,10 @@
  */
 
 const BACKEND_API_URL = process.env.BACKEND_API_URL;
+export const BACKEND_PROXY_TIMEOUT_MS = 110_000;
+export const VERCEL_VOICE_MAX_DURATION_MS = 120_000;
+export const CLOUD_RUN_TIMEOUT_MS = 300_000;
+export const ISSUE_696_WORST_OBSERVED_LATENCY_MS = 97_630;
 
 if (!BACKEND_API_URL) {
   console.warn(
@@ -71,9 +75,10 @@ export async function backendFetch<T = unknown>(
     mergedHeaders["X-API-Key"] = apiKey;
   }
 
-  // Keep this below the Vercel route maxDuration (60s) so proxy requests fail
-  // with a controlled backend timeout response before the platform returns 504.
-  const effectiveSignal = signal ?? AbortSignal.timeout(timeoutMs ?? 55_000);
+  // Keep the default proxy timeout below Vercel's 120s route maxDuration and
+  // above the Issue #696 observed 60-97s cold-start range. This lets the client
+  // receive a controlled error instead of a platform-level silent timeout.
+  const effectiveSignal = signal ?? AbortSignal.timeout(timeoutMs ?? BACKEND_PROXY_TIMEOUT_MS);
 
   const fetchInit: RequestInit = {
     method,
@@ -89,7 +94,7 @@ export async function backendFetch<T = unknown>(
   try {
     response = await fetch(url, fetchInit);
   } catch (error) {
-    if (timeoutMs !== undefined && signal === undefined && isAbortLikeError(error)) {
+    if (signal === undefined && isAbortLikeError(error)) {
       return {
         ok: false,
         status: BACKEND_TIMEOUT_STATUS,

--- a/frontend/vercel.json
+++ b/frontend/vercel.json
@@ -10,19 +10,19 @@
   ],
   "functions": {
     "src/app/api/voice/route.ts": {
-      "maxDuration": 60
+      "maxDuration": 120
     },
     "src/app/api/voice/filler/route.ts": {
-      "maxDuration": 60
+      "maxDuration": 120
     },
     "src/app/api/qa/route.ts": {
-      "maxDuration": 60
+      "maxDuration": 120
     },
     "src/app/api/slides/route.ts": {
-      "maxDuration": 60
+      "maxDuration": 120
     },
     "src/app/api/character/route.ts": {
-      "maxDuration": 60
+      "maxDuration": 120
     },
     "src/app/api/marp/route.ts": {
       "maxDuration": 15

--- a/scripts/validate-p0-cloudrun-vercel-timeouts.mjs
+++ b/scripts/validate-p0-cloudrun-vercel-timeouts.mjs
@@ -1,0 +1,132 @@
+#!/usr/bin/env node
+import { execFileSync } from 'node:child_process';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+const repoRoot = resolve(import.meta.dirname, '..');
+const vercelConfigPath = resolve(repoRoot, 'frontend/vercel.json');
+const proxyConfigPath = resolve(repoRoot, 'frontend/src/lib/api/backend-proxy.ts');
+const workflowPath = resolve(repoRoot, '.github/workflows/ci.yml');
+
+const expected = {
+  service: process.env.CLOUD_RUN_SERVICE || 'engineer-cafe-backend',
+  region: process.env.CLOUD_RUN_REGION || 'asia-northeast1',
+  minScale: 5,
+  maxScale: 15,
+  containerConcurrency: 1,
+  timeoutSeconds: 300,
+  startupCpuBoost: true,
+  cpuThrottling: false,
+  vercelMaxDurationSeconds: 120,
+  proxyTimeoutMs: 110_000,
+};
+
+const expectedPiperPlus = {
+  service: process.env.PIPER_PLUS_SERVICE || 'piper-plus',
+  region: process.env.PIPER_PLUS_REGION || 'asia-northeast1',
+  minScale: 2,
+  maxScale: 10,
+  containerConcurrency: 4,
+  timeoutSeconds: 300,
+  startupCpuBoost: true,
+  cpuThrottling: false,
+};
+
+function fail(message) {
+  console.error(`P0 timeout validation failed: ${message}`);
+  process.exitCode = 1;
+}
+
+const vercel = JSON.parse(readFileSync(vercelConfigPath, 'utf8'));
+for (const routePath of [
+  'src/app/api/voice/route.ts',
+  'src/app/api/voice/filler/route.ts',
+  'src/app/api/qa/route.ts',
+]) {
+  const maxDuration = vercel.functions?.[routePath]?.maxDuration;
+  if (maxDuration !== expected.vercelMaxDurationSeconds) {
+    fail(`${routePath} maxDuration must be ${expected.vercelMaxDurationSeconds}s, got ${maxDuration}`);
+  }
+}
+
+const proxySource = readFileSync(proxyConfigPath, 'utf8');
+if (!proxySource.includes('BACKEND_PROXY_TIMEOUT_MS = 110_000')) {
+  fail(`backend proxy timeout must be ${expected.proxyTimeoutMs}ms`);
+}
+
+const workflowSource = readFileSync(workflowPath, 'utf8');
+for (const requiredDeployFlag of [
+  '--min-instances 5',
+  '--max-instances 15',
+  '--cpu-boost',
+  '--no-cpu-throttling',
+]) {
+  if (!workflowSource.includes(requiredDeployFlag)) {
+    fail(`backend deploy workflow must include ${requiredDeployFlag}`);
+  }
+}
+
+if (expected.proxyTimeoutMs >= expected.vercelMaxDurationSeconds * 1000) {
+  fail('proxy timeout must stay below Vercel maxDuration');
+}
+
+if (expected.vercelMaxDurationSeconds >= expected.timeoutSeconds) {
+  fail('Vercel maxDuration must stay below Cloud Run timeoutSeconds=300');
+}
+
+function describeCloudRunService(serviceName, region) {
+  const output = execFileSync(
+    'gcloud',
+    [
+      'run',
+      'services',
+      'describe',
+      serviceName,
+      '--region',
+      region,
+      '--format=json',
+    ],
+    { encoding: 'utf8' },
+  );
+  return JSON.parse(output);
+}
+
+function validateLiveService(service, config) {
+  const annotations = service.spec?.template?.metadata?.annotations ?? {};
+  const spec = service.spec?.template?.spec ?? {};
+
+  const minScale = Number(annotations['autoscaling.knative.dev/minScale']);
+  const maxScale = Number(annotations['autoscaling.knative.dev/maxScale']);
+  const containerConcurrency = Number(spec.containerConcurrency);
+  const timeoutSeconds = Number(spec.timeoutSeconds);
+  const startupCpuBoost = annotations['run.googleapis.com/startup-cpu-boost'] === 'true';
+  const cpuThrottling = annotations['run.googleapis.com/cpu-throttling'] !== 'false';
+
+  if (minScale < config.minScale) fail(`${config.service} minScale must be >= ${config.minScale}, got ${minScale}`);
+  if (maxScale < config.maxScale) fail(`${config.service} maxScale must be >= ${config.maxScale}, got ${maxScale}`);
+  if (containerConcurrency !== config.containerConcurrency) {
+    fail(`${config.service} containerConcurrency must be ${config.containerConcurrency}, got ${containerConcurrency}`);
+  }
+  if (timeoutSeconds !== config.timeoutSeconds) {
+    fail(`${config.service} timeoutSeconds must be ${config.timeoutSeconds}, got ${timeoutSeconds}`);
+  }
+  if (startupCpuBoost !== config.startupCpuBoost) fail(`${config.service} startup CPU boost must be enabled`);
+  if (cpuThrottling !== config.cpuThrottling) fail(`${config.service} CPU throttling must be disabled`);
+}
+
+if (process.env.CHECK_LIVE_CLOUD_RUN === '1') {
+  try {
+    validateLiveService(describeCloudRunService(expected.service, expected.region), expected);
+    validateLiveService(describeCloudRunService(expectedPiperPlus.service, expectedPiperPlus.region), expectedPiperPlus);
+  } catch (error) {
+    fail(`could not describe live Cloud Run services: ${error instanceof Error ? error.message : String(error)}`);
+  }
+} else {
+  console.log('Skipping live Cloud Run describe; set CHECK_LIVE_CLOUD_RUN=1 to verify deployed service settings.');
+}
+
+if (process.exitCode) {
+  process.exit(process.exitCode);
+}
+
+console.log('P0 Vercel/Cloud Run timeout settings validated.');


### PR DESCRIPTION
## Summary
- Raises Vercel API maxDuration for voice/QA/slide/character proxy routes to 120s.
- Raises the effective `/api/voice` and `/api/voice/filler` backend proxy budget to 110s, preserving #705 controlled 504 timeout UX.
- Aligns backend deploy settings and validation with the current live Cloud Run posture: minScale=5, maxScale=15, startup CPU boost enabled, CPU throttling disabled.
- Adds CI/static/live validation for the timeout hierarchy and deploy flags.

## Evidence
- Live Cloud Run is revision engineer-cafe-backend-00160-rvf / engineer-cafe-backend-00161-fbk lineage with minScale=5, maxScale=15, containerConcurrency=1, timeoutSeconds=300, startup-cpu-boost=true, cpu-throttling=false.
- Prior logs showed `/api/voice/filler` at 67.407s and STT warmup/model load in the 34-55s range, matching #696.

## Validation
- `pnpm --dir frontend exec tsx src/__tests__/api-proxy-contract.test.ts`
- `pnpm --dir frontend exec tsx src/__tests__/vercel-timeout-hierarchy.test.ts`
- `node scripts/validate-p0-cloudrun-vercel-timeouts.mjs`
- `CHECK_LIVE_CLOUD_RUN=1 node scripts/validate-p0-cloudrun-vercel-timeouts.mjs`
- `pnpm --dir frontend typecheck`
- `git diff --check`

## Notes
- Requires Vercel plan support for 120s functions.
- Cloud Run cost increases because minScale is now 5 and CPU throttling is disabled.

Refs #696