### PR TITLE
fix: tighten memory warning evaluation

### DIFF
--- a/backend/evaluation/live_quality_gates.py
+++ b/backend/evaluation/live_quality_gates.py
@@ -175,30 +175,118 @@ def check_safety(answer: str) -> bool:
 
 
 def denies_explicit_ltm_recall(answer: str) -> bool:
-    """Return true when the answer explicitly says the prior SSID is not remembered."""
+    """Return true when the answer explicitly says prior information is not remembered."""
     text = answer.lower()
     explicit_denials = (
         "含まれていない",
         "残っておりません",
         "残っていません",
+        "残っていない",
         "記録がありません",
         "記録にはありません",
+        "記録が見当たりません",
+        "記録は見当たりません",
         "覚えていません",
         "覚えておりません",
         "把握できておりません",
+        "把握しておりません",
         "確認できません",
-        "履歴には",
+        "伺っておりません",
+        "伺っていません",
+        "保存されていません",
+        "保存されておりません",
         "not in",
+        "no record",
+        "no history",
+        "no information",
         "do not have",
         "don't have",
         "cannot find",
         "can't find",
+        "not found",
+        "not recorded",
+        "not saved",
+        "not stored",
         "not remember",
         "don't remember",
         "do not remember",
         "was not saved",
     )
     return any(phrase in text for phrase in explicit_denials)
+
+
+def recalled_facts(answer: str, facts: list[str]) -> list[str]:
+    """Return expected facts, excluding denial-only suggestion text."""
+    found = [f for f in facts if f in answer]
+    if denies_explicit_ltm_recall(answer):
+        return [f for f in found if _fact_appears_affirmatively_recalled(answer, f)]
+    return found
+
+
+def _fact_appears_affirmatively_recalled(answer: str, fact: str) -> bool:
+    affirmative_markers = (
+        "前に",
+        "以前",
+        "覚えています",
+        "覚えております",
+        "記憶しています",
+        "記憶しております",
+        "保存されています",
+        "保存されております",
+        "残っています",
+        "残っております",
+        "伺いました",
+        "伺っています",
+        "お聞き",
+        "好き",
+        "希望",
+        "です",
+        "でした",
+        "previously",
+        "you told",
+        "remember",
+        "recorded",
+        "saved",
+        "preference",
+    )
+    contrast_markers = ("が、", "が,", "しかし", "ただし", "but", "however")
+    suggestion_markers = (
+        "もし",
+        "よろしければ",
+        "改めて",
+        "教えて",
+        "など",
+        "例えば",
+        "例:",
+        "例：",
+        "if you",
+        "please tell",
+        "let me know",
+        "for example",
+    )
+
+    segments = [s.strip() for s in re.split(r"(?<=[。.!！?？])\s*|[\r\n]+", answer) if s.strip()]
+    for segment in segments:
+        if fact not in segment:
+            continue
+        lower = segment.lower()
+        has_affirmative_marker = any(
+            marker in segment or marker in lower for marker in affirmative_markers
+        )
+        has_contrast_marker = any(
+            marker in segment or marker in lower for marker in contrast_markers
+        )
+        has_suggestion_marker = any(
+            marker in segment or marker in lower for marker in suggestion_markers
+        )
+        segment_denies = denies_explicit_ltm_recall(segment)
+        if segment_denies:
+            if has_contrast_marker and has_affirmative_marker and not has_suggestion_marker:
+                return True
+            continue
+        if not has_suggestion_marker:
+            return True
+    return False
 
 
 def flatten_metadata_sources(value: Any) -> set[str]:
@@ -596,7 +684,7 @@ async def run_m_suite(
                     client, base_url, api_key, q, "ja", s2, visitor_id, timeout, pacer
                 )
             facts = case["expected_recall_facts"]
-            found = [f for f in facts if f in last_answer]
+            found = recalled_facts(last_answer, facts)
             if http != 200:
                 status = "FAIL"
             elif len(found) == len(facts):
