### PR TITLE
fix: improve alpha C answer routing

### DIFF
--- a/backend/agents/business_info_agent.py
+++ b/backend/agents/business_info_agent.py
@@ -220,6 +220,7 @@ class BusinessInfoAgent:
             "facility": "facility-info",
             "wifi": "facility-info",
             "reception": "general",
+            "contact": "contact",
         }
 
         return category_mapping.get(request_type or "", "general")
@@ -439,6 +440,11 @@ Information: {context}
     ) -> Optional[Dict]:
         """Return complete answers for common visitor-critical business questions."""
         normalized = query.lower()
+        if self._asks_saino_cafe(normalized):
+            answer = self._saino_cafe_answer(normalized, language)
+            if answer:
+                return self._canonical_result(answer, request_type)
+
         if self._asks_closed_days(normalized):
             answers = {
                 "ja": (
@@ -485,6 +491,32 @@ Information: {context}
                         "[relaxed]DevDay는 ENGINEER IGNITION CAMP(EIC)의 최종 전시회로, "
                         "2026년 2월 23일 18:00에 열릴 예정입니다. 피치가 아니라 "
                         "전시 형식으로 진행됩니다."
+                    ),
+                }
+                return self._canonical_result(answers.get(language, answers["ja"]), request_type)
+
+            if self._asks_eic_completion_conditions(normalized):
+                answers = {
+                    "ja": (
+                        "[relaxed]EICの修了認定には、講義3回への参加、LT発表、"
+                        "Dev & Tips 5回中3回への参加、Boot Camp 2日間への参加、"
+                        "DevDayでの展示発表の5要件をすべて満たす必要があります。"
+                    ),
+                    "en": (
+                        "[relaxed]To complete EIC, participants must attend three "
+                        "lectures, give an LT presentation, attend three of five "
+                        "Dev & Tips sessions, join the two-day Boot Camp, and exhibit "
+                        "at DevDay."
+                    ),
+                    "zh": (
+                        "[relaxed]EIC的结业认定需要满足五项条件：参加3次讲义、"
+                        "进行LT发表、参加5次Dev & Tips中的3次、参加2天Boot Camp、"
+                        "并在DevDay进行展示发表。"
+                    ),
+                    "ko": (
+                        "[relaxed]EIC 수료 인정에는 강의 3회 참가, LT 발표, "
+                        "Dev & Tips 5회 중 3회 참가, Boot Camp 2일 참가, "
+                        "DevDay 전시 발표의 5가지 조건을 모두 충족해야 합니다."
                     ),
                 }
                 return self._canonical_result(answers.get(language, answers["ja"]), request_type)
@@ -663,6 +695,128 @@ Information: {context}
         return None
 
     @staticmethod
