### PR TITLE
ci: bound alpha live verification steps

### DIFF
--- a/.github/workflows/alpha-live-verification.yml
+++ b/.github/workflows/alpha-live-verification.yml
@@ -140,9 +140,12 @@ jobs:
         id: alpha_a
         if: contains(format(',{0},', inputs.suites), ',a,') || contains(format(',{0},', inputs.suites), ',all,')
         continue-on-error: true
+        timeout-minutes: 60
         env:
           API_SECRET_KEY: ${{ secrets.BACKEND_API_KEY }}
-        run: scripts/alpha-smoke-comprehensive.sh --timestamp "${ALPHA_TIMESTAMP}-a" --host "$ALPHA_SMOKE_BASE_URL" --scenarios A --timeout 120 --sleep 3.2
+        run: |
+          echo "A voice round-trip smoke step timeout: 60 minutes; per-request timeout: 120 seconds"
+          scripts/alpha-smoke-comprehensive.sh --timestamp "${ALPHA_TIMESTAMP}-a" --host "$ALPHA_SMOKE_BASE_URL" --scenarios A --timeout 120 --sleep 3.2
 
       - name: B LangGraph routing live smoke
         id: alpha_b

--- a/backend/evaluation/run_live_api_eval.py
+++ b/backend/evaluation/run_live_api_eval.py
@@ -34,6 +34,7 @@ DEFAULT_REPORTS_DIR = Path(__file__).parent.parent / "tests" / "evaluation" / "r
 DEFAULT_CHAT_INTERVAL_SECONDS = 2.2
 DEFAULT_CHAT_RETRY_ATTEMPTS = 4
 DEFAULT_CHAT_RETRY_BACKOFF_SECONDS = 2.0
+DEFAULT_CHAT_TIMEOUT_SECONDS = 60.0
 
 ALL_LANGUAGES = ("ja", "en", "zh", "ko")
 CASE_SUITE_DIAGNOSTIC_29 = "diagnostic-29"
@@ -265,6 +266,12 @@ def _collection_error_record(
     }
 
 
+def _emit_progress(message: str) -> None:
+    """Print progress immediately so long GitHub Actions runs do not look stalled."""
+    print(message, flush=True)
+    logger.info(message)
+
+
 def _report_file_timestamp(value: Optional[str] = None) -> str:
     """Return a filesystem-safe timestamp marker for report artifact names."""
     raw = (value or "").strip()
@@ -293,6 +300,7 @@ async def _call_chat_api(
     api_key: Optional[str] = None,
     retry_attempts: int = DEFAULT_CHAT_RETRY_ATTEMPTS,
     retry_backoff_seconds: float = DEFAULT_CHAT_RETRY_BACKOFF_SECONDS,
+    timeout_seconds: float = DEFAULT_CHAT_TIMEOUT_SECONDS,
 ) -> Dict[str, Any]:
     """Call the /api/chat endpoint and return the response."""
     headers: Dict[str, str] = {"Content-Type": "application/json"}
