### PR TITLE
fix: cap STT hedge latency

### DIFF
--- a/backend/agents/stt_agent.py
+++ b/backend/agents/stt_agent.py
@@ -48,6 +48,7 @@ logger = logging.getLogger(__name__)
 
 _stt_postprocess_client: Optional["_stt_httpx.AsyncClient"] = None
 _qwen_stt_executor: Optional[concurrent.futures.ThreadPoolExecutor] = None
+_vosk_stt_executor: Optional[concurrent.futures.ThreadPoolExecutor] = None
 
 
 def _is_real_openrouter_key(value: str) -> bool:
@@ -82,6 +83,16 @@ def _get_qwen_stt_executor() -> concurrent.futures.ThreadPoolExecutor:
             thread_name_prefix="qwen-stt",
         )
     return _qwen_stt_executor
+
+
+def _get_vosk_stt_executor() -> concurrent.futures.ThreadPoolExecutor:
+    global _vosk_stt_executor
+    if _vosk_stt_executor is None:
+        _vosk_stt_executor = concurrent.futures.ThreadPoolExecutor(
+            max_workers=2,
+            thread_name_prefix="vosk-stt",
+        )
+    return _vosk_stt_executor
 
 
 # ---------------------------------------------------------------------------
@@ -352,6 +363,52 @@ def _parse_qwen_stt_hedge_grace(
         return adjusted
 
     return timeout
+
+
+def _parse_qwen_stt_latency_budget(
+    raw_value: Optional[str],
+    *,
+    hard_timeout: float,
+) -> float | None:
+    """Parse the end-to-end STT budget used to cap optional Qwen grace wait."""
+
+    default = 10.0
+    if raw_value is None or raw_value.strip() == "":
+        budget = default
+    else:
+        try:
+            budget = float(raw_value)
+        except (TypeError, ValueError):
+            logger.warning(
+                "Invalid QWEN_STT_LATENCY_BUDGET_SECONDS=%r; falling back to %.1fs",
+                raw_value,
+                default,
+            )
+            budget = default
+
+    if not math.isfinite(budget):
+        logger.warning(
+            "Invalid QWEN_STT_LATENCY_BUDGET_SECONDS=%r; falling back to %.1fs",
+            raw_value,
+            default,
+        )
+        budget = default
+
+    if budget <= 0:
+        return None
+
+    if budget >= hard_timeout:
+        adjusted = max(0.05, hard_timeout * 0.8)
+        logger.warning(
+            "QWEN_STT_LATENCY_BUDGET_SECONDS %.2fs must be less than QWEN_STT_TIMEOUT %.2fs; "
+            "using %.2fs",
+            budget,
+            hard_timeout,
+            adjusted,
+        )
+        return adjusted
+
+    return budget
 
 
 def _normalize_vosk_route_transcript(transcript: str, language: Optional[str]) -> str:
@@ -867,11 +924,10 @@ class LocalSTTClient:
         """WAVバイト列を受け取り、TranscriptionResult を返します (thread pool経由)。"""
         try:
             loop = asyncio.get_running_loop()
-            with concurrent.futures.ThreadPoolExecutor() as pool:
-                return await loop.run_in_executor(
-                    pool,
-                    lambda: self._sync_transcribe(audio_data, language, grammar),
-                )
+            return await loop.run_in_executor(
+                _get_vosk_stt_executor(),
+                lambda: self._sync_transcribe(audio_data, language, grammar),
+            )
         except ValueError as e:
             message = f"Invalid audio data for STT transcription: {e}"
             logger.warning(message)
@@ -1226,6 +1282,7 @@ class STTAgent:
         self._qwen_timeout = None
         self._qwen_hedge_delay = None
         self._qwen_hedge_grace = 0.0
+        self._qwen_latency_budget = None
         if stt_client:
             self.stt_client = stt_client
         elif self.stt_provider == "vosk":
@@ -1256,6 +1313,10 @@ class STTAgent:
                 os.getenv("QWEN_STT_HEDGE_GRACE_SECONDS"),
                 hard_timeout=self._qwen_timeout,
                 hedge_delay=self._qwen_hedge_delay,
+            )
+            self._qwen_latency_budget = _parse_qwen_stt_latency_budget(
+                os.getenv("QWEN_STT_LATENCY_BUDGET_SECONDS"),
+                hard_timeout=self._qwen_timeout,
             )
             if _stt_preload_vosk_fallback_enabled():
                 self._vosk_fallback_client.preload_models()
@@ -1515,6 +1576,7 @@ class STTAgent:
                 timeout_s=self._qwen_timeout,
                 hedge_delay_s=self._qwen_hedge_delay,
                 hedge_grace_s=self._qwen_hedge_grace,
