### PR TITLE
fix: tighten routing edge cases

### DIFF
--- a/backend/config/routing_constants.py
+++ b/backend/config/routing_constants.py
@@ -338,6 +338,30 @@ FAREWELL_KEYWORDS = [
     "gotta go",
 ]
 
+ENGLISH_FAREWELL_KEYWORDS = [
+    "goodbye",
+    "bye",
+    "leaving",
+    "going home",
+    "see you",
+    "heading out",
+    "gotta go",
+]
+
+JAPANESE_FAREWELL_KEYWORDS = [
+    keyword for keyword in FAREWELL_KEYWORDS if keyword not in ENGLISH_FAREWELL_KEYWORDS
+]
+
+
+def _compile_english_farewell_pattern(keyword: str) -> re.Pattern:
+    escaped_keyword = re.escape(keyword).replace(r"\ ", r"\s+")
+    return re.compile(rf"(?<![a-z0-9]){escaped_keyword}(?![a-z0-9])")
+
+
+ENGLISH_FAREWELL_PATTERNS = [
+    _compile_english_farewell_pattern(keyword) for keyword in ENGLISH_FAREWELL_KEYWORDS
+]
+
 EARTHQUAKE_KEYWORDS = [
     "地震",
     "earthquake",
@@ -756,6 +780,14 @@ def match_keywords(text: str, keywords: List[str]) -> bool:
     return any(kw.lower() in lower_text for kw in keywords)
 
 
+def match_farewell_keywords(text: str) -> bool:
+    """退館フレーズを判定する。英語は語境界つきで substring 誤爆を避ける。"""
+    lower_text = text.lower()
+    return any(kw in lower_text for kw in JAPANESE_FAREWELL_KEYWORDS) or any(
+        pattern.search(lower_text) for pattern in ENGLISH_FAREWELL_PATTERNS
+    )
+
+
 LOCATION_KEYWORDS = ["場所", "どこ", "アクセス", "住所", "location", "where", "address"]
 
 
@@ -776,7 +808,7 @@ def extract_request_type(query: str) -> Optional[str]:
 
     if match_keywords(lower_query, EMERGENCY_KEYWORDS):
         return "emergency"
-    if match_keywords(lower_query, FAREWELL_KEYWORDS):
+    if match_farewell_keywords(lower_query):
         return "farewell"
     if match_keywords(lower_query, LOST_FOUND_KEYWORDS):
         return "lost_found"
@@ -814,12 +846,6 @@ def extract_request_type(query: str) -> Optional[str]:
         return "photography"
     if match_keywords(lower_query, CHILDREN_NOISE_KEYWORDS):
         return "children_noise"
-    if match_keywords(lower_query, LOCATION_KEYWORDS):
-        return "location"
-    if match_keywords(lower_query, BOOKING_KEYWORDS):
-        return "booking"
-    if match_keywords(lower_query, RECEPTION_KEYWORDS):
-        return "reception"
     if match_keywords(lower_query, FLOOR_LAYOUT_KEYWORDS):
         return "floor_layout"
     if match_keywords(lower_query, FACILITY_EQUIPMENT_KEYWORDS):
@@ -836,5 +862,11 @@ def extract_request_type(query: str) -> Optional[str]:
         return "event"
     if match_keywords(lower_query, SLIDE_KEYWORDS):
         return "slide"
+    if match_keywords(lower_query, LOCATION_KEYWORDS):
+        return "location"
+    if match_keywords(lower_query, BOOKING_KEYWORDS):
+        return "booking"
+    if match_keywords(lower_query, RECEPTION_KEYWORDS):
+        return "reception"
 
     return None

--- a/backend/tests/agents/test_orchestrator_fast_routing.py
+++ b/backend/tests/agents/test_orchestrator_fast_routing.py
@@ -452,6 +452,34 @@ class TestOrchestratorFastRouting:
         if result is not None:
             assert result["agent"] != "farewell", f"reception query leaked to farewell: {result}"
 
+    def test_english_see_your_floor_map_not_farewell(self, orchestrator):
+        result = orchestrator._try_fast_routing("Can I see your floor map?")
+
+        assert result is not None
+        assert result["agent"] == "facility"
+        assert result["request_type"] == "floor_layout"
+
+    def test_english_see_your_hours_not_farewell(self, orchestrator):
+        result = orchestrator._try_fast_routing("Can I see your opening hours?")
+
+        assert result is not None
+        assert result["agent"] == "business_info"
+        assert result["request_type"] == "hours"
+
+    def test_hajimete_does_not_preempt_floor_map(self, orchestrator):
+        result = orchestrator._try_fast_routing("初めて来ました。フロアマップを見せてください。")
+
+        assert result is not None
+        assert result["agent"] == "facility"
+        assert result["request_type"] == "floor_layout"
+
+    def test_hajimete_does_not_preempt_parking(self, orchestrator):
+        result = orchestrator._try_fast_routing("初めて来ました。駐車場はありますか？")
+
+        assert result is not None
+        assert result["agent"] == "facility"
+        assert result["request_type"] == "parking"
+
 
 def test_zh_greeting_template_content():
     """Chinese greeting templates should exist for all time periods"""

--- a/backend/tests/config/test_routing_constants.py
+++ b/backend/tests/config/test_routing_constants.py
@@ -95,9 +95,37 @@ class TestReceptionRouting:
         """受付の場所を聞く質問は来館受付フローではなく施設案内として扱う"""
         assert extract_request_type("受付はどこにありますか？") == "location"
 
+    @pytest.mark.parametrize(
+        "query,expected",
+        [
+            ("初めて来ました。フロアマップを見せてください。", "floor_layout"),
+            ("初めて来ました。駐車場はありますか？", "parking"),
+        ],
+    )
+    def test_hajimete_does_not_preempt_more_specific_intents(self, query, expected):
+        """広い「初めて」は具体的な施設系意図を奪わない"""
+        assert extract_request_type(query) == expected
+
     def test_reception_maps_to_business_info(self):
         """receptionカテゴリがbusiness_infoにマッピングされることを確認"""
         assert CATEGORY_TO_AGENT_MAP["reception"] == "business_info"
+
+
+class TestFarewellRouting:
+    """退館キーワードルーティングテスト"""
+
+    @pytest.mark.parametrize(
+        "query,expected",
+        [
+            ("see you", "farewell"),
+            ("Goodbye!", "farewell"),
+            ("Can I see your floor map?", "floor_layout"),
+            ("Can I see your opening hours?", "hours"),
+        ],
+    )
+    def test_english_farewell_requires_phrase_boundary(self, query, expected):
+        """see your は see you 退館フレーズとして扱わない"""
+        assert extract_request_type(query) == expected
 
 
 class TestEmergencyRoutingIntegration:

--- a/backend/utils/intent_classifier.py
+++ b/backend/utils/intent_classifier.py
@@ -20,7 +20,6 @@ from backend.config.routing_constants import (
     EXCLUSIVE_RENTAL_KEYWORDS,
     EVENT_KEYWORDS,
     FACILITY_EQUIPMENT_KEYWORDS,
-    FAREWELL_KEYWORDS,
     FLOOR_KEYWORDS,
     FLOOR_LAYOUT_KEYWORDS,
     FOOD_DRINK_KEYWORDS,
@@ -36,6 +35,7 @@ from backend.config.routing_constants import (
     SMOKING_KEYWORDS,
     TOILET_KEYWORDS,
     WIFI_KEYWORDS,
+    match_farewell_keywords,
     match_keywords,
 )
 
@@ -301,7 +301,7 @@ def classify_fast_intent(query: str) -> Optional[FastIntent]:
             reasoning="Assistant profile/capability question detected",
         )
 
-    farewell_substring_hit = match_keywords(lower_query, FAREWELL_KEYWORDS)
+    farewell_substring_hit = match_farewell_keywords(lower_query)
     farewell_anchored_hit = bool(_MATA_KIMASU_FAREWELL_RE.search(query))
     has_service_intent = bool(_SERVICE_INTENT_RE.search(query))
     has_emergency = match_keywords(lower_query, EMERGENCY_KEYWORDS)
@@ -392,18 +392,6 @@ def classify_fast_intent(query: str) -> Optional[FastIntent]:
         )
     if match_keywords(lower_query, EVENT_KEYWORDS):
         return FastIntent("event", "events", "event", "Event keyword detected")
