### PR TITLE
[codex] Add Android large-audio HTML fallback

### DIFF
--- a/frontend/scripts/tests/android-audio-fallback-test.ts
+++ b/frontend/scripts/tests/android-audio-fallback-test.ts
@@ -1,0 +1,132 @@
+import assert from 'node:assert/strict';
+
+type Listener = () => void;
+
+class MockAudioElement {
+  public preload = '';
+  public volume = 1;
+  public src = '';
+  public currentTime = 0;
+  public duration = 1;
+  public paused = true;
+  public ended = false;
+  private listeners = new Map<string, Set<Listener>>();
+
+  setAttribute() {}
+  removeAttribute() {}
+  load() {}
+
+  addEventListener(event: string, listener: Listener) {
+    const listeners = this.listeners.get(event) ?? new Set<Listener>();
+    listeners.add(listener);
+    this.listeners.set(event, listeners);
+  }
+
+  removeEventListener(event: string, listener: Listener) {
+    this.listeners.get(event)?.delete(listener);
+  }
+
+  async play() {
+    this.paused = false;
+    this.listeners.get('play')?.forEach((listener) => listener());
+  }
+
+  pause() {
+    this.paused = true;
+    this.listeners.get('pause')?.forEach((listener) => listener());
+  }
+}
+
+class HangingAudioContext {
+  public state = 'running' as AudioContextState;
+  public destination = {};
+  public sampleRate = 44_100;
+  public currentTime = 0;
+
+  async resume() {}
+  async close() {
+    this.state = 'closed';
+  }
+
+  createGain() {
+    return { gain: { value: 1 }, connect() {} };
+  }
+
+  createBuffer() {
+    return {};
+  }
+
+  createBufferSource() {
+    return { buffer: null, connect() {}, start() {}, stop() {}, onended: null };
+  }
+
+  decodeAudioData() {
+    return new Promise<AudioBuffer>(() => {});
+  }
+}
+
+Object.defineProperty(globalThis, 'window', {
+  value: {
+    innerWidth: 390,
+    AudioContext: HangingAudioContext,
+    webkitAudioContext: HangingAudioContext,
+    setTimeout,
+    clearTimeout,
+  },
+  configurable: true,
+});
+Object.defineProperty(globalThis, 'document', {
+  value: {
+    addEventListener() {},
+    removeEventListener() {},
+  },
+  configurable: true,
+});
+Object.defineProperty(globalThis, 'navigator', {
+  value: {
+    userAgent: 'Mozilla/5.0 (Linux; Android 14; Pixel 8) AppleWebKit/537.36 Chrome/124 Mobile Safari/537.36',
+    vendor: 'Google Inc.',
+  },
+  configurable: true,
+});
+Object.defineProperty(globalThis, 'Audio', { value: MockAudioElement, configurable: true });
+Object.defineProperty(URL, 'createObjectURL', {
+  value: () => 'blob:mock-audio',
+  configurable: true,
+});
+Object.defineProperty(URL, 'revokeObjectURL', {
+  value: () => {},
+  configurable: true,
+});
+
+async function main() {
+  const { AudioDataProcessor } = await import('../../src/lib/audio/audio-data-processor');
+  const { MobileAudioService, DeviceDetector } = await import('../../src/lib/audio/mobile-audio-service');
+  const { WebAudioPlayer } = await import('../../src/lib/audio/web-audio-player');
+
+  const largeBase64 = 'A'.repeat(Math.ceil((AudioDataProcessor.LARGE_AUDIO_FALLBACK_THRESHOLD_BYTES + 16) / 3) * 4);
+  assert.ok(
+    AudioDataProcessor.estimateAudioDataSize(largeBase64) > AudioDataProcessor.LARGE_AUDIO_FALLBACK_THRESHOLD_BYTES,
+  );
+  assert.equal(DeviceDetector.getRecommendedAudioMethod(), 'html-audio');
+
+  let didPlay = false;
+  const service = new MobileAudioService({
+    onPlay: () => {
+      didPlay = true;
+    },
+  });
+  const result = await service.playAudio(largeBase64);
+  assert.equal(result.success, true);
+  assert.equal(result.method, 'html-audio');
+  assert.equal(didPlay, true);
+
+  const player = new WebAudioPlayer({ decodeTimeoutMs: 10 } as never);
+  const loadResult = await player.loadAudioData('UklGRiQAAABXQVZFZm10IBAAAAABAAEA');
+  assert.equal(loadResult.success, false);
+  assert.match(loadResult.error?.message ?? '', /timed out/);
+
+  console.log('Android audio fallback checks passed.');
+}
+
+void main();

