### PR TITLE
test(e2e): M5Stack reception sensor webhook round-trip simulation (Refs #585 #706)

### DIFF
--- a/frontend/e2e/fixtures/m5stack-payloads.ts
+++ b/frontend/e2e/fixtures/m5stack-payloads.ts
@@ -1,0 +1,19 @@
+/**
+ * Shared POST bodies for /api/reception/sensor-trigger contract tests.
+ * Schema matches backend SensorTriggerRequest (required distance_mm + device_id).
+ */
+export const m5stackPayloads = {
+  /** Matches frontend DEFAULT_DEVICE_ID in device-webhook polling. */
+  tofClose: { sensor_type: 'ToF', distance_mm: 350, device_id: 'm5stack-001' },
+  tofFar: { sensor_type: 'ToF', distance_mm: 800, device_id: 'm5stack-001' },
+  invalidLongSensorType: {
+    sensor_type: 'X'.repeat(51),
+    distance_mm: 350,
+    device_id: 'm5stack-validation',
+  },
+  rateLimitDevice: {
+    sensor_type: 'ToF',
+    distance_mm: 500,
+    device_id: 'm5stack-e2e-rate-limit',
+  },
+};

--- a/frontend/e2e/fixtures/m5stack-payloads.ts
+++ b/frontend/e2e/fixtures/m5stack-payloads.ts
@@ -11,9 +11,9 @@ export const m5stackPayloads = {
     distance_mm: 350,
     device_id: 'm5stack-validation',
   },
-  rateLimitDevice: {
+  rateLimitDevice: (suffix: string = String(Date.now())) => ({
     sensor_type: 'ToF',
     distance_mm: 500,
-    device_id: 'm5stack-e2e-rate-limit',
-  },
+    device_id: `m5stack-e2e-rate-limit-${suffix}`,
+  }),
 };

--- a/frontend/e2e/m5stack-reception-flow.spec.ts
+++ b/frontend/e2e/m5stack-reception-flow.spec.ts
@@ -5,6 +5,11 @@ import { expect, test } from '@playwright/test';
 
 import { m5stackPayloads } from './fixtures/m5stack-payloads';
 
