### PR TITLE
[codex] Fix JA live policy routing

### DIFF
--- a/backend/agents/facility_agent.py
+++ b/backend/agents/facility_agent.py
@@ -217,6 +217,7 @@ class FacilityAgent:
             "food_drink": "food_drink",
             "parking": "parking",
             "bicycle": "bicycle",
+            "pets": "policy",
         }
         return category_by_request_type.get(request_type or "", "facility-info")
 
@@ -575,6 +576,53 @@ class FacilityAgent:
             }
             return self._canonical_result(answers.get(language, answers["ja"]), request_type)
 
+        if request_type == "temporary_exit" or self._asks_temporary_exit_policy(normalized):
+            answers = {
+                "ja": (
+                    "[relaxed]15分以内の一時外出は、受付カードを持ったまま自由に"
+                    "出入りできます。15分以上離席する場合は、受付カードを返却して"
+                    "一度退館手続きをしてください。"
+                ),
+                "en": (
+                    "[relaxed]You may step out freely for up to 15 minutes while "
+                    "keeping your reception card. If you will be away for 15 minutes "
+                    "or longer, please return the card and complete checkout once."
+                ),
+                "zh": (
+                    "[relaxed]15分钟以内的临时外出可以保留接待卡自由进出。"
+                    "如果离开15分钟以上，请归还接待卡并先办理退馆手续。"
+                ),
+                "ko": (
+                    "[relaxed]15분 이내의 일시 외출은 접수 카드를 가지고 자유롭게 "
+                    "출입할 수 있습니다. 15분 이상 자리를 비울 때는 접수 카드를 "
+                    "반납하고 한 번 퇴관 절차를 해 주세요."
+                ),
+            }
+            return self._canonical_result(answers.get(language, answers["ja"]), request_type)
+
+        if request_type == "pets" or self._asks_pet_policy(normalized):
+            answers = {
+                "ja": (
+                    "[relaxed]盲導犬、聴導犬、介助犬などの補助犬は同伴できます。"
+                    "それ以外のペットは、テラス席を含めて施設全域で同伴できません。"
+                ),
+                "en": (
+                    "[relaxed]Service dogs, such as guide, hearing, or assistance "
+                    "dogs, are allowed. Other pets are not allowed anywhere in the "
+                    "facility, including the terrace."
+                ),
+                "zh": (
+                    "[relaxed]导盲犬、助听犬、介助犬等辅助犬可以同行。"
+                    "除此之外的宠物，包括露台座位在内，设施全域都不能带入。"
+                ),
+                "ko": (
+                    "[relaxed]안내견, 청각도우미견, 보조견 같은 보조견은 동반할 "
+                    "수 있습니다. 그 외 반려동물은 테라스를 포함한 시설 전체에 "
+                    "동반할 수 없습니다."
+                ),
+            }
+            return self._canonical_result(answers.get(language, answers["ja"]), request_type)
+
         if self._asks_printer_or_copier(normalized):
             answers = {
                 "ja": (
@@ -696,6 +744,44 @@ class FacilityAgent:
             "餐饮",
             "음식",
             "음료",
+        )
+        return any(keyword in query for keyword in keywords)
+
+    @staticmethod
+    def _asks_temporary_exit_policy(query: str) -> bool:
+        keywords = (
+            "一時外出",
+            "途中外出",
+            "外出のルール",
+            "出入り",
+            "再入館",
+            "再入場",
+            "離席",
+            "15分以内",
+            "15分以上",
+            "temporary exit",
+            "step out",
+            "leave temporarily",
+            "re-enter",
+            "reentry",
+        )
+        return any(keyword in query for keyword in keywords)
+
+    @staticmethod
+    def _asks_pet_policy(query: str) -> bool:
+        keywords = (
+            "ペット",
+            "動物",
+            "補助犬",
+            "盲導犬",
+            "聴導犬",
+            "介助犬",
+            "pet",
+            "pets",
+            "service animal",
+            "service dog",
+            "guide dog",
+            "assistance dog",
         )
         return any(keyword in query for keyword in keywords)
 

--- a/backend/agents/facility_agent.py
+++ b/backend/agents/facility_agent.py
@@ -12,6 +12,7 @@ from backend.config.prompts.facility_prompts import (
     FACILITY_ENHANCEMENT_KEYWORDS,
     build_facility_prompt,
 )
+from backend.config.routing_constants import match_pet_policy_keywords
 from backend.llm import get_llm_provider, get_model_config
 from backend.tools.enhanced_rag import EnhancedRAGSearch
 from backend.utils.language_types import DEFAULT_NOT_FOUND_RESPONSE
@@ -769,21 +770,7 @@ class FacilityAgent:
 
     @staticmethod
     def _asks_pet_policy(query: str) -> bool:
-        keywords = (
-            "ペット",
-            "動物",
-            "補助犬",
-            "盲導犬",
-            "聴導犬",
-            "介助犬",
-            "pet",
-            "pets",
-            "service animal",
-            "service dog",
-            "guide dog",
-            "assistance dog",
-        )
-        return any(keyword in query for keyword in keywords)
+        return match_pet_policy_keywords(query)
 
     @staticmethod
     def _asks_3d_printer_filament_price(query: str) -> bool:

--- a/backend/config/routing_constants.py
+++ b/backend/config/routing_constants.py
@@ -659,6 +659,13 @@ PET_POLICY_KEYWORDS = [
     "guide dog",
 ]
 
+PET_POLICY_EXCLUSION_KEYWORDS = [
+    "ペットボトル",
+    "petボトル",
+    "pet bottle",
+    "plastic bottle",
+]
+
 POLICY_KEYWORDS = [
     *ACCESSIBILITY_KEYWORDS,
     *PHOTOGRAPHY_KEYWORDS,
@@ -817,6 +824,35 @@ def match_farewell_keywords(text: str) -> bool:
     )
 
 
+def match_pet_policy_keywords(text: str) -> bool:
+    """Pet policy keywords with bottle/whole-word guards."""
+    lower_text = text.lower()
+    if any(kw.lower() in lower_text for kw in PET_POLICY_EXCLUSION_KEYWORDS):
+        return False
+
+    japanese_keywords = [
+        "ペット",
+        "動物",
+        "補助犬",
+        "盲導犬",
+        "聴導犬",
+        "介助犬",
+    ]
+    if any(kw in lower_text for kw in japanese_keywords):
+        return True
+
+    english_keywords = [
+        "pet",
+        "pets",
+        "animal",
+        "service animal",
+        "service dog",
+        "guide dog",
+        "assistance dog",
+    ]
+    return any(re.search(rf"\b{re.escape(kw)}\b", lower_text) for kw in english_keywords)
+
+
 LOCATION_KEYWORDS = ["場所", "どこ", "アクセス", "住所", "location", "where", "address"]
 
 
@@ -877,7 +913,7 @@ def extract_request_type(query: str) -> Optional[str]:
         return "children_noise"
     if match_keywords(lower_query, TEMPORARY_EXIT_KEYWORDS):
         return "temporary_exit"
-    if match_keywords(lower_query, PET_POLICY_KEYWORDS):
+    if match_pet_policy_keywords(lower_query):
         return "pets"
     if match_keywords(lower_query, FLOOR_LAYOUT_KEYWORDS):
         return "floor_layout"

--- a/backend/config/routing_constants.py
+++ b/backend/config/routing_constants.py
@@ -632,10 +632,39 @@ CHILDREN_NOISE_KEYWORDS = [
     "noise",
 ]
 
+TEMPORARY_EXIT_KEYWORDS = [
+    "一時外出",
+    "途中外出",
+    "外出のルール",
+    "出入り",
+    "再入館",
+    "再入場",
+    "離席",
+    "15分以内",
+    "15分以上",
+]
+
+PET_POLICY_KEYWORDS = [
+    "ペット",
+    "動物",
+    "補助犬",
+    "盲導犬",
+    "聴導犬",
+    "介助犬",
+    "pet",
+    "pets",
+    "animal",
+    "service animal",
+    "service dog",
+    "guide dog",
+]
+
 POLICY_KEYWORDS = [
     *ACCESSIBILITY_KEYWORDS,
     *PHOTOGRAPHY_KEYWORDS,
     *CHILDREN_NOISE_KEYWORDS,
+    *TEMPORARY_EXIT_KEYWORDS,
+    *PET_POLICY_KEYWORDS,
 ]
 
 
@@ -846,6 +875,10 @@ def extract_request_type(query: str) -> Optional[str]:
         return "photography"
     if match_keywords(lower_query, CHILDREN_NOISE_KEYWORDS):
         return "children_noise"
+    if match_keywords(lower_query, TEMPORARY_EXIT_KEYWORDS):
+        return "temporary_exit"
+    if match_keywords(lower_query, PET_POLICY_KEYWORDS):
+        return "pets"
     if match_keywords(lower_query, FLOOR_LAYOUT_KEYWORDS):
         return "floor_layout"
     if match_keywords(lower_query, FACILITY_EQUIPMENT_KEYWORDS):

--- a/backend/tests/agents/test_facility_agent.py
+++ b/backend/tests/agents/test_facility_agent.py
@@ -343,6 +343,13 @@ class TestFacilityAgent:
         assert "同伴できません" in response["answer"]
         assert response["metadata"]["sources"] == ["enhanced_rag"]
 
+    def test_pet_policy_does_not_match_pet_bottle_or_english_substrings(self):
+        """ペットボトル and English substrings should not use the pet policy answer."""
+        agent = FacilityAgent()
+
+        assert not agent._asks_pet_policy("ペットボトルは持ち込めますか？")
+        assert not agent._asks_pet_policy("Tell me about the competition rules.")
+
     def test_pet_policy_uses_policy_rag_category_when_not_canonical(self):
         """ペット系 request_type は policy カテゴリのKBを検索する"""
         agent = FacilityAgent()

--- a/backend/tests/agents/test_facility_agent.py
+++ b/backend/tests/agents/test_facility_agent.py
@@ -318,6 +318,37 @@ class TestFacilityAgent:
 
         assert response is None
 
+    def test_temporary_exit_canonical_response_japanese(self):
+        """gt-038: 一時外出ルールは受付カード保持/返却条件まで固定する"""
+        agent = FacilityAgent()
+        response = agent._get_canonical_response("一時外出のルールは？", "temporary_exit", "ja")
+
+        assert response is not None
+        assert "15分以内" in response["answer"]
+        assert "受付カード" in response["answer"]
+        assert "15分以上" in response["answer"]
+        assert "退館手続き" in response["answer"]
+        assert response["metadata"]["sources"] == ["enhanced_rag"]
+
+    def test_pet_policy_canonical_response_japanese(self):
+        """gt-057: 補助犬は可、それ以外のペットはテラス含め不可に固定する"""
+        agent = FacilityAgent()
+        response = agent._get_canonical_response("ペットを連れて入れますか？", "pets", "ja")
+
+        assert response is not None
+        assert "補助犬" in response["answer"]
+        assert "同伴できます" in response["answer"]
+        assert "それ以外のペット" in response["answer"]
+        assert "テラス" in response["answer"]
+        assert "同伴できません" in response["answer"]
+        assert response["metadata"]["sources"] == ["enhanced_rag"]
+
+    def test_pet_policy_uses_policy_rag_category_when_not_canonical(self):
+        """ペット系 request_type は policy カテゴリのKBを検索する"""
+        agent = FacilityAgent()
+
+        assert agent._map_request_type_to_rag_category("pets") == "policy"
+
     @pytest.mark.asyncio
     async def test_smoking_query_uses_smoking_rag_category(self):
         """喫煙ポリシーはfacility-infoではなくsmokingカテゴリで検索する"""

--- a/backend/tests/agents/test_orchestrator_fast_routing.py
+++ b/backend/tests/agents/test_orchestrator_fast_routing.py
@@ -44,6 +44,15 @@ class TestOrchestratorFastRouting:
         assert result["request_type"] == "food_drink", "Should be food_drink type"
         assert result["reasoning"] == "Food/drink policy keyword detected"
 
+    def test_pet_bottle_query_stays_food_drink(self, orchestrator):
+        """ペットボトル should not trigger the pet policy fast path."""
+        result = orchestrator._try_fast_routing("ペットボトルの飲み物は持ち込めますか？")
+
+        assert result is not None
+        assert result["agent"] == "facility"
+        assert result["request_type"] == "food_drink"
+        assert result["reasoning"] == "Food/drink policy keyword detected"
+
     def test_food_drink_verb_variations(self, orchestrator):
         """Test various food/drink verb patterns"""
         test_queries = [

--- a/backend/tests/agents/test_orchestrator_fast_routing.py
+++ b/backend/tests/agents/test_orchestrator_fast_routing.py
@@ -425,6 +425,23 @@ class TestOrchestratorFastRouting:
         assert result["request_type"] == "farewell"
         assert result["category"] == "farewell"
 
+    @pytest.mark.parametrize(
+        ("query", "request_type"),
+        [
+            ("一時外出のルールは？", "temporary_exit"),
+            ("ペットを連れて入れますか？", "pets"),
+        ],
+    )
+    def test_alpha_c_ragas_live_source_cases_route_to_facility(
+        self, orchestrator, query, request_type
+    ):
+        """gt-038/gt-057 should not fall through to broad business_info fallback."""
+        result = orchestrator._try_fast_routing(query)
+        assert result is not None
+        assert result["agent"] == "facility"
+        assert result["category"] == "facility-info"
+        assert result["request_type"] == request_type
+
     def test_emergency_kaji_overrides_farewell(self, orchestrator):
         """P1 guard: 火事なので帰ります must not route to farewell."""
         result = orchestrator._try_fast_routing("火事なので帰ります")

--- a/backend/tests/config/test_routing_constants.py
+++ b/backend/tests/config/test_routing_constants.py
@@ -68,6 +68,7 @@ class TestNewRoutingKeywords:
             ("食べ物の持ち込みはできますか？", "food_drink"),
             ("Can I bring food?", "food_drink"),
             ("飲み物は持ってきていいですか？", "food_drink"),
+            ("ペットボトルの飲み物は持ち込めますか？", "food_drink"),
         ],
     )
     def test_food_drink_keywords(self, query, expected):
