### PR TITLE
fix: harden mobile audio decode fallbacks

### DIFF
--- a/frontend/src/__tests__/lip-sync-analyzer.test.ts
+++ b/frontend/src/__tests__/lip-sync-analyzer.test.ts
@@ -1,0 +1,72 @@
+import assert from "node:assert/strict";
+import { after, test } from "node:test";
+
+import { LipSyncAnalyzer, shouldSkipLipSyncAnalysis } from "../lib/lip-sync-analyzer";
+
+const originalWindow = (globalThis as typeof globalThis & { window?: unknown }).window;
+const originalNavigator = globalThis.navigator;
+const originalConsoleError = console.error;
+
+const setUserAgent = (userAgent: string): void => {
+  Object.defineProperty(globalThis, "navigator", {
+    configurable: true,
+    value: { userAgent },
+  });
+};
+
+after(() => {
+  Object.defineProperty(globalThis, "window", {
+    configurable: true,
+    value: originalWindow,
+  });
+  Object.defineProperty(globalThis, "navigator", {
+    configurable: true,
+    value: originalNavigator,
+  });
+  console.error = originalConsoleError;
+});
+
+test("shouldSkipLipSyncAnalysis skips large Android audio only", () => {
+  setUserAgent("Mozilla/5.0 (Linux; Android 14; Pixel 8) AppleWebKit/537.36");
+  assert.equal(shouldSkipLipSyncAnalysis(new Blob([new Uint8Array(1_000_001)])), true);
+  assert.equal(shouldSkipLipSyncAnalysis(new Blob([new Uint8Array(128)])), false);
+
+  setUserAgent("Mozilla/5.0 (iPhone; CPU iPhone OS 17_0 like Mac OS X) AppleWebKit/605.1.15");
+  assert.equal(shouldSkipLipSyncAnalysis(new Blob([new Uint8Array(1_000_001)])), false);
+});
+
+test("LipSyncAnalyzer decode timeout rejects instead of hanging", async () => {
+  class HangingAudioContext {
+    public state = "running" as AudioContextState;
+
+    async resume() {}
+    async close() {
+      this.state = "closed";
+    }
+    createAnalyser() {
+      return { fftSize: 0 };
+    }
+    decodeAudioData() {
+      return new Promise<AudioBuffer>(() => {});
+    }
+  }
+
+  setUserAgent("Mozilla/5.0 (Macintosh; Intel Mac OS X 14_0) AppleWebKit/605.1.15");
+  Object.defineProperty(globalThis, "window", {
+    configurable: true,
+    value: {
+      AudioContext: HangingAudioContext,
+      webkitAudioContext: HangingAudioContext,
+    },
+  });
+
+  console.error = () => undefined;
+  const analyzer = new LipSyncAnalyzer();
+
+  await assert.rejects(
+    () => analyzer.analyzeLipSync(new Blob([new Uint8Array(32)]), 20),
+    /Lip-sync audio decode timed out/,
+  );
+
+  analyzer.dispose();
+});

--- a/frontend/src/__tests__/mobile-audio-service.test.ts
+++ b/frontend/src/__tests__/mobile-audio-service.test.ts
@@ -3,10 +3,17 @@ import { after, test } from "node:test";
 
 import {
   estimateAudioDataByteLength,
+  MobileAudioService,
   shouldUseHtmlAudioFirstForPlayback,
 } from "../lib/audio/mobile-audio-service";
+import { AudioPlaybackService } from "../lib/audio/audio-playback-service";
 
 const originalNavigator = globalThis.navigator;
