### PR TITLE
fix: sanitize postgres null bytes before persistence

### DIFF
--- a/backend/tests/utils/test_checkpointer.py
+++ b/backend/tests/utils/test_checkpointer.py
@@ -92,6 +92,101 @@ class TestCheckpointerFactory:
 
 class TestResilientAsyncPostgresSaver:
     @pytest.mark.asyncio
+    async def test_aget_tuple_strips_postgres_nul_chars_before_read(self):
+        saver = checkpointer.ResilientAsyncPostgresSaver(
+            factory=MagicMock(),
+            pool=MagicMock(),
+        )
+        saver._run_with_connection_retry = AsyncMock(return_value={"ok": True})
+
+        await saver.aget_tuple({"configurable": {"thread_id": "session\x00-1"}})
+
+        args = saver._run_with_connection_retry.await_args.args
+        assert args[2] == {"configurable": {"thread_id": "session-1"}}
+
+    @pytest.mark.asyncio
+    async def test_aput_strips_postgres_nul_chars_before_write(self):
+        saver = checkpointer.ResilientAsyncPostgresSaver(
+            factory=MagicMock(),
+            pool=MagicMock(),
+        )
+        saver._run_with_connection_retry = AsyncMock(return_value={"ok": True})
+
+        await saver.aput(
+            {"configurable": {"thread_id": "session\x00-1"}},
+            {"channel_values": {"messages": ["hello\x00"]}},
+            {"source": "workflow\x00"},
+            {"channel\x00": "v\x001"},
+        )
+
+        args = saver._run_with_connection_retry.await_args.args
+        assert args[2] == {"configurable": {"thread_id": "session-1"}}
+        assert args[3] == {"channel_values": {"messages": ["hello"]}}
+        assert args[4] == {"source": "workflow"}
+        assert args[5] == {"channel": "v1"}
+
+    @pytest.mark.asyncio
+    async def test_aput_writes_strips_postgres_nul_chars_before_write(self):
+        saver = checkpointer.ResilientAsyncPostgresSaver(
+            factory=MagicMock(),
+            pool=MagicMock(),
+        )
+        saver._run_with_connection_retry = AsyncMock(return_value=None)
+
+        await saver.aput_writes(
+            {"configurable": {"thread_id": "session\x00-1"}},
+            [("answer", "ok\x00")],
+            "task\x00",
+            "path\x00",
+        )
+
+        args = saver._run_with_connection_retry.await_args.args
+        assert args[2] == {"configurable": {"thread_id": "session-1"}}
+        assert args[3] == [("answer", "ok")]
+        assert args[4] == "task"
+        assert args[5] == "path"
+
+    @pytest.mark.asyncio
+    async def test_alist_strips_postgres_nul_chars_before_read(self):
+        saver = checkpointer.ResilientAsyncPostgresSaver(
+            factory=MagicMock(),
+            pool=MagicMock(),
+        )
+
+        async def mock_alist(_self, config, *, filter=None, before=None, limit=None):
+            assert config == {"configurable": {"thread_id": "session-1"}}
+            assert filter == {"source": "workflow"}
+            assert before == {"configurable": {"checkpoint_id": "checkpoint-1"}}
+            assert limit == 1
+            yield {"checkpoint_id": "one"}
+
+        with patch.object(checkpointer.AsyncPostgresSaver, "alist", mock_alist):
+            result = [
+                item
+                async for item in saver.alist(
+                    {"configurable": {"thread_id": "session\x00-1"}},
+                    filter={"source": "workflow\x00"},
+                    before={"configurable": {"checkpoint_id": "checkpoint\x00-1"}},
+                    limit=1,
+                )
+            ]
+
+        assert result == [{"checkpoint_id": "one"}]
+
+    @pytest.mark.asyncio
+    async def test_adelete_thread_strips_postgres_nul_chars(self):
+        saver = checkpointer.ResilientAsyncPostgresSaver(
+            factory=MagicMock(),
+            pool=MagicMock(),
+        )
+        saver._run_with_connection_retry = AsyncMock(return_value=None)
+
+        await saver.adelete_thread("session\x00-1")
+
+        args = saver._run_with_connection_retry.await_args.args
+        assert args[2] == "session-1"
+
+    @pytest.mark.asyncio
     async def test_alist_retries_after_stale_connection(self):
         initial_pool = MagicMock()
         initial_pool.close = AsyncMock()