@@ -307,7 +315,12 @@ async def _call_chat_api(
     url = f"{base_url.rstrip('/')}/api/chat"
     attempts = max(1, retry_attempts)
     for attempt in range(attempts):
-        response = await client.post(url, json=payload, headers=headers, timeout=60.0)
+        response = await client.post(
+            url,
+            json=payload,
+            headers=headers,
+            timeout=timeout_seconds,
+        )
         try:
             response.raise_for_status()
             return response.json()
@@ -340,6 +353,7 @@ async def run_live_api_evaluation(
     chat_interval_seconds: float = 0.0,
     chat_retry_attempts: int = DEFAULT_CHAT_RETRY_ATTEMPTS,
     chat_retry_backoff_seconds: float = DEFAULT_CHAT_RETRY_BACKOFF_SECONDS,
+    chat_timeout_seconds: float = DEFAULT_CHAT_TIMEOUT_SECONDS,
 ) -> Dict[str, Any]:
     """Run RAGAS evaluation against the live API.
 
@@ -352,6 +366,7 @@ async def run_live_api_evaluation(
         chat_interval_seconds: Minimum seconds between live /api/chat request starts.
         chat_retry_attempts: Total /api/chat attempts for retryable 429 responses.
         chat_retry_backoff_seconds: Base exponential backoff for 429 responses.
+        chat_timeout_seconds: Per-attempt timeout for live /api/chat calls.
 
     Returns:
         Evaluation result dictionary with per-language metrics.
@@ -367,8 +382,18 @@ async def run_live_api_evaluation(
     requested_case_counts: Dict[str, int] = {}
     collection_errors: Dict[str, List[Dict[str, Any]]] = {}
     last_chat_started: Optional[float] = None
+    total_requested_cases = sum(
+        1 for query in config.get("queries", []) if query.get("language") in selected_languages
+    )
+    collected_count = 0
+    collection_error_count = 0
 
     # Phase 1: Collect live API responses
+    _emit_progress(
+        "Live API collection phase start: "
+        f"case_suite={case_suite} total_cases={total_requested_cases} "
+        f"languages={','.join(selected_languages)} timeout_per_attempt={chat_timeout_seconds:.1f}s"
+    )
     async with httpx.AsyncClient() as client:
         for lang in selected_languages:
             queries = [q for q in config["queries"] if q["language"] == lang]
@@ -376,22 +401,26 @@ async def run_live_api_evaluation(
             lang_collection_errors: List[Dict[str, Any]] = []
             requested_case_counts[lang] = len(queries)
 
-            logger.info("Evaluating %d queries for language: %s", len(queries), lang)
+            _emit_progress(f"Live API collection language start: {lang} cases={len(queries)}")
 
-            for query in queries:
+            for lang_index, query in enumerate(queries, start=1):
+                global_index = collected_count + collection_error_count + 1
                 gt_id = query["ground_truth_id"]
                 gt_case = gt_lookup.get(gt_id)
                 if gt_case is None:
-                    logger.warning(
-                        "Skipping %s: ground truth %s not found",
-                        query["id"],
-                        gt_id,
+                    message = f"ground truth {gt_id} not found"
+                    collection_error_count += 1
+                    _emit_progress(
+                        "Live API collection case error: "
+                        f"{global_index}/{total_requested_cases} "
+                        f"{lang} {lang_index}/{len(queries)} {query['id']} "
+                        f"type=missing_ground_truth error={message}"
                     )
                     lang_collection_errors.append(
                         _collection_error_record(
                             query,
                             error_type="missing_ground_truth",
-                            message=f"ground truth {gt_id} not found",
+                            message=message,
                         )
                     )
                     continue
@@ -404,6 +433,12 @@ async def run_live_api_evaluation(
                             await asyncio.sleep(sleep_for)
                     start = time.monotonic()
                     last_chat_started = start
+                    _emit_progress(
+                        "Live API collection case start: "
+                        f"{global_index}/{total_requested_cases} "
+                        f"{lang} {lang_index}/{len(queries)} {query['id']} "
+                        f"category={query.get('category', '?')}"
+                    )
                     api_response = await _call_chat_api(
                         client,
                         base_url=base_url,
@@ -412,6 +447,7 @@ async def run_live_api_evaluation(
                         api_key=api_key,
                         retry_attempts=chat_retry_attempts,
                         retry_backoff_seconds=chat_retry_backoff_seconds,
+                        timeout_seconds=chat_timeout_seconds,
                     )
                     elapsed = time.monotonic() - start
 
@@ -451,15 +487,22 @@ async def run_live_api_evaluation(
                             },
                         }
                     )
-                    logger.info(
-                        "  [%s] %s -> agent=%s (%.1fs)",
-                        query["id"],
-                        query["question"][:40],
-                        metadata_dict.get("agent", "?"),
-                        elapsed,
+                    collected_count += 1
+                    _emit_progress(
+                        "Live API collection case done: "
+                        f"{global_index}/{total_requested_cases} "
+                        f"{lang} {lang_index}/{len(queries)} {query['id']} "
+                        f"agent={metadata_dict.get('agent', '?')} "
+                        f"sources_ok={sources_ok} elapsed={elapsed:.1f}s"
                     )
                 except Exception as exc:
-                    logger.error("  [%s] API call failed: %s", query["id"], exc)
+                    collection_error_count += 1
+                    _emit_progress(
+                        "Live API collection case error: "
+                        f"{global_index}/{total_requested_cases} "
+                        f"{lang} {lang_index}/{len(queries)} {query['id']} "
+                        f"type=api_call_failed error={exc}"
+                    )
                     lang_collection_errors.append(
                         _collection_error_record(
                             query,
@@ -470,8 +513,22 @@ async def run_live_api_evaluation(
 
             all_eval_cases[lang] = lang_cases
             collection_errors[lang] = lang_collection_errors
+            _emit_progress(
+                "Live API collection language done: "
+                f"{lang} collected={len(lang_cases)}/{len(queries)} "
+                f"errors={len(lang_collection_errors)}"
+            )
+
+    _emit_progress(
+        "Live API collection phase done: "
+        f"collected={collected_count}/{total_requested_cases} errors={collection_error_count}"
+    )
 
     # Phase 2: Run RAGAS evaluation
+    _emit_progress(
+        "RAGAS scoring phase start: "
+        f"languages={','.join(selected_languages)} metrics={','.join(selected_metrics)}"
+    )
     try:
         from evaluation.ragas_pipeline import RagasEvaluator, resolve_ragas_judge_metadata
     except ImportError:
@@ -492,6 +549,11 @@ async def run_live_api_evaluation(
             ]
         )
         if not cases:
+            _emit_progress(
+                "RAGAS language skipped: "
+                f"{lang} reason=no_evaluable_cases requested={requested_count} "
+                f"collection_errors={len(lang_collection_errors)}"
+            )
             per_language_results[lang] = {
                 "language": lang,
                 "error": "no evaluable cases",
@@ -514,7 +576,10 @@ async def run_live_api_evaluation(
         )
 
         if not evaluator.is_available:
-            logger.warning("RAGAS not available, returning API responses only")
+            _emit_progress(
+                "RAGAS language skipped: "
+                f"{lang} reason=ragas_not_available collected={len(cases)}"
+            )
             per_language_results[lang] = {
                 "language": lang,
                 "error": "ragas not installed",
@@ -541,7 +606,7 @@ async def run_live_api_evaluation(
             }
             continue
 
-        logger.info("Running RAGAS evaluation for %s (%d cases)...", lang, len(cases))
+        _emit_progress(f"RAGAS language start: {lang} cases={len(cases)}")
         report = await evaluator.evaluate_batch(cases)
         report_error_count = len(
             [error for error in getattr(report, "errors", []) if str(error).strip()]
@@ -585,6 +650,13 @@ async def run_live_api_evaluation(
             "errors": report.errors,
             "results": per_case_results,
         }
+        _emit_progress(
+            "RAGAS language done: "
+            f"{lang} evaluated={report.evaluated_cases}/{requested_count} "
+            f"ragas_errors={ragas_error_count}"
+        )
+
+    _emit_progress("RAGAS scoring phase done")
 
     # Phase 3: Compare with targets
     requested_total = sum(
@@ -644,6 +716,7 @@ async def run_live_api_evaluation(
             "chat_interval_seconds": chat_interval_seconds,
             "chat_retry_attempts": chat_retry_attempts,
             "chat_retry_backoff_seconds": chat_retry_backoff_seconds,
+            "chat_timeout_seconds": chat_timeout_seconds,
         },
         "per_language": per_language_results,
         "comparison": comparison,
@@ -1053,6 +1126,12 @@ def main() -> None:
         default=DEFAULT_CHAT_RETRY_BACKOFF_SECONDS,
         help="Base exponential backoff seconds for retryable 429 responses.",
     )
+    parser.add_argument(
+        "--chat-timeout-seconds",
+        type=float,
+        default=DEFAULT_CHAT_TIMEOUT_SECONDS,
+        help="Per-attempt timeout seconds for live /api/chat calls.",
+    )
     parser.add_argument("--verbose", action="store_true", help="Enable debug logging.")
     args = parser.parse_args()
 
@@ -1075,6 +1154,7 @@ def main() -> None:
             chat_interval_seconds=args.chat_interval_seconds,
             chat_retry_attempts=args.chat_retry_attempts,
             chat_retry_backoff_seconds=args.chat_retry_backoff_seconds,
+            chat_timeout_seconds=args.chat_timeout_seconds,
         )
     )
 

--- a/backend/tests/evaluation/test_ragas_live_case_suites.py
+++ b/backend/tests/evaluation/test_ragas_live_case_suites.py
@@ -238,6 +238,7 @@ async def test_live_eval_keeps_alpha_127_manifest_count_when_api_collection_fail
         "chat_interval_seconds": 0.0,
         "chat_retry_attempts": 4,
         "chat_retry_backoff_seconds": 2.0,
+        "chat_timeout_seconds": 60.0,
     }
     assert (tmp_path / "live_api_eval_alpha-live-test-c.json").is_file()
     assert (tmp_path / "live_api_eval_alpha-live-test-c.txt").is_file()

--- a/scripts/rag-api-live-test.sh
+++ b/scripts/rag-api-live-test.sh
@@ -15,6 +15,8 @@ set -euo pipefail
 #   RAG_API_LIVE_METRICS           Comma-separated RAGAS metrics.
 #   RAG_API_LIVE_CHAT_INTERVAL_SECONDS
 #                                   Minimum seconds between /api/chat starts (default: 2.2).
+#   RAG_API_LIVE_CHAT_TIMEOUT_SECONDS
+#                                   Per-attempt /api/chat timeout seconds (default: 60).
 #   RAG_API_LIVE_TOTAL_TIMEOUT_SECONDS
 #                                   Whole runner wall-clock timeout; 0 disables (default: 7200).
 #   OPENAI_API_KEY / OPENROUTER_API_KEY are required by the RAGAS evaluator.
@@ -35,6 +37,7 @@ METRICS="${RAG_API_LIVE_METRICS:-answer_correctness}"
 CASE_SUITE="${RAG_API_LIVE_CASE_SUITE:-diagnostic-29}"
 TIMESTAMP="$(date +%Y%m%d_%H%M%S)"
 CHAT_INTERVAL_SECONDS="${RAG_API_LIVE_CHAT_INTERVAL_SECONDS:-2.2}"
+CHAT_TIMEOUT_SECONDS="${RAG_API_LIVE_CHAT_TIMEOUT_SECONDS:-60}"
 CHAT_RETRY_ATTEMPTS="${RAG_API_LIVE_CHAT_RETRY_ATTEMPTS:-4}"
 CHAT_RETRY_BACKOFF_SECONDS="${RAG_API_LIVE_CHAT_RETRY_BACKOFF_SECONDS:-2.0}"
 TOTAL_TIMEOUT_SECONDS="${RAG_API_LIVE_TOTAL_TIMEOUT_SECONDS:-7200}"
@@ -60,6 +63,8 @@ Options:
   --timestamp VALUE      Stable timestamp marker for logs and report names
   --chat-interval-seconds VALUE
                          Minimum seconds between live /api/chat request starts (default: 2.2)
+  --chat-timeout-seconds VALUE
+                         Per-attempt timeout seconds for live /api/chat requests (default: 60)
   --chat-retry-attempts VALUE
                          Total /api/chat attempts for retryable 429 responses (default: 4)
   --chat-retry-backoff-seconds VALUE
@@ -91,6 +96,7 @@ while [ "$#" -gt 0 ]; do
     --output-dir) OUTPUT_DIR="$2"; shift 2 ;;
     --timestamp) TIMESTAMP="$2"; shift 2 ;;
     --chat-interval-seconds) CHAT_INTERVAL_SECONDS="$2"; shift 2 ;;
+    --chat-timeout-seconds) CHAT_TIMEOUT_SECONDS="$2"; shift 2 ;;
     --chat-retry-attempts) CHAT_RETRY_ATTEMPTS="$2"; shift 2 ;;
     --chat-retry-backoff-seconds) CHAT_RETRY_BACKOFF_SECONDS="$2"; shift 2 ;;
     --no-check-targets) CHECK_TARGETS=0; shift ;;
@@ -105,6 +111,18 @@ require_cmd() {
     echo "Error: required command not found: $1" >&2
     exit 2
   fi
+}
+
+timeout_cmd() {
+  if command -v timeout >/dev/null 2>&1; then
+    printf 'timeout'
+    return 0
+  fi
+  if command -v gtimeout >/dev/null 2>&1; then
+    printf 'gtimeout'
+    return 0
+  fi
+  return 1
 }
 
 fetch_api_key_from_gcloud() {
@@ -235,6 +253,7 @@ main() {
     echo "Languages: ${LANG_ARGS[*]}"
     echo "Metrics: ${METRIC_ARGS[*]}"
     echo "Chat interval seconds: $CHAT_INTERVAL_SECONDS"
+    echo "Chat timeout seconds: $CHAT_TIMEOUT_SECONDS"
     echo "Chat retry attempts: $CHAT_RETRY_ATTEMPTS"
     echo "Chat retry backoff seconds: $CHAT_RETRY_BACKOFF_SECONDS"
     echo "Runner total timeout seconds: $TOTAL_TIMEOUT_SECONDS"
@@ -267,17 +286,21 @@ main() {
   echo "Languages: ${LANG_ARGS[*]}"
   echo "Metrics: ${METRIC_ARGS[*]}"
   echo "Chat interval seconds: $CHAT_INTERVAL_SECONDS"
+  echo "Chat timeout seconds: $CHAT_TIMEOUT_SECONDS"
   echo "Chat retry attempts: $CHAT_RETRY_ATTEMPTS"
   echo "Chat retry backoff seconds: $CHAT_RETRY_BACKOFF_SECONDS"
   echo "RAGAS batch strategy: ${RAGAS_BATCH_STRATEGY:-single}"
   echo "RAGAS per-case timeout: ${RAGAS_OUTER_SINGLE_TIMEOUT:-300}s"
   echo "RAGAS max workers: ${RAGAS_MAX_WORKERS:-1}"
   echo "Runner total timeout: ${TOTAL_TIMEOUT_SECONDS}s"
+  echo "Expected JSON report: $OUTPUT_DIR/live_api_eval_${TIMESTAMP}.json"
+  echo "Expected text report: $OUTPUT_DIR/live_api_eval_${TIMESTAMP}.txt"
 
-  cmd=(python evaluation/run_live_api_eval.py --base-url "$BASE_URL" --case-suite "$CASE_SUITE" --languages "${LANG_ARGS[@]}" --metrics "${METRIC_ARGS[@]}" --output-dir "$OUTPUT_DIR" --report-timestamp "$TIMESTAMP" --chat-interval-seconds "$CHAT_INTERVAL_SECONDS" --chat-retry-attempts "$CHAT_RETRY_ATTEMPTS" --chat-retry-backoff-seconds "$CHAT_RETRY_BACKOFF_SECONDS")
+  cmd=(python evaluation/run_live_api_eval.py --base-url "$BASE_URL" --case-suite "$CASE_SUITE" --languages "${LANG_ARGS[@]}" --metrics "${METRIC_ARGS[@]}" --output-dir "$OUTPUT_DIR" --report-timestamp "$TIMESTAMP" --chat-interval-seconds "$CHAT_INTERVAL_SECONDS" --chat-timeout-seconds "$CHAT_TIMEOUT_SECONDS" --chat-retry-attempts "$CHAT_RETRY_ATTEMPTS" --chat-retry-backoff-seconds "$CHAT_RETRY_BACKOFF_SECONDS")
   if [ "$CHECK_TARGETS" = "1" ]; then
     cmd+=(--check-targets)
   fi
+  set +e
   (
     cd "$ROOT_DIR/backend"
     if command -v uv >/dev/null 2>&1; then
@@ -288,13 +311,17 @@ main() {
 
     # asyncio.wait_for cannot stop a provider call already running in a worker thread.
     # The outer process timeout keeps C/RAGAS from consuming the entire workflow.
-    if [ "$TOTAL_TIMEOUT_SECONDS" != "0" ] && command -v timeout >/dev/null 2>&1; then
+    timeout_binary=""
+    if [ "$TOTAL_TIMEOUT_SECONDS" != "0" ]; then
+      timeout_binary="$(timeout_cmd || true)"
+    fi
+    if [ -n "$timeout_binary" ]; then
       API_SECRET_KEY="$API_KEY" \
         RAGAS_BATCH_STRATEGY="${RAGAS_BATCH_STRATEGY:-single}" \
         RAGAS_OUTER_SINGLE_TIMEOUT="${RAGAS_OUTER_SINGLE_TIMEOUT:-300}" \
         RAGAS_MAX_WORKERS="${RAGAS_MAX_WORKERS:-1}" \
         PYTHONPATH="$ROOT_DIR:$ROOT_DIR/backend:${PYTHONPATH:-}" \
-        timeout --kill-after=30s "${TOTAL_TIMEOUT_SECONDS}s" "${runner_cmd[@]}"
+        "$timeout_binary" --kill-after=30s "${TOTAL_TIMEOUT_SECONDS}s" "${runner_cmd[@]}"
     else
       if [ "$TOTAL_TIMEOUT_SECONDS" != "0" ]; then
         echo "Warning: timeout command not found; running without whole-runner timeout" >&2
@@ -307,6 +334,20 @@ main() {
         "${runner_cmd[@]}"
     fi
   )
+  status=$?
+  set -e
+  if [ "$status" -ne 0 ]; then
+    echo "C live RAGAS failed with status $status" >&2
+    if [ "$status" -eq 124 ]; then
+      echo "Failure reason: whole-runner timeout after ${TOTAL_TIMEOUT_SECONDS}s." >&2
+    elif [ "$status" -eq 137 ]; then
+      echo "Failure reason: runner was killed, commonly after timeout kill-after or OOM." >&2
+    fi
+    echo "Check progress above for the last completed phase/case." >&2
+    echo "Expected JSON report if the runner reached artifact writing: $OUTPUT_DIR/live_api_eval_${TIMESTAMP}.json" >&2
+    echo "Expected text report if the runner reached artifact writing: $OUTPUT_DIR/live_api_eval_${TIMESTAMP}.txt" >&2
+    exit "$status"
+  fi
 }
 
 main "$@"


### PR DESCRIPTION
## Summary
- Add a native 60-minute GitHub Actions timeout to the A voice round-trip smoke step.
- Add flushed C/RAGAS collection and scoring progress logs, including language/case start/done/error markers.
- Add configurable live `/api/chat` timeout, expected report path logging, `timeout`/`gtimeout` detection, and clearer timeout/killed diagnostics for C/RAGAS.

## Why
The SHA-matched A run hung without a step-level budget (#732), and the C alpha-127 run can remain opaque for long periods (#670). These changes keep the release gate bounded and debuggable while preserving C scoring/provider semantics, including direct OpenAI metadata from #712.

## Validation
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/alpha-live-verification.yml")'`
- `bash -n scripts/alpha-smoke-comprehensive.sh`
- `scripts/alpha-smoke-comprehensive.sh --scenarios A --dry-run`
- `bash -n scripts/rag-api-live-test.sh`
- `python3 -m py_compile backend/evaluation/run_live_api_eval.py`
- `scripts/rag-api-live-test.sh --case-suite diagnostic-29 --languages ja --metrics answer_correctness --timestamp telemetry-check --dry-run`
- `cd backend && uv run pytest tests/evaluation/test_ragas_live_case_suites.py -q` (8 passed)

Refs #670
Refs #732