### PR TITLE
Guard alpha voice gates against TTS fallback audio

### DIFF
--- a/backend/agents/voice_agent.py
+++ b/backend/agents/voice_agent.py
@@ -976,6 +976,7 @@ class VoiceAgent:
                     "cleanText": fb_text,
                     "error": str(e),
                     "format": audio_format,
+                    "fallback_used": True,
                     "tts_cache_hit": False,
                 }
             except Exception as fallback_error:

--- a/backend/main.py
+++ b/backend/main.py
@@ -1229,6 +1229,8 @@ async def voice_api(request: Request, body: VoiceRequest):
                     provider=body.ttsProvider or os.getenv("TTS_PROVIDER", "voicevox"),
                     format=audio_format,
                     cacheHit=result.get("tts_cache_hit"),
+                    fallbackUsed=bool(result.get("fallback_used")),
+                    error=result.get("error") if result.get("fallback_used") else None,
                 ),
             )
 

--- a/backend/tests/agents/test_voice_agent.py
+++ b/backend/tests/agents/test_voice_agent.py
@@ -512,6 +512,8 @@ async def test_text_to_speech_piper_fallback_japanese_to_voicevox(monkeypatch):
     assert result["success"] is True
     assert result["audioResponse"] == "VOICEVOX_FALLBACK_BASE64"
     assert result["format"] == "audio/wav"
+    assert result["fallback_used"] is True
+    assert "piper connection error" in result["error"]
 
 
 @pytest.mark.asyncio
@@ -541,3 +543,5 @@ async def test_text_to_speech_piper_fallback_english_to_kokoro(monkeypatch):
     assert result["success"] is True
     assert result["audioResponse"] == "KOKORO_FALLBACK_BASE64"
     assert result["format"] == "audio/wav"
+    assert result["fallback_used"] is True
+    assert "piper connection error" in result["error"]

--- a/backend/tests/test_main_endpoints.py
+++ b/backend/tests/test_main_endpoints.py
@@ -466,6 +466,30 @@ class TestVoiceEndpoint:
                 assert resp.phase == "text_to_speech"
                 assert resp.upstreamStatus["provider"] == "piper"
 
+    @pytest.mark.asyncio
+    async def test_voice_tts_fallback_is_reported_in_upstream_status(self):
+        mock_agent = AsyncMock()
+        mock_agent.text_to_speech = AsyncMock(
+            return_value={
+                "success": True,
+                "audioResponse": "d2F2",
+                "format": "audio/wav",
+                "emotion": "sad",
+                "error": "Piper unavailable",
+                "fallback_used": True,
+            }
+        )
+        with patch("backend.main._get_voice_agent_for_provider_key", return_value=mock_agent):
+            from backend.main import VoiceRequest, voice_api
+
+            body = VoiceRequest(action="text_to_speech", text="hello", ttsProvider="piper")
+            resp = await voice_api(_mock_request(), body)
+
+        assert resp.success is True
+        assert resp.upstreamStatus["provider"] == "piper"
+        assert resp.upstreamStatus["fallbackUsed"] is True
+        assert resp.upstreamStatus["error"] == "Piper unavailable"
+
 
 class TestSlidesEndpoint:
     @pytest.mark.asyncio

--- a/scripts/alpha-smoke-comprehensive.sh
+++ b/scripts/alpha-smoke-comprehensive.sh
@@ -286,6 +286,23 @@ is_success_json() {
   [ "$LAST_HTTP" = "200" ] && { [ "$success" = "True" ] || [ "$success" = "true" ] || [ -z "$success" ]; }
 }
 
+tts_fallback_problem() {
+  local fallback_used upstream_error error clean_text
+  fallback_used="$(printf '%s' "$LAST_BODY" | json_get upstreamStatus.fallbackUsed)"
+  upstream_error="$(printf '%s' "$LAST_BODY" | json_get upstreamStatus.error)"
+  error="$(printf '%s' "$LAST_BODY" | json_get error)"
+  clean_text="$(printf '%s' "$LAST_BODY" | json_get cleanText)"
+  if [ "$fallback_used" = "True" ] || [ "$fallback_used" = "true" ]; then
+    printf '%s' "${upstream_error:-${error:-fallbackUsed=true}}"
+    return
+  fi
+  case "$clean_text" in
+    *"音声の生成に失敗しました"*|*"failed to generate the audio response"*|*"Failed to generate speech"*)
+      printf '%s' "$clean_text"
+      ;;
+  esac
+}
+
 chat_success() {
   [ "$LAST_HTTP" = "200" ] && [ -n "$(printf '%s' "$LAST_BODY" | json_get answer)" ]
 }