--- a/backend/tests/utils/test_memory_helper.py
+++ b/backend/tests/utils/test_memory_helper.py
@@ -214,6 +214,32 @@ class TestSimplifiedMemoryHelper:
         assert "expires_at" not in call_args
 
     @pytest.mark.asyncio
+    @patch("backend.utils.memory_helper.create_client")
+    async def test_store_message_strips_postgres_nul_chars(self, mock_create_client):
+        """PostgreSQL jsonb/text に保存できないNUL文字を保存前に除去する"""
+        mock_client = Mock()
+        mock_table = Mock()
+        mock_insert = Mock()
+        mock_insert.execute = Mock(return_value=Mock(data=[{"id": 1}]))
+        mock_table.insert = Mock(return_value=mock_insert)
+        mock_client.table = Mock(return_value=mock_table)
+        mock_create_client.return_value = mock_client
+
+        helper = SimplifiedMemoryHelper()
+
+        await helper.store_message(
+            role="user",
+            content="営業時間\x00は？",
+            session_id="test\x00-session",
+            metadata={"emotion": "curious\x00"},
+        )
+
+        call_args = mock_table.insert.call_args[0][0]
+        assert call_args["value"]["content"] == "営業時間は？"
+        assert call_args["value"]["sessionId"] == "test-session"
+        assert call_args["value"]["emotion"] == "curious"
+
+    @pytest.mark.asyncio
     async def test_store_message_without_supabase(self):
         """Supabaseなしでのメッセージ保存（スキップされる）"""
         helper = SimplifiedMemoryHelper()

--- a/backend/tests/utils/test_postgres_sanitizer.py
+++ b/backend/tests/utils/test_postgres_sanitizer.py
@@ -1,0 +1,29 @@
+from backend.utils.postgres_sanitizer import (
+    contains_postgres_null_byte,
+    sanitize_for_postgres,
+)
+
+
+def test_sanitize_for_postgres_handles_nested_values():
+    value = {
+        "ke\x00y": [
+            "a\x00b",
+            ("c\x00d", {"inner": "e\x00f"}),
+            {"g\x00h"},
+        ],
+        "unchanged": 3,
+    }
+
+    assert sanitize_for_postgres(value) == {
+        "key": [
+            "ab",
+            ("cd", {"inner": "ef"}),
+            {"gh"},
+        ],
+        "unchanged": 3,
+    }
+
+
+def test_contains_postgres_null_byte_detects_nested_values():
+    assert contains_postgres_null_byte({"nested": ["ok", "bad\x00value"]})
+    assert not contains_postgres_null_byte({"nested": ["ok", "safe"]})

--- a/backend/tests/workflows/test_main_workflow.py
+++ b/backend/tests/workflows/test_main_workflow.py
@@ -244,6 +244,144 @@ class TestMainWorkflowMemoryIntegration:
 
     @pytest.mark.asyncio
     @patch("backend.workflows.main_workflow.OrchestratorAgent")