@@ -86,6 +87,17 @@ class TestNewRoutingKeywords:
     def test_live_ragas_policy_keywords(self, query, expected):
         """C/RAGAS live source guard cases should have deterministic policy request types."""
         assert extract_request_type(query) == expected
+
+    @pytest.mark.parametrize(
+        "query",
+        [
+            "ペットボトルは持ち込めますか？",
+            "Tell me about the competition rules.",
+        ],
+    )
+    def test_pet_policy_keywords_avoid_substring_false_positives(self, query):
+        """Pet policy should not catch bottle or English substring matches."""
+        assert extract_request_type(query) != "pets"
 
 
 class TestReceptionRouting:

--- a/backend/tests/config/test_routing_constants.py
+++ b/backend/tests/config/test_routing_constants.py
@@ -74,6 +74,19 @@ class TestNewRoutingKeywords:
         """飲食キーワードがfood_drinkにルーティングされることを確認"""
         assert extract_request_type(query) == expected
 
+    @pytest.mark.parametrize(
+        "query,expected",
+        [
+            ("一時外出のルールは？", "temporary_exit"),
+            ("15分以上離席するときはどうすればいいですか？", "temporary_exit"),
+            ("ペットを連れて入れますか？", "pets"),
+            ("盲導犬は同伴できますか？", "pets"),
+        ],
+    )
+    def test_live_ragas_policy_keywords(self, query, expected):
+        """C/RAGAS live source guard cases should have deterministic policy request types."""
+        assert extract_request_type(query) == expected
+
 
 class TestReceptionRouting:
     """受付キーワードルーティングテスト"""

