### PR TITLE
docs: mark voice timeout proof closed

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 - B routing / slide live smoke は targeted run `25254789937` で `64 passed, 0 warned, 0 failed` まで復旧しました。
 - Welcome UI, compact artifact, Cloud Run Supabase UUID/log hygiene は resolved として issue close 済みです。
 - ただし alpha はまだ **NO-GO** です。最新 full suite run `25272361091` の完走結果、C-127 live collection completion、Q/C answer quality、live/device proof が残っています。
-- PR #692/#693/#695/#699/#700/#701/#702/#703/#705/#707/#709 は merge 済みです。#696/#697/#698 は実装修正済みですが、live/device proof が終わるまで open 維持です。
+- PR #692/#693/#695/#699/#700/#701/#702/#703/#705/#707/#709 は merge 済みです。#696 は live proof 後に close 済み、#697/#698 は live/device proof が終わるまで open 維持です。
 
 詳細は [docs/STATUS.md](docs/STATUS.md) を参照してください。
 
@@ -44,7 +44,7 @@ Browser
 - RAGAS は direct OpenAI と C-127 manifest accounting まで修正済みですが、post-#692 run `25270459825`
   は `/api/chat` 429 により `35/127` evaluated でした。PR #695 後の C-127 rerun が必要です。
 - Q suite は PR #693 merge 後の proof を、最新 full suite run `25272361091` で再確認中です。
-- Voice timeout / mobile audio は PR #705/#707/#709 で修正済みですが、#696/#697/#698 は live/device proof 待ちです。
+- Voice timeout / mobile audio は PR #705/#707/#709 で修正済みです。#696 は close 済み、#697/#698 は live/device proof 待ちです。
 - B routing / slide live smoke と Cloud Run UUID log hygiene は 2026-05-03 時点の deployed staging で解消確認済みです。
 
 この README は現況の入口だけを扱います。監査結果と production readiness の論点は [docs/STATUS.md](docs/STATUS.md) に集約しています。
@@ -98,9 +98,9 @@ make dev
 
 2026-05-03 時点で把握した主要な alpha open items:
 
-- P0 / alpha-scope: `#583`, `#584`, `#585`, `#611`, `#612`, `#643`, `#696`, `#697`
+- P0 / alpha-scope: `#583`, `#584`, `#585`, `#611`, `#612`, `#643`, `#697`
 - P1 / alpha-scope: `#653`, `#670`, `#672`, `#698`
-- Resolved in the latest remediation pass: `#658`, `#659`, `#660`, `#661`, `#662`, `#671`, `#691`, `#694`
+- Resolved in the latest remediation pass: `#658`, `#659`, `#660`, `#661`, `#662`, `#671`, `#691`, `#694`, `#696`
 - Merged and awaiting live proof: PR `#693` for Q quality, PR `#695/#701` for C-127 pacing / coverage, PR `#699` for C source routing, PR `#700/#703` for live harness hardening, PR `#702` for log hygiene, PR `#705/#709` for voice timeout budget, PR `#707` for mobile audio playback
 
 ## 注意

--- a/docs/README.md
+++ b/docs/README.md
@@ -85,7 +85,7 @@ PR #674, #675, #676 に加えて、#692, #693, #695, #699, #700, #701, #702, #70
 で、C-127 completion proof にはなっていません。#695 は 429 pacing / retry 修正として merge 済みで、
 post-#695/#701 C-127 proof は run `25272361091` で確認中です。#693 は Q suite 残 failure 修正として merge 済みで、
 同 run で post-deploy proof を確認中です。#705/#709 は voice timeout budget、#707 は mobile audio playback の
-実装修正として merge/deploy 済みですが、#696/#697/#698 は live/device proof まで open 維持です。
+実装修正として merge/deploy 済みです。#696 は live proof 後に close 済み、#697/#698 は live/device proof まで open 維持です。
 
 Resolved:
 
@@ -100,7 +100,7 @@ Resolved:
 - #700 Welcome camera-flow guard
 - #702 alpha Cloud Run log-noise reduction
 - #703 STT warmup before voice live
-- #696 voice backend timeout budget: PR #705/#709 merged/deployed, live proof pending
+- #696 voice backend timeout budget: PR #705/#709 merged/deployed and closed after live proof
 - #697 iOS delayed TTS playback: PR #707 merged, device proof pending
 - #698 Android large-audio playback: PR #707 merged, device proof pending
 
@@ -109,7 +109,7 @@ Still active:
 - #583 C-127 completion proof: run `25272361091` must collect/evaluate `127/127`
 - #653 / #672 Q/C answer quality
 - #670 RAGAS full-run speed / telemetry closeout
-- #696 / #697 / #698 live/device proof
+- #697 / #698 live/device proof
 - #611 / #584 / #585 live-only proof / issue-scope decisions
 
 ## 直近の次アクション

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -42,7 +42,7 @@ Supabase については、CLI で linked project の確認まではできまし
 1. 最新 full suite run `25272361091` の outcome / artifact を確認する
 2. C-127 が live `/api/chat` 429 なしで `127/127` collect/evaluate できることの証明
 3. Q suite の残 failure が #693 後に解消されたことの証明
-4. #696/#697/#698 の voice timeout / mobile playback live-device proof
+4. #697/#698 の mobile playback live-device proof
 5. RAGAS full-run speed / telemetry の operational closeout
 
 現行の実装判断は [ADR 018](adr/018-alpha-fast-response-and-assistant-profile-routing.md) と
