### PR TITLE
[codex] Harden alpha live Cloud Run error gate

### DIFF
--- a/.github/workflows/alpha-live-verification.yml
+++ b/.github/workflows/alpha-live-verification.yml
@@ -182,7 +182,30 @@ jobs:
         continue-on-error: true
         env:
           API_SECRET_KEY: ${{ secrets.BACKEND_API_KEY }}
-        run: scripts/alpha-smoke-comprehensive.sh --timestamp "${ALPHA_TIMESTAMP}-d" --host "$ALPHA_SMOKE_BASE_URL" --scenarios D --timeout 120 --sleep 2.2 --parallel 1
+        shell: bash
+        run: |
+          set -uo pipefail
+          d_started_at="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+          scripts/alpha-smoke-comprehensive.sh --timestamp "${ALPHA_TIMESTAMP}-d" --host "$ALPHA_SMOKE_BASE_URL" --scenarios D --timeout 120 --sleep 2.2 --parallel 1
+          smoke_status=$?
+
+          settle_seconds="${ALPHA_CLOUD_LOGGING_SETTLE_SECONDS:-20}"
+          if [[ "$settle_seconds" =~ ^[0-9]+$ && "$settle_seconds" -gt 0 ]]; then
+            sleep "$settle_seconds"
+          fi
+
+          d_finished_at="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+          scripts/cloud-logging-verify.sh \
+            --timestamp "${ALPHA_TIMESTAMP}-d-cloudrun" \
+            --since "$d_started_at" \
+            --until "$d_finished_at" \
+            --limit 1000 \
+            --error-gate-only
+          log_gate_status=$?
+
+          if [[ "$smoke_status" -ne 0 || "$log_gate_status" -ne 0 ]]; then
+            exit 1
+          fi
 
       - name: E Cloud Logging verification
         id: cloud_logging

--- a/backend/tests/scripts/test_cloud_logging_verify.py
+++ b/backend/tests/scripts/test_cloud_logging_verify.py
@@ -1,0 +1,134 @@
+import json
+import subprocess
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[3]
+SCRIPT = ROOT / "scripts" / "cloud-logging-verify.sh"
+SINCE = "2026-05-03T00:00:00Z"
+UNTIL = "2026-05-03T00:05:00Z"
+
+
+def _write_json(input_dir: Path, name: str, rows: list[dict]) -> None:
+    (input_dir / f"{name}.json").write_text(json.dumps(rows), encoding="utf-8")
+
+
+def _run_error_gate(
+    input_dir: Path, output_dir: Path, timestamp: str
+) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        [
+            "bash",
+            str(SCRIPT),
+            "--input-dir",
+            str(input_dir),
+            "--output-dir",
+            str(output_dir),
+            "--timestamp",
+            timestamp,
+            "--since",
+            SINCE,
+            "--until",
+            UNTIL,
+            "--error-gate-only",
+        ],
+        cwd=ROOT,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+
+
+def test_error_gate_fails_on_chat_api_5xx(tmp_path: Path) -> None:
+    input_dir = tmp_path / "logs"
+    output_dir = tmp_path / "reports"
+    input_dir.mkdir()
+
+    _write_json(
+        input_dir,
+        "chat_api_5xx",
+        [
+            {
+                "timestamp": "2026-05-03T00:01:00Z",
+                "severity": "WARNING",
+                "httpRequest": {
+                    "requestMethod": "POST",
+                    "requestUrl": "https://service.example/api/chat",
+                    "status": 500,
+                },
+                "jsonPayload": {"message": "request_completed_slow"},
+            }
+        ],
+    )
+
+    result = _run_error_gate(input_dir, output_dir, "chat-5xx")
+
+    assert result.returncode == 1
+    report = (output_dir / "cloud-logging-check-chat-5xx.md").read_text(encoding="utf-8")
+    assert "- 1 /api/chat 5xx log row(s) found." in report
+    assert "| `/api/chat` 5xx rows | FAIL | 1 matching log row(s) |" in report
+
+
+def test_error_gate_fails_on_ltm_store_write_failed(tmp_path: Path) -> None:
+    input_dir = tmp_path / "logs"
+    output_dir = tmp_path / "reports"
+    input_dir.mkdir()
+
+    _write_json(
+        input_dir,
+        "chat_response",
+        [
+            {
+                "timestamp": "2026-05-03T00:02:00Z",
+                "jsonPayload": {
+                    "event": "chat_response",
+                    "request_id": "req-alpha-d",
+                    "language": "ja",
+                    "route": "general_knowledge",
+                    "rag_fallback": False,
+                    "ltm_store_write": "failed",
+                    "latency_ms": 1234,
+                },
+            }
+        ],
+    )
+
+    result = _run_error_gate(input_dir, output_dir, "ltm-failed")
+
+    assert result.returncode == 1
+    report = (output_dir / "cloud-logging-check-ltm-failed.md").read_text(encoding="utf-8")
+    assert "- 1 chat_response log(s) reported ltm_store_write=failed." in report
+    assert (
+        "| `ltm_store_write=failed` rows | FAIL | 1 matching chat_response log row(s) |" in report
+    )
+
+
+def test_error_gate_passes_without_chat_or_persistence_errors(tmp_path: Path) -> None:
+    input_dir = tmp_path / "logs"
+    output_dir = tmp_path / "reports"
+    input_dir.mkdir()
+
+    _write_json(
+        input_dir,
+        "chat_response",
+        [
+            {
+                "timestamp": "2026-05-03T00:03:00Z",
+                "jsonPayload": {
+                    "event": "chat_response",
+                    "request_id": "req-alpha-d-ok",
+                    "language": "ja",
+                    "route": "general_knowledge",
+                    "rag_fallback": False,
+                    "ltm_store_write": "success",
+                    "latency_ms": 900,
+                },
+            }
+        ],
+    )
+
+    result = _run_error_gate(input_dir, output_dir, "clean")
+
+    assert result.returncode == 0, result.stderr
+    report = (output_dir / "cloud-logging-check-clean.md").read_text(encoding="utf-8")
+    assert "- Overall passed: yes" in report
+    assert "| `/api/chat` 5xx rows | PASS | 0 matching log row(s) |" in report