+test.skip(
+  !process.env.BACKEND_API_URL && !process.env.PLAYWRIGHT_BASE_URL,
+  'M5Stack E2E requires a reachable backend (BACKEND_API_URL or PLAYWRIGHT_BASE_URL must be set)',
+);
+
 /**
  * M5Stack sensor webhook → backend → kiosk sensor polling → Welcome flow (Refs #585 / #706).
  *
@@ -153,6 +158,14 @@ test.describe('M5Stack reception sensor webhook (API + kiosk polling)', () => {
       headers,
     });
     expect(missingType.status()).toBe(422);
+    const missingTypeBody = (await missingType.json()) as {
+      detail?: Array<{ loc?: unknown[] }>;
+    };
+    expect(
+      missingTypeBody.detail?.some(
+        (detail) => Array.isArray(detail.loc) && detail.loc.includes('sensor_type'),
+      ),
+    ).toBe(true);
 
     const longType = await request.post(url, {
       data: m5stackPayloads.invalidLongSensorType,
@@ -166,7 +179,7 @@ test.describe('M5Stack reception sensor webhook (API + kiosk polling)', () => {
   }) => {
     const headers = backendRequestHeaders();
     const url = backendTriggerUrl();
-    const payload = m5stackPayloads.rateLimitDevice;
+    const payload = m5stackPayloads.rateLimitDevice();
 
     const first = await request.post(url, { data: payload, headers });
     expect(first.status(), await first.text()).toBe(200);
@@ -182,7 +195,7 @@ test.describe('M5Stack reception sensor webhook (API + kiosk polling)', () => {
     expect(secondJson.success).toBe(false);
     expect(secondJson.action).toBe('rate_limited');
 
-    await sleep(6_000);
+    await sleep(7_000);
 
     const third = await request.post(url, { data: payload, headers });
     expect(third.status(), await third.text()).toBe(200);

--- a/frontend/e2e/m5stack-reception-flow.spec.ts
+++ b/frontend/e2e/m5stack-reception-flow.spec.ts
@@ -1,0 +1,193 @@
+import fs from 'node:fs';
+import path from 'node:path';
+
+import { expect, test } from '@playwright/test';
+
+import { m5stackPayloads } from './fixtures/m5stack-payloads';
+
+/**
+ * M5Stack sensor webhook → backend → kiosk sensor polling → Welcome flow (Refs #585 / #706).
+ *
+ * POST /api/reception/sensor-trigger targets BACKEND_API_URL directly (no Next.js proxy route).
+ * The kiosk polls /api/reception/sensor-status via the frontend and dispatches device-detection.
+ */
+
+test.describe.configure({ mode: 'serial' });
+
+const RECEPTION_START_URL = '/api/reception/start';
+const QA_CHAT_URL = '/api/qa';
+
+function backendTriggerUrl(): string {
+  const base = (process.env.BACKEND_API_URL ?? 'http://127.0.0.1:8000').replace(/\/$/, '');
+  return `${base}/api/reception/sensor-trigger`;
+}
+
+function backendRequestHeaders(): Record<string, string> {
+  const headers: Record<string, string> = {
+    'Content-Type': 'application/json',
+  };
+  const key = process.env.BACKEND_API_KEY;
+  if (key) {
+    headers['X-API-Key'] = key;
+  }
+  return headers;
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+async function dismissInitialModal(page: import('@playwright/test').Page) {
+  const modal = page.getByRole('dialog');
+  const closeButton = page.getByTestId('initial-settings-close');
+  if (await closeButton.isVisible({ timeout: 3_000 }).catch(() => false)) {
+    await page.waitForTimeout(1_500);
+    const deadline = Date.now() + 30_000;
+    while (Date.now() < deadline && !(await modal.isHidden().catch(() => false))) {
+      await closeButton.click({ timeout: 1_000, force: true }).catch(() => {});
+      if (!(await modal.isHidden().catch(() => false))) {
+        await closeButton.evaluate((button) => {
+          if (button instanceof HTMLButtonElement) {
+            button.click();
+          }
+        }).catch(() => {});
+      }
+      await page.waitForTimeout(250);
+    }
+    await expect(modal).toBeHidden({ timeout: 10_000 });
+  }
+  await expect(page.getByTestId('kiosk-voice-button')).toBeVisible({ timeout: 5_000 });
+}
+
+function mockReceptionStart(page: import('@playwright/test').Page) {
+  return page.route(`**${RECEPTION_START_URL}`, async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({
+        reception_session_id: 'mock-reception-m5stack-e2e',
+        greeting: 'エンジニアカフェへようこそ！ご用件をお聞かせください。',
+        stage: 'greeting',
+      }),
+    });
+  });
+}
+
+async function keepOcrCameraPending(page: import('@playwright/test').Page) {
+  await page.addInitScript(() => {
+    const mediaDevices = navigator.mediaDevices;
+    if (!mediaDevices) {
+      return;
+    }
+    mediaDevices.getUserMedia = async () =>
+      new Promise<MediaStream>(() => {
+        /* keep OCR from opening a real camera */
+      });
+  });
+}
+
+async function installDeterministicVoiceRecorder(page: import('@playwright/test').Page) {
+  const sampleAudioBase64 = fs
+    .readFileSync(path.resolve(__dirname, 'fixtures/voice/sample.wav'))
+    .toString('base64');
+
+  await page.addInitScript(({ audioBase64 }) => {
+    (window as Window & { __PLAYWRIGHT_VOICE_AUDIO_BASE64__?: string }).__PLAYWRIGHT_VOICE_AUDIO_BASE64__ =
+      audioBase64;
+  }, { audioBase64: sampleAudioBase64 });
+}
+
+test.describe('M5Stack reception sensor webhook (API + kiosk polling)', () => {
+  test('happy path: sensor-trigger accepted then Welcome narration appears', async ({
+    page,
+    request,
+  }) => {
+    await page.addInitScript(() => {
+      window.localStorage.setItem('engineer_cafe_kiosk_trigger_mode', 'device');
+    });
+    await installDeterministicVoiceRecorder(page);
+    await keepOcrCameraPending(page);
+    await mockReceptionStart(page);
+    await page.route(`**${QA_CHAT_URL}`, async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({ answer: 'テスト応答', emotion: 'neutral', metadata: {} }),
+      });
+    });
+    await page.route('**/api/voice', async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({ success: true }),
+      });
+    });
+
+    await page.goto('/', { waitUntil: 'domcontentloaded' });
+    await dismissInitialModal(page);
+
+    const triggerUrl = backendTriggerUrl();
+    const res = await request.post(triggerUrl, {
+      data: m5stackPayloads.tofClose,
+      headers: backendRequestHeaders(),
+    });
+    expect(res.status(), await res.text()).toBe(200);
+    const body = (await res.json()) as { success: boolean; action: string };
+    expect(body.success).toBe(true);
+    expect(body.action).toBe('trigger_received');
+
+    await expect(page.getByTestId('kiosk-welcome-ocr-overlay')).toBeHidden({ timeout: 8_000 });
+    await expect(page.getByTestId('response-text')).toContainText('エンジニアカフェへようこそ', {
+      timeout: 15_000,
+    });
+  });
+
+  test('schema validation: missing sensor_type and too-long sensor_type return 422', async ({
+    request,
+  }) => {
+    const headers = backendRequestHeaders();
+    const url = backendTriggerUrl();
+
+    const missingType = await request.post(url, {
+      data: { distance_mm: 350, device_id: 'm5stack-schema-missing-type' },
+      headers,
+    });
+    expect(missingType.status()).toBe(422);
+
+    const longType = await request.post(url, {
+      data: m5stackPayloads.invalidLongSensorType,
+      headers,
+    });
+    expect(longType.status()).toBe(422);
+  });
+
+  test('rate limit: rapid same-device triggers then success after cooldown', async ({
+    request,
+  }) => {
+    const headers = backendRequestHeaders();
+    const url = backendTriggerUrl();
+    const payload = m5stackPayloads.rateLimitDevice;
+
+    const first = await request.post(url, { data: payload, headers });
+    expect(first.status(), await first.text()).toBe(200);
+    expect((await first.json()) as { success: boolean }).toEqual(
+      expect.objectContaining({ success: true, action: 'trigger_received' }),
+    );
+
+    await sleep(100);
+
+    const second = await request.post(url, { data: payload, headers });
+    expect(second.status(), await second.text()).toBe(200);
+    const secondJson = (await second.json()) as { success: boolean; action: string };
+    expect(secondJson.success).toBe(false);
+    expect(secondJson.action).toBe('rate_limited');
+
+    await sleep(6_000);
+
+    const third = await request.post(url, { data: payload, headers });
+    expect(third.status(), await third.text()).toBe(200);
+    expect((await third.json()) as { success: boolean }).toEqual(
+      expect.objectContaining({ success: true, action: 'trigger_received' }),
+    );
+  });
+});


