### PR TITLE
fix: retain pending mobile audio playback

### DIFF
--- a/frontend/e2e/mobile-audio-proof.spec.ts
+++ b/frontend/e2e/mobile-audio-proof.spec.ts
@@ -1,0 +1,36 @@
+import { expect, test } from '@playwright/test';
+
+import { MOCK_VOICE_RESPONSE, setupMarpMocks, setupWebAudioMock } from './helpers/mocks';
+import { clickPlayPause, gotoGuide, waitForSlide } from './helpers/marp';
+
+test.describe('mobile audio proof harness (#697/#698)', () => {
+  test.beforeEach(async ({ page }) => {
+    await setupWebAudioMock(page);
+    await setupMarpMocks(page);
+  });
+
+  test('mobile WebKit-style slide narration survives delayed TTS before playback', async ({
+    page,
+  }) => {
+    const voiceRequests: Array<Record<string, unknown>> = [];
+
+    await page.route('/api/voice', async (route) => {
+      const body = route.request().postDataJSON() as Record<string, unknown>;
+      voiceRequests.push(body);
+      await new Promise((resolve) => setTimeout(resolve, 750));
+      await route.fulfill({ json: MOCK_VOICE_RESPONSE });
+    });
+
+    await gotoGuide(page, 'ja');
+    await waitForSlide(page, 1, 3);
+
+    await clickPlayPause(page);
+
+    await expect
+      .poll(() => voiceRequests.filter((body) => body.action === 'text_to_speech').length, {
+        timeout: 10_000,
+      })
+      .toBeGreaterThan(0);
+    await waitForSlide(page, 2, 3);
+  });
+});