@@ -400,15 +417,17 @@ EOF
 )
 
 run_voice_case() {
-  local case_id="$1" lang="$2" category="$3" text="$4" session_id transcript provider answer emotion audio sim status
+  local case_id="$1" lang="$2" category="$3" text="$4"
+  local session_id transcript provider answer emotion audio sim status fallback_problem
   session_id="alpha-a-$TIMESTAMP-$case_id"
 
   post_json "/api/voice" "$(voice_tts_body "$text" "$lang" "$session_id" "$TTS_PROVIDER")"
   audio="$(printf '%s' "$LAST_BODY" | json_get audioResponse)"
-  if is_success_json && [ -n "$audio" ]; then
+  fallback_problem="$(tts_fallback_problem)"
+  if is_success_json && [ -n "$audio" ] && [ -z "$fallback_problem" ]; then
     record_result "A" "$case_id" "tts_source" "PASS" "$LAST_HTTP" "$LAST_TIME_MS" "$lang" "$category" "$TTS_PROVIDER" "audio generated"
   else
-    record_result "A" "$case_id" "tts_source" "FAIL" "$LAST_HTTP" "$LAST_TIME_MS" "$lang" "$category" "" "missing source audio"
+    record_result "A" "$case_id" "tts_source" "FAIL" "$LAST_HTTP" "$LAST_TIME_MS" "$lang" "$category" "" "${fallback_problem:-missing source audio}"
     return
   fi
 
@@ -449,10 +468,11 @@ PY
 
   post_json "/api/voice" "$(voice_tts_body "$answer" "$lang" "$session_id" "$TTS_PROVIDER")"
   audio="$(printf '%s' "$LAST_BODY" | json_get audioResponse)"
-  if is_success_json && [ -n "$audio" ]; then
+  fallback_problem="$(tts_fallback_problem)"
+  if is_success_json && [ -n "$audio" ] && [ -z "$fallback_problem" ]; then
     record_result "A" "$case_id" "tts_answer" "PASS" "$LAST_HTTP" "$LAST_TIME_MS" "$lang" "$TTS_PROVIDER" "audio" "round-trip complete"
   else
-    record_result "A" "$case_id" "tts_answer" "FAIL" "$LAST_HTTP" "$LAST_TIME_MS" "$lang" "$TTS_PROVIDER" "" "answer TTS failed"
+    record_result "A" "$case_id" "tts_answer" "FAIL" "$LAST_HTTP" "$LAST_TIME_MS" "$lang" "$TTS_PROVIDER" "" "${fallback_problem:-answer TTS failed}"
   fi
 }
 

--- a/scripts/voice-pipeline-live-preflight.sh
+++ b/scripts/voice-pipeline-live-preflight.sh
@@ -108,6 +108,21 @@ def response_route(body: dict[str, Any]) -> str:
     return ""
 
 
+def tts_fallback_problem(body: dict[str, Any]) -> str:
+    upstream = body.get("upstreamStatus") if isinstance(body.get("upstreamStatus"), dict) else {}
+    if upstream.get("fallbackUsed") is True:
+        return compact(upstream.get("error") or body.get("error") or "fallbackUsed=true")
+    clean_text = str(body.get("cleanText") or "")
+    fallback_phrases = (
+        "音声の生成に失敗しました",
+        "failed to generate the audio response",
+        "Failed to generate speech",
+    )
+    if any(phrase in clean_text for phrase in fallback_phrases):
+        return compact(clean_text)
+    return ""
+
+
 def similarity(expected: str, actual: str) -> float:
     def norm(text: str) -> str:
         return "".join(text.lower().split())
