### PR TITLE
docs: sync alpha status after voice timeout deploy

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,12 +6,12 @@
 
 ## 現在の要約
 
-- 2026-05-03 時点で、alpha live verification の workflow は Cloud Run SHA match 付きで targeted suite を安定実行できます。
-- Cloud Run staging は develop SHA `d789a2cd899779423947c40a3d65e19382f52d30` の revision `engineer-cafe-backend-00148-82c` で検証済みです。
+- 2026-05-03 時点で、alpha live verification の workflow は Cloud Run SHA match 付きで targeted / full suite を実行できます。
+- Cloud Run staging は develop SHA `6ce1ac81983c7ae53ddfdfc58eba1ee043a83fa8` の revision `engineer-cafe-backend-00162-mlr` で SHA 一致、`/health` OK です。
 - B routing / slide live smoke は targeted run `25254789937` で `64 passed, 0 warned, 0 failed` まで復旧しました。
 - Welcome UI, compact artifact, Cloud Run Supabase UUID/log hygiene は resolved として issue close 済みです。
-- ただし alpha はまだ **NO-GO** です。C-127 live collection completion、Q/C answer quality、live-only proof が残っています。
-- PR #692/#693/#695 は merge 済みですが、#693 後 Q rerun と #695 後 C-127 rerun が未完了です。
+- ただし alpha はまだ **NO-GO** です。最新 full suite run `25272361091` の完走結果、C-127 live collection completion、Q/C answer quality、live/device proof が残っています。
+- PR #692/#693/#695/#699/#700/#701/#702/#703/#705/#707/#709 は merge 済みです。#696/#697/#698 は実装修正済みですが、live/device proof が終わるまで open 維持です。
 
 詳細は [docs/STATUS.md](docs/STATUS.md) を参照してください。
 
@@ -43,7 +43,8 @@ Browser
 - STT / voice preflight は run `25258764528` で PASS し、#658 は close 済みです。
 - RAGAS は direct OpenAI と C-127 manifest accounting まで修正済みですが、post-#692 run `25270459825`
   は `/api/chat` 429 により `35/127` evaluated でした。PR #695 後の C-127 rerun が必要です。
-- Q suite は PR #693 merge 後の targeted rerun 待ちです。
+- Q suite は PR #693 merge 後の proof を、最新 full suite run `25272361091` で再確認中です。
+- Voice timeout / mobile audio は PR #705/#707/#709 で修正済みですが、#696/#697/#698 は live/device proof 待ちです。
 - B routing / slide live smoke と Cloud Run UUID log hygiene は 2026-05-03 時点の deployed staging で解消確認済みです。
 
 この README は現況の入口だけを扱います。監査結果と production readiness の論点は [docs/STATUS.md](docs/STATUS.md) に集約しています。
@@ -97,10 +98,10 @@ make dev
 
 2026-05-03 時点で把握した主要な alpha open items:
 
-- P0 / alpha-scope: `#583`, `#584`, `#585`, `#611`, `#612`, `#643`
-- P1 / alpha-scope: `#653`, `#670`, `#672`
+- P0 / alpha-scope: `#583`, `#584`, `#585`, `#611`, `#612`, `#643`, `#696`, `#697`
+- P1 / alpha-scope: `#653`, `#670`, `#672`, `#698`
 - Resolved in the latest remediation pass: `#658`, `#659`, `#660`, `#661`, `#662`, `#671`, `#691`, `#694`
-- Merged and awaiting live proof: PR `#693` for Q quality, PR `#695` for C-127 `/api/chat` pacing / 429 retry
+- Merged and awaiting live proof: PR `#693` for Q quality, PR `#695/#701` for C-127 pacing / coverage, PR `#699` for C source routing, PR `#700/#703` for live harness hardening, PR `#702` for log hygiene, PR `#705/#709` for voice timeout budget, PR `#707` for mobile audio playback
 
 ## 注意
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -79,11 +79,13 @@
 
 ## 2026-05-03 Alpha Remediation Snapshot
 