--- a/scripts/cloud-logging-verify.sh
+++ b/scripts/cloud-logging-verify.sh
@@ -18,6 +18,10 @@ OUTPUT_DIR="$ROOT_DIR/backend/tests/reports"
 TIMESTAMP="$(date +%Y%m%d_%H%M%S)"
 DRY_RUN=0
 LIMIT=1000
+SINCE=""
+UNTIL=""
+ERROR_GATE_ONLY=0
+INPUT_DIR=""
 
 usage() {
   sed -n '4,9p' "$0"
@@ -32,6 +36,10 @@ Options:
   --limit N              Max log rows per query (default: 1000)
   --output-dir DIR       Report directory (default: backend/tests/reports)
   --timestamp VALUE      Stable timestamp for output names
+  --since RFC3339        Override lookback start timestamp
+  --until RFC3339        Optional inclusive end timestamp
+  --error-gate-only      Only fail on /api/chat 5xx or persistence error rows
+  --input-dir DIR        Read pre-fetched JSON logs from DIR instead of gcloud (tests)
   --dry-run              Validate local checks and print gcloud filters only
   -h, --help             Show this usage
 
@@ -60,6 +68,10 @@ is_number() {
   [[ "${1:-}" =~ ^[0-9]+([.][0-9]+)?$ ]]
 }
 
+is_filter_safe_timestamp() {
+  [[ -n "${1:-}" && "$1" != *'"'* && "$1" != *$'\n'* && "$1" != *$'\r'* ]]
+}
+
 while [ "$#" -gt 0 ]; do
   case "$1" in
     --project) [ "$#" -ge 2 ] || die "--project requires a value"; PROJECT_ID="$2"; shift 2 ;;
@@ -70,6 +82,10 @@ while [ "$#" -gt 0 ]; do
     --limit) [ "$#" -ge 2 ] || die "--limit requires a value"; LIMIT="$2"; shift 2 ;;
     --output-dir) [ "$#" -ge 2 ] || die "--output-dir requires a value"; OUTPUT_DIR="$2"; shift 2 ;;
     --timestamp) [ "$#" -ge 2 ] || die "--timestamp requires a value"; TIMESTAMP="$2"; shift 2 ;;