+                latency_budget_s=self._qwen_latency_budget,
                 audio_bytes=len(audio_data),
                 qwen_postprocess_enabled=qwen_postprocess_enabled,
             )
@@ -1684,6 +1746,7 @@ class STTAgent:
                         stt_qwen_duration_ms=_duration_ms(overall_started_at),
                         hedge_delay_s=self._qwen_hedge_delay,
                         hedge_grace_s=self._qwen_hedge_grace,
+                        latency_budget_s=self._qwen_latency_budget,
                     )
                     vosk_fallback_allowed.set()
                     done, _pending = await asyncio.wait(
@@ -1725,34 +1788,58 @@ class STTAgent:
                             and not qwen_task.done()
                             and not vosk_trusted
                         ):
-                            log_stt_event(
-                                event="stt_qwen_hedge_grace_start",
-                                stt_trace_id=stt_trace_id,
-                                provider="qwen-primary",
-                                language=language,
-                                success=False,
-                                hedge_grace_s=self._qwen_hedge_grace,
-                                stt_qwen_duration_ms=_duration_ms(overall_started_at),
-                            )
-                            try:
-                                qwen_result = await asyncio.wait_for(
-                                    asyncio.shield(qwen_task),
-                                    timeout=self._qwen_hedge_grace,
+                            remaining_budget = self._qwen_hedge_grace
+                            if self._qwen_latency_budget is not None:
+                                remaining_budget = min(
+                                    remaining_budget,
+                                    self._qwen_latency_budget
+                                    - (time.perf_counter() - overall_started_at),
                                 )
-                            except asyncio.TimeoutError:
+                            if remaining_budget <= 0:
                                 log_stt_event(
-                                    event="stt_qwen_hedge_grace_complete",
+                                    event="stt_qwen_hedge_grace_skipped",
                                     stt_trace_id=stt_trace_id,
                                     provider="qwen-primary",
                                     language=language,
                                     success=False,
-                                    error_type="TimeoutError",
                                     hedge_grace_s=self._qwen_hedge_grace,
+                                    latency_budget_s=self._qwen_latency_budget,
                                     stt_qwen_duration_ms=_duration_ms(overall_started_at),
                                 )
-                            except Exception as exc:
-                                qwen_result = exc
-                                qwen_error_for_log = exc
+                                remaining_budget = 0.0
+                            if remaining_budget > 0:
+                                log_stt_event(
+                                    event="stt_qwen_hedge_grace_start",
+                                    stt_trace_id=stt_trace_id,
+                                    provider="qwen-primary",
+                                    language=language,
+                                    success=False,
+                                    hedge_grace_s=self._qwen_hedge_grace,
+                                    latency_budget_s=self._qwen_latency_budget,
+                                    effective_hedge_grace_s=remaining_budget,
+                                    stt_qwen_duration_ms=_duration_ms(overall_started_at),
+                                )
+                                try:
+                                    qwen_result = await asyncio.wait_for(
+                                        asyncio.shield(qwen_task),
+                                        timeout=remaining_budget,
+                                    )
+                                except asyncio.TimeoutError:
+                                    log_stt_event(
+                                        event="stt_qwen_hedge_grace_complete",
+                                        stt_trace_id=stt_trace_id,
+                                        provider="qwen-primary",
+                                        language=language,
+                                        success=False,
+                                        error_type="TimeoutError",
+                                        hedge_grace_s=self._qwen_hedge_grace,
+                                        latency_budget_s=self._qwen_latency_budget,
+                                        effective_hedge_grace_s=remaining_budget,
+                                        stt_qwen_duration_ms=_duration_ms(overall_started_at),
+                                    )
+                                except Exception as exc:
+                                    qwen_result = exc
+                                    qwen_error_for_log = exc
                 except Exception as exc:
                     qwen_result = exc
                     qwen_error_for_log = exc

--- a/backend/tests/agents/test_stt_agent.py
+++ b/backend/tests/agents/test_stt_agent.py
@@ -180,6 +180,41 @@ class TestLocalSTTClient:
                 assert "empty" in str(exc_info.value).lower()
 
     @pytest.mark.asyncio
+    async def test_transcribe_cancellation_does_not_wait_for_blocking_executor(
+        self, test_wav_16khz
+    ):
+        """Vosk cancellation should not wait for a blocking worker thread."""
+        import concurrent.futures
+
+        import backend.agents.stt_agent as _mod
+
+        client = LocalSTTClient()
+        completed = threading.Event()
+
+        def blocking_transcribe(*args, **kwargs):
+            time.sleep(0.3)
+            completed.set()
+            return TranscriptionResult(text="late", confidence=0.8, language="ja")
+
+        shared = concurrent.futures.ThreadPoolExecutor(
+            max_workers=1,
+            thread_name_prefix="vosk-stt-test",
+        )
+
+        started_at = time.perf_counter()
+        with patch.object(client, "_sync_transcribe", side_effect=blocking_transcribe):
+            with patch.object(_mod, "_get_vosk_stt_executor", return_value=shared):
+                with pytest.raises(asyncio.TimeoutError):
+                    await asyncio.wait_for(
+                        client.transcribe(test_wav_16khz, language="ja"),
+                        timeout=0.01,
+                    )
+
+        assert time.perf_counter() - started_at < 0.2
+        assert completed.wait(timeout=1.0), "Vosk worker should finish after cancellation"
+        shared.shutdown(wait=True)
+
+    @pytest.mark.asyncio
     async def test_transcribe_invalid_json_raises_error(self, test_wav_16khz):
         """LocalSTTClient raises error if Vosk returns malformed JSON"""
         client = LocalSTTClient()
@@ -988,6 +1023,7 @@ class TestSTTAgent:
         assert agent._qwen_timeout == pytest.approx(24.0)
         assert agent._qwen_hedge_delay == pytest.approx(4.0)
         assert agent._qwen_hedge_grace == pytest.approx(6.0)
+        assert agent._qwen_latency_budget == pytest.approx(10.0)
 
     def test_init_qwen_primary_timeout_env_numeric(self, monkeypatch):
         """qwen-primary accepts numeric QWEN_STT_TIMEOUT values."""
@@ -1002,6 +1038,7 @@ class TestSTTAgent:
         assert agent._qwen_timeout == pytest.approx(2.5)
         assert agent._qwen_hedge_delay == pytest.approx(2.0)
         assert agent._qwen_hedge_grace == pytest.approx(0.4)
+        assert agent._qwen_latency_budget == pytest.approx(2.0)
 
     def test_init_qwen_primary_hedge_delay_env_numeric(self, monkeypatch):
         """qwen-primary accepts numeric QWEN_STT_HEDGE_DELAY_SECONDS values."""
@@ -1033,6 +1070,19 @@ class TestSTTAgent:
         assert agent._qwen_timeout == pytest.approx(24.0)
         assert agent._qwen_hedge_delay == pytest.approx(3.5)
         assert agent._qwen_hedge_grace == pytest.approx(2.5)
+
+    def test_init_qwen_primary_latency_budget_env_numeric(self, monkeypatch):
+        """qwen-primary accepts numeric QWEN_STT_LATENCY_BUDGET_SECONDS values."""
+        monkeypatch.setenv("QWEN_STT_TIMEOUT", "24")
+        monkeypatch.setenv("QWEN_STT_LATENCY_BUDGET_SECONDS", "8.5")
+
+        with (
+            patch("backend.agents.stt_agent.Qwen06BCpuSTTClient"),
+            patch("backend.agents.stt_agent.LocalSTTClient"),
+        ):
+            agent = STTAgent(stt_provider="qwen-primary")
+
+        assert agent._qwen_latency_budget == pytest.approx(8.5)
 
     def test_vosk_transcript_trusted_for_alpha_route_keywords(self):
         """Route-stable Vosk transcripts can skip the Qwen grace wait."""
@@ -2130,6 +2180,7 @@ class TestQwenPrimaryFallback:
         agent._qwen_timeout = 10.0
         agent._qwen_hedge_delay = None
         agent._qwen_hedge_grace = 0.0
+        agent._qwen_latency_budget = None
         return agent
 
     @pytest.mark.asyncio
@@ -2548,6 +2599,48 @@ class TestQwenPrimaryFallback:
             if record.name == "backend.observability.stt"
         ]
         assert "stt_qwen_hedge_grace_complete" in events
