### PR TITLE
docs: reset alpha status after May 3 verification

### DIFF
--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -6,7 +6,8 @@ Last updated: 2026-05-03
 
 このページは、`develop` 上の現行コード、2026-04-19 の live audit、2026-04-29 の実機音声 UX 確認、
 2026-05-02 の alpha-live-verification full run / targeted C run、2026-05-03 の PR #674/#675/#676
-deploy verification、PR #692/#693/#695/#699/#700/#701/#702/#703/#705/#707/#709 merge 後の alpha issue 状態をもとに更新しています。
+deploy verification、PR #692/#693/#695/#699/#700/#701/#702/#703/#705/#707/#709 merge 後の alpha issue 状態、
+および 2026-05-03 夜の reset snapshot をもとに更新しています。
 
 確認元:
 
@@ -18,6 +19,7 @@ deploy verification、PR #692/#693/#695/#699/#700/#701/#702/#703/#705/#707/#709 
 - 2026-05-03 JST の post-#692 C-127 run `25270459825`
 - 2026-05-03 JST の post-#709 Cloud Run deploy revision `engineer-cafe-backend-00162-mlr`
 - 2026-05-03 JST の SHA-matched full alpha-live-verification run `25272361091`
+- 2026-05-03 JST の C/Q run `25274709049` と STT/D/M run `25275030436`
 - 現在 open の GitHub Issue
 
 Supabase については、CLI で linked project の確認まではできましたが、このセッションでは recent runtime log
@@ -33,24 +35,47 @@ Supabase については、CLI で linked project の確認まではできまし
   live `/api/chat` 429 により `evaluated=35`, `collection_errors=92` だった
 - PR #693 は Q quality 修正、PR #695/#701 は C-127 pacing / coverage 修正、PR #699/#700/#702/#703 は C source / live harness / log hygiene hardening として merge 済み
 - PR #705/#709 は voice backend timeout / Vercel budget 修正、PR #707 は iOS/Android mobile audio 修正として merge 済み
-- 最新 full suite run `25272361091` は Cloud Run revision `engineer-cafe-backend-00162-mlr` / SHA `6ce1ac81983c7ae53ddfdfc58eba1ee043a83fa8` で実行中
-- ただし latest `suites=all` の green proof はまだなく、alpha release はまだ GO できない
+- PR #727/#731/#730/#734/#735 は merge 済み。ただし #717/#719/#697/#698/#585 は proof-gated issue として open のまま
+- #736 は frontend node test discovery PR として open。今回の docs reset では merge しない
+- 最新の有効な C/Q run `25274709049` は Q `25/25` PASS だが、C alpha-127 は `127/127/127` 完走後に JA/EN answer correctness と KO source gate で FAIL
+- 最新の有効な STT/D/M run `25275030436` は D/M が warning-only で通った一方、STT latency p95 `15624ms` で FAIL
+- latest `suites=all` の green proof はまだなく、alpha release はまだ GO できない
 - 現在の主リスクは「未実装の基本機能」ではなく「会話 UX の基本品質、実測 latency、route 整合性、評価 gate の透明性」
 
 特に優先度が高いのは次の 5 点です。
 
-1. 最新 full suite run `25272361091` の outcome / artifact を確認する
-2. C-127 が live `/api/chat` 429 なしで `127/127` collect/evaluate できることの証明
-3. Q suite の残 failure が #693 後に解消されたことの証明
-4. #697/#698 の mobile playback live-device proof
-5. RAGAS full-run speed / telemetry の operational closeout
+1. #658: STT current-revision latency を targeted run で green に戻す
+2. #583/#672: C alpha-127 の JA/EN answer correctness と KO source grounding を直す
+3. #697/#698/#585: mobile playback / onsite proof を実機で取る
+4. #655/#716: memory WARN の扱いを決め、必要なら rebase して targeted M proof を取る
+5. #717/#719/#670: infra / telemetry issue を proof-gated に close する
 
 現行の実装判断は [ADR 018](adr/018-alpha-fast-response-and-assistant-profile-routing.md) と