-PR #674, #675, #676 に加えて、#692, #693, #695 を develop に merge 済みです。
+PR #674, #675, #676 に加えて、#692, #693, #695, #699, #700, #701, #702, #703, #705, #707, #709 を develop に merge 済みです。
 #692 は C-127 accounting を修正し、run `25270459825` で `requested=127` を確認しました。
 ただし同 run は live `/api/chat` 429 により `evaluated=35`, `collection_errors=92`
 で、C-127 completion proof にはなっていません。#695 は 429 pacing / retry 修正として merge 済みで、
-post-#695 C-127 rerun 待ちです。#693 は Q suite 残 failure 修正として merge 済みで、post-deploy Q rerun 待ちです。
+post-#695/#701 C-127 proof は run `25272361091` で確認中です。#693 は Q suite 残 failure 修正として merge 済みで、
+同 run で post-deploy proof を確認中です。#705/#709 は voice timeout budget、#707 は mobile audio playback の
+実装修正として merge/deploy 済みですが、#696/#697/#698 は live/device proof まで open 維持です。
 
 Resolved:
 
@@ -95,17 +97,25 @@ Resolved:
 - #671 RAGAS direct OpenAI provider secret
 - #691 C-127 manifest accounting: PR #692
 - #694 C-127 `/api/chat` 429 collection blocker: PR #695 merged, live proof pending
+- #700 Welcome camera-flow guard
+- #702 alpha Cloud Run log-noise reduction
+- #703 STT warmup before voice live
+- #696 voice backend timeout budget: PR #705/#709 merged/deployed, live proof pending
+- #697 iOS delayed TTS playback: PR #707 merged, device proof pending
+- #698 Android large-audio playback: PR #707 merged, device proof pending
 
 Still active:
 
-- #583 C-127 completion proof: post-#695 rerun must collect/evaluate `127/127`
+- #583 C-127 completion proof: run `25272361091` must collect/evaluate `127/127`
 - #653 / #672 Q/C answer quality
 - #670 RAGAS full-run speed / telemetry closeout
+- #696 / #697 / #698 live/device proof
 - #611 / #584 / #585 live-only proof / issue-scope decisions
 
 ## 直近の次アクション
 
-- #695 後に `suites=c-127` を rerun し、`requested=127`, `evaluated=127`, `collection_errors=0` を確認する
-- #693 後に `suites=q` を rerun し、#653 の残 failure が 0 になったか確認する
+- run `25272361091` を監視し、full suite の outcome / artifact を正本として確認する
+- C-127 で `requested=127`, `evaluated=127`, `collection_errors=0` を確認する
+- Q suite で #653 の残 failure が 0 になったか確認する
 - C-127 が完走してから #672 の answer/source quality を case-level telemetry で修正する
-- #670 は post-#695 C-127 artifact で provider/model/progress と compact report が十分に残ることを確認して close 判断する
+- #670 は post-#695/#701 C-127 artifact で provider/model/progress と compact report が十分に残ることを確認して close 判断する

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -6,7 +6,7 @@ Last updated: 2026-05-03
 
 このページは、`develop` 上の現行コード、2026-04-19 の live audit、2026-04-29 の実機音声 UX 確認、
 2026-05-02 の alpha-live-verification full run / targeted C run、2026-05-03 の PR #674/#675/#676
-deploy verification、PR #692/#693/#695 merge 後の alpha issue 状態をもとに更新しています。
+deploy verification、PR #692/#693/#695/#699/#700/#701/#702/#703/#705/#707/#709 merge 後の alpha issue 状態をもとに更新しています。
 
 確認元:
 
@@ -16,6 +16,8 @@ deploy verification、PR #692/#693/#695 merge 後の alpha issue 状態をもと
 - 2026-05-02 JST の `alpha-live-verification` run `25244933308` / `25247945549`
 - 2026-05-03 JST の targeted B run `25254789937` と Cloud Run revision `engineer-cafe-backend-00148-82c`
 - 2026-05-03 JST の post-#692 C-127 run `25270459825`
+- 2026-05-03 JST の post-#709 Cloud Run deploy revision `engineer-cafe-backend-00162-mlr`
+- 2026-05-03 JST の SHA-matched full alpha-live-verification run `25272361091`
 - 現在 open の GitHub Issue
 
 Supabase については、CLI で linked project の確認まではできましたが、このセッションでは recent runtime log