+    async def test_format_response_strips_postgres_nul_chars_from_memory_candidates(
+        self, mock_orchestrator_class
+    ):
+        """candidate/LTM Store 書き込み前に PostgreSQL 非対応のNUL文字を除去する"""
+        from backend.workflows.main_workflow import MainWorkflow
+
+        mock_orchestrator_class.return_value = AsyncMock()
+
+        with patch("backend.utils.memory_helper.get_memory_helper") as mock_get_helper:
+            mock_helper = AsyncMock()
+            mock_helper.store_message = AsyncMock()
+            mock_get_helper.return_value = mock_helper
+
+            with (
+                patch(
+                    "backend.utils.memory_extractor.extract_memories",
+                    return_value=[],
+                ),
+                patch(
+                    "backend.utils.memory_extractor.extract_memory_candidates",
+                    return_value=[
+                        {
+                            "status": "candidate",
+                            "candidate_type": "visitor_name",
+                            "content": "田\x00中",
+                            "confidence": 0.9,
+                            "evidence": {"query": "私は田\x00中です"},
+                        }
+                    ],
+                ),
+                patch(
+                    "backend.utils.memory_feature_flags.get_memory_feature_flags",
+                    return_value=SimpleNamespace(
+                        enable_memory_candidates=True,
+                        enable_memory_promotion=False,
+                        enable_style_profile=False,
+                        enable_long_term_memory_rerank=False,
+                    ),
+                ),
+                patch.dict(os.environ, {"ENABLE_MEMORY_CANDIDATES": "true"}),
+            ):
+                workflow = MainWorkflow()
+                runtime = MagicMock()
+                runtime.context = MagicMock()
+                runtime.context.user_id = "visitor\x00-4"
+                runtime.store = MagicMock()
+                runtime.store.aput = AsyncMock()
+
+                state = {
+                    "query": "私は田\x00中です",
+                    "answer": "こんにちは田\x00中さん",
+                    "session_id": "test-session",
+                    "language": "ja",
+                }
+
+                async def _passthrough(op, **kw):
+                    return await op(runtime.store)
+
+                with patch(
+                    "backend.workflows.main_workflow.store_with_retry",
+                    side_effect=_passthrough,
+                ):
+                    await workflow._format_response_node(state, runtime)
+
+                calls = runtime.store.aput.await_args_list
+                candidate_args = calls[0].args
+                fast_path_args = calls[1].args
+                assert candidate_args[0] == ("visitor_memory_candidates", "visitor-4")
+                assert candidate_args[2]["content"] == "田中"
+                assert candidate_args[2]["evidence"]["query"] == "私は田中です"
+                assert fast_path_args[0] == ("visitor_memories", "visitor-4")
+                assert fast_path_args[2]["data"] == "田中"
+
+    @pytest.mark.asyncio
+    @patch("backend.workflows.main_workflow.OrchestratorAgent")
+    async def test_format_response_strips_postgres_nul_chars_before_memory_promotion(
+        self, mock_orchestrator_class
+    ):
+        """candidate promotion も保存済み namespace と同じ安全な user_id で読む"""
+        from backend.workflows.main_workflow import MainWorkflow
+
+        mock_orchestrator_class.return_value = AsyncMock()
+
+        with patch("backend.utils.memory_helper.get_memory_helper") as mock_get_helper:
+            mock_helper = AsyncMock()
+            mock_helper.store_message = AsyncMock()
+            mock_get_helper.return_value = mock_helper
+
+            promoter = MagicMock()
+            promoter.promote_for_user = AsyncMock(return_value={"promoted": 0})
+
+            with (
+                patch(
+                    "backend.utils.memory_extractor.extract_memories",
+                    return_value=[],
+                ),
+                patch(
+                    "backend.utils.memory_extractor.extract_memory_candidates",
+                    return_value=[],
+                ),
+                patch(
+                    "backend.utils.memory_feature_flags.get_memory_feature_flags",
+                    return_value=SimpleNamespace(
+                        enable_memory_candidates=True,
+                        enable_memory_promotion=True,
+                        enable_style_profile=False,
+                        enable_long_term_memory_rerank=False,
+                    ),
+                ),
+                patch(
+                    "backend.services.memory_promoter.get_memory_promoter",
+                    return_value=promoter,
+                ),
+                patch.dict(os.environ, {"ENABLE_MEMORY_CANDIDATES": "true"}),
+            ):
+                workflow = MainWorkflow()
+                runtime = MagicMock()
+                runtime.context = MagicMock()
+                runtime.context.user_id = "visitor\x00-promote"
+                runtime.store = MagicMock()
+
+                state = {
+                    "query": "覚えてください",
+                    "answer": "覚えました",
+                    "session_id": "test-session",
+                    "language": "ja",
+                }
+
+                await workflow._format_response_node(state, runtime)
+
+                promoter.promote_for_user.assert_awaited_once_with(
+                    runtime.store,
+                    "visitor-promote",
+                    delete_promoted_candidates=False,
+                )
+
+    @pytest.mark.asyncio
+    @patch("backend.workflows.main_workflow.OrchestratorAgent")
     async def test_format_response_skips_memory_candidates_when_flag_disabled(
         self, mock_orchestrator_class
     ):
@@ -706,6 +844,66 @@ class TestMainWorkflowMemoryIntegration:
                 lt = result["context"]["long_term_memory"]
                 assert lt
                 assert lt[0]["type"] == "explicit_remember"