-[Alpha Remediation Plan 2026-05-02](plans/alpha-remediation-plan-2026-05-02.md) を優先する。
+[Alpha Reset Plan 2026-05-03](plans/alpha-reset-plan-2026-05-03.md) を優先する。
+
+## 2026-05-03 Reset Snapshot
+
+詳細な正本は [Alpha Live Verification Status 2026-05-03](testing/alpha-live-verification-status-2026-05-03.md)
+と [Alpha Reset Plan 2026-05-03](plans/alpha-reset-plan-2026-05-03.md)。
+
+Reset 時点の結論:
+
+- **NO-GO**。
+- C/Q run `25274709049`: C alpha-127 は `requested=127`, `collected=127`, `evaluated=127`,
+  `collection_errors=0`, direct OpenAI まで到達したが、JA `0.5671 < 0.85`,
+  EN `0.6914 < 0.75`, KO `gt-113` source `[fallback]` で FAIL。Q は `25 PASS / 0 WARN / 0 FAIL`。
+- STT/D/M run `25275030436`: STT は p95 `15624ms`, over-10s `14/29` で FAIL。
+  D は `45 passed, 10 warned, 0 failed`、M は `4 PASS / 1 WARN / 0 FAIL`。
+- #653/#721/#729/#732 は close 済み。
+- #658 は STT latency proof により reopen/open。
+- #717/#719/#697/#698/#585 は implementation merge では閉じず、runtime/device proof を待つ。
+- #736 は open のまま。docs reset 後に別 PR として判断する。
 
 ## 2026-05-03 Alpha Remediation Snapshot
 
-最新の deployed staging / harness 状態:
+過去 snapshot。最新判断では上記 2026-05-03 Reset Snapshot を優先する。
+
+当時の deployed staging / harness 状態:
 
 - develop SHA: `6ce1ac81983c7ae53ddfdfc58eba1ee043a83fa8`
 - Cloud Run revision: `engineer-cafe-backend-00162-mlr`
@@ -66,7 +91,8 @@ Supabase については、CLI で linked project の確認まではできまし
 - PR #693 merge SHA: `14cb8e5b3c4f9711a77c634d3db80f8bf4f80efd`
 - PR #695 merge SHA: `ed25199e4c7104ac0f6e2f027c4fdadd72280182`
 - PR #699/#700/#701/#702/#703/#705/#707/#709 are all included in deployed Cloud Run SHA `6ce1ac81983c7ae53ddfdfc58eba1ee043a83fa8`
-- Full alpha-live-verification run `25272361091` is in progress with `suites=all`, `c_ragas_suite=alpha-127`, and SHA match required
+- At this historical snapshot, full alpha-live-verification run `25272361091` had been dispatched with
+  `suites=all`, `c_ragas_suite=alpha-127`, and SHA match required.
 
 Resolved or implemented in the 2026-05-03 remediation pass:
 
@@ -87,13 +113,15 @@ Still blocking or important:
 - #696: voice backend timeout / warmup UX is closed after post-#705/#709 live proof.
 - #697: iOS delayed TTS playback remains P0 until post-#707 iPad/iPhone Safari proof.
 - #698: Android large-audio playback remains P1 until post-#707 Android phone proof or explicit alpha demotion.
-- #653: Q quality remains P1 until post-#693 `suites=q` rerun has 0 failures.
+- #653: Q quality was still pending in this historical snapshot; it is now closed by run `25274709049`
+  with `25 PASS / 0 WARN / 0 FAIL`.
 - #672: C answer/source quality remains P1, but current C metrics are not release-proof until C-127 collection completes.
 - #670: RAGAS telemetry is implemented, but post-#695/#701 C-127 artifact still needs operational proof before close.
 
 ## 2026-05-02 Alpha Live Verification Snapshot
 
-最新の正本は [Alpha Live Verification Status 2026-05-02](testing/alpha-live-verification-status-2026-05-02.md)。
+この snapshot は履歴。最新の正本は
+[Alpha Live Verification Status 2026-05-03](testing/alpha-live-verification-status-2026-05-03.md)。
 
 - Full run: `25244933308`
 - Targeted C/RAGAS run: `25247945549`
@@ -113,7 +141,8 @@ Resolved in the 2026-05-02 / 2026-05-03 remediation pass:
 
 Still blocking:
 
-- #583: C-127 completion proof after #695
+- #583: C-127 completion proof after #695 was still pending in this historical snapshot; run
+  `25274709049` later proved complete accounting/collection and exposed quality/source failures.
 - #653 / #672: Q/C answer quality
 - #670: full-run RAGAS speed / telemetry closeout
 
@@ -266,24 +295,26 @@ current turn の high-confidence intent なしに route を固定してはいけ
 
 ## いま重要な Open Issues
 