+    --since) [ "$#" -ge 2 ] || die "--since requires a value"; SINCE="$2"; shift 2 ;;
+    --until) [ "$#" -ge 2 ] || die "--until requires a value"; UNTIL="$2"; shift 2 ;;
+    --error-gate-only) ERROR_GATE_ONLY=1; shift ;;
+    --input-dir) [ "$#" -ge 2 ] || die "--input-dir requires a value"; INPUT_DIR="$2"; shift 2 ;;
     --dry-run) DRY_RUN=1; shift ;;
     -h|--help) usage 0 ;;
     *) echo "Unknown arg: $1" >&2; usage 1 ;;
@@ -82,19 +98,29 @@ done
 is_positive_int "$MINUTES" || die "--minutes must be a positive integer"
 is_positive_int "$LIMIT" || die "--limit must be a positive integer"
 is_number "$THRESHOLD" || die "--threshold must be numeric"
+[ -z "$SINCE" ] || is_filter_safe_timestamp "$SINCE" || die "--since must be a non-empty timestamp without quotes or newlines"
+[ -z "$UNTIL" ] || is_filter_safe_timestamp "$UNTIL" || die "--until must be a non-empty timestamp without quotes or newlines"
+[ -z "$INPUT_DIR" ] || [ -d "$INPUT_DIR" ] || die "--input-dir must be an existing directory"
 require_cmd python3
 
 REPORT="$OUTPUT_DIR/cloud-logging-check-$TIMESTAMP.md"
-BASE_FILTER='resource.type="cloud_run_revision"'
-BASE_FILTER="$BASE_FILTER AND resource.labels.service_name=\"$SERVICE_NAME\""
-BASE_FILTER="$BASE_FILTER AND resource.labels.location=\"$REGION\""
-BASE_FILTER="$BASE_FILTER AND timestamp >= \"$(python3 - "$MINUTES" <<'PY'
+WINDOW_START="$SINCE"
+if [ -z "$WINDOW_START" ]; then
+  WINDOW_START="$(python3 - "$MINUTES" <<'PY'
 from datetime import datetime, timedelta, timezone
 import sys
 minutes = int(sys.argv[1])
 print((datetime.now(timezone.utc) - timedelta(minutes=minutes)).isoformat().replace("+00:00", "Z"))
 PY