@@ -29,16 +31,19 @@ Supabase については、CLI で linked project の確認まではできまし
 - PR #674/#675/#676 により、B routing / slide live smoke、Welcome UI、compact artifacts、Supabase UUID log hygiene は解消済み
 - PR #692 により C-127 manifest accounting は解消済み。run `25270459825` で `requested=127` になったが、
   live `/api/chat` 429 により `evaluated=35`, `collection_errors=92` だった
-- PR #693 は Q quality 修正、PR #695 は C-127 pacing / retry 修正として merge 済み。どちらも post-deploy live rerun 待ち
+- PR #693 は Q quality 修正、PR #695/#701 は C-127 pacing / coverage 修正、PR #699/#700/#702/#703 は C source / live harness / log hygiene hardening として merge 済み
+- PR #705/#709 は voice backend timeout / Vercel budget 修正、PR #707 は iOS/Android mobile audio 修正として merge 済み
+- 最新 full suite run `25272361091` は Cloud Run revision `engineer-cafe-backend-00162-mlr` / SHA `6ce1ac81983c7ae53ddfdfc58eba1ee043a83fa8` で実行中
 - ただし latest `suites=all` の green proof はまだなく、alpha release はまだ GO できない
 - 現在の主リスクは「未実装の基本機能」ではなく「会話 UX の基本品質、実測 latency、route 整合性、評価 gate の透明性」
 
-特に優先度が高いのは次の 4 点です。
+特に優先度が高いのは次の 5 点です。
 
-1. C-127 が live `/api/chat` 429 なしで `127/127` collect/evaluate できることの証明
-2. Q suite の残 failure が #693 後に解消されたことの証明
-3. C-127 完走後の answer/source quality 判断
-4. RAGAS full-run speed / telemetry の operational closeout
+1. 最新 full suite run `25272361091` の outcome / artifact を確認する
+2. C-127 が live `/api/chat` 429 なしで `127/127` collect/evaluate できることの証明
+3. Q suite の残 failure が #693 後に解消されたことの証明
+4. #696/#697/#698 の voice timeout / mobile playback live-device proof
+5. RAGAS full-run speed / telemetry の operational closeout
 
 現行の実装判断は [ADR 018](adr/018-alpha-fast-response-and-assistant-profile-routing.md) と
 [Alpha Remediation Plan 2026-05-02](plans/alpha-remediation-plan-2026-05-02.md) を優先する。
@@ -47,21 +52,23 @@ Supabase については、CLI で linked project の確認まではできまし
 
 最新の deployed staging / harness 状態:
 
-- develop SHA: `d789a2cd899779423947c40a3d65e19382f52d30`
-- Cloud Run revision: `engineer-cafe-backend-00148-82c`
+- develop SHA: `6ce1ac81983c7ae53ddfdfc58eba1ee043a83fa8`
+- Cloud Run revision: `engineer-cafe-backend-00162-mlr`
 - Traffic: latest revision 100%
 - Health: `/health` OK
-- develop CI: `25253946681`, success including backend-test, backend-test-ragas, backend-deploy-staging smoke
+- develop CI after PR #709: `25271932807`, success including frontend voice-live and `ci-success`
 - Targeted B run: `25254789937`
 - B result: `64 passed, 0 warned, 0 failed`
 - B1-BIZ-003: `土日祝日も利用できますか。` -> `business_info`, `1258ms`
 - Cloud Logging UUID / reception persistence errors during B run window: 0 rows
 - PR #692 merge SHA: `d74264e808e9b2a0244d3a1a9e5dfe12671530ea`
 - Post-#692 C-127 run: `25270459825`, `requested=127`, `evaluated=35`, `collection_errors=92`