-- `#583`: C-127 completion proof
-- `#653`: Q-content quality
+- `#583`: C-127 alpha gate proof; accounting/collection is complete, but answer/source quality still fails
+- `#658`: STT current-revision latency
 - `#672`: Direct OpenAI C/RAGAS JA target miss
 - `#670`: C/RAGAS runtime and telemetry
 - `#611`: Cerebras dynamic filler / fast first-response path
 
 ## 推奨する実装順
 
-1. run `25272361091` または targeted `suites=c-127` rerun で #583 / #670 / #672 の判断材料を取る
-2. PR #693 後の `suites=q` rerun で #653 を close できるか判断する
-3. C-127 が `127/127` 完走してから C answer/source quality を直す (`#672`)
-4. RAGAS full-run telemetry / runtime を close 判断する (`#670`)
-5. #611 / #584 / #585 の live-only proof を収集するか、alpha GO から demote / waive する
+1. #658 を targeted `suites=stt,v` で直す
+2. run `25274709049` の C artifacts を読んで #583/#672 を直し、targeted `suites=c-127` で証明する
+3. #697/#698/#585 の live-device / onsite proof を取る
+4. #655/#716 を rebase するか alpha では WARN acceptance として明文化する
+5. #717/#719/#670 を workflow/artifact proof で close する
 
 ## 参照
 
 - [SECURITY.md](SECURITY.md)
 - [DEPLOYMENT.md](DEPLOYMENT.md)
+- [testing/alpha-live-verification-status-2026-05-03.md](testing/alpha-live-verification-status-2026-05-03.md)
+- [plans/alpha-reset-plan-2026-05-03.md](plans/alpha-reset-plan-2026-05-03.md)
 - [testing/alpha-live-verification-status-2026-05-02.md](testing/alpha-live-verification-status-2026-05-02.md)
 - [plans/alpha-remediation-plan-2026-05-02.md](plans/alpha-remediation-plan-2026-05-02.md)
 - [plans/alpha-fast-response-implementation-2026-04-30.md](plans/alpha-fast-response-implementation-2026-04-30.md)

--- a/docs/adr/008-operational-verification-and-deployment-guardrails.md
+++ b/docs/adr/008-operational-verification-and-deployment-guardrails.md
@@ -103,3 +103,19 @@ PR #674, #675, #676 の remediation と deployed staging 検証を踏まえ、�
 - B routing / slide smoke の GO 証跡は targeted B run `25254789937` とする。この run は Cloud Run revision `engineer-cafe-backend-00148-82c`、image tag `d789a2cd899779423947c40a3d65e19382f52d30` で `64 passed, 0 warned, 0 failed`。
 - Compact artifact split は release gate の一部とする。成功時も compact reports が残り、heavy browser artifacts は failure-oriented にする。
 - Current-revision STT gate が失敗している限り、B/H/log hygiene が green でも alpha GO とはしない。
+
+## 2026-05-03 Reset 追記
+
+同日の長時間 merge / verification sweep 後、以下を追加の運用ルールとする。
+
+- Runtime-sensitive issue は implementation PR の auto-close に任せない。#717/#719/#697/#698/#585
+  のような proof-gated issue は、merge 後に必要なら reopen し、workflow / device / run-window proof
+  が揃ってから close する。
+- Full-suite workflow は最終確認として扱う。既知の STT latency や C/RAGAS quality failure がある間は、
+  targeted suite を優先し、full `suites=all` の再 dispatch を連発しない。
+- Docs reset PR は実装停止点として許可する。Issue map、ADR、status が drift した場合は、新規実装より先に
+  docs-only PR で判断基準を固定する。
+- "PASS with WARN" は alpha GO では自動的に pass とみなさない。D/M の memory warning のように
+  product risk が残る場合は、WARN acceptance または follow-up issue を明示する。
+- Open PR は ready-looking でも reset 指示後に opportunistic merge しない。#736 のような hygiene PR は、
+  docs reset 後に別判断として扱う。

--- a/docs/adr/019-alpha-live-ragas-case-accounting.md
+++ b/docs/adr/019-alpha-live-ragas-case-accounting.md
@@ -145,6 +145,33 @@ collection-success-only report に戻せる。ただし、その状態の C-127 
 ADR 019 itself is implemented and #691 is closed. Remaining C-127 proof depends on #694 / PR #695
 and a post-#695 `suites=c-127` rerun that reaches `evaluated=127` and `collection_errors=0`.
 