--- a/frontend/src/lib/audio/audio-data-processor.ts
+++ b/frontend/src/lib/audio/audio-data-processor.ts
@@ -31,6 +31,7 @@ export interface AudioProcessingResult<T = Blob> {
 export class AudioDataProcessor {
   private static readonly CHUNK_SIZE = 8192;
   private static readonly BASE64_PATTERN = /^[A-Za-z0-9+/]*={0,2}$/;
+  static readonly LARGE_AUDIO_FALLBACK_THRESHOLD_BYTES = 1024 * 1024;
   
   /**
    * Clean and validate base64 string
@@ -242,6 +243,27 @@ export class AudioDataProcessor {
     } catch (error) {
       return false;
     }
+  }
+
+  /**
+   * Estimate audio payload size without decoding the full base64 string.
+   */
+  static estimateAudioDataSize(data: string | ArrayBuffer | Blob): number {
+    if (data instanceof Blob) {
+      return data.size;
+    }
+
+    if (data instanceof ArrayBuffer) {
+      return data.byteLength;
+    }
+
+    if (data.startsWith('blob:') || data.startsWith('http')) {
+      return 0;
+    }
+
+    const cleaned = this.cleanBase64(data);
+    const padding = cleaned.endsWith('==') ? 2 : cleaned.endsWith('=') ? 1 : 0;
+    return Math.max(0, Math.floor((cleaned.length * 3) / 4) - padding);
   }
 
   /**

--- a/frontend/src/lib/audio/audio-playback-service.ts
+++ b/frontend/src/lib/audio/audio-playback-service.ts
@@ -107,6 +107,7 @@ export class AudioPlaybackService {
       // Keep track of playback state for lip-sync
       let playbackStartTime = 0;
       let isPlaying = false;
+      let playbackMethod = 'web-audio';
 
       let lipSyncData: LipSyncData | null = null;
       const pre = options.precomputedLipSync;
@@ -185,7 +186,7 @@ export class AudioPlaybackService {
             options.onPlaybackEnd?.();
             
             // Resolve the Promise when audio playback ends
-            safeResolve({ success: true, method: 'web-audio' });
+            safeResolve({ success: true, method: playbackMethod });
           },
           onError: (error) => {
             const audioError = error instanceof AudioError
@@ -212,6 +213,7 @@ export class AudioPlaybackService {
               safeReject(audioError);
               return; // Early exit to prevent further processing
             }
+            playbackMethod = result.method || playbackMethod;
             // Don't resolve here - wait for onEnded callback
           })
           .catch((error) => {
@@ -243,10 +245,11 @@ export class AudioPlaybackService {
   ): Promise<AudioOperationResult> {
     // Create a Promise that resolves when audio playback is complete
     return new Promise<AudioOperationResult>((resolve, reject) => {
+      let playbackMethod = 'web-audio';
       const audioService = new MobileAudioService({
         volume,
         onEnded: () => {
-          resolve({ success: true, method: 'web-audio' });
+          resolve({ success: true, method: playbackMethod });
         },
         onError: (error) => {
           reject(error);
@@ -257,7 +260,9 @@ export class AudioPlaybackService {
       audioService.playAudio(audioData).then((result) => {
         if (!result.success) {
           reject(result.error!);
+          return;
         }
+        playbackMethod = result.method || playbackMethod;
         // Don't resolve here - wait for onEnded callback
       }).catch((error) => {
         const audioError = AudioError.fromError(error as Error, AudioErrorType.PLAYBACK_FAILED);

--- a/frontend/src/lib/audio/mobile-audio-service.ts
+++ b/frontend/src/lib/audio/mobile-audio-service.ts
@@ -17,6 +17,8 @@ import {
 export interface MobileAudioOptions extends MobileAudioPlayerOptions {
   retryAttempts?: number;
   retryDelay?: number;
+  largeAudioThresholdBytes?: number;
+  decodeTimeoutMs?: number;
 }
 
 // Legacy type alias for backward compatibility
@@ -36,6 +38,9 @@ export class MobileAudioService {
     this.options = {
       retryAttempts: 3,
       retryDelay: 1000,
+      enableFallback: true,
+      preferredMethod: 'auto',
+      largeAudioThresholdBytes: AudioDataProcessor.LARGE_AUDIO_FALLBACK_THRESHOLD_BYTES,
       ...options
     };
     this.interactionManager = AudioInteractionManager.getInstance();
@@ -54,19 +59,32 @@ export class MobileAudioService {
   public async playAudio(audioData: AudioDataInput): Promise<AudioOperationResult> {
     try {
       const result = await this.withPlaybackStartTimeout(async () => {
-        if (DeviceDetector.isIOS()) {
+        if (this.shouldPreferHtmlAudio(audioData)) {
           const htmlAudioResult = await this.tryHtmlAudio(audioData);
           if (htmlAudioResult.success) {
+            return htmlAudioResult;
+          }
+
+          if (this.options.preferredMethod === 'html-audio') {
             return htmlAudioResult;
           }
 
           console.warn('[MOBILE-AUDIO] HTML audio fallback failed, retrying Web Audio:', htmlAudioResult.error);
         }
 
-        return this.tryWebAudio(audioData);
+        const webAudioResult = await this.tryWebAudio(audioData);
+        if (
+          !webAudioResult.success &&
+          this.options.enableFallback !== false &&
+          this.options.preferredMethod !== 'web-audio'
+        ) {
+          return this.tryHtmlAudio(audioData);
+        }
+
+        return webAudioResult;
       });
       if (result.success) {
-        this.currentMethod = (result.method as 'web-audio' | null) ?? 'web-audio';
+        this.currentMethod = (result.method as 'web-audio' | 'html-audio' | null) ?? 'web-audio';
         return result;
       }
       
@@ -84,10 +102,42 @@ export class MobileAudioService {
       const audioError = AudioError.fromError(error as Error, AudioErrorType.PLAYBACK_FAILED);
       return {
         success: false,
-        method: 'web-audio',
+        method: this.currentMethod ?? 'web-audio',
         error: audioError
       };
     }
+  }
+
+  private getAudioSize(audioData: AudioDataInput): number {
+    try {
+      return AudioDataProcessor.estimateAudioDataSize(audioData);
+    } catch (error) {
+      console.warn('[MOBILE-AUDIO] Failed to estimate audio size:', error);
+      return 0;
+    }
+  }
+
+  private shouldPreferHtmlAudio(audioData: AudioDataInput): boolean {
+    if (this.options.preferredMethod === 'html-audio') {
+      return true;
+    }
+
+    if (this.options.preferredMethod === 'web-audio' || this.options.enableFallback === false) {
+      return false;
+    }
+
+    if (DeviceDetector.isIOS()) {
+      return true;
+    }
+
+    const audioSize = this.getAudioSize(audioData);
+    const threshold = this.options.largeAudioThresholdBytes ?? AudioDataProcessor.LARGE_AUDIO_FALLBACK_THRESHOLD_BYTES;
+    const isLargeAudio = audioSize > threshold;
+    const isUrlString =
+      typeof audioData === 'string' &&
+      (audioData.startsWith('blob:') || audioData.startsWith('http'));
+
+    return DeviceDetector.isAndroid() && DeviceDetector.isMobile() && (isLargeAudio || isUrlString);
   }
 
   /**
@@ -161,10 +211,12 @@ export class MobileAudioService {
 
   private async tryHtmlAudio(audioData: AudioDataInput): Promise<AudioOperationResult> {
     try {
-      const audioBlob = await this.toAudioBlob(audioData);
       this.cleanupHtmlAudio();
 
-      const audioUrl = URL.createObjectURL(audioBlob);
+      const shouldReuseUrl =
+        typeof audioData === 'string' &&
+        (audioData.startsWith('blob:') || audioData.startsWith('http'));
+      const audioUrl = shouldReuseUrl ? audioData : URL.createObjectURL(await this.toAudioBlob(audioData));
       const audio = new Audio(audioUrl);
       audio.preload = 'auto';
       audio.volume = this.options.volume ?? 0.8;
@@ -193,7 +245,7 @@ export class MobileAudioService {
       const onError = () => {
         const audioError = new AudioError(
           AudioErrorType.PLAYBACK_FAILED,
-          'HTML audio playback failed on iOS',
+          'HTML audio playback failed on mobile',
         );
         this.options.onError?.(audioError);
         this.cleanupHtmlAudio();
@@ -212,7 +264,7 @@ export class MobileAudioService {
       };
 
       this.htmlAudioElement = audio;
-      this.htmlAudioUrl = audioUrl;
+      this.htmlAudioUrl = shouldReuseUrl ? null : audioUrl;
 
       await audio.play();
       emitPlay();
@@ -451,9 +503,9 @@ export class DeviceDetector {
       return 'web-audio';
     }
     
-    // Android generally works well with both, prefer Web Audio for consistency
+    // Android decodeAudioData can hang on large payloads; prefer HTML Audio.
     if (this.isAndroid()) {
-      return 'web-audio';
+      return 'html-audio';
     }
 
     // Desktop - either works, Web Audio preferred for advanced features

--- a/frontend/src/lib/audio/web-audio-player.ts
+++ b/frontend/src/lib/audio/web-audio-player.ts
@@ -20,6 +20,7 @@ import {
 } from './audio-user-interaction-gate';
 
 export class WebAudioPlayer {
+  private static readonly DEFAULT_DECODE_TIMEOUT_MS = 8000;
   private ownsAudioContext = false;
   private audioContext: AudioContext | null = null;
   private audioBuffer: AudioBuffer | null = null;
@@ -44,6 +45,38 @@ export class WebAudioPlayer {
     this.options = { ...this.options, ...options };
     if (this.gainNode && options.volume !== undefined) {
       this.gainNode.gain.value = Math.max(0, Math.min(1, options.volume));
+    }
+  }
+
+  private getDecodeTimeoutMs(): number {
+    const timeout = (this.options as AudioPlayerOptions & { decodeTimeoutMs?: number }).decodeTimeoutMs;
+    return typeof timeout === 'number' && timeout > 0
+      ? timeout
+      : WebAudioPlayer.DEFAULT_DECODE_TIMEOUT_MS;
+  }
+
+  private async decodeAudioDataWithTimeout(arrayBuffer: ArrayBuffer): Promise<AudioBuffer> {
+    const timeoutMs = this.getDecodeTimeoutMs();
+    let timeoutId: ReturnType<typeof setTimeout> | null = null;
+
+    const timeoutPromise = new Promise<AudioBuffer>((_, reject) => {
+      timeoutId = setTimeout(() => {
+        reject(new AudioError(
+          AudioErrorType.DECODE_FAILED,
+          `Audio decode timed out after ${timeoutMs}ms`,
+        ));
+      }, timeoutMs);
+    });
+
+    try {
+      return await Promise.race([
+        this.audioContext!.decodeAudioData(arrayBuffer.slice(0)),
+        timeoutPromise,
+      ]);
+    } finally {
+      if (timeoutId) {
+        clearTimeout(timeoutId);
+      }
     }
   }
 
@@ -166,7 +199,7 @@ export class WebAudioPlayer {
       }
       
       try {
-        this.audioBuffer = await this.audioContext!.decodeAudioData(arrayBuffer.slice(0)); // Clone to avoid issues
+        this.audioBuffer = await this.decodeAudioDataWithTimeout(arrayBuffer);
       } catch (decodeError) {
         console.error('[WebAudioPlayer] Failed to decode audio data:', {
           error: decodeError,


### PR DESCRIPTION
## Summary
- Adds a 1MB payload threshold and size estimator so Android mobile avoids Web Audio decode for large TTS payloads.
- Adds an 8s decodeAudioData timeout to prevent silent hangs.
- Routes large Android audio and blob/http URLs through HTMLAudioElement fallback and propagates the actual playback method.
- Adds a focused tsx regression script for Android fallback and decode timeout behavior.

## Root Cause
- Android Chrome can hang inside decodeAudioData for larger base64 audio, and the Android path did not reliably prefer HTML audio fallback.

## Validation
- pnpm exec tsx scripts/tests/android-audio-fallback-test.ts
- pnpm typecheck
- git diff --check

## Stacking
- Base branch is codex/p0-ios-audio-unlock-v2. Merge #697 first, then this PR, to keep web-audio-player.ts conflict-free.

Fixes #698