+
+    @pytest.mark.asyncio
+    @patch("backend.workflows.main_workflow.OrchestratorAgent")
+    async def test_memory_loader_strips_postgres_nul_chars_from_ltm_lookup(
+        self, mock_orchestrator_class
+    ):
+        """LTM Store 読み込み前に namespace/query のNUL文字を除去する"""
+        from backend.workflows.main_workflow import MainWorkflow
+
+        mock_orchestrator_class.return_value = AsyncMock()
+
+        with patch("backend.utils.memory_helper.get_memory_helper") as mock_get_helper:
+            mock_helper = AsyncMock()
+            mock_helper.get_context = AsyncMock(
+                return_value={
+                    "recent_messages": [],
+                    "context_string": "",
+                    "inherited_request_type": None,
+                }
+            )
+            mock_helper.store_message = AsyncMock()
+            mock_get_helper.return_value = mock_helper
+
+            with patch(
+                "backend.utils.memory_feature_flags.get_memory_feature_flags",
+                return_value=SimpleNamespace(
+                    enable_memory_candidates=False,
+                    enable_memory_promotion=False,
+                    enable_style_profile=False,
+                    enable_long_term_memory_rerank=False,
+                ),
+            ):
+                workflow = MainWorkflow()
+                runtime = MagicMock()
+                runtime.context = MagicMock()
+                runtime.context.user_id = "visitor\x00-load"
+                runtime.store = MagicMock()
+                runtime.store.asearch = AsyncMock(return_value=[])
+
+                state = {
+                    "query": "覚え\x00てる？",
+                    "session_id": "test-session",
+                    "language": "ja",
+                    "context": {},
+                }
+
+                async def _passthrough(op, **kw):
+                    return await op(runtime.store)
+
+                with patch(
+                    "backend.workflows.main_workflow.store_with_retry",
+                    side_effect=_passthrough,
+                ):
+                    await workflow._memory_loader_node(state, runtime)
+
+                runtime.store.asearch.assert_awaited_once_with(
+                    ("visitor_memories", "visitor-load"),
+                    query="覚えてる？",
+                    limit=5,
+                )
 
 
 class TestWorkflowGraphStructure:

--- a/backend/utils/checkpointer.py
+++ b/backend/utils/checkpointer.py
@@ -24,6 +24,8 @@ from psycopg import AsyncConnection, InterfaceError, OperationalError
 from psycopg.rows import dict_row
 from psycopg_pool import AsyncConnectionPool, PoolClosed
 
+from backend.utils.postgres_sanitizer import sanitize_for_postgres
+
 logger = logging.getLogger(__name__)
 
 _T = TypeVar("_T")
@@ -207,7 +209,11 @@ class ResilientAsyncPostgresSaver(AsyncPostgresSaver):
             return await operation(*args, **kwargs)
 
     async def aget_tuple(self, config: RunnableConfig) -> Any:
-        return await self._run_with_connection_retry("aget_tuple", super().aget_tuple, config)
+        return await self._run_with_connection_retry(
+            "aget_tuple",
+            super().aget_tuple,
+            cast(RunnableConfig, sanitize_for_postgres(config)),
+        )
 
     async def alist(
         self,
@@ -218,11 +224,14 @@ class ResilientAsyncPostgresSaver(AsyncPostgresSaver):
         limit: int | None = None,
     ) -> AsyncGenerator[Any, None]:
         stale_pool = self.pool
+        safe_config = cast(RunnableConfig | None, sanitize_for_postgres(config))
+        safe_filter = cast(dict[str, Any] | None, sanitize_for_postgres(filter))
+        safe_before = cast(RunnableConfig | None, sanitize_for_postgres(before))
         try:
             async for item in super().alist(
-                config,
-                filter=filter,
-                before=before,
+                safe_config,
+                filter=safe_filter,
+                before=safe_before,
                 limit=limit,
             ):
                 yield item
@@ -237,9 +246,9 @@ class ResilientAsyncPostgresSaver(AsyncPostgresSaver):
             )
             await self.recreate(reason=error, stale_pool=stale_pool)
             async for item in super().alist(
-                config,
-                filter=filter,
-                before=before,
+                safe_config,
+                filter=safe_filter,
+                before=safe_before,
                 limit=limit,
             ):
                 yield item