-- PR #693 merge SHA: `14cb8e5b3c4f9711a77c634d3db80f8bf4f80efd`; Q rerun pending
-- PR #695 merge SHA: `ed25199e4c7104ac0f6e2f027c4fdadd72280182`; post-#695 C-127 rerun pending
+- PR #693 merge SHA: `14cb8e5b3c4f9711a77c634d3db80f8bf4f80efd`
+- PR #695 merge SHA: `ed25199e4c7104ac0f6e2f027c4fdadd72280182`
+- PR #699/#700/#701/#702/#703/#705/#707/#709 are all included in deployed Cloud Run SHA `6ce1ac81983c7ae53ddfdfc58eba1ee043a83fa8`
+- Full alpha-live-verification run `25272361091` is in progress with `suites=all`, `c_ragas_suite=alpha-127`, and SHA match required
 
-Resolved in PR #674/#675/#676:
+Resolved or implemented in the 2026-05-03 remediation pass:
 
 - #659: B routing / slide live smoke
 - #660: Welcome UI live scenario
@@ -70,13 +77,19 @@ Resolved in PR #674/#675/#676:
 - #671: RAGAS provider secret issue
 - #691: C-127 manifest accounting
 - #694: C-127 `/api/chat` 429 collection blocker implementation merged in PR #695; live proof pending
+- #700: Welcome camera-flow guard
+- #702: alpha Cloud Run log-noise reduction
+- #703: STT warmup before voice live
 
 Still blocking or important:
 
-- #583: C-127 completion remains P0 until post-#695 run collects/evaluates `127/127` with `collection_errors=0`.
+- #583: C-127 completion remains P0 until post-#695/#701 run collects/evaluates `127/127` with `collection_errors=0`.
+- #696: voice backend timeout / warmup UX remains P0 until post-#705/#709 live proof shows no silent fail path.
+- #697: iOS delayed TTS playback remains P0 until post-#707 iPad/iPhone Safari proof.
+- #698: Android large-audio playback remains P1 until post-#707 Android phone proof or explicit alpha demotion.
 - #653: Q quality remains P1 until post-#693 `suites=q` rerun has 0 failures.
 - #672: C answer/source quality remains P1, but current C metrics are not release-proof until C-127 collection completes.
-- #670: RAGAS telemetry is implemented, but post-#695 C-127 artifact still needs operational proof before close.
+- #670: RAGAS telemetry is implemented, but post-#695/#701 C-127 artifact still needs operational proof before close.
 
 ## 2026-05-02 Alpha Live Verification Snapshot
 

--- a/docs/plans/alpha-remediation-plan-2026-05-02.md
+++ b/docs/plans/alpha-remediation-plan-2026-05-02.md
@@ -1,7 +1,8 @@
 # Alpha Remediation Plan 2026-05-02
 
 This is the execution plan for the implementation sessions after the 2026-05-02 alpha live
-verification run. It includes the 2026-05-03 remediation status after PR #674, #675, and #676.
+verification run. It includes the 2026-05-03 remediation status through PR #709 and the
+SHA-matched full alpha-live-verification run `25272361091`.
 
 ## Current State
 
@@ -13,25 +14,41 @@ The workflow infrastructure is now complete enough to run targeted alpha gates e
 - Compact reports and failure-oriented heavy artifacts are split.
 - RAGAS provider/model/case progress telemetry is emitted.
 - B routing / slide live smoke is green on deployed staging.
+- Voice backend timeout budget is aligned across Vercel proxy, Next.js routes, and Cloud Run deploy guard.
+- iOS delayed TTS and Android large-audio playback have product-side fixes merged.
 
 The product is still **NO-GO** for alpha because there is no latest `suites=all` green proof.
 The C-127 manifest accounting defect is fixed by PR #692, but post-#692 validation exposed a
-live `/api/chat` 429 collection blocker.
+live `/api/chat` 429 collection blocker. A new SHA-matched full run is in progress.
 
 Latest deployed verification:
 
-- backend deploy SHA: `d1280aa64643aae7b22df875ee22f13cbfe294a2`
-- Cloud Run revision: `engineer-cafe-backend-00157-b6c`
+- backend deploy SHA: `6ce1ac81983c7ae53ddfdfc58eba1ee043a83fa8`
+- Cloud Run revision: `engineer-cafe-backend-00162-mlr`
 - PR #692 merge SHA: `d74264e808e9b2a0244d3a1a9e5dfe12671530ea`
 - C-127 run after #692: `25270459825`
 - C-127 result after #692: failure, `alpha-127` requested `127`, evaluated `35`, collection errors `92`