+## 2026-05-03 Reset 追記
+
+Post-#695/#701 run `25274709049` reached the accounting bar:
+
+- `case_suite`: `alpha-127`
+- requested cases: `127`
+- collected cases: `127`
+- evaluated cases: `127`
+- collection errors: `0`
+- RAGAS errors: `0`
+- provider: direct OpenAI
+- model: `gpt-5.2-2025-12-11`
+
+This closes the original accounting and collection-completion concern for ADR 019. The remaining
+C alpha blocker is no longer "did the harness really test 127 cases?" but "did the product answer and
+source those 127 cases well enough?"
+
+Current remaining C failures from that run:
+
+- JA answer correctness: `0.5671`, target `0.85`
+- EN answer correctness: `0.6914`, target `0.75`
+- KO source gate: `gt-113` returned `[fallback]` instead of `enhanced_rag`, `knowledge_base`, or
+  `knowledge_base_cached`
+
+Therefore, future C triage should not reopen ADR 019 unless accounting regresses. Track product
+quality/source defects in #583/#672.
+
 ## 参照
 
 - Run: <https://github.com/EngineerCafeJP/engineercafe-navigator/actions/runs/25268597241>

--- a/docs/handoffs/alpha-reset-handoff-2026-05-03.md
+++ b/docs/handoffs/alpha-reset-handoff-2026-05-03.md
@@ -1,0 +1,37 @@
+# Alpha Reset Handoff 2026-05-03
+
+Use this handoff when resuming implementation after the docs reset PR.
+
+## Stop Rule
+
+Implementation and merge monitoring stopped at the user's request. Do not continue the previous
+full-suite watch loop or opportunistically merge open PRs before re-reading the reset status.
+
+Primary references:
+
+- [Alpha Live Verification Status 2026-05-03](../testing/alpha-live-verification-status-2026-05-03.md)
+- [Alpha Reset Plan 2026-05-03](../plans/alpha-reset-plan-2026-05-03.md)
+- [ADR 008](../adr/008-operational-verification-and-deployment-guardrails.md)
+- [ADR 019](../adr/019-alpha-live-ragas-case-accounting.md)
+
+## Known Open PRs
+
+- #736: frontend node test discovery. CI was green when checked, but it was intentionally left
+  unmerged for the reset.
+- #716: memory warning tightening. Draft/conflicting; rebase before any merge decision.
+- #706: M5Stack hardware integration. Keep open until firmware/security/hardware proof is ready.
+
+## Known Closed/Resolved Issues From Sweep
+
+- #653: Q quality, after run `25274709049` reported `25 PASS / 0 WARN / 0 FAIL`.
+- #721: null-byte / persistence issue, after D/M run `25275030436` had zero Cloud Logging errors.
+- #729: backend pytest timeout dependency, via #734.
+- #732: unbounded alpha workflow step timeout, via #735.
+
+## Resume Order
+
+1. Read the current GitHub issue/PR state. Develop may have moved since this handoff.
+2. If #736 is still open, treat it as a separate hygiene PR. Do not mix it with P0 fixes.
+3. Start with #658 STT latency. Use targeted STT runs.
+4. Then fix #583/#672 C answer/source quality using run `25274709049` artifacts.
+5. Only after targeted STT and C are green, consider another full `suites=all` dispatch.

--- a/docs/plans/alpha-remediation-plan-2026-05-02.md
+++ b/docs/plans/alpha-remediation-plan-2026-05-02.md
@@ -4,6 +4,11 @@ This is the execution plan for the implementation sessions after the 2026-05-02 
 verification run. It includes the 2026-05-03 remediation status through PR #709 and the
 SHA-matched full alpha-live-verification run `25272361091`.
 
+> 2026-05-03 reset note: this plan is now historical for the long remediation sweep. Use
+> [Alpha Reset Plan 2026-05-03](alpha-reset-plan-2026-05-03.md) for the next implementation session.
+> The previous "watch full run" posture has been replaced by targeted STT, C/RAGAS, and device-proof
+> work.
+
 ## Current State
 
 The workflow infrastructure is now complete enough to run targeted alpha gates end to end:
@@ -31,11 +36,15 @@ Latest deployed verification:
 - PR #695 merge SHA: `ed25199e4c7104ac0f6e2f027c4fdadd72280182`
 - PR #699/#700/#701/#702/#703 are merged for C source routing, Welcome guard, C-127 coverage, log hygiene, and STT warmup
 - PR #705/#707/#709 are merged; #696 is closed after live proof, and #697/#698 mobile audio proof remains open