--- a/backend/tools/enhanced_rag.py
+++ b/backend/tools/enhanced_rag.py
@@ -39,6 +39,7 @@ RPC_SIMILARITY_THRESHOLDS: Dict[str, float] = {
     "food_drink": 0.30,
     "parking": 0.30,
     "bicycle": 0.30,
+    "policy": 0.30,
 }
 DEFAULT_RPC_SIMILARITY_THRESHOLD = 0.30
 RPC_TIMEOUT_SECONDS = 10.0
@@ -57,6 +58,7 @@ CATEGORY_THRESHOLDS = {
     "food_drink": {"high": 0.70, "medium": 0.50, "term_match": 0.20},
     "parking": {"high": 0.70, "medium": 0.50, "term_match": 0.20},
     "bicycle": {"high": 0.70, "medium": 0.50, "term_match": 0.20},
+    "policy": {"high": 0.70, "medium": 0.50, "term_match": 0.20},
 }
 DEFAULT_THRESHOLDS = {"high": 0.78, "medium": 0.58, "term_match": 0.25}
 
@@ -559,6 +561,7 @@ class EnhancedRAGSearch:
             "food_drink": ["飲食", "食べ物", "drink", "food"],
             "parking": ["駐車場", "parking"],
             "bicycle": ["駐輪場", "bicycle parking"],