-- PR #695 merge SHA: `ed25199e4c7104ac0f6e2f027c4fdadd72280182`; post-#695 C-127 rerun pending
+- PR #695 merge SHA: `ed25199e4c7104ac0f6e2f027c4fdadd72280182`
+- PR #699/#700/#701/#702/#703 are merged for C source routing, Welcome guard, C-127 coverage, log hygiene, and STT warmup
+- PR #705/#707/#709 are merged; voice timeout / mobile audio proof remains open
+- Full alpha-live-verification run `25272361091` is in progress with `suites=all`, `c_ragas_suite=alpha-127`
 - Q targeted run before #693: `25269072919` failed with `23 PASS / 0 WARN / 2 FAIL`
-- PR #693 merge SHA: `14cb8e5b3c4f9711a77c634d3db80f8bf4f80efd`; post-#693 Q rerun pending
+- PR #693 merge SHA: `14cb8e5b3c4f9711a77c634d3db80f8bf4f80efd`; post-#693 Q proof is included in run `25272361091`
 
 ## Implementation Order
 
-### 1. #583 / #694 C-127 live collection completion
+### 1. Watch full run `25272361091`
+
+Goal: use the first post-#709 full run as the current alpha gate proof attempt.
+
+Tasks:
+
+- Confirm SHA match against Cloud Run image `6ce1ac81983c7ae53ddfdfc58eba1ee043a83fa8`.
+- Collect the compact report artifact and workflow summary.
+- If C-127 or Q still fails, split only the failing area into targeted reruns.
+- Do not close #643/#612 until this run is green or an explicit waiver/demotion is recorded.
+
+### 2. #583 / #694 C-127 live collection completion
 
 Goal: make C-127 collect and evaluate all 127 selected manifest cases through live `/api/chat`.
 
@@ -43,16 +60,16 @@ Status:
 - PR #692 fixed manifest accounting: post-#692 run `25270459825` reports `requested=127`.
 - The same run evaluated only `35/127` because live `/api/chat` returned `92` `429 Too Many Requests`
   collection errors.
-- PR #695 is merged with C-127 pacing / 429 retry and compact artifact polish, but live proof is pending.
+- PR #695 is merged with C-127 pacing / 429 retry, and PR #701 adds coverage summary polish, but live proof is pending.
 
 Tasks:
 
-- Re-run `suites=c-127` after PR #695 is deployed or explicitly pass the current deployed backend SHA
-  if the merge is harness-only.
+- Use run `25272361091` as the current C-127 proof attempt. If it fails, re-run only `suites=c-127`
+  against the deployed SHA or the next targeted fix SHA.
 - Require `suite_coverage.requested_total_cases=127`, `evaluated=127`, and `collection_errors=0`.
 - Only interpret #672 C answer/source metrics after collection completes.
 
-### 2. #653 / #672 answer quality
+### 3. #653 / #672 answer quality
 
 Goal: remove current Q/C answer-quality failures without masking real product issues.
 
@@ -66,7 +83,7 @@ Latest Q run `25269072919` improved from 3 failures to 2 failures:
 - `Q-BIZ-EN-003`: route OK, sources OK, missing expected fact `reservation`.
 - `Q-DAILY-JA-001`: route OK, answer OK, latency `2205ms`.
 - `Q-EVT-EN-001` now passes.
-- PR #693 is merged for the two remaining failures; post-deploy `suites=q` proof is pending.
+- PR #693 is merged for the two remaining failures; proof is pending in the current full run.
 
 Current C/RAGAS direct OpenAI C-127 status:
 
@@ -76,13 +93,13 @@ Current C/RAGAS direct OpenAI C-127 status:
 
 Tasks:
 