### PR DESCRIPTION
## Summary

Adds Playwright E2E spec simulating the M5Stack sensor webhook round-trip (POST /api/reception/sensor-trigger → reception polling → Welcome).

Refs #585 sub-scenario S-1 (M5Stack sensor webhook simulation), Refs #706 (M5Stack PR contract).

Refs #585

## Touched files

- frontend/e2e/m5stack-reception-flow.spec.ts (new)
- frontend/e2e/fixtures/m5stack-payloads.ts (new)

## NOT touched

- frontend/src/lib/audio/** unchanged
- frontend/src/app/components/VoiceInterface.tsx / MarpViewer.tsx unchanged
- backend/** unchanged
- frontend/src/__tests__/** unchanged
- .github/workflows/** unchanged (CI integration follow-up tracked in a separate PR)

## Local verification

```bash
cd frontend
# Requires a reachable backend: either run uvicorn on 127.0.0.1:8000 (default when BACKEND_API_URL unset),
# or set BACKEND_API_KEY + BACKEND_API_URL for Cloud Run (same as CI secrets).
pnpm exec playwright test e2e/m5stack-reception-flow.spec.ts --project=chromium
```

Do not set `PLAYWRIGHT_BASE_URL` when relying on `playwright.config.ts` webServer auto-start.

## Open follow-ups (separate PRs)

1. ci.yml frontend-playwright-e2e job に本 spec を追加 + BACKEND_API_KEY 環境変数の伝播
2. (optional) M5Stack 実機 firmware と連携した実 round-trip 検証は #706 マージ後

## Independent from

- iOS tap-to-enable PR (#697 系, parallel Codex worker)
- alpha-live-verification (no workflow change)