-- Full alpha-live-verification run `25272361091` is in progress with `suites=all`, `c_ragas_suite=alpha-127`
+- At this historical snapshot, full alpha-live-verification run `25272361091` had been dispatched with
+  `suites=all`, `c_ragas_suite=alpha-127`
 - Q targeted run before #693: `25269072919` failed with `23 PASS / 0 WARN / 2 FAIL`
 - PR #693 merge SHA: `14cb8e5b3c4f9711a77c634d3db80f8bf4f80efd`; post-#693 Q proof is included in run `25272361091`
 
 ## Implementation Order
+
+This section is superseded by [Alpha Reset Plan 2026-05-03](alpha-reset-plan-2026-05-03.md). It is
+kept for audit history only.
 
 ### 1. Watch full run `25272361091`
 
@@ -130,7 +139,8 @@ Status: completed and closed.
 
 - Current-revision scoping is implemented.
 - Historical risk reporting is separated from release gate reporting.
-- GitHub issue #658 is closed after run `25258764528` passed `suites=stt,v`.
+- GitHub issue #658 was closed after run `25258764528` passed `suites=stt,v`, but this historical
+  status is superseded by the 2026-05-03 reset after run `25275030436` failed STT latency again.
 
 ### #660 H-UI Welcome OCR overlay
 

--- a/docs/plans/alpha-reset-plan-2026-05-03.md
+++ b/docs/plans/alpha-reset-plan-2026-05-03.md
@@ -1,0 +1,137 @@
+# Alpha Reset Plan 2026-05-03
+
+This plan is the next-session entry point after the long-running 2026-05-03 implementation and
+merge sweep. It replaces the "watch the full run" posture from
+[Alpha Remediation Plan 2026-05-02](alpha-remediation-plan-2026-05-02.md).
+
+## Reset Decision
+
+Stop implementation churn, merge a docs-only reset, then resume with targeted fixes. The repository
+has enough workflow coverage now; repeated full-suite runs before fixing known blockers waste time
+and make issue state harder to trust.
+
+Current alpha status: **NO-GO**.
+
+## Ground Truth At Reset
+
+- `develop`: `3b3b370265834d8db032917d4452e9a488d055ca`
+- Latest valid C/Q proof: run `25274709049`
+- Latest valid STT/D/M proof: run `25275030436`
+- C/Q conclusion:
+  - C alpha-127 accounted and evaluated all 127 cases with direct OpenAI.
+  - Q passed 25/25.
+  - C failed JA/EN answer correctness and KO source grounding.
+- STT/D/M conclusion:
+  - STT failed current-revision latency.
+  - D/log hygiene passed with memory warnings.
+  - M passed with one cross-session recall warning.
+
+## P0 / P1 Work Queue
+
+### P0-A: #658 STT latency
+
+Goal: make current deployed STT pass the alpha gate without hiding real latency.
+
+Evidence:
+
+- Run `25275030436`
+- p95 `15624ms`
+- max `15976ms`
+- over 10s `14/29` (`48.3%`)
+- no timeout errors
+
+Next steps:
+
+- Inspect per-sample STT artifacts and provider path split.
+- Determine whether latency is model warmup, Qwen primary, Vosk fallback, Cloud Run resource, or
+  test pacing.
+- Fix product/runtime first. Adjust the gate only if the current threshold is demonstrably invalid.
+- Re-run `suites=stt,v`, then comment #658 with exact counters.
+
+### P0-B: #583 / #672 C alpha-127 quality and sources
+
+Goal: make the complete 127-case C gate pass with direct OpenAI.
+
+Evidence:
+
+- Run `25274709049`
+- requested/collected/evaluated `127/127/127`
+- collection errors `0`
+- JA answer correctness `0.5671 < 0.85`
+- EN answer correctness `0.6914 < 0.75`
+- KO source failure: `gt-113` returned `[fallback]`
+
+Next steps:
+
+- Pull and inspect C artifacts before changing code.
+- Classify failures into answer generation, retrieval/source, fixture expectation, or threshold.
+- Prefer product-side fixes for routing, source selection, and answer content.
+- Re-run `suites=c-127`; do not use partial C metrics as release proof.
+
+### P0-C: #697 / #698 / #585 device and onsite proof
+
+Goal: prove merged audio and M5Stack changes on real target devices.
+
+Evidence:
+
+- PR #730 implemented iOS tap-to-enable UI, but #697/#634/#635/#471 remain proof-gated.
+- PR #731 implemented M5Stack simulation E2E, but #585 requires real M5Stack + kiosk proof.
+
+Next steps:
+
+- Capture iPhone/iPad Safari delayed TTS proof for #697.
+- Capture Android large-audio proof for #698 or explicitly demote it with rationale.
+- Keep #706 open until hardware firmware/security/readiness proof is present.
+- Keep #585 open until real device and 2h onsite round-trip proof is attached.
+
+### P1-A: #655 / #716 memory warning semantics
+
+Goal: decide whether M-LTM warnings are alpha blockers or post-alpha hardening.
+
+Evidence:
+
+- Run `25275030436`
+- M: `4 PASS / 1 WARN / 0 FAIL`
+- warning: `M-LTM-001` cross-session recall empty
+- #716 is draft/conflicting and should not merge before rebase.
+
+Next steps:
+
+- Rebase #716 only after STT and C are no longer blocking.
+- Keep M warning semantics explicit: do not silently turn warnings into passes.
+- Re-run `suites=m` after #716 or an alternative memory fix.
+
+### P1-B: #717 / #719 operational proof
+
+Goal: close infra issues only after env and workflow proof.
+
+Evidence:
+
+- PR #727 merged implementation and runbooks.
+- #717/#719 were intentionally reopened because implementation-only closure is insufficient.
+
+Next steps:
+
+- Configure required secrets/env.
+- Run the DB drift workflow and cron alert path once.
+- Attach proof windows/artifacts, then close.
+
+### Hygiene / Sequencing
+
+- #736 is ready-looking but was intentionally left open at reset. Merge it separately only after
+  this docs PR is merged and current branch protection state is clear.
+- #670 should close only after the next C/Q proof demonstrates useful logs and compact artifacts.
+- Avoid closing #634/#635/#471 independently unless #697 remains the canonical proof tracker or
+  the device proof passes.
+
+## Definition Of Alpha GO
+
+Alpha GO requires all of the following:
+
+- C alpha-127 complete and green: `127/127/127`, zero collection/RAGAS errors, thresholds pass.
+- Q green: no failures.
+- STT current-revision gate green.
+- D/log hygiene has no live error signatures in the run window.
+- M warnings are either fixed or explicitly accepted as non-blocking.
+- iOS/Android/onsite proof issues are closed or explicitly waived with dated rationale.
+- #643 umbrella has linked run URLs and artifact evidence for each accepted gate.