-- Re-run `q` after PR #693 and close #653 only if the Q suite has `0 FAIL`.
-- Re-run `c-127` after PR #695 and only then read the report artifacts for exact expected facts and actual answers.
+- Read Q outcome from run `25272361091` and close #653 only if the Q suite has `0 FAIL`.
+- Read C-127 outcome from run `25272361091` and only then inspect report artifacts for exact expected facts and actual answers.
 - Decide whether each failure is response generation, source retrieval, ground truth, or threshold drift.
 - Fix the smallest product-side issue first; only adjust tests when the expected answer is wrong.
 - Re-run `q` and `c`.
 
-### 3. #670 RAGAS operational closeout
+### 4. #670 RAGAS operational closeout
 
 Goal: make slow or failing C/Q gates diagnosable in GitHub Actions artifacts.
 
@@ -98,6 +115,14 @@ Tasks:
 - Close #670 only after one full C/Q operational proof.
 
 ## Completed Items
+
+### #696 / #697 / #698 voice and mobile playback implementation
+
+Status: implemented, proof pending.
+
+- PR #705/#709 align Vercel maxDuration, voice/filler proxy timeout, controlled 504 UX, and Cloud Run deploy guard.
+- PR #707 keeps the iOS gesture-unlocked AudioContext path and adds Android large-audio HTML playback fallback.
+- #696/#697/#698 remain open until live logs and target-device proof are attached.
 
 ### #658 STT long-tail latency
 

--- a/docs/testing/alpha-final-scenarios.md
+++ b/docs/testing/alpha-final-scenarios.md
@@ -48,6 +48,13 @@ Current confirmed target:
   `google_calendar` / `connpass` も許容します。緊急・受付・farewell の即時応答は source なしでも source gate 上は許容し、
   回答品質は `answer_correctness` 側で判定します。
 - GitHub step conclusion だけで suite の成否を判断しないでください。`continue-on-error` のため、summary / artifact の suite outcome を正本にします。