+
+    @pytest.mark.asyncio
+    async def test_qwen_grace_skips_when_latency_budget_is_exhausted(self, caplog):
+        """The optional Qwen grace wait must not push Vosk fallback past budget."""
+        caplog.set_level(logging.INFO, logger="backend.observability.stt")
+
+        async def too_late_qwen(*args, **kwargs):
+            await asyncio.sleep(0.30)
+            return TranscriptionResult(text="too late", confidence=0.9, language="ja")
+
+        async def untrusted_vosk(*args, **kwargs):
+            await asyncio.sleep(0.05)
+            return TranscriptionResult(text="fast fallback", confidence=0.8, language="ja")
+
+        mock_qwen = MagicMock()
+        mock_qwen.transcribe = too_late_qwen
+        mock_vosk = MagicMock(spec=LocalSTTClient)
+        mock_vosk.transcribe = AsyncMock(side_effect=untrusted_vosk)
+
+        agent = self._make_agent(mock_qwen, mock_vosk)
+        agent._qwen_timeout = 10.0
+        agent._qwen_hedge_delay = 0.01
+        agent._qwen_hedge_grace = 0.20
+        agent._qwen_latency_budget = 0.03
+
+        loop = asyncio.get_running_loop()
+        started_at = loop.time()
+        result = await agent.speech_to_text(b"audio", language="ja")
+        elapsed = loop.time() - started_at
+
+        assert result["success"] is True
+        assert result["provider"] == "vosk-fallback"
+        assert result["transcript"] == "fast fallback"
+        assert elapsed < 0.15
+
+        events = [
+            getattr(record, "event", None)
+            for record in caplog.records
+            if record.name == "backend.observability.stt"
+        ]
+        assert "stt_qwen_hedge_grace_skipped" in events
+        assert "stt_qwen_hedge_grace_start" not in events
 
     @pytest.mark.asyncio
     async def test_qwen_error_vosk_fallback(self):

