### PR TITLE
test: discover frontend node test files

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -18,6 +18,7 @@
     "import:markdown": "tsx -r dotenv/config scripts/import-markdown-knowledge.ts",
     "setup:admin": "tsx -r dotenv/config scripts/setup-admin-knowledge.ts",
     "test": "cd scripts/tests && tsx run-tests.ts",
+    "test:node": "tsx scripts/tests/run-tests.ts node",
     "test:e2e": "playwright test --config=playwright.config.ts",
     "test:e2e:ui": "playwright test --config=playwright.config.ts --ui",
     "test:integrated": "cd scripts/tests && tsx run-tests.ts integrated",

--- a/frontend/scripts/tests/run-tests.ts
+++ b/frontend/scripts/tests/run-tests.ts
@@ -4,8 +4,19 @@
  * Main entry point for running all tests or specific test suites
  */
 
-import { execSync } from 'child_process';
+import { execFileSync } from 'child_process';
+import { readdirSync } from 'fs';
 import * as path from 'path';
+
+const frontendRoot = path.resolve(__dirname, '../..');
+const nodeTestsDir = path.join(frontendRoot, 'src', '__tests__');
+const nodeTestSetup = './src/__tests__/node-test-setup.ts';
+const tsxBin = path.join(
+  frontendRoot,
+  'node_modules',
+  '.bin',
+  process.platform === 'win32' ? 'tsx.cmd' : 'tsx',
+);
 
 const testSuites = {
   'integrated': {
@@ -25,6 +36,11 @@ const testSuites = {
   }
 };
 
+const nodeTestSuite = {
+  name: 'Node Test Suite',
+  description: 'Discovers and runs src/__tests__/**/*.test.ts via node:test'
+};
+
 function printUsage() {
   console.log(`
 Engineer Cafe Navigator - Test Runner
@@ -38,19 +54,65 @@ Available test suites:
   Object.entries(testSuites).forEach(([key, suite]) => {
     console.log(`  ${key.padEnd(12)} - ${suite.description}`);
   });
+  console.log(`  ${'node'.padEnd(12)} - ${nodeTestSuite.description}`);
   
   console.log(`
 Run all tests:
-  pnpm test:run
+  pnpm test
 
 Run specific test:
-  pnpm test:run integrated
-  pnpm test:run router
-  pnpm test:run calendar
+  pnpm test integrated
+  pnpm test router
+  pnpm test calendar
+  pnpm test node
 `);
 }
 
+function discoverNodeTestFiles(dir = nodeTestsDir): string[] {
+  return readdirSync(dir, { withFileTypes: true })
+    .flatMap((entry) => {
+      const fullPath = path.join(dir, entry.name);
+      if (entry.isDirectory()) {
+        return discoverNodeTestFiles(fullPath);
+      }
+      if (!entry.isFile() || !entry.name.endsWith('.test.ts')) {
+        return [];
+      }
+      return [path.relative(frontendRoot, fullPath)];
+    })
+    .sort();
+}
+
+function runNodeTests() {
+  const files = discoverNodeTestFiles();
+
+  if (files.length === 0) {
+    console.log('\nNo node:test files found in src/__tests__');
+    return;
+  }
+
+  console.log(`\n🚀 Running ${nodeTestSuite.name}...`);
+  console.log('='.repeat(60));
+  console.log(`Discovered ${files.length} node:test file(s):`);
+  files.forEach((file) => console.log(`  - ${file}`));
+
+  execFileSync(tsxBin, ['--test', '--import', nodeTestSetup, ...files], {
+    stdio: 'inherit',
+    cwd: frontendRoot,
+  });
+}
+
 async function runTest(suiteName: string) {
+  if (suiteName === 'node') {
+    try {
+      runNodeTests();
+    } catch (error) {
+      console.error(`\n❌ Test suite failed: ${suiteName}`);
+      process.exit(1);
+    }
+    return;
+  }
+
   const suite = testSuites[suiteName as keyof typeof testSuites];
   
   if (!suite) {
@@ -63,7 +125,7 @@ async function runTest(suiteName: string) {
   console.log('=' .repeat(60));
   
   try {
-    execSync(`npx tsx ${suite.script}`, {
+    execFileSync(tsxBin, [suite.script], {
       stdio: 'inherit',
       cwd: __dirname
     });
@@ -84,13 +146,22 @@ async function runAllTests() {
     console.log('-'.repeat(60));
     
     try {
-      execSync(`npx tsx ${suite.script}`, {
+      execFileSync(tsxBin, [suite.script], {
         stdio: 'inherit',
         cwd: __dirname
       });
     } catch (error) {
       failedSuites.push(key);
     }
+  }
+
+  console.log(`\n\n📋 ${nodeTestSuite.name}`);
+  console.log('-'.repeat(60));
+
+  try {
+    runNodeTests();
+  } catch (error) {
+    failedSuites.push('node');
   }
   
   console.log('\n\n' + '='.repeat(60));
@@ -102,7 +173,11 @@ async function runAllTests() {
   } else {
     console.log(`❌ ${failedSuites.length} test suite(s) failed:`);
     failedSuites.forEach(suite => {
-      console.log(`   - ${testSuites[suite as keyof typeof testSuites].name}`);
+      if (suite === 'node') {
+        console.log(`   - ${nodeTestSuite.name}`);
+      } else {
+        console.log(`   - ${testSuites[suite as keyof typeof testSuites].name}`);
+      }
     });
     process.exit(1);
   }

--- a/frontend/src/__tests__/node-test-setup.ts
+++ b/frontend/src/__tests__/node-test-setup.ts
@@ -1,0 +1,23 @@
+import { webcrypto } from 'node:crypto';
+
+if (!globalThis.CustomEvent) {
+  globalThis.CustomEvent = class CustomEvent<T = unknown> extends Event {
+    readonly detail: T;
+
+    constructor(type: string, eventInitDict: CustomEventInit<T> = {}) {
+      super(type, eventInitDict);
+      this.detail = eventInitDict.detail as T;
+    }
+
+    initCustomEvent(): void {
+      // Legacy DOM API shape required by TypeScript's CustomEvent interface.
+    }
+  } as typeof CustomEvent;
+}
+
+if (!globalThis.crypto) {
+  Object.defineProperty(globalThis, 'crypto', {
+    value: webcrypto,
+    configurable: true,
+  });
+}


### PR DESCRIPTION
## Summary
- Add `pnpm test:node` for frontend `node:test` suites.
- Extend the existing frontend test runner so `pnpm test node` discovers `src/__tests__/**/*.test.ts`, including nested audio and monitoring tests.
- Add a small Node test setup shim for `CustomEvent` and Web Crypto globals.

## Why
`pnpm test` did not reach newer `node:test` files such as `src/__tests__/audio/audio-user-interaction-gate.test.ts`; legacy suites also relied on `npx` path resolution. This makes the node-test path explicit and reproducible.

## Validation
- `pnpm install --frozen-lockfile`
- `pnpm test:node` (18 files discovered, 80 tests passed)
- `pnpm test node` (18 files discovered, 80 tests passed)
- `pnpm exec tsc --noEmit --pretty false scripts/tests/run-tests.ts src/__tests__/node-test-setup.ts`
- `git diff --check`

Fixes #733