+- 2026-05-03 の current proof run は `25272361091` です。`suites=all`, `c_ragas_suite=alpha-127`,
+  `expected_backend_sha=6ce1ac81983c7ae53ddfdfc58eba1ee043a83fa8` で dispatch 済みです。
+- Same-day harness hardening from PR #700/#701/#702/#703 is included in the current develop baseline:
+  Welcome camera-flow guard, C-127 coverage summary, alpha Cloud Run log hygiene, and STT warmup before voice live.
+- Voice/device GO proof after #705/#707/#709 must include Cloud Run/Vercel evidence for `/api/voice`
+  and `/api/voice/filler` timeout behavior (#696), iPad/iPhone Safari delayed TTS playback (#697),
+  and Android phone >1MB audio playback without `decodeAudioData` hang (#698).
 - Harness-only workflow/script rerun では、backend deploy が意図的に変わっていない場合だけ
   `require_deployed_sha_match=true` のまま `expected_backend_sha=<Cloud Run image tag の 40-char commit SHA>` を渡します。
   `expected_backend_sha` は full SHA のみ許容されます。

--- a/docs/testing/alpha-live-verification-status-2026-05-02.md
+++ b/docs/testing/alpha-live-verification-status-2026-05-02.md
@@ -1,7 +1,7 @@
 # Alpha Live Verification Status 2026-05-02
 
 このドキュメントは、2026-05-02 JST 時点の alpha live verification 正本に、2026-05-03 JST
-の PR #674/#675/#676 remediation 結果を追記したものです。古い 2026-04-25 status は履歴として残しますが、
+の PR #674/#675/#676/#692/#693/#695/#699/#700/#701/#702/#703/#705/#707/#709 remediation 結果を追記したものです。古い 2026-04-25 status は履歴として残しますが、
 次の実装判断ではこのファイルを優先します。
 
 ## 結論
@@ -12,8 +12,24 @@
 実行経路は成立しました。一方で、alpha GO を止める blocker がまだ残っています。
 
 2026-05-03 時点で、B routing / slide live smoke、Welcome UI、artifact split、Supabase UUID
-log hygiene、Cloud Run Qwen runtime dependency、STT/voice preflight、C-127 manifest accounting は
-解消済みです。残る P0 は C-127 live collection completion と live-only proof 群です。
+log hygiene、Cloud Run Qwen runtime dependency、STT/voice preflight、C-127 manifest accounting、
+Welcome camera-flow guard、C-127 coverage summary、STT warmup before voice live、
+voice timeout budget、mobile audio fallback は実装修正済みです。残る P0 は full suite run
+`25272361091` の outcome、C-127 live collection completion、voice/device proof、live-only proof 群です。
+
+## 2026-05-03 Post-#709 Full Suite Dispatch
+
+- Run: <https://github.com/EngineerCafeJP/engineercafe-navigator/actions/runs/25272361091>
+- Suites: `all`
+- C/RAGAS suite: `alpha-127`
+- Expected backend SHA: `6ce1ac81983c7ae53ddfdfc58eba1ee043a83fa8`
+- Cloud Run revision before dispatch: `engineer-cafe-backend-00162-mlr`
+- Image:
+  `asia-northeast1-docker.pkg.dev/aipartner-426616/cloud-run-source-deploy/engineer-cafe-backend:6ce1ac81983c7ae53ddfdfc58eba1ee043a83fa8`
+- Health: `/health` OK
+- Status at doc update: in progress
+
+This run supersedes cancelled run `25271271437` as the current alpha gate proof attempt.
 
 ## 2026-05-02 Baseline Deploy / SHA Sync
 
@@ -162,12 +178,15 @@ coverage, not provider configuration.
 
 - #583: C/RAGAS gate now has `c-127`, and PR #692 fixed manifest accounting. Post-#692 run
   `25270459825` still evaluated only `35/127` because live `/api/chat` returned 92 `429` collection
-  errors. PR #695 is merged; post-#695 rerun is pending.
+  errors. PR #695/#701 are merged; full run `25272361091` is the current proof attempt.
+- #696: PR #705/#709 are merged and deployed for voice backend timeout / Vercel budget; live proof is pending.
+- #697: PR #707 is merged for iOS delayed TTS playback; iPad/iPhone Safari proof is pending.
 - #643 / #612: umbrella issues remain open until the alpha gate is green.
 - #611 / #584 / #585: fast first-response, edge/failure tolerance, and 2h kiosk soak still need final proof.
 
 ### P1
 
+- #698: PR #707 is merged for Android large-audio playback; Android phone proof is pending.
 - #672: Direct OpenAI C/RAGAS still misses answer quality targets, but the latest post-#692 C metrics
   are not release-proof because C-127 collection failed.
   - JA: `0.585`, target `0.85`
@@ -203,11 +222,12 @@ Observed impact:
 
 ## Next Implementation Order
 
-1. Post-#695 `suites=c-127`: prove `requested=127`, `evaluated=127`, `collection_errors=0`.
-2. Post-#693 `suites=q`: prove #653 has `0 FAIL`.
-3. #672: triage C answer/source quality only after C-127 collection completes.
-4. #670: verify full C/Q telemetry and runtime with the current artifact split.
-5. #611 / #584 / #585: collect or split the remaining live-only alpha proof.
+1. Watch full run `25272361091`: prove SHA match, collect artifacts, and decide GO / targeted reruns.
+2. C-127: prove `requested=127`, `evaluated=127`, `collection_errors=0`.
+3. Q: prove #653 has `0 FAIL`.
+4. #696/#697/#698: collect Cloud Run/Vercel logs and real-device proof.
+5. #672: triage C answer/source quality only after C-127 collection completes.
+6. #670: verify full C/Q telemetry and runtime with the current artifact split.
 
 ## Useful Commands
 


### PR DESCRIPTION
## Summary
- Sync README and alpha docs with PR #699/#700/#701/#702/#703/#705/#707/#709 merge/deploy state.
- Record Cloud Run revision `engineer-cafe-backend-00162-mlr`, develop SHA `6ce1ac81983c7ae53ddfdfc58eba1ee043a83fa8`, and full alpha run `25272361091` as the current proof attempt.
- Clarify that #696/#697/#698 and #672 remain open until live/device or C-127 proof is attached.

## Verification
- `git diff --check`

## Notes
- #696 and #672 were reopened separately because they were closed from implementation evidence while the documented proof gates are still pending.
