### PR TITLE
fix: align alpha stt fallback gate contract

### DIFF
--- a/backend/agents/stt_agent.py
+++ b/backend/agents/stt_agent.py
@@ -1523,6 +1523,19 @@ class STTAgent:
                     self.stt_client.transcribe(audio_data, language=language),
                     timeout=self._qwen_timeout,
                 )
+            except asyncio.CancelledError:
+                log_stt_event(
+                    event="stt_qwen_complete",
+                    stt_trace_id=stt_trace_id,
+                    provider="qwen-primary",
+                    language=language,
+                    success=False,
+                    cancelled=True,
+                    error_type="CancelledError",
+                    stt_qwen_duration_ms=_duration_ms(qwen_started_at),
+                    qwen_postprocess_enabled=qwen_postprocess_enabled,
+                )
+                raise
             except Exception as exc:
                 log_stt_event(
                     event="stt_qwen_complete",

--- a/backend/tests/agents/test_stt_agent.py
+++ b/backend/tests/agents/test_stt_agent.py
@@ -2462,6 +2462,15 @@ class TestQwenPrimaryFallback:
         ]
         assert "stt_vosk_early_accept" in events
         assert "stt_qwen_hedge_grace_start" not in events
+        qwen_complete = next(
+            record
+            for record in caplog.records
+            if record.name == "backend.observability.stt"
+            and getattr(record, "event", None) == "stt_qwen_complete"
+        )
+        assert qwen_complete.success is False
+        assert qwen_complete.cancelled is True
+        assert qwen_complete.error_type == "CancelledError"
 
     @pytest.mark.asyncio
     async def test_vosk_hours_confusion_normalizes_and_skips_grace(self, caplog):

--- a/backend/tests/scripts/test_alpha_smoke_comprehensive_contract.py
+++ b/backend/tests/scripts/test_alpha_smoke_comprehensive_contract.py
@@ -1,0 +1,31 @@
+import subprocess
+from pathlib import Path
+
+ROOT_DIR = Path(__file__).resolve().parents[3]
+SCRIPT = ROOT_DIR / "scripts" / "alpha-smoke-comprehensive.sh"
+
+
+def test_alpha_smoke_allows_vosk_fallback_by_default() -> None:
+    result = subprocess.run(
+        [str(SCRIPT), "--dry-run", "--scenarios", "A"],
+        check=True,
+        cwd=ROOT_DIR,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+
+    assert "Require Qwen primary for A STT: 0" in result.stdout
+
+
+def test_alpha_smoke_keeps_explicit_strict_qwen_option() -> None:
+    result = subprocess.run(
+        [str(SCRIPT), "--dry-run", "--scenarios", "A", "--require-qwen-primary"],
+        check=True,
+        cwd=ROOT_DIR,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+
+    assert "Require Qwen primary for A STT: 1" in result.stdout

--- a/scripts/alpha-smoke-comprehensive.sh
+++ b/scripts/alpha-smoke-comprehensive.sh
@@ -31,7 +31,7 @@ SLEEP_SECONDS=1
 TTS_PROVIDER="piper"
 PARALLEL=5
 STT_THRESHOLD=0.50
-REQUIRE_QWEN_PRIMARY="${ALPHA_SMOKE_REQUIRE_QWEN_PRIMARY:-1}"
+REQUIRE_QWEN_PRIMARY="${ALPHA_SMOKE_REQUIRE_QWEN_PRIMARY:-0}"
 RETRIES="${ALPHA_SMOKE_RETRIES:-3}"
 LTM_RECALL_RETRIES="${ALPHA_SMOKE_LTM_RECALL_RETRIES:-2}"
 LTM_RECALL_RETRY_SLEEP="${ALPHA_SMOKE_LTM_RECALL_RETRY_SLEEP:-2}"
@@ -61,7 +61,8 @@ Options:
   --tts-provider NAME    TTS provider for A-4 round-trip audio (default: piper)
   --parallel N           D-1 visitor parallelism (default: 5)
   --stt-threshold FLOAT  A-4 SequenceMatcher similarity threshold (default: 0.50)
-  --allow-vosk-fallback  Allow A scenario STT provider to be vosk-fallback (debug only)
+  --allow-vosk-fallback  Allow A scenario STT provider to be vosk-fallback (default)
+  --require-qwen-primary Require A scenario STT provider to be qwen-primary
   --retries N            Retries for HTTP 429 responses (default: 3)
   --dry-run              Validate script data and planned requests without network
   -h, --help             Show this usage
@@ -88,6 +89,7 @@ while [ "$#" -gt 0 ]; do
     --parallel) PARALLEL="$2"; shift 2 ;;
     --stt-threshold) STT_THRESHOLD="$2"; shift 2 ;;
     --allow-vosk-fallback) REQUIRE_QWEN_PRIMARY=0; shift ;;