@@ -84,7 +84,7 @@ Resolved or implemented in the 2026-05-03 remediation pass:
 Still blocking or important:
 
 - #583: C-127 completion remains P0 until post-#695/#701 run collects/evaluates `127/127` with `collection_errors=0`.
-- #696: voice backend timeout / warmup UX remains P0 until post-#705/#709 live proof shows no silent fail path.
+- #696: voice backend timeout / warmup UX is closed after post-#705/#709 live proof.
 - #697: iOS delayed TTS playback remains P0 until post-#707 iPad/iPhone Safari proof.
 - #698: Android large-audio playback remains P1 until post-#707 Android phone proof or explicit alpha demotion.
 - #653: Q quality remains P1 until post-#693 `suites=q` rerun has 0 failures.

--- a/docs/plans/alpha-remediation-plan-2026-05-02.md
+++ b/docs/plans/alpha-remediation-plan-2026-05-02.md
@@ -30,7 +30,7 @@ Latest deployed verification:
 - C-127 result after #692: failure, `alpha-127` requested `127`, evaluated `35`, collection errors `92`
 - PR #695 merge SHA: `ed25199e4c7104ac0f6e2f027c4fdadd72280182`
 - PR #699/#700/#701/#702/#703 are merged for C source routing, Welcome guard, C-127 coverage, log hygiene, and STT warmup
-- PR #705/#707/#709 are merged; voice timeout / mobile audio proof remains open
+- PR #705/#707/#709 are merged; #696 is closed after live proof, and #697/#698 mobile audio proof remains open
 - Full alpha-live-verification run `25272361091` is in progress with `suites=all`, `c_ragas_suite=alpha-127`
 - Q targeted run before #693: `25269072919` failed with `23 PASS / 0 WARN / 2 FAIL`
 - PR #693 merge SHA: `14cb8e5b3c4f9711a77c634d3db80f8bf4f80efd`; post-#693 Q proof is included in run `25272361091`
@@ -118,11 +118,11 @@ Tasks:
 
 ### #696 / #697 / #698 voice and mobile playback implementation
 
-Status: implemented, proof pending.
+Status: #696 closed after live proof; #697/#698 implemented, device proof pending.
 
 - PR #705/#709 align Vercel maxDuration, voice/filler proxy timeout, controlled 504 UX, and Cloud Run deploy guard.
 - PR #707 keeps the iOS gesture-unlocked AudioContext path and adds Android large-audio HTML playback fallback.
-- #696/#697/#698 remain open until live logs and target-device proof are attached.
+- #697/#698 remain open until target-device proof is attached. #696 timeout regression remains covered by #643 full-run evidence.
 
 ### #658 STT long-tail latency
 

--- a/docs/testing/alpha-final-scenarios.md
+++ b/docs/testing/alpha-final-scenarios.md
@@ -53,7 +53,7 @@ Current confirmed target:
 - Same-day harness hardening from PR #700/#701/#702/#703 is included in the current develop baseline:
   Welcome camera-flow guard, C-127 coverage summary, alpha Cloud Run log hygiene, and STT warmup before voice live.
 - Voice/device GO proof after #705/#707/#709 must include Cloud Run/Vercel evidence for `/api/voice`
-  and `/api/voice/filler` timeout behavior (#696), iPad/iPhone Safari delayed TTS playback (#697),
+  and `/api/voice/filler` timeout behavior (closed as #696), iPad/iPhone Safari delayed TTS playback (#697),
   and Android phone >1MB audio playback without `decodeAudioData` hang (#698).
 - Harness-only workflow/script rerun では、backend deploy が意図的に変わっていない場合だけ
   `require_deployed_sha_match=true` のまま `expected_backend_sha=<Cloud Run image tag の 40-char commit SHA>` を渡します。

--- a/docs/testing/alpha-live-verification-status-2026-05-02.md
+++ b/docs/testing/alpha-live-verification-status-2026-05-02.md
@@ -179,7 +179,7 @@ coverage, not provider configuration.
 - #583: C/RAGAS gate now has `c-127`, and PR #692 fixed manifest accounting. Post-#692 run
   `25270459825` still evaluated only `35/127` because live `/api/chat` returned 92 `429` collection
   errors. PR #695/#701 are merged; full run `25272361091` is the current proof attempt.
-- #696: PR #705/#709 are merged and deployed for voice backend timeout / Vercel budget; live proof is pending.
+- #696: PR #705/#709 are merged and deployed for voice backend timeout / Vercel budget; focused filler proof plus V/STT/A live proof are attached, and the issue is closed.
 - #697: PR #707 is merged for iOS delayed TTS playback; iPad/iPhone Safari proof is pending.
 - #643 / #612: umbrella issues remain open until the alpha gate is green.
 - #611 / #584 / #585: fast first-response, edge/failure tolerance, and 2h kiosk soak still need final proof.
@@ -225,7 +225,7 @@ Observed impact:
 1. Watch full run `25272361091`: prove SHA match, collect artifacts, and decide GO / targeted reruns.
 2. C-127: prove `requested=127`, `evaluated=127`, `collection_errors=0`.
 3. Q: prove #653 has `0 FAIL`.
-4. #696/#697/#698: collect Cloud Run/Vercel logs and real-device proof.
+4. #697/#698: collect real-device proof.
 5. #672: triage C answer/source quality only after C-127 collection completes.
 6. #670: verify full C/Q telemetry and runtime with the current artifact split.
 


### PR DESCRIPTION
## Summary
- Mark #696 as closed after focused `/api/voice/filler` proof and V/STT/A live proof in run `25272361091`.
- Keep #697/#698 as the remaining mobile device playback proof items.

## Verification
- `git diff --check`