-    # Reception before current_info so 今日 + 再受付 is not misclassified (Q-RECV-JA-002).
-    if match_keywords(lower_query, RECEPTION_KEYWORDS):
-        return FastIntent(
-            "business_info", "reception", "reception", "Reception/check-in keyword detected"
-        )
-    if is_current_info_request(lower_query):
-        return FastIntent(
-            "general_knowledge",
-            "current_info",
-            "current_info",
-            "Current-information small-talk request detected",
-        )
     if match_keywords(lower_query, SLIDE_KEYWORDS):
         return FastIntent("slide", "slide", "slide", "Slide keyword detected")
     if match_keywords(lower_query, COMMUNITY_KEYWORDS):
@@ -477,6 +465,19 @@ def classify_fast_intent(query: str) -> Optional[FastIntent]:
     if match_keywords(lower_query, FOOD_DRINK_KEYWORDS):
         return FastIntent(
             "facility", "facility-info", "food_drink", "Food/drink policy keyword detected"
+        )
+    # Reception stays before current_info so 今日 + 再受付 is not misclassified (Q-RECV-JA-002),
+    # but after specific facility/event/business intents so broad 初めて does not preempt them.
+    if match_keywords(lower_query, RECEPTION_KEYWORDS):
+        return FastIntent(
+            "business_info", "reception", "reception", "Reception/check-in keyword detected"
+        )
+    if is_current_info_request(lower_query):
+        return FastIntent(
+            "general_knowledge",
+            "current_info",
+            "current_info",
+            "Current-information small-talk request detected",
         )
 
     return None


### PR DESCRIPTION
## Summary
- add boundary-aware English farewell matching so `see your ...` no longer trips the farewell route
- let specific facility/event/business intents beat broad reception keywords like `初めて`
- add focused regression coverage for #654

## Verification
- `uv run pytest tests/config/test_routing_constants.py -q`
- `uv run pytest tests/agents/test_orchestrator_fast_routing.py -q`
- `uv run ruff check config/routing_constants.py utils/intent_classifier.py tests/config/test_routing_constants.py tests/agents/test_orchestrator_fast_routing.py`

Closes #654