+    def _asks_saino_cafe(query: str) -> bool:
+        return any(
+            keyword in query
+            for keyword in (
+                "saino",
+                "サイノ",
+                "サイノカフェ",
+                "cafe&bar",
+                "併設カフェ",
+            )
+        )
+
+    @staticmethod
+    def _saino_cafe_answer(query: str, language: str) -> Optional[str]:
+        if any(
+            keyword in query for keyword in ("営業時間", "business hours", "opening hours", "hours")
+        ):
+            answers = {
+                "ja": (
+                    "[relaxed]cafe&bar sainoの営業時間は、平日はDay Time "
+                    "12:00〜17:00、Night Time 18:00〜20:00、土日祝は"
+                    "11:00〜20:00です。定休日は月曜と水曜です。"
+                ),
+                "en": (
+                    "[relaxed]cafe&bar saino is open on weekdays from 12:00 to "
+                    "17:00 for Day Time and 18:00 to 20:00 for Night Time, and "
+                    "on weekends and holidays from 11:00 to 20:00. It is closed "
+                    "on Mondays and Wednesdays."
+                ),
+                "zh": (
+                    "[relaxed]cafe&bar saino平日Day Time为12:00到17:00，"
+                    "Night Time为18:00到20:00；周末和节假日为11:00到20:00。"
+                    "周一和周三定休。"
+                ),
+                "ko": (
+                    "[relaxed]cafe&bar saino의 영업시간은 평일 Day Time "
+                    "12:00-17:00, Night Time 18:00-20:00이며, 주말과 공휴일은 "
+                    "11:00-20:00입니다. 정기 휴일은 월요일과 수요일입니다."
+                ),
+            }
+            return answers.get(language, answers["ja"])
+
+        if any(keyword in query for keyword in ("フード", "food", "menu", "メニュー", "ランチ")):
+            answers = {
+                "ja": (
+                    "[relaxed]サイノカフェのフードは、てりたまハンバーグサンド"
+                    "700円、ツナチーズメルトサンド700円、あんバター白玉サンド"
+                    "650円、ワッフル420円、アイスクリーム420円などがあります。"
+                    "ドリンクセットは50円引きです。"
+                ),
+                "en": (
+                    "[relaxed]cafe&bar saino serves food such as teritama hamburger "
+                    "sandwiches for 700 yen, tuna cheese melt sandwiches for 700 yen, "
+                    "an-butter shiratama sandwiches for 650 yen, waffles for 420 yen, "
+                    "and ice cream for 420 yen. Drink sets are 50 yen off."
+                ),
+                "zh": (
+                    "[relaxed]saino咖啡有照烧鸡蛋汉堡三明治700日元、金枪鱼芝士"
+                    "热三明治700日元、红豆黄油白玉三明治650日元、华夫饼420日元、"
+                    "冰淇淋420日元等。饮料套餐可减50日元。"
+                ),
+                "ko": (
+                    "[relaxed]saino 카페의 푸드 메뉴에는 데리타마 햄버그 샌드 "
+                    "700엔, 참치 치즈 멜트 샌드 700엔, 앙버터 시라타마 샌드 "
+                    "650엔, 와플 420엔, 아이스크림 420엔 등이 있습니다. "
+                    "드링크 세트는 50엔 할인됩니다."
+                ),
+            }
+            return answers.get(language, answers["ja"])
+
+        if any(
+            keyword in query for keyword in ("コーヒー", "coffee", "カフェラテ", "値段", "price")
+        ):
+            answers = {
+                "ja": (
+                    "[relaxed]サイノカフェのコーヒーは、ブレンドコーヒー380円、"
+                    "シングルオリジン460円から、エスプレッソ400円、カフェラテ"
+                    "570円、カフェモカ700円です。"
+                ),
+                "en": (
+                    "[relaxed]At cafe&bar saino, blended coffee is 380 yen, single "
+                    "origin coffee starts at 460 yen, espresso is 400 yen, cafe latte "
+                    "is 570 yen, and cafe mocha is 700 yen."
+                ),
+                "zh": (
+                    "[relaxed]saino咖啡的拼配咖啡是380日元，单品咖啡460日元起，"
+                    "浓缩咖啡400日元，拿铁570日元，摩卡700日元。"
+                ),
+                "ko": (
+                    "[relaxed]saino 카페의 커피는 블렌드 커피 380엔, 싱글 오리진 "
+                    "460엔부터, 에스프레소 400엔, 카페라테 570엔, 카페모카 700엔입니다."
+                ),
+            }
+            return answers.get(language, answers["ja"])
+
+        if any(keyword in query for keyword in ("アルコール", "お酒", "alcohol", "beer", "bar")):
+            answers = {
+                "ja": (
+                    "[relaxed]はい、cafe&bar sainoはNight Timeの18:00〜20:00に"
+                    "バー営業をしています。ハイネケン500円、ハイボール450円から、"
+                    "カクテル各700円などがあります。"
+                ),
+                "en": (
+                    "[relaxed]Yes. cafe&bar saino operates as a bar during Night "
+                    "Time from 18:00 to 20:00. Heineken is 500 yen, highballs start "
+                    "at 450 yen, and cocktails are 700 yen each."
+                ),
+                "zh": (
+                    "[relaxed]可以。cafe&bar saino在Night Time 18:00到20:00作为酒吧营业。"
+                    "喜力啤酒500日元，Highball 450日元起，鸡尾酒每杯700日元等。"
+                ),
+                "ko": (
+                    "[relaxed]네, cafe&bar saino는 Night Time인 18:00-20:00에 "
+                    "바로도 운영합니다. 하이네켄은 500엔, 하이볼은 450엔부터, "
+                    "칵테일은 각 700엔입니다."
+                ),
+            }
+            return answers.get(language, answers["ja"])
+
+        return None
+
+    @staticmethod
     def _canonical_result(answer: str, request_type: Optional[str]) -> Dict:
         return {
             "answer": answer,
@@ -770,6 +924,27 @@ Information: {context}
         if request_type != "community":
             return False
         keywords = ("engineer ignition camp", "eic", "devday")
+        return any(keyword in query for keyword in keywords)
+
+    @staticmethod
+    def _asks_eic_completion_conditions(query: str) -> bool:
+        if not any(keyword in query for keyword in ("eic", "engineer ignition camp")):
+            return False
+        keywords = (
+            "修了",
+            "認定",
+            "条件",
+            "completion",
+            "complete",
+            "certificate",
+            "requirements",
+            "结业",
+            "认定",
+            "条件",
+            "수료",
+            "인정",
+            "조건",
+        )
         return any(keyword in query for keyword in keywords)
 
     @staticmethod

--- a/backend/agents/facility_agent.py
+++ b/backend/agents/facility_agent.py
@@ -348,6 +348,13 @@ class FacilityAgent:
     ) -> Optional[Dict]:
         """Return complete answers for common visitor-critical facility questions."""
         normalized = query.lower()