--- a/scripts/stt-live-preflight.sh
+++ b/scripts/stt-live-preflight.sh
@@ -143,6 +143,7 @@ def load_rows(raw_path: str) -> list[dict[str, Any]]:
             {
                 "timestamp": entry.get("timestamp"),
                 "revision": (entry.get("resource") or {}).get("labels", {}).get("revision_name"),
+                "trace_id": payload.get("stt_trace_id") or "",
                 "winner": payload.get("stt_winner") or payload.get("provider") or "unknown",
                 "provider": payload.get("provider") or "unknown",
                 "duration_ms": duration_ms,
@@ -269,11 +270,18 @@ if gate_revision:
     for key, value in history["revision_counts"].most_common():
         lines.append(f"| {key} | {value} |")
 if timeout_rows or over_10s:
-    lines.extend(["", "| Timestamp | Revision | Winner | Provider | Duration ms | Error |", "| --- | --- | --- | --- | ---: | --- |"])
+    lines.extend(
+        [
+            "",
+            "| Timestamp | Revision | Trace | Winner | Provider | Duration ms | Error |",
+            "| --- | --- | --- | --- | --- | ---: | --- |",
+        ]
+    )
     risk_rows = {
         (
             row["timestamp"],
             row["revision"],
+            row["trace_id"],
             row["winner"],
             row["provider"],
             row["duration_ms"],
@@ -283,7 +291,7 @@ if timeout_rows or over_10s:
     }.values()
     for row in sorted(risk_rows, key=lambda x: x["duration_ms"], reverse=True)[:20]:
         lines.append(
-            f"| {row['timestamp']} | {row['revision']} | {row['winner']} | "
+            f"| {row['timestamp']} | {row['revision']} | {row['trace_id']} | {row['winner']} | "
             f"{row['provider']} | {row['duration_ms']} | {row['qwen_error_type']} |"
         )
 


### PR DESCRIPTION
## Summary
- Reuse a shared Vosk executor so cancelled fallback work does not block successful Qwen STT returns.
- Add `QWEN_STT_LATENCY_BUDGET_SECONDS` to cap optional Qwen grace after Vosk is ready.
- Include `stt_trace_id` in STT preflight risk rows for direct trace lookup.

## Root cause
Run 25275030436 showed STT p95 15624ms with 14/29 samples over 10s. The slow path was not TimeoutError; it came from Qwen/Vosk hedge behavior:
- Qwen winners could wait on cancelled Vosk executor shutdown.
- Vosk fallback winners could wait the full Qwen grace and land at 14-16s even when Vosk was ready around 8-10s.

## Validation
- `cd backend && pytest tests/agents/test_stt_agent.py -q` -> 123 passed
- `cd backend && pytest tests/services/test_stt_warmup_service.py tests/api/test_voice_api.py tests/scripts/test_alpha_smoke_comprehensive_contract.py -q` -> 29 passed
- `cd backend && ruff check agents/stt_agent.py tests/agents/test_stt_agent.py`
- `cd backend && black --check agents/stt_agent.py tests/agents/test_stt_agent.py`
- `cd backend && bash -n ../scripts/stt-live-preflight.sh`
- `cd backend && ../scripts/stt-live-preflight.sh --dry-run --timestamp test --revision engineer-cafe-backend-test --minutes 1 --limit 1`
- `git diff --check`

## Live proof after merge
After deploy, rerun targeted `suites=stt,v` with SHA match and close #658 only if the current-revision p95/over-10s gate is green.

Refs #658
