### PR TITLE
fix: gate alpha ragas on direct openai

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ Browser
 - `continue-on-error` のため、GitHub step が success に見えても suite outcome が failure の場合があります。
 - STT / voice preflight は run `25258764528` で PASS し、#658 は close 済みです。
 - RAGAS は direct OpenAI と C-127 manifest accounting まで修正済みですが、post-#692 run `25270459825`
-  は `/api/chat` 429 により `35/127` evaluated でした。PR #695 後の C-127 rerun が必要です。
+  は `/api/chat` 429 により `35/127` evaluated でした。current proof run `25272361091` の artifact 確認が必要です。
 - Q suite は PR #693 merge 後の proof を、最新 full suite run `25272361091` で再確認中です。
 - Voice timeout / mobile audio は PR #705/#707/#709 で修正済みですが、#696/#697/#698 は live/device proof 待ちです。
 - B routing / slide live smoke と Cloud Run UUID log hygiene は 2026-05-03 時点の deployed staging で解消確認済みです。

--- a/backend/evaluation/ragas_pipeline.py
+++ b/backend/evaluation/ragas_pipeline.py
@@ -117,6 +117,50 @@ _COLUMN_NAME_MAP = {
 }
 
 
+def resolve_ragas_judge_metadata() -> Dict[str, Any]:
+    """Return non-secret metadata for the RAGAS judge provider selected by env."""
+    openai_present = bool(os.environ.get("OPENAI_API_KEY"))
+    openrouter_present = bool(os.environ.get("OPENROUTER_API_KEY"))
+
+    if openai_present:
+        return {
+            "provider": "openai",
+            "provider_label": "direct OpenAI",
+            "model": OPENAI_EVAL_MODEL,
+            "embeddings_provider": "ragas_default_openai",
+            "embeddings_model": None,
+            "fallback": False,
+            "openai_key_present": True,
+            "openrouter_key_present": openrouter_present,
+            "release_gate_eligible": True,
+        }
+
+    if openrouter_present:
+        return {
+            "provider": "openrouter",
+            "provider_label": "OpenRouter fallback",
+            "model": OPENROUTER_EVAL_MODEL,
+            "embeddings_provider": "openrouter",
+            "embeddings_model": OPENROUTER_EMBEDDING_MODEL,
+            "fallback": True,
+            "openai_key_present": False,
+            "openrouter_key_present": True,
+            "release_gate_eligible": False,
+        }
+
+    return {
+        "provider": "none",
+        "provider_label": "none",
+        "model": None,
+        "embeddings_provider": None,
+        "embeddings_model": None,
+        "fallback": False,
+        "openai_key_present": False,
+        "openrouter_key_present": False,
+        "release_gate_eligible": False,
+    }
+
+
 @dataclass(frozen=True)
 class RagasResult:
     """単一ケースの RAGAS 評価結果（6メトリクス）"""

