### PR TITLE
fix: drop late voice filler playback

### DIFF
--- a/frontend/src/__tests__/voice-filler-playback.test.ts
+++ b/frontend/src/__tests__/voice-filler-playback.test.ts
@@ -1,0 +1,29 @@
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+
+import { createVoiceFillerPlaybackGate } from '../lib/voice-filler-playback';
+
+test('voice filler gate accepts non-empty audio while turn is active', () => {
+  const gate = createVoiceFillerPlaybackGate({ aborted: false });
+
+  assert.equal(gate.canEnqueue('audio-b64'), true);
+  assert.equal(gate.canEnqueue(''), false);
+  assert.equal(gate.canEnqueue(null), false);
+});
+
+test('voice filler gate drops late audio after assistant response is ready', () => {
+  const gate = createVoiceFillerPlaybackGate({ aborted: false });
+
+  gate.close();
+
+  assert.equal(gate.canEnqueue('audio-b64'), false);
+});
+
+test('voice filler gate drops audio after the voice turn is aborted', () => {
+  const signal = { aborted: false };
+  const gate = createVoiceFillerPlaybackGate(signal);
+
+  signal.aborted = true;
+
+  assert.equal(gate.canEnqueue('audio-b64'), false);
+});

--- a/frontend/src/app/components/VoiceInterface.tsx
+++ b/frontend/src/app/components/VoiceInterface.tsx
@@ -10,6 +10,7 @@ import { cn } from '@/lib/cn';
 import { EmotionTagParser } from '@/lib/emotion-tag-parser';
 import { formatError } from '@/lib/error-messages';
 import { LipSyncAnalyzer, type LipSyncFrame } from '@/lib/lip-sync-analyzer';
+import { createVoiceFillerPlaybackGate } from '@/lib/voice-filler-playback';
 import { mergePlaybackMetadataWithTtsVrmControl } from '@/lib/voice/tts-vrm-metadata';
 import { preprocessTTS } from '@/utils/tts-preprocess';
 import { AlertCircle, Loader2, Mic, MicOff, Volume2, VolumeX, XCircle } from 'lucide-react';
@@ -565,6 +566,7 @@ export default function VoiceInterface({
     async (trimmed: string, abortController: AbortController) => {
       const signal = abortController.signal;
       const visitorId = ensureVisitorId();
+      const fillerGate = createVoiceFillerPlaybackGate(signal);
 
       cancelFastFiller();
       stopPlayback(false);
@@ -594,11 +596,7 @@ export default function VoiceInterface({
                   return;
                 }
                 const data = (await res.json()) as Record<string, unknown>;
-                const audio =
-                  typeof data.audioResponse === 'string' && data.audioResponse.length > 0
-                    ? data.audioResponse
-                    : null;
-                if (!audio || signal.aborted) {
+                if (!fillerGate.canEnqueue(data.audioResponse)) {
                   return;
                 }
                 const q = audioQueueRef.current;
@@ -610,7 +608,7 @@ export default function VoiceInterface({
                 q.add({
                   id: `filler-${Date.now()}`,
                   priority: 10,
-                  audioData: audio,
+                  audioData: data.audioResponse,
                 });
               } catch {
                 /* degrade silently */
@@ -682,6 +680,7 @@ export default function VoiceInterface({
           throw ttsError;
         }
 
+        fillerGate.close();
         // Filler runs in parallel; do not await — slow filler must not delay main TTS enqueue.
         void fillerTask.catch(() => {});
 
@@ -760,6 +759,7 @@ export default function VoiceInterface({
           }, 240);
         }
       } catch (voiceError) {
+        fillerGate.close();
         if (voiceError instanceof DOMException && voiceError.name === 'AbortError') {
           return;
         }

--- a/frontend/src/lib/voice-filler-playback.ts
+++ b/frontend/src/lib/voice-filler-playback.ts
@@ -1,0 +1,27 @@
+export interface VoiceFillerPlaybackGate {
+  canEnqueue: (audioResponse: unknown) => audioResponse is string;
+  close: () => void;
+}
+
+/**
+ * Keeps parallel filler audio from arriving after the real assistant response is ready.
+ */
+export function createVoiceFillerPlaybackGate(
+  signal?: Pick<AbortSignal, 'aborted'>,
+): VoiceFillerPlaybackGate {
+  let accepting = true;
+
+  return {
+    canEnqueue(audioResponse: unknown): audioResponse is string {
+      return (
+        accepting &&
+        signal?.aborted !== true &&
+        typeof audioResponse === 'string' &&
+        audioResponse.length > 0
+      );
+    },
+    close() {
+      accepting = false;
+    },
+  };
+}


### PR DESCRIPTION
## Summary
- add a per-turn filler playback gate so late filler audio is dropped once the real assistant response is ready
- drop filler audio when the voice turn has been aborted
- add focused regression tests for the filler gate

This narrows #611 to the implemented alpha path: fast first audible response via static filler + fast answer routing. It does not add dynamic Cerebras-generated filler.

## Verification
- `pnpm --dir frontend exec tsx --test src/__tests__/api-voice-filler-route.test.ts src/__tests__/voice-filler-playback.test.ts`
- `pnpm --dir frontend exec tsc --noEmit --pretty false`
- `uv run pytest tests/api/test_voice_filler_api.py`

Refs #611