+        from backend.agents.business_info_agent import BusinessInfoAgent
+
+        if BusinessInfoAgent._asks_saino_cafe(normalized):
+            answer = BusinessInfoAgent._saino_cafe_answer(normalized, language)
+            if answer:
+                return self._canonical_result(answer, request_type)
+
         if self._asks_3d_printer_filament_price(normalized):
             answers = {
                 "ja": (

--- a/backend/config/routing_constants.py
+++ b/backend/config/routing_constants.py
@@ -535,6 +535,11 @@ FOOD_DRINK_KEYWORDS = [
     "外带食物",
     "饮料",
     "餐饮",
+    "음식",
+    "음료",
+    "외부 음식",
+    "가져와",
+    "반입",
 ]
 
 BOOKING_KEYWORDS = [
@@ -575,6 +580,22 @@ FACILITY_EQUIPMENT_KEYWORDS = [
     "online meeting",
     "video call",
     "take a call",
+]
+
+CONTACT_KEYWORDS = [
+    "連絡先",
+    "問い合わせ",
+    "問合せ",
+    "お問い合わせ",
+    "問い合わせフォーム",
+    "電話番号",
+    "contact",
+    "contact form",
+    "phone number",
+    "联系",
+    "联系电话",
+    "연락",
+    "전화번호",
 ]
 
 EXCLUSIVE_RENTAL_KEYWORDS = [
@@ -794,6 +815,7 @@ CATEGORY_TO_AGENT_MAP: Dict[str, AgentNodeName] = {
     "bicycle": "facility",
     "smoking": "facility",
     "food_drink": "facility",
+    "contact": "business_info",
     "policy": "facility",
     "emergency": "facility",
     "reception": "business_info",
@@ -889,6 +911,8 @@ def extract_request_type(query: str) -> Optional[str]:
         return "community"
     if match_keywords(lower_query, ACCESS_DIRECTION_KEYWORDS):
         return "access"
+    if match_keywords(lower_query, CONTACT_KEYWORDS):
+        return "contact"
     if match_keywords(lower_query, NEARBY_FACILITY_KEYWORDS):
         return "nearby"
     if match_keywords(lower_query, BUILDING_KEYWORDS):

--- a/backend/tests/agents/test_business_info_agent.py
+++ b/backend/tests/agents/test_business_info_agent.py
@@ -22,6 +22,7 @@ class TestBusinessInfoAgent:
         assert self.agent._map_request_type_to_category("location") == "location"
         assert self.agent._map_request_type_to_category("access") == "location"
         assert self.agent._map_request_type_to_category("reception") == "general"
+        assert self.agent._map_request_type_to_category("contact") == "contact"
         assert self.agent._map_request_type_to_category("unknown") == "general"
 
     def test_get_request_type_prompt_japanese(self):
@@ -258,6 +259,49 @@ class TestBusinessInfoAgent:
         assert response is not None
         assert "2026年2月23日18:00" in response["answer"]
         assert "展示形式" in response["answer"]
+
+    def test_eic_completion_conditions_canonical(self):
+        """gt-023: EICの修了認定条件を汎用EIC説明に倒さない"""
+        response = self.agent._get_canonical_response(
+            "EICの修了認定条件を教えてください",
+            "community",
+            "ja",
+        )
+
+        assert response is not None
+        assert "講義3回" in response["answer"]
+        assert "LT発表" in response["answer"]
+        assert "Dev & Tips 5回中3回" in response["answer"]
+        assert "Boot Camp 2日間" in response["answer"]
+        assert "DevDay" in response["answer"]
+        assert "短期集中" not in response["answer"]
+
+    def test_saino_hours_precedes_engineer_cafe_hours(self):
+        """gt-015: sainoの営業時間をエンジニアカフェ開館時間に倒さない"""
+        response = self.agent._get_canonical_response(
+            "cafe&bar sainoの営業時間は？",
+            "hours",
+            "ja",
+        )
+
+        assert response is not None
+        assert "Day Time 12:00〜17:00" in response["answer"]
+        assert "Night Time 18:00〜20:00" in response["answer"]
+        assert "月曜と水曜" in response["answer"]
+        assert "朝9時から夜22時" not in response["answer"]
+
+    def test_saino_coffee_price_precedes_engineer_cafe_pricing(self):
+        """gt-017: 価格fast-path後もsainoのコーヒー価格を返す"""
+        response = self.agent._get_canonical_response(
+            "サイノカフェのコーヒーの値段は？",
+            "price",
+            "ja",
+        )
+
+        assert response is not None
+        assert "ブレンドコーヒー380円" in response["answer"]
+        assert "カフェラテ570円" in response["answer"]
+        assert "施設・設備の利用料は無料" not in response["answer"]
 
     @pytest.mark.asyncio
     async def test_chinese_canonical_ignores_stale_state_context(self):

--- a/backend/tests/agents/test_facility_agent.py
+++ b/backend/tests/agents/test_facility_agent.py
@@ -262,6 +262,50 @@ class TestFacilityAgent:
         assert "外带食物原则上不允许" in response["answer"]
         assert "cafe&bar saino" in response["answer"]
 
+    def test_saino_food_menu_canonical_precedes_food_policy(self):
+        """gt-016: サイノカフェのメニューを一般持ち込みポリシーに倒さない"""
+        agent = FacilityAgent()
+        response = agent._get_canonical_response(
+            "サイノカフェのフードメニューを教えてください",
+            "food_drink",
+            "ja",
+        )
+
+        assert response is not None
+        assert "てりたまハンバーグサンド" in response["answer"]
+        assert "ツナチーズメルトサンド" in response["answer"]
+        assert "ドリンクセット" in response["answer"]
+        assert "持ち込み" not in response["answer"]
+
+    def test_saino_alcohol_canonical_precedes_food_policy(self):
+        """gt-018: サイノカフェのアルコール質問を一般飲食ポリシーに倒さない"""
+        agent = FacilityAgent()
+        response = agent._get_canonical_response(
+            "サイノカフェでアルコールは飲めますか？",
+            "food_drink",
+            "ja",
+        )
+
+        assert response is not None
+        assert "18:00〜20:00" in response["answer"]
+        assert "ハイネケン500円" in response["answer"]
+        assert "カクテル各700円" in response["answer"]
+        assert "持ち込み" not in response["answer"]
+
+    def test_saino_coffee_price_canonical(self):
+        """gt-017: サイノカフェのコーヒー価格を具体価格で固定する"""
+        agent = FacilityAgent()
+        response = agent._get_canonical_response(
+            "サイノカフェのコーヒーの値段は？",
+            "food_drink",
+            "ja",
+        )
+
+        assert response is not None
+        assert "ブレンドコーヒー380円" in response["answer"]
+        assert "カフェラテ570円" in response["answer"]
+        assert "カフェモカ700円" in response["answer"]
+
     def test_access_canonical_response_english(self):
         """アクセス案内は施設名と最寄り駅を含める"""
         agent = FacilityAgent()

--- a/backend/tests/agents/test_orchestrator_fast_routing.py
+++ b/backend/tests/agents/test_orchestrator_fast_routing.py
@@ -451,6 +451,24 @@ class TestOrchestratorFastRouting:
         assert result["category"] == "facility-info"
         assert result["request_type"] == request_type
 
+    def test_alpha_ko_food_policy_routes_to_facility(self, orchestrator):
+        """gt-113: Korean outside-food query must use facility knowledge, not fallback."""
+        result = orchestrator._try_fast_routing("외부 음식을 가져와도 되나요?")
+
+        assert result is not None
+        assert result["agent"] == "facility"
+        assert result["category"] == "facility-info"
+        assert result["request_type"] == "food_drink"
+
+    def test_alpha_en_contact_routes_to_business_info(self, orchestrator):
+        """gt-009b/gt-096: English contact questions should hit canonical contact answer."""
+        result = orchestrator._try_fast_routing("How can I contact Engineer Cafe?")
+
+        assert result is not None
+        assert result["agent"] == "business_info"
+        assert result["category"] == "contact"
+        assert result["request_type"] == "contact"
+
     def test_emergency_kaji_overrides_farewell(self, orchestrator):
         """P1 guard: 火事なので帰ります must not route to farewell."""
         result = orchestrator._try_fast_routing("火事なので帰ります")

--- a/backend/tests/config/test_routing_constants.py
+++ b/backend/tests/config/test_routing_constants.py
@@ -69,10 +69,22 @@ class TestNewRoutingKeywords:
             ("Can I bring food?", "food_drink"),
             ("飲み物は持ってきていいですか？", "food_drink"),
             ("ペットボトルの飲み物は持ち込めますか？", "food_drink"),
+            ("외부 음식을 가져와도 되나요?", "food_drink"),
         ],
     )
     def test_food_drink_keywords(self, query, expected):
         """飲食キーワードがfood_drinkにルーティングされることを確認"""
+        assert extract_request_type(query) == expected
+
+    @pytest.mark.parametrize(
+        "query,expected",
+        [
+            ("How can I contact Engineer Cafe?", "contact"),
+            ("エンジニアカフェの連絡先を教えてください", "contact"),
+        ],
+    )
+    def test_contact_keywords(self, query, expected):
+        """連絡先キーワードがcontactにルーティングされることを確認"""
         assert extract_request_type(query) == expected
 
     @pytest.mark.parametrize(

--- a/backend/utils/intent_classifier.py
+++ b/backend/utils/intent_classifier.py
@@ -16,6 +16,7 @@ from backend.config.routing_constants import (
     CHILDREN_NOISE_KEYWORDS,
     COMMUNITY_KEYWORDS,
     CONSULTATION_KEYWORDS,
+    CONTACT_KEYWORDS,
     EMERGENCY_KEYWORDS,
     EXCLUSIVE_RENTAL_KEYWORDS,
     EVENT_KEYWORDS,
@@ -462,6 +463,13 @@ def classify_fast_intent(query: str) -> Optional[FastIntent]:
     if match_keywords(lower_query, FACILITY_EQUIPMENT_KEYWORDS):
         return FastIntent(
             "facility", "facility-info", "facility", "Facility equipment keyword detected"
+        )
+    if match_keywords(lower_query, CONTACT_KEYWORDS):
+        return FastIntent(
+            "business_info",
+            "contact",
+            "contact",
+            "Contact keyword detected",
         )
     if match_keywords(lower_query, FLOOR_LAYOUT_KEYWORDS):
         return FastIntent(


### PR DESCRIPTION
## Summary
- Add canonical Saino cafe answers for hours, food menu, coffee prices, and alcohol/bar questions before broader facility/food policies.
- Add canonical EIC completion requirement answer.
- Add deterministic contact routing and Korean food-policy routing keywords.
- Add focused regressions for the observed alpha-127 failing cases.

## Root cause
Run 25274709049 proved C alpha-127 accounting and direct OpenAI were correct, but quality/source still failed. The main failure clusters were known fact cases falling through to broad or fallback answers: Saino questions collapsed into Engineer Cafe hours/food policy, EIC completion asked for requirements but got a generic overview, English contact questions missed canonical contact routing, and Korean food-policy routed to fallback sources.

## Validation
- `cd backend && pytest tests/agents/test_business_info_agent.py tests/agents/test_facility_agent.py tests/agents/test_orchestrator_fast_routing.py tests/config/test_routing_constants.py tests/evaluation/test_fast_path_accuracy.py tests/evaluation/test_ragas_live_case_suites.py -q` -> 186 passed
- `cd backend && black --check agents/business_info_agent.py agents/facility_agent.py config/routing_constants.py utils/intent_classifier.py tests/agents/test_business_info_agent.py tests/agents/test_facility_agent.py tests/agents/test_orchestrator_fast_routing.py tests/config/test_routing_constants.py`
- `cd backend && ruff check agents/business_info_agent.py agents/facility_agent.py config/routing_constants.py utils/intent_classifier.py tests/agents/test_business_info_agent.py tests/agents/test_facility_agent.py tests/agents/test_orchestrator_fast_routing.py tests/config/test_routing_constants.py`
- `git diff --check`

## Live proof after merge
Run targeted `suites=c-127` with `c_ragas_suite=alpha-127`, direct OpenAI, and SHA match. Close #672 only if JA/EN correctness and KO source gate pass.

Refs #583 #672