@@ -398,7 +413,14 @@ def run_case(args: argparse.Namespace, api_key: str, rows: list[dict[str, Any]],
         timeout=args.timeout,
     )
     audio = tts_source.get("audioResponse")
-    if http == 200 and tts_source.get("success") is True and isinstance(audio, str) and len(audio) > 64:
+    fallback_problem = tts_fallback_problem(tts_source)
+    if (
+        http == 200
+        and tts_source.get("success") is True
+        and isinstance(audio, str)
+        and len(audio) > 64
+        and not fallback_problem
+    ):
         record(
             rows,
             case_id=case.case_id,
@@ -420,9 +442,9 @@ def run_case(args: argparse.Namespace, api_key: str, rows: list[dict[str, Any]],
             http=http,
             duration_ms=duration_ms,
             language=case.language,
-            expected="audioResponse",
-            actual="missing",
-            notes=compact(raw),
+            expected="audioResponse without fallback",
+            actual="fallback" if fallback_problem else "missing",
+            notes=fallback_problem or compact(raw),
         )
         return
 
@@ -522,17 +544,19 @@ def run_case(args: argparse.Namespace, api_key: str, rows: list[dict[str, Any]],
         timeout=args.timeout,
     )
     answer_audio = tts_answer.get("audioResponse")
+    fallback_problem = tts_fallback_problem(tts_answer)
     if (
         http == 200
         and tts_answer.get("success") is True
         and isinstance(answer_audio, str)
         and len(answer_audio) > 64
+        and not fallback_problem
     ):
         answer_status = "PASS"
         actual = str(tts_answer.get("audioFormat") or "audio")
     else:
         answer_status = "FAIL"
-        actual = "missing"
+        actual = "fallback" if fallback_problem else "missing"
     record(
         rows,
         case_id=case.case_id,
@@ -541,9 +565,9 @@ def run_case(args: argparse.Namespace, api_key: str, rows: list[dict[str, Any]],
         http=http,
         duration_ms=duration_ms,
         language=case.language,
-        expected=args.tts_provider,
+        expected=f"{args.tts_provider} without fallback",
         actual=actual,
-        notes=compact(raw),
+        notes=fallback_problem or compact(raw),
     )
 
 


### PR DESCRIPTION
## Summary
- report TTS fallback usage from `VoiceAgent` through `/api/voice` `upstreamStatus`
- fail alpha voice gates when a TTS response is fallback/error audio instead of the requested source or answer audio
- add focused regression tests for Piper fallback observability

## Root cause / impact
The failed alpha voice run `25279768160` generated source audio whose spoken content was the fallback phrase `申し訳ございません。音声の生成に失敗しました。`. The gate only checked for `success=true` and non-empty `audioResponse`, so it accepted that fallback WAV as valid input. STT then transcribed the fallback phrase and LangGraph routing failed for business/facility/event cases as `general_knowledge`.

PR #745 fixed the underlying PiperPlus 500, but the alpha gate still needed a guard so future provider fallback audio cannot masquerade as valid scenario audio.

## Validation
- `mise exec -- python -m pytest backend/tests/test_main_endpoints.py::TestVoiceEndpoint::test_voice_tts_fallback_is_reported_in_upstream_status backend/tests/agents/test_voice_agent.py::test_text_to_speech_piper_fallback_japanese_to_voicevox backend/tests/agents/test_voice_agent.py::test_text_to_speech_piper_fallback_english_to_kokoro`
- `bash -n scripts/alpha-smoke-comprehensive.sh`
- `bash -n scripts/voice-pipeline-live-preflight.sh`
- `scripts/voice-pipeline-live-preflight.sh --dry-run --case-set smoke --timestamp dry-run-tts-fallback-gate`
- `scripts/alpha-smoke-comprehensive.sh --dry-run --scenarios A --timestamp dry-run-tts-fallback-gate`
- `git diff --check`

## Follow-up after merge
- redeploy backend so `/api/voice` exposes `upstreamStatus.fallbackUsed`
- rerun the alpha voice suites against backend SHA from this PR and current PiperPlus revision `piper-plus-00007-2sd`
- rerun C/RAG sequentially after the stuck run `25279769381` finishes cancellation