--- a/backend/evaluation/run_live_api_eval.py
+++ b/backend/evaluation/run_live_api_eval.py
@@ -473,10 +473,12 @@ async def run_live_api_evaluation(
 
     # Phase 2: Run RAGAS evaluation
     try:
-        from evaluation.ragas_pipeline import RagasEvaluator
+        from evaluation.ragas_pipeline import RagasEvaluator, resolve_ragas_judge_metadata
     except ImportError:
         sys.path.insert(0, str(Path(__file__).parent.parent))
-        from evaluation.ragas_pipeline import RagasEvaluator
+        from evaluation.ragas_pipeline import RagasEvaluator, resolve_ragas_judge_metadata
+
+    ragas_judge_metadata = resolve_ragas_judge_metadata()
 
     for lang in selected_languages:
         cases = all_eval_cases.get(lang, [])
@@ -599,10 +601,12 @@ async def run_live_api_evaluation(
     )
     comparison["suite_coverage"] = suite_coverage
     comparison["evaluation_summary"] = evaluation_summary
+    comparison["ragas_judge"] = ragas_judge_metadata
     comparison["alpha_release_gate_met"] = (
         comparison["all_targets_met"]
         and suite_coverage["release_blocking"]
         and suite_coverage["passed"]
+        and ragas_judge_metadata["release_gate_eligible"]
     )
     report_text = _format_report(
         per_language_results,
@@ -625,11 +629,13 @@ async def run_live_api_evaluation(
         "languages": selected_languages,
         "metrics": list(selected_metrics),
         "ragas_context_source": "golden_dataset",
+        "ragas_judge": ragas_judge_metadata,
         "live_source_gate_enabled": check_live_sources,
         "artifact_metadata": {
             "report_timestamp": report_file_ts,
             "json_report_filename": json_report_filename,
             "text_report_filename": text_report_filename,
+            "ragas_judge": ragas_judge_metadata,
             "expected_total_cases": config.get("expected_total_cases"),
             "manifest_language_counts": manifest_language_counts,
             "selected_language_counts": {
@@ -817,6 +823,24 @@ def _format_report(
                     f"/errors:{errors_by_language.get(lang, 0)}"
                     for lang in languages
                 ),
+                "",
+            ]
+        )
+
+    ragas_judge = comparison.get("ragas_judge", {})
+    if ragas_judge:
+        provider_gate = "PASS" if ragas_judge.get("release_gate_eligible") else "FAIL"
+        fallback = "yes" if ragas_judge.get("fallback") else "no"
+        lines.extend(
+            [
+                "RAGAS judge:",
+                f"  provider: {ragas_judge.get('provider_label', ragas_judge.get('provider'))}",
+                f"  model: {ragas_judge.get('model') or 'n/a'}",
+                "  embeddings: "
+                f"{ragas_judge.get('embeddings_provider') or 'n/a'}"
+                f"/{ragas_judge.get('embeddings_model') or 'default'}",
+                f"  fallback: {fallback}",
+                f"  release_gate_eligible: {provider_gate}",
                 "",
             ]
         )

--- a/backend/tests/evaluation/test_ragas_live_case_suites.py
+++ b/backend/tests/evaluation/test_ragas_live_case_suites.py
@@ -20,6 +20,18 @@ from backend.evaluation.run_live_api_eval import (
     run_live_api_evaluation,
 )
 
+NO_RAGAS_JUDGE_METADATA = {
+    "provider": "none",
+    "provider_label": "none",
+    "model": None,
+    "embeddings_provider": None,
+    "embeddings_model": None,
+    "fallback": False,
+    "openai_key_present": False,
+    "openrouter_key_present": False,
+    "release_gate_eligible": False,
+}
+
 
 def test_diagnostic_case_suite_preserves_29_case_manifest():
     config = _load_case_suite_config(CASE_SUITE_DIAGNOSTIC_29)
@@ -166,7 +178,10 @@ async def test_live_eval_keeps_alpha_127_manifest_count_when_api_collection_fail
     monkeypatch.setitem(
         __import__("sys").modules,
         "evaluation.ragas_pipeline",
-        SimpleNamespace(RagasEvaluator=FakeRagasEvaluator),
+        SimpleNamespace(
+            RagasEvaluator=FakeRagasEvaluator,
+            resolve_ragas_judge_metadata=lambda: NO_RAGAS_JUDGE_METADATA,
+        ),
     )
 
     result = await run_live_api_evaluation(
@@ -216,6 +231,7 @@ async def test_live_eval_keeps_alpha_127_manifest_count_when_api_collection_fail
         "report_timestamp": "alpha-live-test-c",
         "json_report_filename": "live_api_eval_alpha-live-test-c.json",
         "text_report_filename": "live_api_eval_alpha-live-test-c.txt",
+        "ragas_judge": NO_RAGAS_JUDGE_METADATA,
         "expected_total_cases": 127,
         "manifest_language_counts": {"ja": 80, "en": 23, "zh": 12, "ko": 12},
         "selected_language_counts": {"ja": 80, "en": 23, "zh": 12, "ko": 12},
@@ -227,12 +243,107 @@ async def test_live_eval_keeps_alpha_127_manifest_count_when_api_collection_fail
     assert (tmp_path / "live_api_eval_alpha-live-test-c.txt").is_file()
     assert "collection_errors: 1 (api_failed=1)" in result["report"]
     assert "Collection/evaluation summary:" in result["report"]
+    assert "RAGAS judge:" in result["report"]
+    assert "provider: none" in result["report"]
     assert "totals: requested=127 collected=126 evaluated=126" in result["report"]
     assert "ja=requested:80/collected:79/evaluated:79/errors:1" in result["report"]
     assert (
         "evaluation_complete: collected=79/80 evaluated=79/80 "
         "collection_errors=1 ragas_errors=0 [FAIL]"
     ) in result["report"]
+    assert "Alpha release gate met: NO" in result["report"]
+
+
+@pytest.mark.asyncio()
+async def test_alpha_127_release_gate_requires_direct_openai_provider(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path,
+):
+    async def fake_call_chat_api(client, *, base_url, question, language, api_key=None, **kwargs):
+        return {
+            "answer": "grounded answer",
+            "metadata": {
+                "agent": "FakeAgent",
+                "category": "test",
+                "route": "fake",
+                "sources": ["knowledge_base_cached", "google_calendar"],
+            },
+        }
+
+    class FakeRagasEvaluator:
+        is_available = True
+
+        def __init__(self, *, metrics, max_cases):
+            self.metrics = metrics
+            self.max_cases = max_cases
+
+        async def evaluate_batch(self, cases):
+            return SimpleNamespace(
+                evaluated_cases=len(cases),
+                skipped_cases=0,
+                metrics={
+                    "context_precision": 1.0,
+                    "answer_correctness": 1.0,
+                    "answer_relevancy": 1.0,
+                    "faithfulness": 1.0,
+                },
+                errors=[],
+                results=[
+                    SimpleNamespace(
+                        question=case["question"],
+                        answer_correctness=1.0,
+                        answer_relevancy=1.0,
+                        faithfulness=1.0,
+                        context_precision=1.0,
+                        error=None,
+                    )
+                    for case in cases
+                ],
+            )
+
+    openrouter_metadata = {
+        "provider": "openrouter",
+        "provider_label": "OpenRouter fallback",
+        "model": "openai/gpt-5-mini",
+        "embeddings_provider": "openrouter",
+        "embeddings_model": "openai/text-embedding-3-small",
+        "fallback": True,
+        "openai_key_present": False,
+        "openrouter_key_present": True,
+        "release_gate_eligible": False,
+    }
+
+    monkeypatch.setattr(
+        "backend.evaluation.run_live_api_eval._call_chat_api",
+        fake_call_chat_api,
+    )
+    monkeypatch.setitem(
+        __import__("sys").modules,
+        "evaluation.ragas_pipeline",
+        SimpleNamespace(
+            RagasEvaluator=FakeRagasEvaluator,
+            resolve_ragas_judge_metadata=lambda: openrouter_metadata,
+        ),
+    )
+
+    result = await run_live_api_evaluation(
+        base_url="http://example.test",
+        languages=ALL_LANGUAGES,
+        output_dir=tmp_path,
+        case_suite=CASE_SUITE_ALPHA_127,
+        metrics=("answer_correctness",),
+        report_timestamp="alpha-live-openrouter",
+    )
+
+    assert result["comparison"]["all_targets_met"] is True
+    assert result["suite_coverage"]["passed"] is True
+    assert result["comparison"]["ragas_judge"] == openrouter_metadata
+    assert result["ragas_judge"] == openrouter_metadata
+    assert result["artifact_metadata"]["ragas_judge"] == openrouter_metadata
+    assert result["comparison"]["alpha_release_gate_met"] is False
+    assert "provider: OpenRouter fallback" in result["report"]
+    assert "release_gate_eligible: FAIL" in result["report"]
+    assert "All targets met: YES" in result["report"]
     assert "Alpha release gate met: NO" in result["report"]
 
 

--- a/backend/tests/evaluation/test_ragas_pipeline.py
+++ b/backend/tests/evaluation/test_ragas_pipeline.py
@@ -18,6 +18,7 @@ from backend.evaluation.ragas_pipeline import (
     RagasReport,
     RagasResult,
     _ragas_available,
+    resolve_ragas_judge_metadata,
 )
 
 # =============================================================================
@@ -392,6 +393,44 @@ class TestResolveEvaluationLLM:
             assert rc.timeout == RAGAS_TIMEOUT
             assert rc.max_retries == RAGAS_MAX_RETRIES
             assert rc.max_workers == RAGAS_MAX_WORKERS
+
+
+class TestRagasJudgeMetadata:
+    """RAGAS judge provider artifact metadata tests."""
+
+    def test_openai_key_takes_priority_over_openrouter(self):
+        env = {"OPENAI_API_KEY": "sk-test", "OPENROUTER_API_KEY": "sk-or-test"}
+        with patch.dict("os.environ", env, clear=True):
+            metadata = resolve_ragas_judge_metadata()
+
+        assert metadata["provider"] == "openai"
+        assert metadata["provider_label"] == "direct OpenAI"
+        assert metadata["model"] == OPENAI_EVAL_MODEL
+        assert metadata["fallback"] is False
+        assert metadata["openai_key_present"] is True
+        assert metadata["openrouter_key_present"] is True
+        assert metadata["release_gate_eligible"] is True
+
+    def test_openrouter_only_is_fallback_and_not_release_gate_eligible(self):
+        with patch.dict("os.environ", {"OPENROUTER_API_KEY": "sk-or-test"}, clear=True):
+            metadata = resolve_ragas_judge_metadata()
+
+        assert metadata["provider"] == "openrouter"
+        assert metadata["provider_label"] == "OpenRouter fallback"
+        assert metadata["fallback"] is True
+        assert metadata["openai_key_present"] is False
+        assert metadata["openrouter_key_present"] is True
+        assert metadata["release_gate_eligible"] is False
+
+    def test_no_keys_records_no_provider(self):
+        with patch.dict("os.environ", {}, clear=True):
+            metadata = resolve_ragas_judge_metadata()
+
+        assert metadata["provider"] == "none"
+        assert metadata["model"] is None
+        assert metadata["openai_key_present"] is False
+        assert metadata["openrouter_key_present"] is False
+        assert metadata["release_gate_eligible"] is False
 
 
 class TestRunConfigDefaults:

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -274,7 +274,7 @@ current turn の high-confidence intent なしに route を固定してはいけ
 
 ## 推奨する実装順
 
-1. PR #695 後の `suites=c-127` rerun で #583 / #670 / #672 の判断材料を取る
+1. run `25272361091` または targeted `suites=c-127` rerun で #583 / #670 / #672 の判断材料を取る
 2. PR #693 後の `suites=q` rerun で #653 を close できるか判断する
 3. C-127 が `127/127` 完走してから C answer/source quality を直す (`#672`)
 4. RAGAS full-run telemetry / runtime を close 判断する (`#670`)

--- a/docs/adr/008-operational-verification-and-deployment-guardrails.md
+++ b/docs/adr/008-operational-verification-and-deployment-guardrails.md
@@ -89,7 +89,7 @@ Alpha live verification の運用結果を踏まえ、以下をガードレー�
 
 - `alpha-live-verification` の GO 証跡は `require_deployed_sha_match=true` を必須にする。
 - GitHub Actions の `continue-on-error` step conclusion は正本にしない。workflow summary と report artifact の suite outcome を正本にする。
-- Alpha RAGAS は direct OpenAI を必須にする。`OPENAI_API_KEY` が空で OpenRouter fallback になった run は diagnostic として扱う。
+- Alpha RAGAS は direct OpenAI を必須にする。`OPENAI_API_KEY` が空で OpenRouter fallback になった run は diagnostic として扱い、`alpha_release_gate_met=false` とする。JSON/text artifact の `ragas_judge` provider/model を GO 証跡に含める。
 - Artifact は compact failure summary と heavy trace/video を分ける。932MB 級 artifact は triage 阻害として扱う。
 - STT preflight は historical 24h risk と current revision release gate を分ける。過去 revision の outlier だけで現行 release gate を落とさない。
 

--- a/docs/testing/alpha-final-scenarios.md
+++ b/docs/testing/alpha-final-scenarios.md
@@ -8,10 +8,10 @@ Alpha 最終 Live 検証は Cloud Run live 環境で実施します。このド�
 
 Current confirmed target:
 
-- develop SHA: `fa7745b7420c0709fcff950ed3bf4c090f0dfc55`
-- Cloud Run revision: `engineer-cafe-backend-00144-q85`
-- Full run: `25244933308`
-- Direct OpenAI C/RAGAS run: `25247945549`
+- develop SHA: `6ce1ac81983c7ae53ddfdfc58eba1ee043a83fa8`
+- Cloud Run revision: `engineer-cafe-backend-00162-mlr`
+- Current full run: `25272361091`
+- Direct OpenAI C/RAGAS: required in the current full run artifact/logs
 
 ## Live Target
 
@@ -36,7 +36,7 @@ Current confirmed target:
   Report の `case_suite=alpha-127` と `suite_coverage.requested_total_cases=127` に加えて、
   `evaluated=127`, `collection_errors=0`, `api_failed_case_count=0` を確認してください。
   Post-#692 run `25270459825` は `requested=127` でしたが、`evaluated=35`, `collection_errors=92`
-  だったため GO proof ではありません。PR #695 後の C-127 rerun が必要です。
+  だったため GO proof ではありません。current proof run `25272361091` の artifact 確認が必要です。
 - C/RAGAS の 127-case artifact では `evaluation_summary` を必ず確認してください。
   `requested_total_cases=127` だけでは GO 証跡になりません。
   `collected_total_cases=127`、`evaluated_total_cases=127`、`collection_error_total=0`、
@@ -64,7 +64,7 @@ gh workflow run alpha-live-verification.yml \
   --ref develop \
   -f suites=all \
   -f require_deployed_sha_match=true \
-  -f expected_backend_sha=19623d5534c409856344215b3062900f35ff2816
+  -f expected_backend_sha=6ce1ac81983c7ae53ddfdfc58eba1ee043a83fa8
 ```
 
 ## A-1 Japanese Realistic Utterances


### PR DESCRIPTION
## Summary
- Add non-secret `ragas_judge` provider/model metadata to live C/RAGAS JSON and text artifacts.
- Make alpha-127 release gate require direct OpenAI; OpenRouter fallback remains diagnostic and sets `alpha_release_gate_met=false`.
- Update ADR/docs so the alpha GO proof explicitly includes direct OpenAI evidence.

## Verification
- `python -m pytest backend/tests/evaluation/test_ragas_pipeline.py backend/tests/evaluation/test_ragas_live_case_suites.py`
- `git diff --check`

## Issue context
This addresses the alpha-scope concern that cloud/full-suite RAGAS may silently fall back to slower OpenRouter while local runs use direct OpenAI.