+            "policy": ["ルール", "ポリシー", "同伴", "補助犬", "一時外出", "policy"],
         }
 
         if category in category_keywords:

--- a/backend/utils/intent_classifier.py
+++ b/backend/utils/intent_classifier.py
@@ -28,7 +28,6 @@ from backend.config.routing_constants import (
     LOST_FOUND_KEYWORDS,
     MEETING_ROOM_KEYWORDS,
     PARKING_KEYWORDS,
-    PET_POLICY_KEYWORDS,
     PHOTOGRAPHY_KEYWORDS,
     PRICING_KEYWORDS,
     RECEPTION_KEYWORDS,
@@ -39,6 +38,7 @@ from backend.config.routing_constants import (
     WIFI_KEYWORDS,
     match_farewell_keywords,
     match_keywords,
+    match_pet_policy_keywords,
 )
 
 _MATA_KIMASU_FAREWELL_RE = re.compile(r"また\s*来(ます|る|ました|るね|ますね)\s*[。!！?？\.]?\s*$")
@@ -452,7 +452,7 @@ def classify_fast_intent(query: str) -> Optional[FastIntent]:
             "temporary_exit",
             "Temporary exit policy keyword detected",
         )
-    if match_keywords(lower_query, PET_POLICY_KEYWORDS):
+    if match_pet_policy_keywords(lower_query):
         return FastIntent(
             "facility",
             "facility-info",

--- a/backend/utils/intent_classifier.py
+++ b/backend/utils/intent_classifier.py
@@ -28,11 +28,13 @@ from backend.config.routing_constants import (
     LOST_FOUND_KEYWORDS,
     MEETING_ROOM_KEYWORDS,
     PARKING_KEYWORDS,
+    PET_POLICY_KEYWORDS,
     PHOTOGRAPHY_KEYWORDS,
     PRICING_KEYWORDS,
     RECEPTION_KEYWORDS,
     SLIDE_KEYWORDS,
     SMOKING_KEYWORDS,
+    TEMPORARY_EXIT_KEYWORDS,
     TOILET_KEYWORDS,
     WIFI_KEYWORDS,
     match_farewell_keywords,
@@ -442,6 +444,20 @@ def classify_fast_intent(query: str) -> Optional[FastIntent]:
             "facility-info",
             "children_noise",
             "Children/noise policy keyword detected",
+        )
+    if match_keywords(lower_query, TEMPORARY_EXIT_KEYWORDS):
+        return FastIntent(
+            "facility",
+            "facility-info",
+            "temporary_exit",
+            "Temporary exit policy keyword detected",
+        )
+    if match_keywords(lower_query, PET_POLICY_KEYWORDS):
+        return FastIntent(
+            "facility",
+            "facility-info",
+            "pets",
+            "Pet policy keyword detected",
         )
     if match_keywords(lower_query, FACILITY_EQUIPMENT_KEYWORDS):
         return FastIntent(


### PR DESCRIPTION
## Summary
- Fix deterministic routing for alpha C/RAGAS live-source failures gt-038 (`一時外出のルールは？`) and gt-057 (`ペットを連れて入れますか？`).
- Add fact-complete FacilityAgent canonical answers for temporary-exit and pet-policy rules, matching checked-in KB/golden facts.
- Add policy RAG category support for pet-policy retrieval and focused regression tests.

## Root Cause
The exact JA policy questions were not covered by fast routing, so live traffic could fall through to LLM routing, land in BusinessInfoAgent with no useful request type, search the broad `general` category, and return fallback with `sources=[fallback]`.

## Validation
- `ruff check backend/config/routing_constants.py backend/utils/intent_classifier.py backend/agents/facility_agent.py backend/tools/enhanced_rag.py backend/tests/agents/test_orchestrator_fast_routing.py backend/tests/agents/test_facility_agent.py backend/tests/config/test_routing_constants.py`
- `pytest tests/agents/test_orchestrator_fast_routing.py tests/agents/test_facility_agent.py tests/config/test_routing_constants.py -q`
- `pytest tests/tools/test_enhanced_rag.py tests/tools/test_enhanced_rag_scoring.py -q`
- Pure behavior check confirmed both exact questions route to `facility`, return expected facts, and expose `sources=[enhanced_rag]`.

Refs #583
Refs #672