-)\""
+)"
+fi
+BASE_FILTER='resource.type="cloud_run_revision"'
+BASE_FILTER="$BASE_FILTER AND resource.labels.service_name=\"$SERVICE_NAME\""
+BASE_FILTER="$BASE_FILTER AND resource.labels.location=\"$REGION\""
+BASE_FILTER="$BASE_FILTER AND timestamp >= \"$WINDOW_START\""
+if [ -n "$UNTIL" ]; then
+  BASE_FILTER="$BASE_FILTER AND timestamp <= \"$UNTIL\""
+fi
 
 event_filter() {
   printf '%s AND (jsonPayload.event="%s" OR labels.event="%s" OR textPayload:"%s")' \
@@ -102,6 +128,7 @@ event_filter() {
 }
 
 chat_filter="$BASE_FILTER AND (jsonPayload.event=\"chat_response\" OR labels.event=\"chat_response\" OR textPayload:\"chat_response\")"
+chat_5xx_filter="$BASE_FILTER AND ((httpRequest.requestMethod=\"POST\" AND httpRequest.requestUrl:\"/api/chat\" AND httpRequest.status>=500) OR (jsonPayload.path=\"/api/chat\" AND jsonPayload.status_code>=500) OR (jsonPayload.extra.path=\"/api/chat\" AND jsonPayload.extra.status_code>=500) OR (jsonPayload.event=\"request_failed\" AND jsonPayload.path=\"/api/chat\") OR (jsonPayload.event=\"request_completed_slow\" AND jsonPayload.path=\"/api/chat\" AND jsonPayload.status_code>=500) OR (textPayload:\"/api/chat\" AND severity>=ERROR))"
 memory_filter="$BASE_FILTER AND ((jsonPayload.logger=\"backend.utils.memory_helper\" AND jsonPayload.level=\"ERROR\") OR jsonPayload.event=\"memory_helper_error\" OR (jsonPayload.logger:\"memory_helper\" AND severity>=ERROR) OR (textPayload:\"memory_helper\" AND severity>=ERROR))"
 uuid_hygiene_filter="$BASE_FILTER AND (textPayload:\"invalid input syntax for type uuid\" OR jsonPayload.message:\"invalid input syntax for type uuid\" OR jsonPayload.exception.message:\"invalid input syntax for type uuid\")"
 reception_hygiene_filter="$BASE_FILTER AND (textPayload:\"Reception session persistence failed\" OR jsonPayload.message:\"Reception session persistence failed\")"
@@ -110,20 +137,30 @@ if [ "$DRY_RUN" = "1" ]; then
   echo "Dry run: no gcloud logging read calls will be executed."
   echo "Project: $PROJECT_ID"
   echo "Output: $REPORT"
-  for event in stt_qwen_start stt_qwen_complete stt_winner; do
-    echo "Filter[$event]: $(event_filter "$event")"
-  done
+  echo "Window start: $WINDOW_START"
+  echo "Window end: ${UNTIL:-none}"
+  echo "Error gate only: $ERROR_GATE_ONLY"
+  if [ "$ERROR_GATE_ONLY" != "1" ]; then
+    for event in stt_qwen_start stt_qwen_complete stt_winner; do
+      echo "Filter[$event]: $(event_filter "$event")"
+    done
+  fi
   echo "Filter[chat_response]: $chat_filter"
+  echo "Filter[chat_api_5xx]: $chat_5xx_filter"
   echo "Filter[memory_helper_error]: $memory_filter"
   echo "Filter[uuid_hygiene]: $uuid_hygiene_filter"
   echo "Filter[reception_hygiene]: $reception_hygiene_filter"
   exit 0
 fi
 
-require_cmd gcloud
 mkdir -p "$OUTPUT_DIR"
-TMP_DIR="$(mktemp -d)"
-trap 'rm -rf "$TMP_DIR"' EXIT
+if [ -n "$INPUT_DIR" ]; then
+  TMP_DIR="$INPUT_DIR"
+else
+  require_cmd gcloud
+  TMP_DIR="$(mktemp -d)"
+  trap 'rm -rf "$TMP_DIR"' EXIT
+fi
 
 read_logs() {
   local filter="$1"
@@ -134,15 +171,20 @@ read_logs() {
     --format=json > "$out"
 }
 
-for event in stt_qwen_start stt_qwen_complete stt_winner; do
-  read_logs "$(event_filter "$event")" "$TMP_DIR/$event.json"
-done
-read_logs "$chat_filter" "$TMP_DIR/chat_response.json"
-read_logs "$memory_filter" "$TMP_DIR/memory_helper_errors.json"
-read_logs "$uuid_hygiene_filter" "$TMP_DIR/uuid_hygiene.json"
-read_logs "$reception_hygiene_filter" "$TMP_DIR/reception_hygiene.json"
+if [ -z "$INPUT_DIR" ]; then
+  if [ "$ERROR_GATE_ONLY" != "1" ]; then
+    for event in stt_qwen_start stt_qwen_complete stt_winner; do
+      read_logs "$(event_filter "$event")" "$TMP_DIR/$event.json"
+    done
+  fi
+  read_logs "$chat_filter" "$TMP_DIR/chat_response.json"
+  read_logs "$chat_5xx_filter" "$TMP_DIR/chat_api_5xx.json"
+  read_logs "$memory_filter" "$TMP_DIR/memory_helper_errors.json"
+  read_logs "$uuid_hygiene_filter" "$TMP_DIR/uuid_hygiene.json"
+  read_logs "$reception_hygiene_filter" "$TMP_DIR/reception_hygiene.json"
+fi
 
-python3 - "$TIMESTAMP" "$PROJECT_ID" "$SERVICE_NAME" "$REGION" "$MINUTES" "$THRESHOLD" "$REPORT" "$TMP_DIR" <<'PY'
+python3 - "$TIMESTAMP" "$PROJECT_ID" "$SERVICE_NAME" "$REGION" "$MINUTES" "$THRESHOLD" "$REPORT" "$TMP_DIR" "$WINDOW_START" "${UNTIL:-}" "$ERROR_GATE_ONLY" <<'PY'
 from __future__ import annotations
 
 import json
@@ -151,7 +193,20 @@ import sys
 from collections import Counter, defaultdict
 from typing import Any
 
-timestamp, project, service, region, minutes, threshold_raw, report, tmp = sys.argv[1:9]
+(
+    timestamp,
+    project,
+    service,
+    region,
+    minutes,
+    threshold_raw,
+    report,
+    tmp,
+    window_start,
+    window_end,
+    error_gate_only_raw,
+) = sys.argv[1:12]
+error_gate_only = error_gate_only_raw == "1"
 threshold = float(threshold_raw)
 if threshold <= 1:
     threshold *= 100
@@ -194,6 +249,45 @@ def md(value: Any) -> str:
     return str(value if value is not None else "").replace("|", "\\|").replace("\n", " ")
 
 
+def entry_message(entry: dict[str, Any]) -> str:
+    data = payload(entry)
+    value = (
+        data.get("message")
+        or data.get("msg")
+        or data.get("error")
+        or entry.get("textPayload")
+        or data.get("event")
+        or ""
+    )
+    return str(value)
+
+
+def entry_http_status(entry: dict[str, Any]) -> Any:
+    http_request = entry.get("httpRequest")
+    if isinstance(http_request, dict) and http_request.get("status") is not None:
+        return http_request.get("status")
+    data = payload(entry)
+    if data.get("status_code") is not None:
+        return data.get("status_code")
+    extra = data.get("extra")
+    if isinstance(extra, dict):
+        return extra.get("status_code")
+    return None
+
+
+def entry_path(entry: dict[str, Any]) -> str:
+    http_request = entry.get("httpRequest")
+    if isinstance(http_request, dict) and http_request.get("requestUrl") is not None:
+        return str(http_request.get("requestUrl"))
+    data = payload(entry)
+    if data.get("path") is not None:
+        return str(data.get("path"))
+    extra = data.get("extra")
+    if isinstance(extra, dict) and extra.get("path") is not None:
+        return str(extra.get("path"))
+    return ""
+
+
 stt_entries: list[dict[str, Any]] = []
 for name in required_stt_events:
     for entry in load(name):
@@ -234,6 +328,11 @@ for index, data in enumerate(chat_entries):
     if missing:
         chat_missing.append({"index": index, "missing": missing, "data": data})
 
+chat_api_5xx_entries = load("chat_api_5xx")
+ltm_store_failed = [
+    data for data in chat_entries if str(field_value(data, "ltm_store_write")).lower() == "failed"
+]
+
 memory_errors = []
 for entry in load("memory_helper_errors"):
     data = payload(entry)
@@ -248,17 +347,24 @@ uuid_hygiene_entries = load("uuid_hygiene")
 reception_hygiene_entries = load("reception_hygiene")
 
 failures: list[str] = []
-if trace_count == 0:
-    failures.append("No structured STT trace events found.")
-if missing_trace_count:
-    failures.append(f"{missing_trace_count} structured STT event(s) are missing stt_trace_id.")
-for name in required_stt_events:
-    if rates[name] < threshold:
-        failures.append(f"{name} generation rate {rates[name]:.2f}% is below threshold {threshold:.2f}%.")
-if not chat_entries:
-    failures.append("No structured chat_response logs found.")
-if chat_missing:
-    failures.append(f"{len(chat_missing)} chat_response log(s) are missing required fields.")
+if not error_gate_only:
+    if trace_count == 0:
+        failures.append("No structured STT trace events found.")
+    if missing_trace_count:
+        failures.append(f"{missing_trace_count} structured STT event(s) are missing stt_trace_id.")
+    for name in required_stt_events:
+        if rates[name] < threshold:
+            failures.append(f"{name} generation rate {rates[name]:.2f}% is below threshold {threshold:.2f}%.")
+    if not chat_entries:
+        failures.append("No structured chat_response logs found.")
+    if chat_missing:
+        failures.append(f"{len(chat_missing)} chat_response log(s) are missing required fields.")
+if chat_api_5xx_entries:
+    failures.append(f"{len(chat_api_5xx_entries)} /api/chat 5xx log row(s) found.")
+if ltm_store_failed:
+    failures.append(f"{len(ltm_store_failed)} chat_response log(s) reported ltm_store_write=failed.")
+if memory_errors:
+    failures.append(f"{len(memory_errors)} memory_helper error log(s) found.")
 if uuid_hygiene_entries:
     failures.append(
         f"{len(uuid_hygiene_entries)} invalid UUID syntax log(s) found; synthetic alpha IDs are still leaking into UUID queries."
@@ -270,13 +376,16 @@ if reception_hygiene_entries:
 
 passed = not failures
 lines = [
-    "# Cloud Logging Structured Event Check",
+    "# Cloud Logging Error Gate" if error_gate_only else "# Cloud Logging Structured Event Check",
     "",
     f"- Timestamp: {timestamp}",
     f"- Project: {project}",
     f"- Service: {service}",
     f"- Region: {region}",
+    f"- Window start: {window_start}",
+    f"- Window end: {window_end or 'now'}",
     f"- Lookback minutes: {minutes}",
+    f"- Error gate only: {'yes' if error_gate_only else 'no'}",
     f"- STT generation threshold: {threshold:.2f}%",
     f"- Overall passed: {'yes' if passed else 'no'}",
     "",
@@ -285,19 +394,28 @@ lines = [
     "| Check | Result | Detail |",
     "| --- | --- | --- |",
 ]
-for name in required_stt_events:
-    result = "PASS" if trace_count and rates[name] >= threshold else "FAIL"
+if not error_gate_only:
+    for name in required_stt_events:
+        result = "PASS" if trace_count and rates[name] >= threshold else "FAIL"
+        lines.append(
+            f"| `{name}` generation | {result} | {rates[name]:.2f}% across {trace_count} STT trace(s); "
+            f"raw structured events: {event_counts[name]}; missing traces: {missing_by_event[name]} |"
+        )
+    chat_passed = bool(chat_entries) and not chat_missing
     lines.append(
-        f"| `{name}` generation | {result} | {rates[name]:.2f}% across {trace_count} STT trace(s); "
-        f"raw structured events: {event_counts[name]}; missing traces: {missing_by_event[name]} |"
+        f"| `chat_response` required fields | {'PASS' if chat_passed else 'FAIL'} | "
+        f"{len(chat_entries)} structured log(s); required: {', '.join(required_chat_fields)} |"
     )
-chat_passed = bool(chat_entries) and not chat_missing
 lines.append(
-    f"| `chat_response` required fields | {'PASS' if chat_passed else 'FAIL'} | "
-    f"{len(chat_entries)} structured log(s); required: {', '.join(required_chat_fields)} |"
+    f"| `/api/chat` 5xx rows | {'FAIL' if chat_api_5xx_entries else 'PASS'} | "
+    f"{len(chat_api_5xx_entries)} matching log row(s) |"
 )
 lines.append(
-    f"| `memory_helper` ERROR samples | {'WARN' if memory_errors else 'PASS'} | "
+    f"| `ltm_store_write=failed` rows | {'FAIL' if ltm_store_failed else 'PASS'} | "
+    f"{len(ltm_store_failed)} matching chat_response log row(s) |"
+)
+lines.append(
+    f"| `memory_helper` ERROR samples | {'FAIL' if memory_errors else 'PASS'} | "
     f"{len(memory_errors)} error log(s) found; samples listed below if present |"
 )
 lines.append(
@@ -314,30 +432,53 @@ if failures:
     for failure in failures:
         lines.append(f"- {failure}")
 
-lines.extend([
-    "",
-    "## STT Events",
-    "",
-    "| Event | Structured count | Trace generation rate | Missing trace count |",
-    "| --- | ---: | ---: | ---: |",
-])
-for name in required_stt_events:
-    lines.append(f"| `{name}` | {event_counts[name]} | {rates[name]:.2f}% | {missing_by_event[name]} |")
+if not error_gate_only:
+    lines.extend([
+        "",
+        "## STT Events",
+        "",
+        "| Event | Structured count | Trace generation rate | Missing trace count |",
+        "| --- | ---: | ---: | ---: |",
+    ])
+    for name in required_stt_events:
+        lines.append(f"| `{name}` | {event_counts[name]} | {rates[name]:.2f}% | {missing_by_event[name]} |")
+
+    lines.extend([
+        "",
+        "## chat_response Schema",
+        "",
+        f"- Rows checked: {len(chat_entries)}",
+        f"- Required fields: {', '.join(required_chat_fields)}",
+    ])
+    if chat_missing:
+        lines.extend(["", "| Row | Missing fields | Timestamp | Request ID | Route | Language |", "| ---: | --- | --- | --- | --- | --- |"])
+        for item in chat_missing[:20]:
+            data = item["data"]
+            lines.append(
+                f"| {item['index']} | {md(', '.join(item['missing']))} | {md(data.get('_timestamp'))} | "
+                f"{md(field_value(data, 'request_id'))} | {md(field_value(data, 'route'))} | {md(field_value(data, 'language'))} |"
+            )
 
 lines.extend([
     "",
-    "## chat_response Schema",
+    "## Cloud Run Error Rows",
     "",
-    f"- Rows checked: {len(chat_entries)}",
-    f"- Required fields: {', '.join(required_chat_fields)}",
+    f"- `/api/chat` 5xx rows: {len(chat_api_5xx_entries)}",
+    f"- `ltm_store_write=failed` rows: {len(ltm_store_failed)}",
 ])
-if chat_missing:
-    lines.extend(["", "| Row | Missing fields | Timestamp | Request ID | Route | Language |", "| ---: | --- | --- | --- | --- | --- |"])
-    for item in chat_missing[:20]:
-        data = item["data"]
+if chat_api_5xx_entries:
+    lines.extend(["", "| Timestamp | Severity | Status | Path | Message |", "| --- | --- | ---: | --- | --- |"])
+    for entry in chat_api_5xx_entries[:10]:
         lines.append(
-            f"| {item['index']} | {md(', '.join(item['missing']))} | {md(data.get('_timestamp'))} | "
-            f"{md(field_value(data, 'request_id'))} | {md(field_value(data, 'route'))} | {md(field_value(data, 'language'))} |"
+            f"| {md(entry.get('timestamp'))} | {md(entry.get('severity'))} | "
+            f"{md(entry_http_status(entry))} | {md(entry_path(entry))[:160]} | {md(entry_message(entry))[:500]} |"
+        )
+if ltm_store_failed:
+    lines.extend(["", "| Timestamp | Request ID | Route | Language |", "| --- | --- | --- | --- |"])
+    for item in ltm_store_failed[:10]:
+        lines.append(
+            f"| {md(item.get('_timestamp'))} | {md(field_value(item, 'request_id'))} | "
+            f"{md(field_value(item, 'route'))} | {md(field_value(item, 'language'))} |"
         )
 
 lines.extend([


### PR DESCRIPTION
## Summary

- Add a focused Cloud Logging error gate for `/api/chat` 5xx rows, `ltm_store_write=failed`, `memory_helper` errors, UUID hygiene rows, and reception persistence failures.
- Run that gate immediately after alpha D memory/state durability using the D suite start/end Cloud Run window, so D fails when the relevant log window contains these rows.
- Keep E as the full Cloud Logging verification, but make the same `/api/chat` and persistence rows fail the E report instead of only warning.
- Add fixture-driven tests for the shell verifier without requiring GCP access.

## Validation

- `bash -n scripts/cloud-logging-verify.sh && bash -n scripts/alpha-smoke-comprehensive.sh`
- `cd backend && python -m black --check tests/scripts/test_cloud_logging_verify.py && python -m pytest tests/scripts/test_cloud_logging_verify.py -q`
- `cd backend && python -m ruff check tests/scripts/test_cloud_logging_verify.py`
- workflow YAML parsed with PyYAML
- `scripts/cloud-logging-verify.sh --dry-run --error-gate-only --since 2026-05-03T00:00:00Z --until 2026-05-03T00:05:00Z --timestamp dryrun`