@@ -604,7 +692,7 @@ async def run_m_suite(
             elif found:
                 status = "WARN"
             else:
-                status = "WARN"
+                status = "FAIL"
             record(
                 rows,
                 suite="m",

--- a/backend/tests/evaluation/test_live_quality_gates.py
+++ b/backend/tests/evaluation/test_live_quality_gates.py
@@ -2,6 +2,7 @@ from evaluation.live_quality_gates import (
     check_answer_quality,
     check_safety,
     denies_explicit_ltm_recall,
+    recalled_facts,
 )
 
 
@@ -48,3 +49,36 @@ def test_explicit_ltm_denial_does_not_hide_concrete_ssid_recall() -> None:
     answer = "前に伝えたWi-FiのSSIDはcafe-freeです。"
 
     assert denies_explicit_ltm_recall(answer) is False
+
+
+def test_explicit_ltm_denial_does_not_treat_history_reference_as_denial() -> None:
+    answer = "会話履歴にはWi-FiのSSIDはcafe-freeと残っています。"
+
+    assert denies_explicit_ltm_recall(answer) is False
+
+
+def test_explicit_ltm_denial_accepts_not_asked_wording() -> None:
+    answer = "これまでの会話履歴を確認した限りでは、SSIDに関する情報は伺っておりません。"
+
+    assert denies_explicit_ltm_recall(answer) is True
+
+
+def test_cross_session_recall_does_not_count_denial_suggestions_as_fact() -> None:
+    answer = (
+        "現時点の会話履歴にはお客様の好きな席に関する具体的な記録が見当たりません。"
+        "もしよろしければ、窓際の席などを改めて教えてください。"
+    )
+
+    assert recalled_facts(answer, ["窓"]) == []
+
+
+def test_cross_session_recall_does_not_count_fact_inside_denial_sentence() -> None:
+    answer = "好きな席が窓側という記録は見当たりません。"
+
+    assert recalled_facts(answer, ["窓"]) == []
+
+
+def test_cross_session_recall_counts_fact_when_denial_phrase_is_corrected() -> None:
+    answer = "記録が見当たりませんでしたが、以前伺った内容では好きな席は窓側です。"
+
+    assert recalled_facts(answer, ["窓"]) == ["窓"]

--- a/backend/tests/utils/test_memory_extractor.py
+++ b/backend/tests/utils/test_memory_extractor.py
@@ -41,6 +41,22 @@ class TestExtractMemories:
         assert "Pythonが好き" in remembers[0]["content"]
         assert remembers[0]["confidence"] == 1.0
 
+    def test_remember_request_ja_tail_form_extracts_fact_not_polite_suffix(self):
+        query = "私の好きな席は窓側です。visitor alpha-m-ltm-123 として覚えてください。"
+
+        result = extract_memories(query, "承知しました", "ja")
+
+        remembers = [m for m in result if m["type"] == "explicit_remember"]
+        assert len(remembers) == 1
+        assert "窓側" in remembers[0]["content"]
+        assert "ください" not in remembers[0]["content"]
+        assert "visitor" not in remembers[0]["content"]
+
+    def test_remember_request_ja_bare_polite_request_is_not_memory(self):
+        result = extract_memories("覚えてください。", "承知しました", "ja")
+
+        assert [m for m in result if m["type"] == "explicit_remember"] == []
+
     def test_language_preference_en(self):
         result = extract_memories("Hello there", "Hi!", "en")
         lang_prefs = [m for m in result if m["type"] == "language_preference"]

--- a/backend/utils/memory_extractor.py
+++ b/backend/utils/memory_extractor.py
@@ -313,10 +313,12 @@ def _extract_location_preference(query: str, language: str) -> str | None:
 
 def _extract_remember_request(query: str, language: str) -> str | None:
     """明示的な「覚えて」リクエストを抽出"""
+    query_for_match = query.strip().rstrip("。.!！?？")
     if language == "ja":
         patterns = [
-            r"(?:覚えて|記憶して|忘れないで)[：:、,]?\s*(.+)",
-            r"(.+)(?:を覚えて|を記憶して|を忘れないで)",
+            r"(.+?)(?:を|として)?(?:覚えて|記憶して|忘れないで)(?:ください|おいてください|おいて|ね)?$",
+            r"(?:覚えて|記憶して|忘れないで)[：:、,]\s*(.+)",
+            r"(?:覚えて|記憶して|忘れないで)\s+(.+)",
         ]
     else:
         patterns = [
@@ -325,9 +327,27 @@ def _extract_remember_request(query: str, language: str) -> str | None:
         ]
 
     for pattern in patterns:
-        match = re.search(pattern, query, re.IGNORECASE)
+        match = re.search(pattern, query_for_match, re.IGNORECASE)
         if match:
-            content = match.group(1).strip().rstrip("。.!！")
-            if len(content) > 2:
+            content = _clean_remember_content(match.group(1))
+            if _is_actionable_remember_content(content):
                 return content
     return None
+
+
+def _clean_remember_content(content: str) -> str:
+    """記憶対象から評価用のvisitor句や末尾の助詞を落とす。"""
+    cleaned = content.strip().rstrip("。.!！?？")
+    cleaned = re.sub(
+        r"(?:[。.!！?？]\s*)?visitor\s+[\w:-]+(?:\s+として)?\s*$",
+        "",
+        cleaned,
+        flags=re.IGNORECASE,
+    )
+    cleaned = re.sub(r"(?:こと|内容)?を$", "", cleaned).strip()
+    return cleaned.rstrip("。.!！?？").strip()
+
+
+def _is_actionable_remember_content(content: str) -> bool:
+    normalized = content.strip().lower()
+    return normalized not in {"ください", "お願いします", "please"} and len(normalized) > 2


### PR DESCRIPTION
## Summary
- fix Japanese explicit remember tail-form extraction so evaluator visitor suffixes and polite endings are not stored as the memory fact
- expand explicit no-memory denial detection used by the M-suite
- prevent denial/suggestion wording from being counted as recalled facts
- tighten M-LTM-001 zero-recall from WARN to FAIL for clearer gate semantics

## Verification
- `python -m pytest backend/tests/utils/test_memory_extractor.py backend/tests/evaluation/test_live_quality_gates.py`
- `python -m pytest backend/tests/services/test_memory_promoter.py backend/tests/utils/test_long_term_memory_reranker.py`
- `git diff --check`

Draft because this changes M-suite WARN/FAIL semantics and should be reviewed against the active full alpha run artifacts before merge.

Refs #655