@@ -254,10 +263,10 @@ class ResilientAsyncPostgresSaver(AsyncPostgresSaver):
         return await self._run_with_connection_retry(
             "aput",
             super().aput,
-            config,
-            checkpoint,
-            metadata,
-            new_versions,
+            cast(RunnableConfig, sanitize_for_postgres(config)),
+            cast(Checkpoint, sanitize_for_postgres(checkpoint)),
+            cast(CheckpointMetadata, sanitize_for_postgres(metadata)),
+            cast(ChannelVersions, sanitize_for_postgres(new_versions)),
         )
 
     async def aput_writes(
@@ -270,14 +279,18 @@ class ResilientAsyncPostgresSaver(AsyncPostgresSaver):
         await self._run_with_connection_retry(
             "aput_writes",
             super().aput_writes,
-            config,
-            writes,
-            task_id,
-            task_path,
+            cast(RunnableConfig, sanitize_for_postgres(config)),
+            sanitize_for_postgres(writes),
+            sanitize_for_postgres(task_id),
+            sanitize_for_postgres(task_path),
         )
 
     async def adelete_thread(self, thread_id: str) -> None:
-        await self._run_with_connection_retry("adelete_thread", super().adelete_thread, thread_id)
+        await self._run_with_connection_retry(
+            "adelete_thread",
+            super().adelete_thread,
+            sanitize_for_postgres(thread_id),
+        )
 
 
 async def create_checkpointer() -> AsyncPostgresSaver:

--- a/backend/utils/memory_helper.py
+++ b/backend/utils/memory_helper.py
@@ -17,6 +17,7 @@ import logging
 from supabase import create_client, Client
 
 from backend.config.routing_constants import extract_request_type
+from backend.utils.postgres_sanitizer import sanitize_for_postgres
 
 logger = logging.getLogger(__name__)
 
@@ -470,7 +471,10 @@ class SimplifiedMemoryHelper:
             return
 
         timestamp = int(datetime.now().timestamp() * 1000)
-        metadata = metadata or {}
+        metadata = sanitize_for_postgres(metadata or {})
+        role = sanitize_for_postgres(role)
+        content = sanitize_for_postgres(content)
+        session_id = sanitize_for_postgres(session_id)
 
         # リクエストタイプの自動抽出（user messageの場合）
         if role == "user" and "request_type" not in metadata:

--- a/backend/utils/postgres_sanitizer.py
+++ b/backend/utils/postgres_sanitizer.py
@@ -1,0 +1,59 @@
+"""Utilities for making values safe for PostgreSQL text and JSON storage."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any, TypeVar, cast
+
+_T = TypeVar("_T")
+
+POSTGRES_NULL_BYTE = "\x00"
+
+
+def sanitize_for_postgres(value: _T) -> _T:
+    """Return ``value`` with NUL bytes removed from all nested strings.
+
+    PostgreSQL rejects U+0000 in both text and json/jsonb values. psycopg's JSON
+    adapter serializes Python NUL bytes as ``\\u0000``, which PostgreSQL then
+    rejects while decoding json/jsonb. Removing only NUL bytes keeps the rest of
+    the user-provided text intact.
+    """
+    if isinstance(value, str):
+        return cast(_T, value.replace(POSTGRES_NULL_BYTE, ""))
+
+    if isinstance(value, Mapping):
+        return cast(
+            _T,
+            {
+                sanitize_for_postgres(key): sanitize_for_postgres(item)
+                for key, item in value.items()
+            },
+        )
+
+    if isinstance(value, list):
+        return cast(_T, [sanitize_for_postgres(item) for item in value])
+
+    if isinstance(value, tuple):
+        return cast(_T, tuple(sanitize_for_postgres(item) for item in value))
+
+    if isinstance(value, set):
+        return cast(_T, {sanitize_for_postgres(item) for item in value})
+
+    return value
+
+
+def contains_postgres_null_byte(value: Any) -> bool:
+    """Return True when ``value`` contains a NUL byte in any nested string."""
+    if isinstance(value, str):
+        return POSTGRES_NULL_BYTE in value
+
+    if isinstance(value, Mapping):
+        return any(
+            contains_postgres_null_byte(key) or contains_postgres_null_byte(item)
+            for key, item in value.items()
+        )
+
+    if isinstance(value, list | tuple | set):
+        return any(contains_postgres_null_byte(item) for item in value)
+
+    return False

--- a/backend/workflows/main_workflow.py
+++ b/backend/workflows/main_workflow.py
@@ -38,6 +38,7 @@ from backend.agents.orchestrator_agent import (
 from backend.agents.orchestrator_agent import OrchestratorAgent as RoutingLogicAgent
 from backend.config.routing_constants import GREETING_KEYWORDS, match_keywords
 from backend.services.memory_promoter import MemoryPromoter
+from backend.utils.postgres_sanitizer import sanitize_for_postgres
 from backend.utils.store import store_with_retry
 
 logger = logging.getLogger(__name__)
@@ -706,9 +707,11 @@ class MainWorkflow:
                 if user_id and user_id != "anonymous" and runtime.store:
                     from backend.utils.memory_feature_flags import get_memory_feature_flags
 
-                    namespace = ("visitor_memories", user_id)
+                    safe_user_id = sanitize_for_postgres(user_id)
+                    namespace = ("visitor_memories", safe_user_id)
+                    safe_query = sanitize_for_postgres(state.get("query", ""))
                     memories = await store_with_retry(
-                        lambda s: s.asearch(namespace, query=state.get("query", ""), limit=5),
+                        lambda s: s.asearch(namespace, query=safe_query, limit=5),
                         store=runtime.store,
                         operation_name="long-term memory load",
                     )
@@ -1317,8 +1320,9 @@ class MainWorkflow:
                 from backend.utils.memory_feature_flags import get_memory_feature_flags
 
                 memory_flags = get_memory_feature_flags()
-                long_term_namespace = ("visitor_memories", user_id)
-                candidate_namespace = ("visitor_memory_candidates", user_id)
+                safe_user_id = sanitize_for_postgres(user_id)
+                long_term_namespace = ("visitor_memories", safe_user_id)
+                candidate_namespace = ("visitor_memory_candidates", safe_user_id)
 
                 def _is_fast_path_memory(memory: dict[str, Any]) -> bool:
                     memory_type = memory.get("candidate_type") or memory.get("type")
@@ -1359,6 +1363,7 @@ class MainWorkflow:
                         "timestamp": time.time(),
                         "source": source,
                     }
+                    value = sanitize_for_postgres(value)
                     await store_with_retry(
                         lambda s, k=key, v=value: s.aput(long_term_namespace, k, v),
                         store=runtime.store,
@@ -1379,7 +1384,7 @@ class MainWorkflow:
                             fast_path_count = 0
                             for candidate in candidates:
                                 candidate_key = str(uuid.uuid4())
-                                candidate_value = dict(candidate)
+                                candidate_value = sanitize_for_postgres(dict(candidate))
                                 await store_with_retry(
                                     lambda s, k=candidate_key, v=candidate_value: s.aput(
                                         candidate_namespace,
@@ -1432,7 +1437,7 @@ class MainWorkflow:
                         promoter = get_memory_promoter()
                         promotion_stats = await promoter.promote_for_user(
                             runtime.store,
-                            user_id,
+                            safe_user_id,
                             delete_promoted_candidates=False,
                         )
                         if promotion_stats.get("promoted", 0) > 0:


### PR DESCRIPTION
## Summary\n- Fixes #721 by stripping PostgreSQL-incompatible NUL bytes at persistence boundaries.\n- Adds a central `sanitize_for_postgres` helper for nested text/json payloads.\n- Applies it to LangGraph checkpoint/write persistence, session message memory, and LTM/candidate store writes.\n\n## Verification\n- `uv run pytest tests/utils/test_postgres_sanitizer.py tests/utils/test_checkpointer.py tests/utils/test_memory_helper.py tests/workflows/test_main_workflow.py::TestMainWorkflowMemoryIntegration::test_format_response_strips_postgres_nul_chars_from_memory_candidates tests/workflows/test_main_workflow.py::TestMainWorkflowMemoryIntegration::test_format_response_shadow_writes_memory_candidates_when_enabled -q`\n- `ruff check backend/utils/postgres_sanitizer.py backend/utils/checkpointer.py backend/utils/memory_helper.py backend/workflows/main_workflow.py backend/tests/utils/test_postgres_sanitizer.py backend/tests/utils/test_checkpointer.py backend/tests/utils/test_memory_helper.py backend/tests/workflows/test_main_workflow.py`\n\n## Notes\n- Active full alpha run 25272361091 already surfaced the Cloud Run 500; this PR is prepared for review but should not be merged until the active run artifacts are captured, unless we intentionally replace that run.\n