### PR TITLE
fix: exclude quality gate pacing from latency

### DIFF
--- a/backend/evaluation/live_quality_gates.py
+++ b/backend/evaluation/live_quality_gates.py
@@ -306,12 +306,14 @@ async def post_json(
         "Content-Type": "application/json",
         "X-API-Key": api_key,
     }
-    started = time.perf_counter()
+    started: float | None = None
     raw = ""
     status = 0
     for attempt in range(retries + 1):
         if pacer:
             await pacer.wait(endpoint)
+        if started is None:
+            started = time.perf_counter()
         try:
             resp = await client.post(
                 f"{base_url.rstrip('/')}{endpoint}",
@@ -330,9 +332,11 @@ async def post_json(
                 delay = 0.0
             await asyncio.sleep(max(delay, 5.0 * (attempt + 1)))
         except Exception as exc:
-            duration_ms = int((time.perf_counter() - started) * 1000)
+            duration_started = started if started is not None else time.perf_counter()
+            duration_ms = int((time.perf_counter() - duration_started) * 1000)
             return 0, duration_ms, {}, f"{type(exc).__name__}: {exc}"
-    duration_ms = int((time.perf_counter() - started) * 1000)
+    duration_started = started if started is not None else time.perf_counter()
+    duration_ms = int((time.perf_counter() - duration_started) * 1000)
     try:
         parsed = json.loads(raw) if raw else {}
     except json.JSONDecodeError:

--- a/backend/tests/evaluation/test_live_quality_gates.py
+++ b/backend/tests/evaluation/test_live_quality_gates.py
@@ -1,7 +1,13 @@
+import asyncio
+import httpx
+import pytest
+import time
+
 from evaluation.live_quality_gates import (
     check_answer_quality,
     check_safety,
     denies_explicit_ltm_recall,
+    post_json,
 )
 
 
@@ -48,3 +54,38 @@ def test_explicit_ltm_denial_does_not_hide_concrete_ssid_recall() -> None:
     answer = "前に伝えたWi-FiのSSIDはcafe-freeです。"
 
     assert denies_explicit_ltm_recall(answer) is False
+
+
+@pytest.mark.asyncio
+async def test_post_json_excludes_initial_pacer_wait_from_duration() -> None:
+    events: list[str] = []
+
+    class Pacer:
+        async def wait(self, endpoint: str) -> None:
+            assert endpoint == "/api/chat"
+            events.append("wait")
+            await asyncio.sleep(0.12)
+
+    async def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(200, json={"answer": "ok"})
+
+    wall_started = time.perf_counter()
+    async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as client:
+        status, duration_ms, parsed, raw = await post_json(
+            client,
+            base_url="https://example.test",
+            api_key="secret",
+            endpoint="/api/chat",
+            body={"query": "少し雑談して"},
+            timeout=1,
+            pacer=Pacer(),
+            retries=0,
+        )
+    wall_elapsed_ms = int((time.perf_counter() - wall_started) * 1000)
+
+    assert status == 200
+    assert parsed == {"answer": "ok"}
+    assert raw == '{"answer":"ok"}'
+    assert wall_elapsed_ms >= 100
+    assert duration_ms < 100
+    assert events[0] == "wait"


### PR DESCRIPTION
## Summary
- Move live quality gate latency measurement to start after the request pacer wait.
- Keep `duration_ms` focused on actual API response time so Q gates do not fail because `ALPHA_QUALITY_CHAT_INTERVAL` sleep is included.
- Add regression coverage for pacer wait exclusion.

Addresses #653.

## Validation
- `backend/.venv/bin/ruff check backend/evaluation/live_quality_gates.py backend/tests/evaluation/test_live_quality_gates.py`
- `backend/.venv/bin/python -m pytest backend/tests/evaluation/test_live_quality_gates.py backend/tests/test_main_endpoints.py::TestChatEndpoint::test_chat_daily_conversation_uses_endpoint_fast_path -q`

## Alpha impact
The 2026-05-03 full run showed Q-DAILY-JA-001 failing with `latency=2201ms`, matching the configured 2.2s pacer interval rather than backend response time. This patch removes that false FAIL path; live Q still needs rerun after merge/deploy.