### PR TITLE
feat(frontend): iOS tap-to-enable UI + i18n unlock messaging (Refs #697 #634 #635 #471)

### DIFF
--- a/frontend/src/__tests__/audio/audio-user-interaction-gate.test.ts
+++ b/frontend/src/__tests__/audio/audio-user-interaction-gate.test.ts
@@ -1,0 +1,172 @@
+import assert from 'node:assert/strict';
+import { afterEach, beforeEach, test } from 'node:test';
+
+import {
+  getTapToEnableAudioMessage,
+  isIOSWebKitAudio,
+} from '../../lib/audio/audio-user-interaction-gate';
+
+interface NavigatorStub {
+  userAgent: string;
+  vendor: string;
+  platform: string;
+  maxTouchPoints: number;
+}
+
+const originalWindowDescriptor = Object.getOwnPropertyDescriptor(globalThis, 'window');
+const originalDocumentDescriptor = Object.getOwnPropertyDescriptor(globalThis, 'document');
+const originalNavigatorDescriptor = Object.getOwnPropertyDescriptor(globalThis, 'navigator');
+
+const restoreGlobalProperty = (
+  key: 'window' | 'document' | 'navigator',
+  descriptor: PropertyDescriptor | undefined,
+): void => {
+  if (descriptor) {
+    Object.defineProperty(globalThis, key, descriptor);
+    return;
+  }
+
+  Reflect.deleteProperty(globalThis, key);
+};
+
+const defineNavigatorProperty = <Key extends keyof NavigatorStub>(
+  key: Key,
+  value: NavigatorStub[Key],
+): void => {
+  Object.defineProperty(globalThis.navigator, key, {
+    configurable: true,
+    value,
+  });
+};
+
+const stubNavigator = ({
+  userAgent,
+  vendor,
+  platform,
+  maxTouchPoints,
+}: NavigatorStub): void => {
+  defineNavigatorProperty('userAgent', userAgent);
+  defineNavigatorProperty('vendor', vendor);
+  defineNavigatorProperty('platform', platform);
+  defineNavigatorProperty('maxTouchPoints', maxTouchPoints);
+};
+
+beforeEach(() => {
+  Object.defineProperty(globalThis, 'window', {
+    configurable: true,
+    value: {},
+  });
+  Object.defineProperty(globalThis, 'document', {
+    configurable: true,
+    value: {},
+  });
+  Object.defineProperty(globalThis, 'navigator', {
+    configurable: true,
+    value: {},
+  });
+
+  stubNavigator({
+    userAgent: '',
+    vendor: '',
+    platform: '',
+    maxTouchPoints: 0,
+  });
+});
+
+afterEach(() => {
+  restoreGlobalProperty('window', originalWindowDescriptor);
+  restoreGlobalProperty('document', originalDocumentDescriptor);
+  restoreGlobalProperty('navigator', originalNavigatorDescriptor);
+});
+
+test('isIOSWebKitAudio returns false outside the browser', { concurrency: false }, () => {
+  Reflect.deleteProperty(globalThis, 'window');
+  Reflect.deleteProperty(globalThis, 'document');
+
+  assert.equal(isIOSWebKitAudio(), false);
+});
+
+test('isIOSWebKitAudio returns true for iPhone UA', { concurrency: false }, () => {
+  stubNavigator({
+    userAgent:
+      'Mozilla/5.0 (iPhone; CPU iPhone OS 17_0 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.0 Mobile/15E148 Safari/604.1',
+    vendor: 'Apple Computer, Inc.',
+    platform: 'iPhone',
+    maxTouchPoints: 1,
+  });
+
+  assert.equal(isIOSWebKitAudio(), true);
+});
+
+test('isIOSWebKitAudio returns true for iPad UA', { concurrency: false }, () => {
+  stubNavigator({
+    userAgent:
+      'Mozilla/5.0 (iPad; CPU OS 16_6 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/16.6 Mobile/15E148 Safari/604.1',
+    vendor: 'Apple Computer, Inc.',
+    platform: 'iPad',
+    maxTouchPoints: 5,
+  });
+
+  assert.equal(isIOSWebKitAudio(), true);
+});
+
+test('isIOSWebKitAudio returns true for iPadOS desktop UA spoofing', { concurrency: false }, () => {
+  stubNavigator({
+    userAgent:
+      'Mozilla/5.0 (Macintosh; Intel Mac OS X 13_4) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/16.5 Safari/605.1.15',
+    vendor: 'Apple Computer, Inc.',
+    platform: 'MacIntel',
+    maxTouchPoints: 5,
+  });
+
+  assert.equal(isIOSWebKitAudio(), true);
+});
+
+test('isIOSWebKitAudio returns false for desktop Chrome', { concurrency: false }, () => {
+  stubNavigator({
+    userAgent:
+      'Mozilla/5.0 (Macintosh; Intel Mac OS X 14_4) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/123.0.0.0 Safari/537.36',
+    vendor: 'Google Inc.',
+    platform: 'MacIntel',
+    maxTouchPoints: 0,
+  });
+
+  assert.equal(isIOSWebKitAudio(), false);
+});
+
+test('isIOSWebKitAudio returns false for desktop Safari on macOS', { concurrency: false }, () => {
+  stubNavigator({
+    userAgent:
+      'Mozilla/5.0 (Macintosh; Intel Mac OS X 14_4) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.4 Safari/605.1.15',
+    vendor: 'Apple Computer, Inc.',
+    platform: 'MacIntel',
+    maxTouchPoints: 0,
+  });
+
+  assert.equal(isIOSWebKitAudio(), false);
+});
+
+test('isIOSWebKitAudio returns false for Android Chrome', { concurrency: false }, () => {
+  stubNavigator({
+    userAgent:
+      'Mozilla/5.0 (Linux; Android 14; Pixel 8) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/123.0.0.0 Mobile Safari/537.36',
+    vendor: 'Google Inc.',
+    platform: 'Linux armv8l',
+    maxTouchPoints: 5,
+  });
+
+  assert.equal(isIOSWebKitAudio(), false);
+});
+
+test('getTapToEnableAudioMessage returns localized messages', { concurrency: false }, () => {
+  assert.equal(getTapToEnableAudioMessage('ja'), '音声を有効にするには、もう一度画面をタップしてください');
+  assert.equal(getTapToEnableAudioMessage('en'), 'Tap once more to enable audio playback');
+  assert.equal(getTapToEnableAudioMessage('zh'), '请再次点按屏幕以启用音频');
+  assert.equal(getTapToEnableAudioMessage('ko'), '오디오를 활성화하려면 화면을 한 번 더 탭하세요');
+});
+
+test('getTapToEnableAudioMessage falls back to English for unknown languages', {
+  concurrency: false,
+}, () => {
+  assert.equal(getTapToEnableAudioMessage('fr'), 'Tap once more to enable audio playback');
+});

--- a/frontend/src/__tests__/audio/audio-user-interaction-gate.test.ts
+++ b/frontend/src/__tests__/audio/audio-user-interaction-gate.test.ts
@@ -170,3 +170,9 @@ test('getTapToEnableAudioMessage falls back to English for unknown languages', {
 }, () => {
   assert.equal(getTapToEnableAudioMessage('fr'), 'Tap once more to enable audio playback');
 });
+
+test('getTapToEnableAudioMessage falls back to English for empty string', {
+  concurrency: false,
+}, () => {
+  assert.equal(getTapToEnableAudioMessage(''), 'Tap once more to enable audio playback');
+});

--- a/frontend/src/app/components/MarpViewer.tsx
+++ b/frontend/src/app/components/MarpViewer.tsx
@@ -6,6 +6,7 @@ import {
   AudioInteractionManager,
   unlockAudioForUserGesture,
 } from '@/lib/audio/audio-interaction-manager';
+import { getTapToEnableAudioMessage } from '@/lib/audio/audio-user-interaction-gate';
 import DOMPurify from 'dompurify';
 import { ChevronLeft, Keyboard, MessageCircle, Pause, Play, RotateCcw, Settings } from 'lucide-react';
 import React, { useCallback, useEffect, useRef, useState } from 'react';
@@ -81,6 +82,47 @@ interface MarpViewerProps {
 
 const SLIDE_TRANSITION_DELAY_MS = 500;
 const NARRATION_SCHEDULE_DELAY_MS = 300;
+
+const getErrorName = (error: unknown): string | null => {
+  if (typeof error !== 'object' || error === null || !('name' in error)) {
+    return null;
+  }
+
+  const name = (error as { name?: unknown }).name;
+  return typeof name === 'string' ? name : null;
+};
+
+const getErrorMessage = (error: unknown): string | null => {
+  if (typeof error !== 'object' || error === null || !('message' in error)) {
+    return null;
+  }
+
+  const message = (error as { message?: unknown }).message;
+  return typeof message === 'string' ? message : null;
+};
+
+const isAudioContextGestureBlocked = (): boolean => {
+  try {
+    const state = AudioInteractionManager.getInstance().getAudioContextState();
+    return state === 'suspended' || (state as string) === 'interrupted';
+  } catch {
+    return false;
+  }
+};
+
+const isNarrationGestureRequiredError = (error: unknown): boolean => {
+  const message = getErrorMessage(error);
+  return (
+    getErrorName(error) === 'NotAllowedError' ||
+    isAudioContextGestureBlocked() ||
+    message?.includes('interaction') === true
+  );
+};
+
+const getNarrationPlaybackFailureMessage = (language: 'ja' | 'en'): string =>
+  language === 'ja'
+    ? 'ナレーションの再生に失敗しました'
+    : 'Narration playback failed';
 
 export default function MarpViewer({
   slideFile = 'engineer-cafe',
@@ -923,15 +965,20 @@ export default function MarpViewer({
         }
 
         advancePresentation(500);
-      } catch (error: any) {
+      } catch (error) {
         resetNarrationFlags();
 
         // Browser autoplay policy requires explicit user interaction.
         if (
-          error?.type === 'user_interaction_required' ||
-          error?.requiresUserInteraction ||
-          error?.name === 'NotAllowedError' ||
-          error?.message?.includes('interaction')
+          (typeof error === 'object' &&
+            error !== null &&
+            'type' in error &&
+            error.type === 'user_interaction_required') ||
+          (typeof error === 'object' &&
+            error !== null &&
+            'requiresUserInteraction' in error &&
+            error.requiresUserInteraction === true) ||
+          isNarrationGestureRequiredError(error)
         ) {
           console.warn('[MarpViewer] autoplay blocked — user interaction required');
           setShowAudioPermissionPrompt(true);
@@ -941,6 +988,14 @@ export default function MarpViewer({
         }
 
         console.error('[MarpViewer] narration playback failed:', error);
+        if (isNarrationGestureRequiredError(error)) {
+          setShowAudioPermissionPrompt(true);
+          setIsPlaying(false);
+          onPresentationComplete?.('stopped');
+          return;
+        }
+
+        setError(getNarrationPlaybackFailureMessage(currentLanguage));
 
         if (isActivePlaybackSession(playbackSession)) {
           advancePresentation(1000);
@@ -952,6 +1007,13 @@ export default function MarpViewer({
         return;
       } else {
         console.error('[MarpViewer] Error narrating slide:', error);
+        if (isNarrationGestureRequiredError(error)) {
+          setShowAudioPermissionPrompt(true);
+          setIsPlaying(false);
+          onPresentationComplete?.('stopped');
+        } else {
+          setError(getNarrationPlaybackFailureMessage(currentLanguage));
+        }
       }
       resetNarrationFlags();
       throw error;
@@ -1704,9 +1766,7 @@ export default function MarpViewer({
               🔊 {language === 'ja' ? '音声再生の許可' : 'Audio Permission Required'}
             </h3>
             <p className="text-gray-700 mb-4">
-              {language === 'ja' 
-                ? 'ブラウザの設定により音声の自動再生がブロックされています。プレゼンテーションを開始するには音声再生を許可してください。' 
-                : 'Audio autoplay is blocked by your browser. Please allow audio playback to start the synchronized presentation.'}
+              {getTapToEnableAudioMessage(currentLanguage)}
             </p>
             <div className="flex justify-end space-x-2">
               <button

--- a/frontend/src/app/components/MarpViewer.tsx
+++ b/frontend/src/app/components/MarpViewer.tsx
@@ -6,7 +6,10 @@ import {
   AudioInteractionManager,
   unlockAudioForUserGesture,
 } from '@/lib/audio/audio-interaction-manager';
-import { getTapToEnableAudioMessage } from '@/lib/audio/audio-user-interaction-gate';
+import {
+  getTapToEnableAudioMessage,
+  type SupportedLang,
+} from '@/lib/audio/audio-user-interaction-gate';
 import DOMPurify from 'dompurify';
 import { ChevronLeft, Keyboard, MessageCircle, Pause, Play, RotateCcw, Settings } from 'lucide-react';
 import React, { useCallback, useEffect, useRef, useState } from 'react';
@@ -119,10 +122,17 @@ const isNarrationGestureRequiredError = (error: unknown): boolean => {
   );
 };
 
-const getNarrationPlaybackFailureMessage = (language: 'ja' | 'en'): string =>
-  language === 'ja'
-    ? 'ナレーションの再生に失敗しました'
-    : 'Narration playback failed';
+const NARRATION_PLAYBACK_FAILURE_MESSAGES: Record<SupportedLang, string> = {
+  ja: 'ナレーションの再生に失敗しました',
+  en: 'Narration playback failed',
+  zh: '旁白播放失败',
+  ko: '내레이션 재생에 실패했습니다',
+};
+
+const getNarrationPlaybackFailureMessage = (language: string): string => {
+  const lang = language as SupportedLang;
+  return NARRATION_PLAYBACK_FAILURE_MESSAGES[lang] ?? NARRATION_PLAYBACK_FAILURE_MESSAGES.en;
+};
 
 export default function MarpViewer({
   slideFile = 'engineer-cafe',

--- a/frontend/src/app/components/VoiceInterface.tsx
+++ b/frontend/src/app/components/VoiceInterface.tsx
@@ -2,8 +2,16 @@
 
 import { AudioQueue } from '@/lib/audio-queue';
 import { AudioDataProcessor } from '@/lib/audio/audio-data-processor';
-import { unlockAudioForUserGesture } from '@/lib/audio/audio-interaction-manager';
-import { markAudioUserInteraction } from '@/lib/audio/audio-user-interaction-gate';
+import {
+  AudioInteractionManager,
+  registerAudioContextSuspensionListener,
+  unlockAudioForUserGesture,
+} from '@/lib/audio/audio-interaction-manager';
+import {
+  getTapToEnableAudioMessage,
+  isIOSWebKitAudio,
+  markAudioUserInteraction,
+} from '@/lib/audio/audio-user-interaction-gate';
 import { MobileAudioService } from '@/lib/audio/mobile-audio-service';
 import { audioStateManager } from '@/lib/audio-state-manager';
 import { cn } from '@/lib/cn';
@@ -399,6 +407,46 @@ export default function VoiceInterface({
     audioQueueRef.current?.setVolume(effectiveVolume);
   }, [volume]);
 
+  const handleAudioUnlockGesture = useCallback(() => {
+    if (sessionState === 'listening') {
+      return;
+    }
+
+    unlockAudioForUserGesture();
+  }, [sessionState]);
+
+  const stopForIOSAudioUnlock = useCallback((): boolean => {
+    if (!isIOSWebKitAudio()) {
+      return false;
+    }
+
+    let state: AudioContextState | null = null;
+    let isReady = false;
+    try {
+      const manager = AudioInteractionManager.getInstance();
+      state = manager.getAudioContextState();
+      isReady = manager.isAudioContextReady() && state === 'running';
+    } catch {
+      isReady = false;
+    }
+
+    if (isReady) {
+      return false;
+    }
+
+    const message = getTapToEnableAudioMessage(currentLanguage);
+    console.warn('[VoiceInterface] iOS AudioContext is not ready; waiting for a tap-to-enable gesture', {
+      state,
+    });
+    cleanupAudioPlayback();
+    setError(message);
+    setIsLoading(false);
+    setLoadingMessage('');
+    setLoadingPhase(null);
+    voiceController.notifySpeakingComplete(true);
+    return true;
+  }, [cleanupAudioPlayback, currentLanguage, voiceController]);
+
   const resetConversation = useCallback(() => {
     setTranscript('');
     setResponse('');
@@ -487,6 +535,10 @@ export default function VoiceInterface({
         return;
       }
 
+      if (stopForIOSAudioUnlock()) {
+        return;
+      }
+
       let audioBytes: Uint8Array;
       try {
         audioBytes = Uint8Array.from(atob(audioBase64), (char) => char.charCodeAt(0));
@@ -558,6 +610,7 @@ export default function VoiceInterface({
       revokeAudioUrl,
       scheduleLipSyncFrames,
       skipAssistantTurnAutoResume,
+      stopForIOSAudioUnlock,
       voiceController,
     ],
   );
@@ -731,6 +784,9 @@ export default function VoiceInterface({
             await playAssistantAudio(ttsResult.audioResponse, playbackMetadata);
             return;
           }
+          if (stopForIOSAudioUnlock()) {
+            return;
+          }
           q.setVolume(isMuted ? 0 : volume);
           q.add({
             id: `assistant-${Date.now()}`,
@@ -782,6 +838,7 @@ export default function VoiceInterface({
       playAssistantAudio,
       scheduleLipSyncFrames,
       skipAssistantTurnAutoResume,
+      stopForIOSAudioUnlock,
       stopPlayback,
       volume,
       voiceController,
@@ -1273,6 +1330,12 @@ export default function VoiceInterface({
   }, [sessionState, onAssistantPlaybackEnd]);
 
   useEffect(() => {
+    return registerAudioContextSuspensionListener(() => {
+      setError(getTapToEnableAudioMessage(currentLanguage));
+    });
+  }, [currentLanguage]);
+
+  useEffect(() => {
     return () => {
       cancelFastFiller();
       cancelPendingRequest();
@@ -1386,6 +1449,8 @@ export default function VoiceInterface({
       <div className="mt-6 flex items-center justify-center gap-3">
         <button
           type="button"
+          onPointerDown={handleAudioUnlockGesture}
+          onTouchEnd={handleAudioUnlockGesture}
           onClick={isListening ? stopListening : startListening}
           disabled={isBusy && !isListening}
           aria-label={isListening ? '録音を停止' : '録音を開始'}
@@ -1415,6 +1480,8 @@ export default function VoiceInterface({
 
         <button
           type="button"
+          onPointerDown={handleAudioUnlockGesture}
+          onTouchEnd={handleAudioUnlockGesture}
           onClick={() => setMuted(!isMuted)}
           aria-label={isMuted ? 'ミュートを解除' : 'ミュートにする'}
           className="flex size-12 items-center justify-center rounded-full border border-slate-200 bg-white text-slate-700 shadow-sm transition-colors duration-200 hover:bg-slate-50"

--- a/frontend/src/lib/audio/audio-interaction-manager.ts
+++ b/frontend/src/lib/audio/audio-interaction-manager.ts
@@ -11,6 +11,32 @@ import {
   resetAudioUserInteractionGate
 } from './audio-user-interaction-gate';
 
+type AudioContextSuspensionListener = (state: AudioContextState) => void;
+
+const audioContextSuspensionListeners = new Set<AudioContextSuspensionListener>();
+
+const isSuspendedAudioContextState = (state: AudioContextState): boolean =>
+  state === 'suspended' || (state as string) === 'interrupted';
+
+const notifyAudioContextSuspensionListeners = (state: AudioContextState): void => {
+  audioContextSuspensionListeners.forEach((listener) => {
+    try {
+      listener(state);
+    } catch (error) {
+      console.error('[AudioInteractionManager] AudioContext suspension listener failed:', error);
+    }
+  });
+};
+
+export function registerAudioContextSuspensionListener(
+  listener: AudioContextSuspensionListener,
+): () => void {
+  audioContextSuspensionListeners.add(listener);
+  return () => {
+    audioContextSuspensionListeners.delete(listener);
+  };
+}
+
 export interface AudioInteractionEvents {
   onContextInitialized?: () => void;
   onInteractionRequired?: () => void;
@@ -132,7 +158,11 @@ export class AudioInteractionManager {
   public async ensureAudioContext(): Promise<AudioContext> {
     if (this.isContextInitialized) {
       await this.globalAudioManager.ensureResumed();
-      return this.globalAudioManager.getContext()!;
+      const context = this.globalAudioManager.getContext()!;
+      if (hasAudioUserInteraction() && isSuspendedAudioContextState(context.state)) {
+        notifyAudioContextSuspensionListeners(context.state);
+      }
+      return context;
     }
 
     this.hasUserInteracted = this.hasUserInteracted || hasAudioUserInteraction();
@@ -142,7 +172,11 @@ export class AudioInteractionManager {
     }
 
     await this.initializeAudioContext();
-    return this.globalAudioManager.getContext()!;
+    const context = this.globalAudioManager.getContext()!;
+    if (hasAudioUserInteraction() && isSuspendedAudioContextState(context.state)) {
+      notifyAudioContextSuspensionListeners(context.state);
+    }
+    return context;
   }
 
   /**

--- a/frontend/src/lib/audio/audio-user-interaction-gate.ts
+++ b/frontend/src/lib/audio/audio-user-interaction-gate.ts
@@ -32,7 +32,7 @@ export const isIOSWebKitAudio = (): boolean => {
   );
 };
 
-type SupportedLang = 'ja' | 'en' | 'zh' | 'ko';
+export type SupportedLang = 'ja' | 'en' | 'zh' | 'ko';
 
 export const getTapToEnableAudioMessage = (language: string = 'ja'): string => {
   const messages: Record<SupportedLang, string> = {

--- a/frontend/src/lib/audio/audio-user-interaction-gate.ts
+++ b/frontend/src/lib/audio/audio-user-interaction-gate.ts
@@ -10,6 +10,41 @@ let resolvePendingInteraction: (() => void) | null = null;
 
 const isBrowser = (): boolean => typeof window !== 'undefined' && typeof document !== 'undefined';
 
+export const isIOSWebKitAudio = (): boolean => {
+  if (!isBrowser()) return false;
+  const ua = navigator.userAgent;
+  const vendor = navigator.vendor || '';
+
+  if (/iPad|iPhone|iPod/.test(ua)) return true;
+  if (
+    typeof navigator.platform === 'string' &&
+    navigator.platform === 'MacIntel' &&
+    (navigator.maxTouchPoints || 0) > 1
+  ) {
+    return true;
+  }
+
+  return (
+    /Safari/.test(ua) &&
+    /Apple/.test(vendor) &&
+    !/Chrome|CriOS|Chromium|Edg/.test(ua) &&
+    /Mobile/.test(ua)
+  );
+};
+
+type SupportedLang = 'ja' | 'en' | 'zh' | 'ko';
+
+export const getTapToEnableAudioMessage = (language: string = 'ja'): string => {
+  const messages: Record<SupportedLang, string> = {
+    ja: '音声を有効にするには、もう一度画面をタップしてください',
+    en: 'Tap once more to enable audio playback',
+    zh: '请再次点按屏幕以启用音频',
+    ko: '오디오를 활성화하려면 화면을 한 번 더 탭하세요',
+  };
+  const lang = language as SupportedLang;
+  return messages[lang] ?? messages.en;
+};
+
 const clearPendingInteraction = (): void => {
   resolvePendingInteraction?.();
   pendingInteractionPromise = null;


### PR DESCRIPTION
## Summary

iOS Safari/iPad transient user activation expiry causes the AudioContext to be unable to resume by the time TTS audio arrives, resulting in silent playback failure. This PR layers UI feedback and gesture priming on top of PR #707's `sharedAudioContext` reuse to recover the user-visible audio experience.

Refs #697
Refs #634
Refs #635
Refs #471

Built on top of PR #707 sharedAudioContext base. Independent from PR #720 voice-filler-playback work and PR #727 cron alert PR.
alpha-live-verification と独立。merge は alpha gate と他 runtime PR との順序に従って判断。

## Behavioural changes

- **`audio-user-interaction-gate.ts`**: new `isIOSWebKitAudio()` (iPadOS 13+ MacIntel + maxTouchPoints detection inclusive) and `getTapToEnableAudioMessage(lang)` (ja / en / zh / ko)
- **`audio-interaction-manager.ts`**: new `registerAudioContextSuspensionListener()` API that fires when `ensureAudioContext()` detects a re-suspension after a prior unlock (mid-session gesture chain expiry)
- **`VoiceInterface.tsx`**: dual `onPointerDown` + `onTouchEnd` binding on mic and mute buttons (covers iOS Safari < 16.4 where `pointerdown` is unreliable as activation event); iOS playback path returns early with toast instead of throwing (cascading error fix); subscribes to suspension listener and surfaces tap-to-enable toast when context drops mid-session
- **`MarpViewer.tsx`**: narration playback failures (NotAllowedError / suspended state heuristic) surface user-visible tap-to-enable message instead of console-only logging

## Validation

- `pnpm --dir frontend exec tsc --noEmit`: pass
- `pnpm --dir frontend lint`: pass (existing MarpViewer hook dependency warnings unchanged)
- `pnpm --dir frontend exec tsx --test src/__tests__/audio/audio-user-interaction-gate.test.ts`: 9/9 pass
- `git diff --check`: clean
- `console.log` scan on changed files: 0 matches

## Out of scope

- Android `decodeAudioData` AbortController (#698 sister issue, separate PR)
- Playwright iOS hardware test (impossible in WebKit emulator; tracked as #643 manual verification)
- Backend NUL byte sanitization (#722 separately merged)

## Files touched

- frontend/src/lib/audio/audio-user-interaction-gate.ts (+35)
- frontend/src/lib/audio/audio-interaction-manager.ts (+38)
- frontend/src/app/components/VoiceInterface.tsx (+71)
- frontend/src/app/components/MarpViewer.tsx (+76)
- frontend/src/__tests__/audio/audio-user-interaction-gate.test.ts (NEW, 9 cases)

## NOT touched

- frontend/src/lib/audio/web-audio-player.ts (PR #707 base preserved)
- frontend/src/lib/audio/mobile-audio-service.ts
- frontend/src/lib/voice-filler-playback.ts (PR #720 owned)
- backend/** unchanged
- .github/workflows/** unchanged

Co-Authored-By: Oz <oz-agent@warp.dev>