+const originalWindow = (globalThis as typeof globalThis & { window?: unknown }).window;
+const originalDocument = (globalThis as typeof globalThis & { document?: unknown }).document;
+const originalAudio = (globalThis as typeof globalThis & { Audio?: unknown }).Audio;
+const originalCreateObjectURL = URL.createObjectURL;
+const originalRevokeObjectURL = URL.revokeObjectURL;
 
 const setUserAgent = (userAgent: string): void => {
   Object.defineProperty(globalThis, "navigator", {
@@ -19,6 +26,26 @@ after(() => {
   Object.defineProperty(globalThis, "navigator", {
     configurable: true,
     value: originalNavigator,
+  });
+  Object.defineProperty(globalThis, "window", {
+    configurable: true,
+    value: originalWindow,
+  });
+  Object.defineProperty(globalThis, "document", {
+    configurable: true,
+    value: originalDocument,
+  });
+  Object.defineProperty(globalThis, "Audio", {
+    configurable: true,
+    value: originalAudio,
+  });
+  Object.defineProperty(URL, "createObjectURL", {
+    configurable: true,
+    value: originalCreateObjectURL,
+  });
+  Object.defineProperty(URL, "revokeObjectURL", {
+    configurable: true,
+    value: originalRevokeObjectURL,
   });
 });
 
@@ -50,4 +77,169 @@ test("non-Android and small Android audio stay on Web Audio first", () => {
 
   setUserAgent("Mozilla/5.0 (Linux; Android 14; Pixel 8) AppleWebKit/537.36");
   assert.equal(shouldUseHtmlAudioFirstForPlayback(smallBase64), false);
+});
+
+test("blob and http audio URLs use HTML audio without creating object URLs", async () => {
+  let lastAudioUrl = "";
+  let createObjectURLCalled = false;
+
+  class MockAudioElement {
+    public preload = "";
+    public volume = 1;
+    public paused = true;
+    public ended = false;
+    private listeners = new Map<string, Set<() => void>>();
+
+    constructor(url: string) {
+      lastAudioUrl = url;
+    }
+
+    setAttribute() {}
+    removeAttribute() {}
+    load() {}
+    pause() {
+      this.paused = true;
+    }
+    addEventListener(event: string, listener: () => void) {
+      const listeners = this.listeners.get(event) ?? new Set<() => void>();
+      listeners.add(listener);
+      this.listeners.set(event, listeners);
+    }
+    removeEventListener(event: string, listener: () => void) {
+      this.listeners.get(event)?.delete(listener);
+    }
+    async play() {
+      this.paused = false;
+      this.listeners.get("play")?.forEach((listener) => listener());
+      setTimeout(() => {
+        this.ended = true;
+        this.listeners.get("ended")?.forEach((listener) => listener());
+      }, 0);
+    }
+  }
+
+  Object.defineProperty(globalThis, "window", {
+    configurable: true,
+    value: { innerWidth: 390, setTimeout, clearTimeout },
+  });
+  Object.defineProperty(globalThis, "document", {
+    configurable: true,
+    value: {
+      addEventListener() {},
+      removeEventListener() {},
+    },
+  });
+  Object.defineProperty(globalThis, "Audio", {
+    configurable: true,
+    value: MockAudioElement,
+  });
+  Object.defineProperty(URL, "createObjectURL", {
+    configurable: true,
+    value: () => {
+      createObjectURLCalled = true;
+      return "blob:created";
+    },
+  });
+  Object.defineProperty(URL, "revokeObjectURL", {
+    configurable: true,
+    value: () => {},
+  });
+
+  const service = new MobileAudioService();
+  const result = await service.playAudio("blob:existing-audio");
+
+  assert.equal(result.success, true);
+  assert.equal(result.method, "html-audio");
+  assert.equal(lastAudioUrl, "blob:existing-audio");
+  assert.equal(createObjectURLCalled, false);
+
+  const httpResult = await service.playAudio("https://example.com/audio.mp3");
+  assert.equal(httpResult.success, true);
+  assert.equal(httpResult.method, "html-audio");
+  assert.equal(lastAudioUrl, "https://example.com/audio.mp3");
+  assert.equal(createObjectURLCalled, false);
+
+  const playbackResult = await AudioPlaybackService.playAudioFast("blob:playback-audio");
+  assert.equal(playbackResult.success, true);
+  assert.equal(playbackResult.method, "html-audio");
+
+  service.dispose();
+});
+
+test("playAudioWithLipSync skips analyzer for blob audio URLs", async () => {
+  let audioContextConstructed = false;
+
+  class MockAudioElement {
+    public preload = "";
+    public volume = 1;
+    public paused = true;
+    public ended = false;
+    private listeners = new Map<string, Set<() => void>>();
+
+    constructor(public readonly url: string) {}
+
+    setAttribute() {}
+    removeAttribute() {}
+    load() {}
+    pause() {
+      this.paused = true;
+    }
+    addEventListener(event: string, listener: () => void) {
+      const listeners = this.listeners.get(event) ?? new Set<() => void>();
+      listeners.add(listener);
+      this.listeners.set(event, listeners);
+    }
+    removeEventListener(event: string, listener: () => void) {
+      this.listeners.get(event)?.delete(listener);
+    }
+    async play() {
+      this.paused = false;
+      this.listeners.get("play")?.forEach((listener) => listener());
+      setTimeout(() => {
+        this.ended = true;
+        this.listeners.get("ended")?.forEach((listener) => listener());
+      }, 0);
+    }
+  }
+
+  class AnalyzerAudioContext {
+    constructor() {
+      audioContextConstructed = true;
+    }
+    async resume() {}
+    createAnalyser() {
+      return { fftSize: 0 };
+    }
+  }
+
+  Object.defineProperty(globalThis, "window", {
+    configurable: true,
+    value: {
+      innerWidth: 390,
+      setTimeout,
+      clearTimeout,
+      AudioContext: AnalyzerAudioContext,
+      webkitAudioContext: AnalyzerAudioContext,
+    },
+  });
+  Object.defineProperty(globalThis, "document", {
+    configurable: true,
+    value: {
+      addEventListener() {},
+      removeEventListener() {},
+    },
+  });
+  Object.defineProperty(globalThis, "Audio", {
+    configurable: true,
+    value: MockAudioElement,
+  });
+
+  const result = await AudioPlaybackService.playAudioWithLipSync("blob:playback-audio", {
+    enableLipSync: true,
+    onVisemeUpdate: () => undefined,
+  });
+
+  assert.equal(result.success, true);
+  assert.equal(result.method, "html-audio");
+  assert.equal(audioContextConstructed, false);
 });

--- a/frontend/src/__tests__/web-audio-player.test.ts
+++ b/frontend/src/__tests__/web-audio-player.test.ts
@@ -26,3 +26,28 @@ test("WebAudioPlayer reuses the gesture-unlocked AudioContext", async () => {
   player.dispose();
   assert.equal(closeCalled, false);
 });
+
+test("WebAudioPlayer returns decode timeout instead of hanging", async () => {
+  const originalConsoleError = console.error;
+  const sharedContext = {
+    state: "running",
+    destination: {},
+    createGain: () => ({
+      connect: () => undefined,
+      gain: { value: 1 },
+    }),
+    decodeAudioData: () => new Promise<AudioBuffer>(() => {}),
+  } as unknown as AudioContext;
+
+  console.error = () => undefined;
+  try {
+    const player = new WebAudioPlayer({ decodeTimeoutMs: 5 }, sharedContext);
+    const result = await player.loadAudioData("UklGRiQAAABXQVZFZm10IBAAAAABAAEA");
+
+    assert.equal(result.success, false);
+    assert.equal(result.error?.type, "decode_failed");
+    assert.match(result.error?.message ?? "", /timed out/);
+  } finally {
+    console.error = originalConsoleError;
+  }
+});

--- a/frontend/src/lib/audio/audio-interfaces.ts
+++ b/frontend/src/lib/audio/audio-interfaces.ts
@@ -161,6 +161,7 @@ export interface AudioPlayerOptions {
   loop?: boolean;
   preload?: boolean;
   crossOrigin?: string;
+  decodeTimeoutMs?: number;
   
   // Event callbacks (legacy support)
   onPlay?: () => void;

--- a/frontend/src/lib/audio/audio-playback-service.ts
+++ b/frontend/src/lib/audio/audio-playback-service.ts
@@ -15,7 +15,7 @@ import {
   type AudioDataInput,
   type AudioOperationResult
 } from './audio-interfaces';
-import { MobileAudioService } from './mobile-audio-service';
+import { isAudioUrlString, MobileAudioService } from './mobile-audio-service';
 
 export interface LipSyncData {
   frames: Array<{
@@ -41,6 +41,10 @@ async function analyzeLipSyncFromAudioData(
   audioData: AudioDataInput
 ): Promise<LipSyncData | null> {
   try {
+    if (isAudioUrlString(audioData)) {
+      return null;
+    }
+
     let blob: Blob | null = null;
     if (typeof audioData === 'string') {
       const blobResult = await AudioDataProcessor.base64ToBlob(audioData);
@@ -107,6 +111,7 @@ export class AudioPlaybackService {
       // Keep track of playback state for lip-sync
       let playbackStartTime = 0;
       let isPlaying = false;
+      let playbackMethod = 'web-audio';
 
       let lipSyncData: LipSyncData | null = null;
       const pre = options.precomputedLipSync;
@@ -185,7 +190,7 @@ export class AudioPlaybackService {
             options.onPlaybackEnd?.();
             
             // Resolve the Promise when audio playback ends
-            safeResolve({ success: true, method: 'web-audio' });
+            safeResolve({ success: true, method: playbackMethod });
           },
           onError: (error) => {
             const audioError = error instanceof AudioError
@@ -212,6 +217,7 @@ export class AudioPlaybackService {
               safeReject(audioError);
               return; // Early exit to prevent further processing
             }
+            playbackMethod = result.method || playbackMethod;
             // Don't resolve here - wait for onEnded callback
           })
           .catch((error) => {
@@ -243,10 +249,11 @@ export class AudioPlaybackService {
   ): Promise<AudioOperationResult> {
     // Create a Promise that resolves when audio playback is complete
     return new Promise<AudioOperationResult>((resolve, reject) => {
+      let playbackMethod = 'web-audio';
       const audioService = new MobileAudioService({
         volume,
         onEnded: () => {
-          resolve({ success: true, method: 'web-audio' });
+          resolve({ success: true, method: playbackMethod });
         },
         onError: (error) => {
           reject(error);
@@ -257,7 +264,9 @@ export class AudioPlaybackService {
       audioService.playAudio(audioData).then((result) => {
         if (!result.success) {
           reject(result.error!);
+          return;
         }
+        playbackMethod = result.method || playbackMethod;
         // Don't resolve here - wait for onEnded callback
       }).catch((error) => {
         const audioError = AudioError.fromError(error as Error, AudioErrorType.PLAYBACK_FAILED);

--- a/frontend/src/lib/audio/mobile-audio-service.ts
+++ b/frontend/src/lib/audio/mobile-audio-service.ts
@@ -51,12 +51,25 @@ export function estimateAudioDataByteLength(audioData: AudioDataInput): number |
 }
 
 export function shouldUseHtmlAudioFirstForPlayback(audioData: AudioDataInput): boolean {
+  if (isAudioUrlString(audioData)) {
+    return true;
+  }
+
   if (!DeviceDetector.isAndroid()) {
     return false;
   }
 
   const byteLength = estimateAudioDataByteLength(audioData);
   return byteLength !== null && byteLength > ANDROID_WEB_AUDIO_DECODE_LIMIT_BYTES;
+}
+
+export function isAudioUrlString(audioData: AudioDataInput): audioData is string {
+  return (
+    typeof audioData === 'string' &&
+    (audioData.startsWith('blob:') ||
+      audioData.startsWith('http://') ||
+      audioData.startsWith('https://'))
+  );
 }
 
 export class MobileAudioService {
@@ -91,8 +104,10 @@ export class MobileAudioService {
   public async playAudio(audioData: AudioDataInput): Promise<AudioOperationResult> {
     try {
       const result = await this.withPlaybackStartTimeout(async () => {
+        const htmlAudioOnly =
+          this.options.preferredMethod === 'html-audio' || isAudioUrlString(audioData);
         if (
-          this.options.preferredMethod === 'html-audio' ||
+          htmlAudioOnly ||
           shouldUseHtmlAudioFirstForPlayback(audioData)
         ) {
           const htmlAudioResult = await this.tryHtmlAudio(audioData);
@@ -103,7 +118,7 @@ export class MobileAudioService {
           console.warn('[MOBILE-AUDIO] HTML audio fallback failed, retrying Web Audio:', htmlAudioResult.error);
         }
 
-        if (this.options.preferredMethod === 'html-audio') {
+        if (htmlAudioOnly) {
           return {
             success: false,
             method: 'html-audio',
@@ -213,10 +228,10 @@ export class MobileAudioService {
 
   private async tryHtmlAudio(audioData: AudioDataInput): Promise<AudioOperationResult> {
     try {
-      const audioBlob = await this.toAudioBlob(audioData);
       this.cleanupHtmlAudio();
 
-      const audioUrl = URL.createObjectURL(audioBlob);
+      const shouldReuseUrl = isAudioUrlString(audioData);
+      const audioUrl = shouldReuseUrl ? audioData : URL.createObjectURL(await this.toAudioBlob(audioData));
       const audio = new Audio(audioUrl);
       audio.preload = 'auto';
       audio.volume = this.options.volume ?? 0.8;
@@ -264,7 +279,7 @@ export class MobileAudioService {
       };
 
       this.htmlAudioElement = audio;
-      this.htmlAudioUrl = audioUrl;
+      this.htmlAudioUrl = shouldReuseUrl ? null : audioUrl;
 
       await audio.play();
       emitPlay();

--- a/frontend/src/lib/audio/web-audio-player.ts
+++ b/frontend/src/lib/audio/web-audio-player.ts
@@ -20,6 +20,7 @@ import {
 } from './audio-user-interaction-gate';
 
 export class WebAudioPlayer {
+  private static readonly DEFAULT_DECODE_TIMEOUT_MS = 8000;
   private audioContext: AudioContext | null = null;
   private audioBuffer: AudioBuffer | null = null;
   private source: AudioBufferSourceNode | null = null;
@@ -45,6 +46,39 @@ export class WebAudioPlayer {
     this.options = { ...this.options, ...options };
     if (this.gainNode && options.volume !== undefined) {
       this.gainNode.gain.value = Math.max(0, Math.min(1, options.volume));
+    }
+  }
+
+  private getDecodeTimeoutMs(): number {
+    return typeof this.options.decodeTimeoutMs === 'number' && this.options.decodeTimeoutMs > 0
+      ? this.options.decodeTimeoutMs
+      : WebAudioPlayer.DEFAULT_DECODE_TIMEOUT_MS;
+  }
+
+  private async decodeAudioDataWithTimeout(arrayBuffer: ArrayBuffer): Promise<AudioBuffer> {
+    const timeoutMs = this.getDecodeTimeoutMs();
+    let timeoutId: ReturnType<typeof setTimeout> | null = null;
+
+    const timeoutPromise = new Promise<AudioBuffer>((_, reject) => {
+      timeoutId = setTimeout(() => {
+        reject(
+          new AudioError(
+            AudioErrorType.DECODE_FAILED,
+            `Audio decode timed out after ${timeoutMs}ms`,
+          ),
+        );
+      }, timeoutMs);
+    });
+
+    try {
+      return await Promise.race([
+        this.audioContext!.decodeAudioData(arrayBuffer.slice(0)),
+        timeoutPromise,
+      ]);
+    } finally {
+      if (timeoutId) {
+        clearTimeout(timeoutId);
+      }
     }
   }
 
@@ -164,7 +198,7 @@ export class WebAudioPlayer {
       }
       
       try {
-        this.audioBuffer = await this.audioContext!.decodeAudioData(arrayBuffer.slice(0)); // Clone to avoid issues
+        this.audioBuffer = await this.decodeAudioDataWithTimeout(arrayBuffer);
       } catch (decodeError) {
         console.error('[WebAudioPlayer] Failed to decode audio data:', {
           error: decodeError,

--- a/frontend/src/lib/lip-sync-analyzer.ts
+++ b/frontend/src/lib/lip-sync-analyzer.ts
@@ -6,6 +6,9 @@
 
 import { lipSyncCache } from './lip-sync-cache';
 
+const DEFAULT_LIP_SYNC_DECODE_TIMEOUT_MS = 3000;
+const MOBILE_LIP_SYNC_ANALYSIS_LIMIT_BYTES = 1_000_000;
+
 export interface LipSyncFrame {
   time: number;
   volume: number;
@@ -16,6 +19,14 @@ export interface LipSyncFrame {
 export interface LipSyncData {
   frames: LipSyncFrame[];
   duration: number;
+}
+
+export function shouldSkipLipSyncAnalysis(audioBlob: Blob): boolean {
+  if (typeof navigator === 'undefined') {
+    return false;
+  }
+
+  return /Android/.test(navigator.userAgent) && audioBlob.size > MOBILE_LIP_SYNC_ANALYSIS_LIMIT_BYTES;
 }
 
 export class LipSyncAnalyzer {
@@ -55,6 +66,33 @@ export class LipSyncAnalyzer {
     }
   }
 
+  private async decodeAudioDataWithTimeout(
+    arrayBuffer: ArrayBuffer,
+    timeoutMs: number,
+  ): Promise<AudioBuffer> {
+    if (!this.audioContext) {
+      throw new Error('AudioContext is not available');
+    }
+
+    let timeoutId: ReturnType<typeof setTimeout> | null = null;
+    const timeoutPromise = new Promise<AudioBuffer>((_, reject) => {
+      timeoutId = setTimeout(() => {
+        reject(new Error(`Lip-sync audio decode timed out after ${timeoutMs}ms`));
+      }, timeoutMs);
+    });
+
+    try {
+      return await Promise.race([
+        this.audioContext.decodeAudioData(arrayBuffer.slice(0)),
+        timeoutPromise,
+      ]);
+    } finally {
+      if (timeoutId) {
+        clearTimeout(timeoutId);
+      }
+    }
+  }
+
   /**
    * Analyze audio blob and generate lip-sync data with intelligent caching and timeout protection
    */
@@ -68,6 +106,10 @@ export class LipSyncAnalyzer {
         return cachedResult;
       }
 
+      if (shouldSkipLipSyncAnalysis(audioBlob)) {
+        return { frames: [], duration: 0 };
+      }
+
       // Initialize AudioContext if needed
       await this.initializeAudioContext();
       
@@ -76,7 +118,11 @@ export class LipSyncAnalyzer {
       }
       
       const arrayBuffer = await audioBlob.arrayBuffer();
-      const audioBuffer = await this.audioContext.decodeAudioData(arrayBuffer);
+      const decodeTimeoutMs = Math.min(
+        DEFAULT_LIP_SYNC_DECODE_TIMEOUT_MS,
+        Math.max(1, Math.floor(timeoutMs / 2)),
+      );
+      const audioBuffer = await this.decodeAudioDataWithTimeout(arrayBuffer, decodeTimeoutMs);
       
       const channelData = audioBuffer.getChannelData(0);
       const sampleRate = audioBuffer.sampleRate;
@@ -136,8 +182,9 @@ export class LipSyncAnalyzer {
     };
 
     // Use Promise.race for timeout handling without async Promise executor
+    let timeoutId: ReturnType<typeof setTimeout> | null = null;
     const timeoutPromise = new Promise<never>((_, reject) => {
-      setTimeout(() => {
+      timeoutId = setTimeout(() => {
         reject(new Error(`Lip-sync analysis timed out after ${timeoutMs}ms`));
       }, timeoutMs);
     });
@@ -147,6 +194,10 @@ export class LipSyncAnalyzer {
     } catch (error) {
       console.error('Error analyzing lip-sync:', error);
       throw error;
+    } finally {
+      if (timeoutId) {
+        clearTimeout(timeoutId);
+      }
     }
   }
 


### PR DESCRIPTION
## Summary
- Add bounded Web Audio decode timeout so `decodeAudioData()` cannot hang playback indefinitely.
- Route blob/http audio URLs through HTML audio without creating extra object URLs, and report the actual playback method.
- Skip Android >1MB lip-sync decode and add a lip-sync decode timeout to protect playback from analysis hangs.

## Verification
- `node --import tsx --test src/__tests__/mobile-audio-service.test.ts src/__tests__/web-audio-player.test.ts src/__tests__/lip-sync-analyzer.test.ts` from `frontend/`
- `pnpm --dir frontend typecheck`
- `git diff --check`

## Issue context
Follow-up for #697/#698 mobile playback risk after #707. This keeps the #707 iOS shared AudioContext path and Android HTML-audio fallback intact.