--- a/docs/testing/alpha-live-verification-status-2026-05-02.md
+++ b/docs/testing/alpha-live-verification-status-2026-05-02.md
@@ -4,6 +4,11 @@
 の PR #674/#675/#676/#692/#693/#695/#699/#700/#701/#702/#703/#705/#707/#709 remediation 結果を追記したものです。古い 2026-04-25 status は履歴として残しますが、
 次の実装判断ではこのファイルを優先します。
 
+> 2026-05-03 reset note: next implementation planning should now use
+> [Alpha Live Verification Status 2026-05-03](alpha-live-verification-status-2026-05-03.md)
+> and [Alpha Reset Plan 2026-05-03](../plans/alpha-reset-plan-2026-05-03.md). The sections below
+> that describe run `25272361091` as "in progress" are historical.
+
 ## 結論
 
 **NO-GO** です。
@@ -134,7 +139,8 @@ Resolved STT follow-up:
 
 - Earlier STT-only run after PR #674 deploy failed with p95/max `29217ms`.
 - A later `suites=stt,v` run `25258764528` passed on Cloud Run `engineer-cafe-backend-00153-r9r`.
-- #658 is closed.
+- At this historical point #658 was closed. It was reopened after run `25275030436` failed the
+  current-revision latency gate again; see the 2026-05-03 reset status.
 
 ### Full Suite
 
@@ -222,12 +228,12 @@ Observed impact:
 
 ## Next Implementation Order
 