--- a/frontend/playwright.config.ts
+++ b/frontend/playwright.config.ts
@@ -27,7 +27,7 @@ export default defineConfig({
   projects: [
     {
       name: 'chromium',
-      testIgnore: /(voice-live|welcome-live|voice-permission-denial)\.spec\.ts/,
+      testIgnore: /(voice-live|welcome-live|voice-permission-denial|mobile-audio-proof)\.spec\.ts/,
       use: {
         ...devices['Desktop Chrome'],
         launchOptions: {
@@ -55,6 +55,13 @@ export default defineConfig({
       testMatch: /voice-permission-denial\.spec\.ts/,
       use: {
         ...devices['Desktop Safari'],
+      },
+    },
+    {
+      name: 'webkit-mobile-audio',
+      testMatch: /mobile-audio-proof\.spec\.ts/,
+      use: {
+        ...devices['iPhone 13'],
       },
     },
   ],

--- a/frontend/src/__tests__/mobile-audio-service.test.ts
+++ b/frontend/src/__tests__/mobile-audio-service.test.ts
@@ -4,6 +4,7 @@ import { after, test } from "node:test";
 import {
   estimateAudioDataByteLength,
   MobileAudioService,
+  shouldResetWebAudioPlayerForDevice,
   shouldUseHtmlAudioFirstForPlayback,
 } from "../lib/audio/mobile-audio-service";
 import { AudioPlaybackService } from "../lib/audio/audio-playback-service";
@@ -66,6 +67,106 @@ test("Android large audio uses HTML audio before Web Audio decode", () => {
   const largeBase64 = "A".repeat(1_333_340);
   assert.equal(estimateAudioDataByteLength(largeBase64), 1_000_005);
   assert.equal(shouldUseHtmlAudioFirstForPlayback(largeBase64), true);
+});
+
+test("mobile Web Audio reset applies to Android phones as well as iOS", () => {
+  setUserAgent("Mozilla/5.0 (Linux; Android 14; Pixel 8) AppleWebKit/537.36");
+  assert.equal(shouldResetWebAudioPlayerForDevice(), true);
+
+  setUserAgent("Mozilla/5.0 (iPhone; CPU iPhone OS 17_0 like Mac OS X) AppleWebKit/605.1.15");
+  assert.equal(shouldResetWebAudioPlayerForDevice(), true);
+
+  setUserAgent("Mozilla/5.0 (Macintosh; Intel Mac OS X 14_4) AppleWebKit/605.1.15");
+  assert.equal(shouldResetWebAudioPlayerForDevice(), false);
+});
+
+test("Android large base64 playback uses HTML audio without constructing AudioContext", async () => {
+  let audioContextConstructed = false;
+  let createdObjectUrl = "";
+
+  class MockAudioElement {
+    public preload = "";
+    public volume = 1;
+    public paused = true;
+    public ended = false;
+    private listeners = new Map<string, Set<() => void>>();
+
+    constructor(public readonly url: string) {}
+
+    setAttribute() {}
+    removeAttribute() {}
+    load() {}
+    pause() {
+      this.paused = true;
+    }
+    addEventListener(event: string, listener: () => void) {
+      const listeners = this.listeners.get(event) ?? new Set<() => void>();
+      listeners.add(listener);
+      this.listeners.set(event, listeners);
+    }
+    removeEventListener(event: string, listener: () => void) {
+      this.listeners.get(event)?.delete(listener);
+    }
+    async play() {
+      this.paused = false;
+      this.listeners.get("play")?.forEach((listener) => listener());
+      setTimeout(() => {
+        this.ended = true;
+        this.listeners.get("ended")?.forEach((listener) => listener());
+      }, 0);
+    }
+  }
+
+  class FailIfConstructedAudioContext {
+    constructor() {
+      audioContextConstructed = true;
+    }
+  }
+
+  setUserAgent("Mozilla/5.0 (Linux; Android 14; Pixel 8) AppleWebKit/537.36");
+  Object.defineProperty(globalThis, "window", {
+    configurable: true,
+    value: {
+      innerWidth: 390,
+      setTimeout,
+      clearTimeout,
+      AudioContext: FailIfConstructedAudioContext,
+      webkitAudioContext: FailIfConstructedAudioContext,
+    },
+  });
+  Object.defineProperty(globalThis, "document", {
+    configurable: true,
+    value: {
+      addEventListener() {},
+      removeEventListener() {},
+    },
+  });
+  Object.defineProperty(globalThis, "Audio", {
+    configurable: true,
+    value: MockAudioElement,
+  });
+  Object.defineProperty(URL, "createObjectURL", {
+    configurable: true,
+    value: (blob: Blob) => {
+      createdObjectUrl = `blob:android-large-${blob.size}`;
+      return createdObjectUrl;
+    },
+  });
+  Object.defineProperty(URL, "revokeObjectURL", {
+    configurable: true,
+    value: () => {},
+  });
+
+  const largeBase64 = Buffer.alloc(1_000_005).toString("base64");
+  const service = new MobileAudioService();
+  const result = await service.playAudio(largeBase64);
+
+  assert.equal(result.success, true);
+  assert.equal(result.method, "html-audio");
+  assert.equal(createdObjectUrl, "blob:android-large-1000005");
+  assert.equal(audioContextConstructed, false);
+
+  service.dispose();
 });
 
 test("non-Android and small Android audio stay on Web Audio first", () => {

--- a/frontend/src/app/components/KioskBottomBar.tsx
+++ b/frontend/src/app/components/KioskBottomBar.tsx
@@ -58,6 +58,10 @@ export function KioskBottomBar({
       : labels.kioskVoice;
 
   const handleKioskVoiceStart = async () => {
+    if (voice.unlockAudioPlayback()) {
+      return;
+    }
+
     unlockAudioForUserGesture();
     clearReturnToIdleTimer();
     setWelcomeMemberOcrOpen(false);

--- a/frontend/src/app/components/VoiceInterface.tsx
+++ b/frontend/src/app/components/VoiceInterface.tsx
@@ -83,6 +83,7 @@ export interface VoiceInterfaceRenderProps {
   cancelSession: () => void;
   clearConversation: () => void;
   clearVisitState: () => void;
+  unlockAudioPlayback: () => boolean;
   sendMessage: (message: string) => Promise<void>;
   /** Speak fixed text (e.g. reception greeting) without running QA. */
   speakPreparedText: (
@@ -214,6 +215,38 @@ const toBase64 = async (blob: Blob): Promise<string> => {
   return VoiceRecorder.arrayBufferToBase64(arrayBuffer);
 };
 
+const isAudioGestureRequiredError = (error: unknown): boolean => {
+  if (
+    typeof error === 'object' &&
+    error !== null &&
+    'requiresUserInteraction' in error &&
+    error.requiresUserInteraction === true
+  ) {
+    return true;
+  }
+
+  if (
+    typeof error === 'object' &&
+    error !== null &&
+    'type' in error &&
+    error.type === 'user_interaction_required'
+  ) {
+    return true;
+  }
+
+  if (error instanceof Error) {
+    const message = error.message.toLowerCase();
+    return (
+      error.name === 'NotAllowedError' ||
+      message.includes('user interaction') ||
+      message.includes('user gesture') ||
+      message.includes('autoplay')
+    );
+  }
+
+  return false;
+};
+
 const stopAudioPlayback = (
   audioQueueRef: MutableRefObject<AudioQueue | null>,
   mobileAudioServiceRef: MutableRefObject<MobileAudioService | null>,
@@ -271,6 +304,11 @@ export default function VoiceInterface({
   const shouldListenRef = useRef(false);
   const fastFillerTimerRef = useRef<number | null>(null);
   const fastFillerUtteranceRef = useRef<SpeechSynthesisUtterance | null>(null);
+  const pendingIOSPlaybackRef = useRef<{
+    audioBase64: string;
+    metadata: VoiceInterfaceMetadata | null;
+  } | null>(null);
+  const isReplayingPendingIOSAudioRef = useRef(false);
 
   useEffect(() => {
     visitorIdRef.current = getOrCreateVisitorId();
@@ -407,15 +445,12 @@ export default function VoiceInterface({
     audioQueueRef.current?.setVolume(effectiveVolume);
   }, [volume]);
 
-  const handleAudioUnlockGesture = useCallback(() => {
-    if (sessionState === 'listening') {
-      return;
-    }
-
-    unlockAudioForUserGesture();
-  }, [sessionState]);
-
-  const stopForIOSAudioUnlock = useCallback((): boolean => {
+  const deferForIOSAudioUnlock = useCallback((
+    pendingPlayback?: {
+      audioBase64: string;
+      metadata: VoiceInterfaceMetadata | null;
+    },
+  ): boolean => {
     if (!isIOSWebKitAudio()) {
       return false;
     }
@@ -432,6 +467,10 @@ export default function VoiceInterface({
 
     if (isReady) {
       return false;
+    }
+
+    if (pendingPlayback) {
+      pendingIOSPlaybackRef.current = pendingPlayback;
     }
 
     const message = getTapToEnableAudioMessage(currentLanguage);
@@ -535,7 +574,10 @@ export default function VoiceInterface({
         return;
       }
 
-      if (stopForIOSAudioUnlock()) {
+      if (deferForIOSAudioUnlock({
+        audioBase64,
+        metadata: metadataForPlayback ?? null,
+      })) {
         return;
       }
 
@@ -610,10 +652,45 @@ export default function VoiceInterface({
       revokeAudioUrl,
       scheduleLipSyncFrames,
       skipAssistantTurnAutoResume,
-      stopForIOSAudioUnlock,
+      deferForIOSAudioUnlock,
       voiceController,
     ],
   );
+
+  const unlockAudioPlayback = useCallback((): boolean => {
+    if (sessionState === 'listening') {
+      return false;
+    }
+
+    unlockAudioForUserGesture();
+
+    const pendingPlayback = pendingIOSPlaybackRef.current;
+    if (!pendingPlayback || isReplayingPendingIOSAudioRef.current) {
+      return false;
+    }
+
+    pendingIOSPlaybackRef.current = null;
+    isReplayingPendingIOSAudioRef.current = true;
+    setError(null);
+
+    void (async () => {
+      try {
+        await AudioInteractionManager.getInstance().forceInitialize();
+        await playAssistantAudio(pendingPlayback.audioBase64, pendingPlayback.metadata);
+      } catch (error) {
+        if (isAudioGestureRequiredError(error)) {
+          pendingIOSPlaybackRef.current = pendingPlayback;
+          setError(getTapToEnableAudioMessage(currentLanguage));
+        } else {
+          setError(formatError(error, currentLanguage));
+        }
+      } finally {
+        isReplayingPendingIOSAudioRef.current = false;
+      }
+    })();
+
+    return true;
+  }, [currentLanguage, playAssistantAudio, sessionState]);
 
   const processVoiceTurnWithParallelFiller = useCallback(
     async (trimmed: string, abortController: AbortController) => {
@@ -784,7 +861,10 @@ export default function VoiceInterface({
             await playAssistantAudio(ttsResult.audioResponse, playbackMetadata);
             return;
           }
-          if (stopForIOSAudioUnlock()) {
+          if (deferForIOSAudioUnlock({
+            audioBase64: ttsResult.audioResponse,
+            metadata: playbackMetadata ?? null,
+          })) {
             return;
           }
           q.setVolume(isMuted ? 0 : volume);
@@ -838,7 +918,7 @@ export default function VoiceInterface({
       playAssistantAudio,
       scheduleLipSyncFrames,
       skipAssistantTurnAutoResume,
-      stopForIOSAudioUnlock,
+      deferForIOSAudioUnlock,
       stopPlayback,
       volume,
       voiceController,
@@ -1251,7 +1331,10 @@ export default function VoiceInterface({
   }, [sessionState, startRecorderCapture, stopRecorderCapture, voiceController.shouldListen]);
 
   const startListening = useCallback(async (): Promise<boolean> => {
-    unlockAudioForUserGesture();
+    if (unlockAudioPlayback() || isReplayingPendingIOSAudioRef.current) {
+      return true;
+    }
+
     shouldListenRef.current = true;
     cancelPendingRequest();
     stopPlayback(false);
@@ -1264,7 +1347,14 @@ export default function VoiceInterface({
     voiceController.startManualSession();
     sendSttWarmup({ language: currentLanguage, sessionId: sessionIdRef.current });
     return true;
-  }, [cancelPendingRequest, currentLanguage, startRecorderCapture, stopPlayback, voiceController]);
+  }, [
+    cancelPendingRequest,
+    currentLanguage,
+    startRecorderCapture,
+    stopPlayback,
+    unlockAudioPlayback,
+    voiceController,
+  ]);
 
   const stopListening = useCallback(() => {
     shouldListenRef.current = false;
@@ -1272,6 +1362,8 @@ export default function VoiceInterface({
   }, [voiceController]);
 
   const cancelSession = useCallback(() => {
+    pendingIOSPlaybackRef.current = null;
+    isReplayingPendingIOSAudioRef.current = false;
     cancelSttWarmup();
     cancelFastFiller();
     cancelPendingRequest();
@@ -1337,6 +1429,8 @@ export default function VoiceInterface({
 
   useEffect(() => {
     return () => {
+      pendingIOSPlaybackRef.current = null;
+      isReplayingPendingIOSAudioRef.current = false;
       cancelFastFiller();
       cancelPendingRequest();
       cleanupAudioPlayback();
@@ -1373,6 +1467,7 @@ export default function VoiceInterface({
       cancelSession,
       clearConversation,
       clearVisitState,
+      unlockAudioPlayback,
       sendMessage,
       speakPreparedText,
       setVolume,
@@ -1400,6 +1495,7 @@ export default function VoiceInterface({
       stopListening,
       toggleLanguage,
       transcript,
+      unlockAudioPlayback,
       voiceController.characterState,
       voiceController.isWakeWordListening,
       voiceController.isWakeWordSupported,
@@ -1449,8 +1545,8 @@ export default function VoiceInterface({
       <div className="mt-6 flex items-center justify-center gap-3">
         <button
           type="button"
-          onPointerDown={handleAudioUnlockGesture}
-          onTouchEnd={handleAudioUnlockGesture}
+          onPointerDown={unlockAudioPlayback}
+          onTouchEnd={unlockAudioPlayback}
           onClick={isListening ? stopListening : startListening}
           disabled={isBusy && !isListening}
           aria-label={isListening ? '録音を停止' : '録音を開始'}
@@ -1480,8 +1576,8 @@ export default function VoiceInterface({
 
         <button
           type="button"
-          onPointerDown={handleAudioUnlockGesture}
-          onTouchEnd={handleAudioUnlockGesture}
+          onPointerDown={unlockAudioPlayback}
+          onTouchEnd={unlockAudioPlayback}
           onClick={() => setMuted(!isMuted)}
           aria-label={isMuted ? 'ミュートを解除' : 'ミュートにする'}
           className="flex size-12 items-center justify-center rounded-full border border-slate-200 bg-white text-slate-700 shadow-sm transition-colors duration-200 hover:bg-slate-50"

--- a/frontend/src/lib/audio/mobile-audio-service.ts
+++ b/frontend/src/lib/audio/mobile-audio-service.ts
@@ -72,6 +72,15 @@ export function isAudioUrlString(audioData: AudioDataInput): audioData is string
   );
 }
 
+export function shouldResetWebAudioPlayerForDevice(): boolean {
+  if (typeof navigator === 'undefined') {
+    return false;
+  }
+
+  const ua = navigator.userAgent;
+  return /iPad|iPhone|iPod|Android/i.test(ua);
+}
+
 export class MobileAudioService {
   private static readonly PLAYBACK_START_TIMEOUT_MS = 8000;
   private webAudioPlayer: WebAudioPlayer | null = null;
@@ -162,9 +171,6 @@ export class MobileAudioService {
    */
   private async tryWebAudio(audioData: AudioDataInput): Promise<AudioOperationResult> {
     try {
-      const isTablet = /iPad|Android.*Tablet/i.test(navigator.userAgent);
-      
-
       // Ensure audio context is ready
       let audioContext: AudioContext;
       try {
@@ -183,11 +189,11 @@ export class MobileAudioService {
         }
       }
 
-      // For tablets, always recreate the player to avoid state issues
+      // Mobile Web Audio state can stale between turns, especially after a
+      // blocked or timed-out playback attempt.
       if (!this.webAudioPlayer) {
         this.webAudioPlayer = new WebAudioPlayer(this.options, audioContext);
-      } else if (isTablet) {
-        // Reset existing player for tablets to avoid state issues
+      } else if (shouldResetWebAudioPlayerForDevice()) {
         this.webAudioPlayer.reset();
       }
 
@@ -393,9 +399,7 @@ export class MobileAudioService {
     if (this.webAudioPlayer) {
       this.webAudioPlayer.stop();
       
-      // Reset for tablets to prevent state issues
-      const isTablet = /iPad|Android.*Tablet/i.test(navigator.userAgent);
-      if (isTablet) {
+      if (shouldResetWebAudioPlayerForDevice()) {
         this.webAudioPlayer.reset();
       }
     }


### PR DESCRIPTION
## Summary
- Preserve pending iOS assistant audio when AudioContext needs a tap-to-enable gesture, then replay the same response on the next trusted tap.
- Route the kiosk voice button through the pending audio unlock/replay path before starting a new recording.
- Reset stale WebAudioPlayer state for Android phones and add Android >1MB HTML-audio coverage.
- Add a mobile WebKit-style delayed slide narration Playwright proof project.

## Why
#730 added tap-to-enable UI, but delayed TTS could still be discarded when iOS required a fresh user gesture after the text response appeared. This keeps the exact pending assistant audio and replays it on tap instead of starting a new turn or silently losing audio.

## Validation
- `cd frontend && pnpm exec tsx src/__tests__/mobile-audio-service.test.ts` -> 8/8
- `cd frontend && pnpm exec tsx src/__tests__/web-audio-player.test.ts` -> 2/2
- `cd frontend && pnpm exec tsx src/__tests__/audio/audio-user-interaction-gate.test.ts` -> 10/10
- `cd frontend && pnpm exec tsx src/__tests__/lip-sync-analyzer.test.ts` -> 2/2
- `cd frontend && pnpm typecheck`
- `cd frontend && pnpm lint` -> passes with existing MarpViewer hook warnings
- `cd frontend && pnpm exec playwright test --config=playwright.config.ts --project=webkit-mobile-audio e2e/mobile-audio-proof.spec.ts` -> 1/1

## Remaining proof
Keep #697/#698 open until real iPhone/iPad Safari and Pixel Chrome proof is attached. Treat #634/#635/#471 as duplicate symptoms under #697 unless device proof shows a separate regression.

Refs #697 #698 #634 #635 #471
