### PR TITLE
feat(infra): cron failure alert + DB schema drift detection (Fixes #717 #719)

### DIFF
--- a/.github/workflows/db-schema-drift.yml
+++ b/.github/workflows/db-schema-drift.yml
@@ -8,14 +8,22 @@ on:
     paths:
       - 'backend/supabase/migrations/**'
 
+permissions:
+  contents: read
+
+concurrency:
+  group: db-schema-drift-${{ github.ref }}
+  cancel-in-progress: false
+
 jobs:
   drift-check:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@v4
 
       - name: Install Supabase CLI
-        run: npm i -g supabase
+        run: npm i -g supabase@^1
 
       - name: Check drift
         env:

--- a/.github/workflows/db-schema-drift.yml
+++ b/.github/workflows/db-schema-drift.yml
@@ -1,0 +1,25 @@
+name: DB Schema Drift Check
+
+on:
+  schedule:
+    - cron: '0 12 * * *'
+  workflow_dispatch:
+  pull_request:
+    paths:
+      - 'backend/supabase/migrations/**'
+
+jobs:
+  drift-check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Supabase CLI
+        run: npm i -g supabase
+
+      - name: Check drift
+        env:
+          SUPABASE_ACCESS_TOKEN: ${{ secrets.SUPABASE_ACCESS_TOKEN }}
+          SUPABASE_PROJECT_ID: ${{ secrets.SUPABASE_PROJECT_ID }}
+          SUPABASE_DB_PASSWORD: ${{ secrets.SUPABASE_DB_PASSWORD }}
+        run: ./scripts/check-db-schema-drift.sh

--- a/docs/runbook/cron-failure.md
+++ b/docs/runbook/cron-failure.md
@@ -1,0 +1,53 @@
+# Cron Failure Runbook
+
+Audience: alpha operators and release owners.
+
+## How alerts are detected
+
+The Vercel cron route `/api/cron/update-knowledge-base` runs daily at 02:00 UTC / 11:00 JST. When the update throws, the route records failure metrics and calls `dispatchCronAlert()`.
+
+If `CRON_SLACK_WEBHOOK_URL` is set in Vercel, Slack receives a message like:
+
+```text
+Cron failure: /api/cron/update-knowledge-base (Supabase request timed out)
+Cron: /api/cron/update-knowledge-base
+Duration: 1234ms
+Metrics tracked: yes
+Deployment: https://<vercel-deployment>
+```
+
+If the webhook is unset or Slack delivery fails, Vercel runtime logs still contain `[CRON_ALERT]`. During alpha, check the Slack alert channel or Vercel cron runtime logs every business day so failures are detected within 24 hours.
+
+## First response
+
+1. Open the Vercel project logs for the latest `/api/cron/update-knowledge-base` invocation.
+2. Confirm whether the failure happened before or after `ragMetrics.trackKnowledgeBaseOperation()`.
+3. Check Supabase project health and recent deployment changes.
+4. Post the failure summary, timestamp, and suspected owner in the alpha operations channel.
+
+## Manual rerun
+
+Use the production cron secret and call the route directly:
+
+```bash
+curl -i \
+  -H "Authorization: Bearer ${CRON_SECRET}" \
+  "https://<vercel-domain>/api/cron/update-knowledge-base"
+```
+
+Expected success response:
+
+```json
+{
+  "success": true,
+  "message": "Knowledge base update completed"
+}
+```
+
+## Recurrence prevention
+
+Keep `CRON_SLACK_WEBHOOK_URL` set for production and preview environments used in alpha. After any cron failure, add the root cause and fix link to the alpha verification notes. If the same failure repeats twice in 7 days, open a P1 issue and assign an owner before the next onsite verification window.
+
+## Escalation
+
+Escalate immediately when the cron has failed for 24 hours, the knowledge base import is stale before onsite verification, or the alert path itself stops posting to Slack. The release owner decides whether to pause alpha validation until a manual rerun succeeds.

--- a/docs/runbook/db-schema-drift.md
+++ b/docs/runbook/db-schema-drift.md
@@ -1,0 +1,55 @@
+# DB Schema Drift Runbook
+
+Audience: backend developers and release owners.
+
+## What the check does
+
+The `DB Schema Drift Check` workflow runs daily at 12:00 UTC / 21:00 JST and on pull requests that change `backend/supabase/migrations/**`. It installs the Supabase CLI, links the project with GitHub Actions secrets, and runs:
+
+```bash
+./scripts/check-db-schema-drift.sh
+```
+
+The script compares local migrations with the linked Supabase project using `supabase db diff --linked --schema public`. It prints the diff and exits 1 when drift is found. It exits 2 when required secrets or tooling are missing.
+
+## Drift response
+
+1. Read the workflow log and identify the table, column, policy, index, or function that differs.
+2. Decide whether production is ahead of migrations or the migration history is missing a reviewed change.
+3. Add a reviewed migration file under `backend/supabase/migrations/`, test it against a safe environment, and rerun the workflow.
+
+Do not resolve drift by changing production directly during alpha unless the release owner approves an incident workaround.
+
+## Creating a manual migration
+
+Create a migration file with a UTC timestamp and descriptive name:
+
+```bash
+timestamp="$(date -u +%Y%m%d%H%M%S)"
+migration="backend/supabase/migrations/${timestamp}_describe_change.sql"
+: > "${migration}"
+${EDITOR:-vi} "${migration}"
+```
+
+Edit the SQL so it is idempotent where practical, includes any needed indexes or RLS policy changes, and can be reviewed without relying on dashboard context.
+
+## Production synchronization
+
+After the migration is reviewed and merged, apply it through the normal release process for the Supabase project. Then rerun `DB Schema Drift Check` with `workflow_dispatch`. The workflow must show no schema changes before a Cloud Run or Vercel deploy that depends on the schema.
+
+## Emergency dashboard change template
+
+Use this commit message body when a dashboard change was unavoidable and needs to be captured afterward:
+
+```text
+Capture emergency Supabase schema change
+
+Reason:
+Production timestamp:
+Operator:
+Affected objects:
+Verification:
+Follow-up issue:
+```
+
+Open the follow-up PR before the next alpha verification window and include the workflow log proving drift is resolved.

--- a/frontend/src/__tests__/monitoring/cron-alerts.test.ts
+++ b/frontend/src/__tests__/monitoring/cron-alerts.test.ts
@@ -1,0 +1,123 @@
+import assert from 'node:assert/strict';
+import { afterEach, test } from 'node:test';
+
+import { dispatchCronAlert } from '../../lib/monitoring/cron-alerts';
+import type { CronAlertContext } from '../../lib/monitoring/cron-alerts';
+
+const env = process.env as Record<string, string | undefined>;
+const originalWebhookUrl = env.CRON_SLACK_WEBHOOK_URL;
+const originalDeploymentUrl = env.VERCEL_DEPLOYMENT_URL;
+const originalFetch = global.fetch;
+const originalConsoleError = console.error;
+
+const baseContext: CronAlertContext = {
+  cronName: '/api/cron/update-knowledge-base',
+  startTime: Date.UTC(2026, 4, 3, 2, 0, 0),
+  duration: 1234,
+  error: new Error('Supabase request timed out'),
+  metricsTracked: true,
+};
+
+afterEach(() => {
+  if (originalWebhookUrl === undefined) {
+    delete env.CRON_SLACK_WEBHOOK_URL;
+  } else {
+    env.CRON_SLACK_WEBHOOK_URL = originalWebhookUrl;
+  }
+
+  if (originalDeploymentUrl === undefined) {
+    delete env.VERCEL_DEPLOYMENT_URL;
+  } else {
+    env.VERCEL_DEPLOYMENT_URL = originalDeploymentUrl;
+  }
+
+  global.fetch = originalFetch;
+  console.error = originalConsoleError;
+});
+
+test(
+  'logs and does not throw when the Slack webhook URL is unset',
+  { concurrency: false },
+  async () => {
+    delete env.CRON_SLACK_WEBHOOK_URL;
+    const errors: unknown[][] = [];
+    console.error = (...args: unknown[]) => {
+      errors.push(args);
+    };
+
+    await assert.doesNotReject(dispatchCronAlert(baseContext));
+
+    assert.equal(errors.length, 1);
+    assert.match(String(errors[0][0]), /CRON_SLACK_WEBHOOK_URL is not set/);
+  }
+);
+
+test(
+  'posts a Slack incoming webhook payload when configured',
+  { concurrency: false },
+  async () => {
+    env.CRON_SLACK_WEBHOOK_URL = 'https://hooks.slack.example/services/test';
+    env.VERCEL_DEPLOYMENT_URL = 'engineer-cafe.vercel.app';
+    let capturedUrl: string | URL | Request | undefined;
+    let capturedInit: RequestInit | undefined;
+
+    global.fetch = (async (input, init) => {
+      capturedUrl = input;
+      capturedInit = init;
+      return new Response('ok', { status: 200 });
+    }) as typeof fetch;
+
+    await dispatchCronAlert(baseContext);
+
+    assert.equal(capturedUrl, 'https://hooks.slack.example/services/test');
+    assert.equal(capturedInit?.method, 'POST');
+    assert.deepEqual(capturedInit?.headers, { 'Content-Type': 'application/json' });
+
+    const body = JSON.parse(String(capturedInit?.body)) as Record<string, unknown>;
+    assert.equal(
+      body.text,
+      'Cron failure: /api/cron/update-knowledge-base (Supabase request timed out)'
+    );
+    assert.match(JSON.stringify(body), /engineer-cafe\.vercel\.app/);
+  }
+);
+
+test(
+  'logs and does not throw when fetch rejects',
+  { concurrency: false },
+  async () => {
+    env.CRON_SLACK_WEBHOOK_URL = 'https://hooks.slack.example/services/test';
+    const errors: unknown[][] = [];
+    console.error = (...args: unknown[]) => {
+      errors.push(args);
+    };
+    global.fetch = (async () => {
+      throw new Error('network down');
+    }) as typeof fetch;
+
+    await assert.doesNotReject(dispatchCronAlert(baseContext));
+
+    assert.equal(errors.length, 1);
+    assert.match(String(errors[0][0]), /Failed to dispatch Slack cron alert/);
+  }
+);
+
+test(
+  'includes cron name, duration, and error message in the payload',
+  { concurrency: false },
+  async () => {
+    env.CRON_SLACK_WEBHOOK_URL = 'https://hooks.slack.example/services/test';
+    let payload = '';
+
+    global.fetch = (async (_input, init) => {
+      payload = String(init?.body);
+      return new Response('ok', { status: 200 });
+    }) as typeof fetch;
+
+    await dispatchCronAlert(baseContext);
+
+    assert.match(payload, /\/api\/cron\/update-knowledge-base/);
+    assert.match(payload, /1234ms/);
+    assert.match(payload, /Supabase request timed out/);
+  }
+);

--- a/frontend/src/__tests__/monitoring/cron-alerts.test.ts
+++ b/frontend/src/__tests__/monitoring/cron-alerts.test.ts
@@ -103,6 +103,27 @@ test(
 );
 
 test(
+  'logs and does not throw when the Slack webhook request times out',
+  { concurrency: false },
+  async () => {
+    env.CRON_SLACK_WEBHOOK_URL = 'https://hooks.slack.example/services/test';
+    const errors: unknown[][] = [];
+    console.error = (...args: unknown[]) => {
+      errors.push(args);
+    };
+    global.fetch = (async () => {
+      throw new DOMException('The operation was aborted', 'AbortError');
+    }) as typeof fetch;
+
+    await assert.doesNotReject(dispatchCronAlert(baseContext));
+
+    assert.equal(errors.length, 1);
+    assert.match(String(errors[0][0]), /Failed to dispatch Slack cron alert/);
+    assert.equal((errors[0][1] as DOMException).name, 'AbortError');
+  }
+);
+
+test(
   'includes cron name, duration, and error message in the payload',
   { concurrency: false },
   async () => {

--- a/frontend/src/app/api/cron/update-knowledge-base/route.ts
+++ b/frontend/src/app/api/cron/update-knowledge-base/route.ts
@@ -1,6 +1,9 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { knowledgeBaseUpdater } from '@/jobs/update-knowledge-base';
+import { dispatchCronAlert } from '@/lib/monitoring/cron-alerts';
 import { ragMetrics } from '@/lib/monitoring/rag-metrics';
+
+const CRON_NAME = '/api/cron/update-knowledge-base';
 
 /**
  * CRON endpoint for automated knowledge base updates
@@ -47,23 +50,38 @@ export async function GET(request: NextRequest) {
     
   } catch (error) {
     const duration = Date.now() - startTime;
+    const cronError = error instanceof Error ? error : new Error('Unknown error');
+    let metricsTracked = false;
     
     console.error('[CRON] Knowledge base update failed:', error);
     
     // Track error metrics
-    await ragMetrics.trackKnowledgeBaseOperation({
-      operation: 'batch_import',
-      category: 'automated_update',
-      count: 0,
+    try {
+      await ragMetrics.trackKnowledgeBaseOperation({
+        operation: 'batch_import',
+        category: 'automated_update',
+        count: 0,
+        duration,
+        success: false,
+        error: cronError.message,
+      });
+      metricsTracked = true;
+    } catch (metricsError) {
+      console.error('[CRON] Failed to track knowledge base error metrics:', metricsError);
+    }
+
+    await dispatchCronAlert({
+      cronName: CRON_NAME,
+      startTime,
       duration,
-      success: false,
-      error: error instanceof Error ? error.message : 'Unknown error',
+      error: cronError,
+      metricsTracked,
     });
     
     return NextResponse.json(
       {
         error: 'Knowledge base update failed',
-        message: error instanceof Error ? error.message : 'Unknown error',
+        message: cronError.message,
         duration: `${duration}ms`,
         timestamp: new Date().toISOString(),
       },

--- a/frontend/src/lib/monitoring/cron-alerts.ts
+++ b/frontend/src/lib/monitoring/cron-alerts.ts
@@ -1,0 +1,122 @@
+export interface CronAlertContext {
+  cronName: string;
+  startTime: number;
+  duration: number;
+  error?: Error;
+  metricsTracked: boolean;
+}
+
+interface SlackBlock {
+  type: 'section' | 'context';
+  text?: {
+    type: 'mrkdwn';
+    text: string;
+  };
+  fields?: Array<{
+    type: 'mrkdwn';
+    text: string;
+  }>;
+  elements?: Array<{
+    type: 'mrkdwn';
+    text: string;
+  }>;
+}
+
+interface SlackPayload {
+  text: string;
+  blocks: SlackBlock[];
+}
+
+const ALERT_PREFIX = '[CRON_ALERT]';
+
+function formatIsoTime(timestamp: number): string {
+  return new Date(timestamp).toISOString();
+}
+
+function getDeploymentUrl(): string | undefined {
+  const deploymentUrl = process.env.VERCEL_DEPLOYMENT_URL;
+
+  if (!deploymentUrl) {
+    return undefined;
+  }
+
+  return deploymentUrl.startsWith('http') ? deploymentUrl : `https://${deploymentUrl}`;
+}
+
+function buildSlackPayload(ctx: CronAlertContext): SlackPayload {
+  const startedAt = formatIsoTime(ctx.startTime);
+  const deploymentUrl = getDeploymentUrl();
+  const errorMessage = ctx.error?.message ?? 'Unknown error';
+  const fields = [
+    `*Cron*\n${ctx.cronName}`,
+    `*Duration*\n${ctx.duration}ms`,
+    `*Started at*\n${startedAt}`,
+    `*Metrics tracked*\n${ctx.metricsTracked ? 'yes' : 'no'}`,
+  ];
+
+  if (deploymentUrl) {
+    fields.push(`*Deployment*\n${deploymentUrl}`);
+  }
+
+  return {
+    text: `Cron failure: ${ctx.cronName} (${errorMessage})`,
+    blocks: [
+      {
+        type: 'section',
+        text: {
+          type: 'mrkdwn',
+          text: `:rotating_light: *Cron failure detected*\n${ctx.cronName}`,
+        },
+      },
+      {
+        type: 'section',
+        fields: fields.map((text) => ({ type: 'mrkdwn', text })),
+      },
+      {
+        type: 'section',
+        text: {
+          type: 'mrkdwn',
+          text: `*Error*\n${errorMessage}`,
+        },
+      },
+      {
+        type: 'context',
+        elements: [
+          {
+            type: 'mrkdwn',
+            text: 'Check Vercel runtime logs, then follow docs/runbook/cron-failure.md.',
+          },
+        ],
+      },
+    ],
+  };
+}
+
+export async function dispatchCronAlert(ctx: CronAlertContext): Promise<void> {
+  const webhookUrl = process.env.CRON_SLACK_WEBHOOK_URL;
+  const payload = buildSlackPayload(ctx);
+
+  if (!webhookUrl) {
+    console.error(`${ALERT_PREFIX} CRON_SLACK_WEBHOOK_URL is not set`, payload);
+    return;
+  }
+
+  try {
+    const response = await fetch(webhookUrl, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify(payload),
+    });
+
+    if (!response.ok) {
+      console.error(
+        `${ALERT_PREFIX} Slack webhook returned ${response.status} ${response.statusText}`,
+        payload
+      );
+    }
+  } catch (error) {
+    console.error(`${ALERT_PREFIX} Failed to dispatch Slack cron alert`, error, payload);
+  }
+}

--- a/frontend/src/lib/monitoring/cron-alerts.ts
+++ b/frontend/src/lib/monitoring/cron-alerts.ts
@@ -108,6 +108,7 @@ export async function dispatchCronAlert(ctx: CronAlertContext): Promise<void> {
         'Content-Type': 'application/json',
       },
       body: JSON.stringify(payload),
+      signal: AbortSignal.timeout(3000),
     });
 
     if (!response.ok) {

--- a/scripts/check-db-schema-drift.sh
+++ b/scripts/check-db-schema-drift.sh
@@ -1,0 +1,68 @@
+#!/usr/bin/env bash
+# Usage: ./scripts/check-db-schema-drift.sh
+# Required env: SUPABASE_ACCESS_TOKEN, SUPABASE_PROJECT_ID, SUPABASE_DB_PASSWORD
+# Exit 0: no drift / Exit 1: drift detected / Exit 2: missing config or tooling failure
+
+set -euo pipefail
+
+required_env=(
+  "SUPABASE_ACCESS_TOKEN"
+  "SUPABASE_PROJECT_ID"
+  "SUPABASE_DB_PASSWORD"
+)
+
+missing_env=()
+for name in "${required_env[@]}"; do
+  if [[ -z "${!name:-}" ]]; then
+    missing_env+=("${name}")
+  fi
+done
+
+if (( ${#missing_env[@]} > 0 )); then
+  printf 'Missing required environment variables: %s\n' "${missing_env[*]}" >&2
+  exit 2
+fi
+
+if ! command -v supabase >/dev/null 2>&1; then
+  printf 'Supabase CLI is required. Install it before running this check.\n' >&2
+  exit 2
+fi
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+supabase_dir="${repo_root}/backend/supabase"
+
+if [[ ! -f "${supabase_dir}/config.toml" ]]; then
+  printf 'Supabase config not found at %s\n' "${supabase_dir}/config.toml" >&2
+  exit 2
+fi
+
+diff_output_file="$(mktemp)"
+trap 'rm -f "${diff_output_file}"' EXIT
+
+(
+  cd "${supabase_dir}"
+  supabase link \
+    --project-ref "${SUPABASE_PROJECT_ID}" \
+    --password "${SUPABASE_DB_PASSWORD}" >/dev/null
+
+  supabase db diff --linked --schema public > "${diff_output_file}"
+) || {
+  cat "${diff_output_file}" >&2 || true
+  printf 'Supabase schema drift check failed before a reliable drift verdict was produced.\n' >&2
+  exit 2
+}
+
+cat "${diff_output_file}"
+
+if grep -Eq 'No schema changes found' "${diff_output_file}"; then
+  printf 'No Supabase schema drift detected.\n'
+  exit 0
+fi
+
+if [[ ! -s "${diff_output_file}" ]]; then
+  printf 'No Supabase schema drift detected.\n'
+  exit 0
+fi
+
+printf 'Supabase schema drift detected. Capture this diff in a reviewed migration before deploy.\n' >&2
+exit 1


### PR DESCRIPTION
## Summary

Closes #717 (cron failure alert) and Closes #719 (DB schema drift detection).

Independent from PR 720 and PR 722; merge after both runtime PRs land.

### Cron failure alert
- Add `dispatchCronAlert()` in `frontend/src/lib/monitoring/cron-alerts.ts`.
- Wire it into `frontend/src/app/api/cron/update-knowledge-base/route.ts` failure path.
- Slack incoming webhook format; falls back to `console.error` when `CRON_SLACK_WEBHOOK_URL` is unset.
- Unit tests in `frontend/src/__tests__/monitoring/cron-alerts.test.ts`.

### DB schema drift detection
- Add `scripts/check-db-schema-drift.sh` using Supabase CLI `db diff --linked --schema public` in read-only mode.
- Add `.github/workflows/db-schema-drift.yml` as a separate workflow for daily checks and migration PRs.
- Add runbooks: `docs/runbook/cron-failure.md`, `docs/runbook/db-schema-drift.md`.

## Validation

- `pnpm --dir frontend exec tsx --test src/__tests__/monitoring/cron-alerts.test.ts`
- `pnpm --dir frontend exec tsc --noEmit`
- `pnpm --dir frontend lint` (passes; existing `MarpViewer.tsx` hook dependency warnings remain)
- `bash scripts/check-db-schema-drift.sh` without SUPABASE_* env exits 2 with the missing secret names
- `rg -n "supabase db (push|reset)|supabase migration repair|db push|db reset|migration repair" scripts/check-db-schema-drift.sh` returned no matches
- `git diff --check` on the modified route and no-index diff checks on new files produced no whitespace errors

## Deployment notes

- Required new GitHub Actions secrets: `SUPABASE_ACCESS_TOKEN`, `SUPABASE_PROJECT_ID`, `SUPABASE_DB_PASSWORD`
- Set the required GitHub Actions secrets with `gh secret set` before merge; the drift workflow exits 2 when they are absent.
- Optional Vercel env: `CRON_SLACK_WEBHOOK_URL`
- `CRON_SLACK_WEBHOOK_URL` is optional but recommended for alpha so cron failures reach Slack instead of only Vercel runtime logs.
- No Cloud Run / piper-plus / voicevox config changes.

## Manual verification after deploy

- Trigger `/api/cron/update-knowledge-base` against a Vercel preview or production URL with `CRON_SECRET`, then verify Slack delivery when `CRON_SLACK_WEBHOOK_URL` is configured.
- Run `DB Schema Drift Check` with `workflow_dispatch` after the Supabase secrets are configured; green means no schema changes were detected.

## Out of scope (intentional)

- PR #720 (filler playback race guard) — runtime fix, separately tracked.
- PR #722 (NUL byte sanitization for /api/chat 500) — runtime fix, separately tracked.
- Sentry / PostHog observability layer (Epic B #483 sub-task B-X-2).
- API key rotation runbook (Epic B #483 sub-task B-X-1).

## Open questions

None.

Refs #483 (Epic B operations reliability)