-1. Watch full run `25272361091`: prove SHA match, collect artifacts, and decide GO / targeted reruns.
-2. C-127: prove `requested=127`, `evaluated=127`, `collection_errors=0`.
-3. Q: prove #653 has `0 FAIL`.
-4. #697/#698: collect real-device proof.
-5. #672: triage C answer/source quality only after C-127 collection completes.
-6. #670: verify full C/Q telemetry and runtime with the current artifact split.
+1. Use the 2026-05-03 reset status as the current source of truth.
+2. #658: fix STT current-revision latency and rerun `suites=stt,v`.
+3. #583/#672: fix C alpha-127 answer/source quality after run `25274709049` proved `127/127/127`.
+4. #697/#698/#585: collect real-device and onsite proof.
+5. #655/#716: resolve or explicitly accept memory WARN semantics.
+6. #717/#719/#670: close only with workflow/artifact proof.
 
 ## Useful Commands
 

--- a/docs/testing/alpha-live-verification-status-2026-05-03.md
+++ b/docs/testing/alpha-live-verification-status-2026-05-03.md
@@ -1,0 +1,150 @@
+# Alpha Live Verification Status 2026-05-03
+
+This is the stop-point status after the 2026-05-03 merge and verification sweep. It supersedes
+the "watch in progress" parts of
+[Alpha Live Verification Status 2026-05-02](alpha-live-verification-status-2026-05-02.md)
+for next implementation planning.
+
+## Conclusion
+
+**NO-GO**.
+
+The alpha gate is now failing on runtime proof, not on missing workflow plumbing:
+
+- Direct OpenAI RAGAS is confirmed.
+- C-127 manifest accounting is fixed: the gate can prove `requested=127`.
+- Q quality is currently green on the latest valid run.
+- D/log hygiene is green for the latest D/M run window.
+- STT current-revision latency is red again.
+- C-127 answer/source quality is still red after complete collection.
+- Mobile/iOS/Android and onsite kiosk proof remain open until target-device evidence is attached.
+
+Do not dispatch another full `suites=all` run until the targeted STT and C/RAGAS blockers below are
+fixed or explicitly waived. Full-suite runs are now expensive confirmation, not the fastest debugger.
+
+## Develop / PR State
+
+- Current documented base: `develop` at `3b3b370265834d8db032917d4452e9a488d055ca`
+  (`Merge pull request #735 from EngineerCafeJP/codex/alpha-verification-bounds`).
+- Merged in the sweep:
+  - #727: cron alert and DB drift mechanism; #717/#719 intentionally remain open for env/workflow proof.
+  - #731: M5Stack reception simulation E2E; #585 remains open for real device and 2h onsite proof.
+  - #730: iOS tap-to-enable UI; #697/#634/#635/#471 intentionally remain open for iPhone/iPad proof.
+  - #734: backend `pytest-timeout`; #729 closed.
+  - #735: alpha verification bounds/telemetry; #732 closed, #670 remains open for live C/Q proof.
+- Open at the stop point:
+  - #736: frontend `node:test` discovery. CI was green when checked, but it is intentionally not merged in this docs reset.
+  - #716: memory warning tightening, draft and conflicting/outdated.
+  - #706: M5Stack hardware integration, open for hardware readiness; simulation coverage from #731 does not replace it.
+
+## Verification Runs
+
+### C/Q: run `25274709049`
+
+- URL: <https://github.com/EngineerCafeJP/engineercafe-navigator/actions/runs/25274709049>
+- Backend SHA: `1110089ab0c85bf267b2e78f19d16ab4b412a5f5`
+- Provider: direct OpenAI
+- Model: `gpt-5.2-2025-12-11`
+- C alpha-127 result: failure
+  - requested: `127`
+  - collected: `127`
+  - evaluated: `127`
+  - collection errors: `0`
+  - RAGAS errors: `0`
+  - JA answer correctness: `0.5671` below target `0.85`
+  - EN answer correctness: `0.6914` below target `0.75`
+  - ZH answer correctness: pass
+  - KO answer correctness: pass
+  - KO source gate failed for `gt-113`: actual sources were `[fallback]` instead of a knowledge source.
+- Q result: pass
+  - `25 PASS / 0 WARN / 0 FAIL`
+  - This is sufficient to close #653, which has been closed.
+
+Interpretation: ADR 019 / PR #692 fixed the accounting problem, and PR #695/#701 fixed the earlier
+429 collection failure enough to evaluate all 127 cases. The remaining C blocker is product quality
+and source grounding, tracked by #583/#672.
+
+### STT/D/M: run `25275030436`
+
+- URL: <https://github.com/EngineerCafeJP/engineercafe-navigator/actions/runs/25275030436>
+- Backend SHA: `1110089ab0c85bf267b2e78f19d16ab4b412a5f5`
+- STT result: failure
+  - samples: `29`
+  - p95: `15624ms`
+  - max: `15976ms`
+  - over 10s: `14/29` (`48.3%`)
+  - qwen-primary samples: `24`
+  - vosk-fallback samples: `5`
+  - no `TimeoutError`
+- D result: pass with warnings
+  - `45 passed, 10 warned, 0 failed`
+  - warnings are `ltm_recall_s2: parallel_ltm`
+  - Cloud Logging gate passed for the run window: `/api/chat` 5xx `0`, `ltm_store_write=failed` `0`,
+    `memory_helper` errors `0`, invalid UUID / null-byte persistence signatures `0`.
+- M result: pass with warning
+  - `4 PASS / 1 WARN / 0 FAIL`
+  - remaining warning: `M-LTM-001` cross-session recall empty.
+
+Interpretation: #721 is closed because the null-byte/persistence class is proven fixed. #658 is
+reopened because STT latency is again a current-revision alpha blocker. #655/#716 remain the memory
+warning track, but they are not the current primary NO-GO reason.
+
+## Issue State To Carry Forward
+
+Primary alpha blockers:
+
+- #643: umbrella alpha gate remains open.
+- #658: STT current-revision latency failure.
+- #583 / #672: C alpha-127 still misses JA/EN answer correctness and KO source grounding.
+- #697 / #698 / #585: target-device and onsite proof.
+
+Important but not first debugger:
+
+- #670: C/RAGAS telemetry/bounds are implemented, but close only after a live C/Q run proves the
+  artifact trail is operationally sufficient.
+- #655 / #716: memory warning semantics remain open; #716 needs rebase/conflict resolution before merge.
+- #717 / #719: infra mechanisms are merged, but env/secret/workflow proof is still required before closure.
+- #706: hardware integration is not replaced by #731's simulation test.
+
+Closed from this sweep:
+
+- #653: Q quality gate passed 25/25.
+- #721: null-byte / persistence live failure class did not recur in D/M proof.
+- #729: backend pytest timeout dependency.
+- #732: unbounded alpha workflow step timeout.
+
+## Next Efficient Order
+
+1. Merge this docs reset PR, then avoid broad implementation until the issue map is stable.
+2. Fix #658 with a targeted STT latency investigation. Re-run only `suites=stt` or `suites=stt,v`.
+3. Fix #672 by inspecting the 127 evaluated C artifacts. Separate response-generation defects,
+   source-retrieval defects, and invalid ground-truth expectations.
+4. Re-run only `suites=c-127` after the #672 fix. Require `requested=127`, `collected=127`,
+   `evaluated=127`, `collection_errors=0`, and source/quality thresholds passing.
+5. Handle #697/#698 with real target-device evidence. Close #634/#635/#471 only as duplicates after
+   #697 remains the canonical proof issue or passes.
+6. Rebase #716 only after the M warning policy is agreed. Run targeted `suites=m` after merge.
+7. Prove #717/#719 with workflow/env evidence, then close them.
+8. Run `suites=all` only after targeted STT and C are green.
+
+## Useful Targeted Commands
+
+```bash
+gh workflow run alpha-live-verification.yml \
+  --ref develop \
+  -f suites=stt,v \
+  -f require_deployed_sha_match=true \
+  -f expected_backend_sha=<deployed-backend-sha>
+
+gh workflow run alpha-live-verification.yml \
+  --ref develop \
+  -f suites=c-127 \
+  -f require_deployed_sha_match=true \
+  -f expected_backend_sha=<deployed-backend-sha>
+
+gh workflow run alpha-live-verification.yml \
+  --ref develop \
+  -f suites=m \
+  -f require_deployed_sha_match=true \
+  -f expected_backend_sha=<deployed-backend-sha>
+```


### PR DESCRIPTION
## Summary
- Add the 2026-05-03 alpha verification reset status and next-session reset plan.
- Update STATUS, ADR 008, and ADR 019 so runtime proof remains the source of truth.
- Mark the older May 2 status/plan as historical where the current STT/C findings supersede it.

## Current alpha conclusion
- NO-GO.
- C/Q run 25274709049 proves direct OpenAI and 127/127/127 accounting, but C still fails JA/EN answer correctness and KO source grounding.
- STT/D/M run 25275030436 reopens the STT latency blocker while D/M are warning-only.
- #736 remains intentionally unmerged for this reset.

## Validation
- git diff --cached --check
- docs-only review of current GitHub PR/issue state