+    --require-qwen-primary) REQUIRE_QWEN_PRIMARY=1; shift ;;
     --retries) RETRIES="$2"; shift 2 ;;
     --dry-run) DRY_RUN=1; shift ;;
     -h|--help) usage 0 ;;
@@ -415,11 +417,13 @@ run_voice_case() {
   provider="$(printf '%s' "$LAST_BODY" | json_get sttProvider)"
   if is_success_json && [ -n "$transcript" ]; then
     if [ "$provider" = "qwen-primary" ]; then
-      record_result "A" "$case_id" "stt_provider" "PASS" "$LAST_HTTP" "$LAST_TIME_MS" "$lang" "qwen-primary" "$provider" "primary provider selected"
+      record_result "A" "$case_id" "stt_provider" "PASS" "$LAST_HTTP" "$LAST_TIME_MS" "$lang" "qwen-primary|vosk-fallback" "$provider" "primary provider selected"
+    elif [ "$provider" = "vosk-fallback" ] && [ "$REQUIRE_QWEN_PRIMARY" != "1" ]; then
+      record_result "A" "$case_id" "stt_provider" "PASS" "$LAST_HTTP" "$LAST_TIME_MS" "$lang" "qwen-primary|vosk-fallback" "$provider" "fallback accepted by alpha STT contract"
     elif [ "$REQUIRE_QWEN_PRIMARY" = "1" ]; then
       record_result "A" "$case_id" "stt_provider" "FAIL" "$LAST_HTTP" "$LAST_TIME_MS" "$lang" "qwen-primary" "${provider:-unknown}" "Qwen primary required; transcript=$transcript"
     else
-      record_result "A" "$case_id" "stt_provider" "WARN" "$LAST_HTTP" "$LAST_TIME_MS" "$lang" "qwen-primary" "${provider:-unknown}" "fallback allowed for this run"
+      record_result "A" "$case_id" "stt_provider" "FAIL" "$LAST_HTTP" "$LAST_TIME_MS" "$lang" "qwen-primary|vosk-fallback" "${provider:-unknown}" "unexpected STT provider; transcript=$transcript"
     fi
     sim="$(similarity "$text" "$transcript")"
     status="$(python3 - "$sim" "$STT_THRESHOLD" <<'PY'
@@ -769,6 +773,7 @@ dry_run() {
   echo "Backend SHA: $BACKEND_SHA"
   echo "Scenarios: $SCENARIOS"
   echo "429 retries: $RETRIES"
+  echo "Require Qwen primary for A STT: $REQUIRE_QWEN_PRIMARY"
   echo "Reports: $REPORT_MD / $REPORT_CSV"
   printf 'A utterances: '; printf '%s\n' "$A_UTTERANCES" | sed '/^$/d' | wc -l | tr -d ' '
   echo ""


### PR DESCRIPTION
## Summary
- Align alpha A-suite STT provider gating with the existing fallback contract by allowing `vosk-fallback` by default.
- Add `--require-qwen-primary` for strict diagnostic runs when Qwen-primary must be enforced explicitly.
- Emit `stt_qwen_complete` for cancelled Qwen hedge tasks so Cloud Logging generation checks do not count normal fallback cancellation as missing telemetry.

Fixes #723.

## Validation
- `backend/.venv/bin/python -m pytest backend/tests/agents/test_stt_agent.py::TestQwenPrimaryFallback backend/tests/scripts/test_alpha_smoke_comprehensive_contract.py -q`
- `backend/.venv/bin/ruff check backend/agents/stt_agent.py backend/tests/agents/test_stt_agent.py backend/tests/scripts/test_alpha_smoke_comprehensive_contract.py`
- `backend/.venv/bin/black --check backend/tests/scripts/test_alpha_smoke_comprehensive_contract.py`
- `bash -n scripts/alpha-smoke-comprehensive.sh scripts/voice-pipeline-live-preflight.sh scripts/cloud-logging-verify.sh`

## Alpha impact
A-suite no longer fails solely because Vosk wins under the documented fallback contract. Strict Qwen-primary proof remains available with `--require-qwen-primary`, and E should now see completion telemetry for cancelled Qwen hedges.