### PR TITLE
fix(frontend): VRMAをidle基準でhips水平リベース（#743）

### DIFF
--- a/frontend/src/app/components/CharacterAvatar.tsx
+++ b/frontend/src/app/components/CharacterAvatar.tsx
@@ -3,9 +3,13 @@
 import { EmotionData, EmotionManager } from '@/lib/emotion-manager';
 import { ExpressionController } from '@/lib/expression-controller';
 import { LipSyncAnalyzer } from '@/lib/lip-sync-analyzer';
+import {
+  DEFAULT_IDLE_VRMA_URL,
+  isIdleVrmaUrl,
+  loadVRMAAnimationClipFromUrl,
+} from '@/lib/vrm-animation-clip';
 import { VRMBlendShapeController, VRMUtils, getLipSyncFactorFromEmotions } from '@/lib/vrm-utils';
 import { VRM, VRMLoaderPlugin } from '@pixiv/three-vrm';
-import { VRMAnimationLoaderPlugin, createVRMAnimationClip } from '@pixiv/three-vrm-animation';
 import { Settings, User, VolumeX } from 'lucide-react';
 import {
   useEffect,
@@ -261,6 +265,8 @@ export default function CharacterAvatar({
   const updateSceneBackgroundRef = useRef<(options: BackgroundOption) => void>(() => {});
   const loadedModelPathRef = useRef(modelPath);
   const loadedVrmSpecVersionRef = useRef<string | null>(null);
+  /** Hips X/Z at t=0 from {@link DEFAULT_IDLE_VRMA_URL}; used to align other VRMA clips. */
+  const idleHipsBaselineRef = useRef<{ x: number; z: number } | null>(null);
 
   const applyRootScenePosition = useCallback((vrm?: VRM | null) => {
     const targetVrm = vrm ?? charactersRef.current;
@@ -655,97 +661,60 @@ export default function CharacterAvatar({
     vrm: VRM,
     loop: boolean = true,
   ) => {
-    const loader = new GLTFLoader();
-    loader.crossOrigin = 'anonymous';
-    
-    // Register the VRMAnimationLoaderPlugin
-    loader.register((parser) => {
-      return new VRMAnimationLoaderPlugin(parser);
-    });
-
     try {
-      const gltf = await loader.loadAsync(animationUrl);
-      
-      // Try different ways to access the animation
-      const vrmAnimation = gltf.userData.vrmAnimations?.[0] || gltf.userData.vrmAnimation;
-      
-      if (vrmAnimation) {
-        let clip: THREE.AnimationClip | null = null;
+      const { clip: initialClip } = await loadVRMAAnimationClipFromUrl(animationUrl, vrm);
+      if (!initialClip) {
+        return { success: false, duration: 0 };
+      }
+      let clip = initialClip;
 
-        if (vrm.lookAt) {
-          if (!vrm.lookAt.target) {
-            const fallbackLookAtTarget = new THREE.Object3D();
-            fallbackLookAtTarget.position.copy(DEFAULT_LOOKAT_TARGET);
-            vrm.lookAt.target = fallbackLookAtTarget;
-          }
-
-          clip = createVRMAnimationClip(vrmAnimation, vrm as any);
+      if (isIdleVrmaUrl(animationUrl)) {
+        const baseline = VRMUtils.sampleHipsPositionXZAtTime(clip, vrm, 0);
+        if (baseline) {
+          idleHipsBaselineRef.current = baseline;
         }
-
-        if (!clip && gltf.animations && gltf.animations.length > 0) {
-          clip = gltf.animations[0];
-        }
-
-        if (!clip) {
-          return { success: false, duration: 0 };
-        }
-        
-        if (!mixerRef.current) {
-          mixerRef.current = new THREE.AnimationMixer(vrm.scene);
-        }
-        
-        // Stop current animation if exists
-        if (currentActionRef.current) {
-          currentActionRef.current.stop();
-        }
-        
-        // Play new animation
-        const action = mixerRef.current.clipAction(clip);
-        if (loop) {
-          action.setLoop(THREE.LoopRepeat, Infinity);
-        } else {
-          action.setLoop(THREE.LoopOnce, 1);
-          action.clampWhenFinished = true;
-        }
-        action.play();
-        currentActionRef.current = action;
-        
-        // Keep root position centralized across animation changes.
-        applyRootScenePosition(vrm);
-        
-        
-        return { success: true, duration: clip.duration };
       } else {
-        
-        // Try using the gltf animations directly
-        if (gltf.animations && gltf.animations.length > 0) {
-          
-          if (!mixerRef.current) {
-            mixerRef.current = new THREE.AnimationMixer(vrm.scene);
+        let baseline = idleHipsBaselineRef.current;
+        if (!baseline) {
+          const idlePack = await loadVRMAAnimationClipFromUrl(DEFAULT_IDLE_VRMA_URL, vrm);
+          if (idlePack.clip) {
+            baseline = VRMUtils.sampleHipsPositionXZAtTime(idlePack.clip, vrm, 0);
+            if (baseline) {
+              idleHipsBaselineRef.current = baseline;
+            }
           }
-          
-          const clip = gltf.animations[0];
-          const action = mixerRef.current.clipAction(clip);
-          if (loop) {
-            action.setLoop(THREE.LoopRepeat, Infinity);
-          } else {
-            action.setLoop(THREE.LoopOnce, 1);
-            action.clampWhenFinished = true;
-          }
-          action.play();
-          currentActionRef.current = action;
-          
-          // Keep root position centralized across animation changes.
-          applyRootScenePosition(vrm);
-          
-          
-          return { success: true, duration: clip.duration };
+        }
+        const other = VRMUtils.sampleHipsPositionXZAtTime(clip, vrm, 0);
+        if (baseline && other) {
+          clip = VRMUtils.rebaseHipsHorizontalInClip(clip, vrm, baseline, other);
         }
       }
+
+      if (!mixerRef.current) {
+        mixerRef.current = new THREE.AnimationMixer(vrm.scene);
+      }
+
+      if (currentActionRef.current) {
+        currentActionRef.current.stop();
+      }
+
+      const action = mixerRef.current.clipAction(clip);
+      if (loop) {
+        action.setLoop(THREE.LoopRepeat, Infinity);
+      } else {
+        action.setLoop(THREE.LoopOnce, 1);
+        action.clampWhenFinished = true;
+      }
+      action.play();
+      currentActionRef.current = action;
+
+      applyRootScenePosition(vrm);
+
+      return { success: true, duration: clip.duration };
     } catch (error) {
       console.error('Error loading VRM animation:', error);
     }
-    
+
     return { success: false, duration: 0 };
   };
 
@@ -801,6 +770,7 @@ export default function CharacterAvatar({
         sceneRef.current.remove(charactersRef.current.scene);
         charactersRef.current = null;
       }
+      idleHipsBaselineRef.current = null;
 
       // Load VRM model via fetch + parseAsync so texture base path is correct.
       // Force TextureLoader instead of ImageBitmapLoader: blob URLs from bufferView
@@ -1390,6 +1360,7 @@ export default function CharacterAvatar({
       VRMUtils.dispose(charactersRef.current);
     }
 
+    idleHipsBaselineRef.current = null;
     loadedVrmSpecVersionRef.current = null;
   };
 

--- a/frontend/src/app/components/CharacterAvatar.tsx
+++ b/frontend/src/app/components/CharacterAvatar.tsx
@@ -5,7 +5,7 @@ import { ExpressionController } from '@/lib/expression-controller';
 import { LipSyncAnalyzer } from '@/lib/lip-sync-analyzer';
 import {
   DEFAULT_IDLE_VRMA_URL,
-  isIdleVrmaUrl,
+  isDefaultIdleVrmaRequest,
   loadVRMAAnimationClipFromUrl,
 } from '@/lib/vrm-animation-clip';
 import { VRMBlendShapeController, VRMUtils, getLipSyncFactorFromEmotions } from '@/lib/vrm-utils';
@@ -668,7 +668,7 @@ export default function CharacterAvatar({
       }
       let clip = initialClip;
 
-      if (isIdleVrmaUrl(animationUrl)) {
+      if (isDefaultIdleVrmaRequest(animationUrl)) {
         const baseline = VRMUtils.sampleHipsPositionXZAtTime(clip, vrm, 0);
         if (baseline) {
           idleHipsBaselineRef.current = baseline;
@@ -747,7 +747,7 @@ export default function CharacterAvatar({
     }
     
     // Return to idle animation
-    await loadVRMAnimation('/animations/idle.vrma', vrm, true);
+    await loadVRMAnimation(DEFAULT_IDLE_VRMA_URL, vrm, true);
     isPlayingSequence.current = false;
   };
 
@@ -857,7 +857,7 @@ export default function CharacterAvatar({
 
         // Load default idle animation
         try {
-          await loadVRMAnimation('/animations/idle.vrma', vrm, true);
+          await loadVRMAnimation(DEFAULT_IDLE_VRMA_URL, vrm, true);
         } catch (animationError) {
           console.error('[CharacterAvatar] Failed to load default idle animation:', animationError);
         }

--- a/frontend/src/app/components/CharacterSettings.tsx
+++ b/frontend/src/app/components/CharacterSettings.tsx
@@ -3,6 +3,7 @@
 import React, { useEffect, useState } from 'react';
 import { Play, User } from 'lucide-react';
 import type { CharacterAnimationData } from '../utils/character-animation-utils';
+import { DEFAULT_IDLE_VRMA_URL } from '@/lib/vrm-animation-clip';
 import KeyframeSettings from './KeyframeSettings';
 
 export interface ControlsState {
@@ -17,7 +18,7 @@ export interface VRMAnimationOption {
   label: string;
 }
 
-const DEFAULT_VRM_ANIMATION = '/animations/idle.vrma';
+const DEFAULT_VRM_ANIMATION = DEFAULT_IDLE_VRMA_URL;
 
 const VISEME_NAMES = ['aa', 'ih', 'ou', 'ee', 'oh'];
 

--- a/frontend/src/lib/vrm-animation-clip.ts
+++ b/frontend/src/lib/vrm-animation-clip.ts
@@ -3,10 +3,46 @@ import { VRMAnimationLoaderPlugin, createVRMAnimationClip } from '@pixiv/three-v
 import * as THREE from 'three';
 import { GLTFLoader } from 'three/examples/jsm/loaders/GLTFLoader.js';
 
+import { EmotionMapping } from '@/lib/emotion-mapping';
+
 /** Same default as CharacterAvatar (1m ahead, 1m up) for VRMLookAt when loading VRMA. */
 const FALLBACK_LOOK_AT_POSITION = new THREE.Vector3(0, 1, 1);
 
-export const DEFAULT_IDLE_VRMA_URL = '/animations/idle.vrma';
+/**
+ * Maps a supported animation key to its public `.vrma` URL (same rule as
+ * {@code CharacterAvatar} {@code /animations/${animation}.vrma}).
+ */
+export function vrmaUrlForAnimationName(animationName: string): string {
+  return `/animations/${animationName}.vrma`;
+}
+
+/**
+ * Standby / default character VRMA: tied to {@link EmotionMapping.DEFAULT_ANIMATION}
+ * (`idle`), not file-name heuristics.
+ */
+export const DEFAULT_IDLE_VRMA_URL = vrmaUrlForAnimationName(EmotionMapping.DEFAULT_ANIMATION);
+
+/** Normalizes request URLs for same-asset comparison (query stripped, path-only for absolute URLs). */
+export function normalizeVrmaAssetPath(animationUrl: string): string {
+  const raw = animationUrl.split('?')[0] ?? animationUrl;
+  if (/^https?:\/\//i.test(raw)) {
+    try {
+      return new URL(raw).pathname;
+    } catch {
+      return raw;
+    }
+  }
+  const path = raw.startsWith('/') ? raw : `/${raw}`;
+  return path.replace(/\/{2,}/g, '/');
+}
+
+/**
+ * True when {@code animationUrl} resolves to the same asset as {@link DEFAULT_IDLE_VRMA_URL}
+ * (standby animation from {@link EmotionMapping}).
+ */
+export function isDefaultIdleVrmaRequest(animationUrl: string): boolean {
+  return normalizeVrmaAssetPath(animationUrl) === normalizeVrmaAssetPath(DEFAULT_IDLE_VRMA_URL);
+}
 
 function ensureVrmLookAtTarget(vrm: VRM): void {
   if (!vrm.lookAt) {
@@ -49,10 +85,4 @@ export async function loadVRMAAnimationClipFromUrl(
   }
 
   return { clip, duration: clip?.duration ?? 0 };
-}
-
-/** Whether {@code animationUrl} points at {@link DEFAULT_IDLE_VRMA_URL}-style idle VRMA. */
-export function isIdleVrmaUrl(animationUrl: string): boolean {
-  const pathOnly = animationUrl.split('?')[0] ?? animationUrl;
-  return pathOnly.endsWith('/idle.vrma') || pathOnly.endsWith('idle.vrma');
 }

--- a/frontend/src/lib/vrm-animation-clip.ts
+++ b/frontend/src/lib/vrm-animation-clip.ts
@@ -1,0 +1,58 @@
+import { VRM } from '@pixiv/three-vrm';
+import { VRMAnimationLoaderPlugin, createVRMAnimationClip } from '@pixiv/three-vrm-animation';
+import * as THREE from 'three';
+import { GLTFLoader } from 'three/examples/jsm/loaders/GLTFLoader.js';
+
+/** Same default as CharacterAvatar (1m ahead, 1m up) for VRMLookAt when loading VRMA. */
+const FALLBACK_LOOK_AT_POSITION = new THREE.Vector3(0, 1, 1);
+
+export const DEFAULT_IDLE_VRMA_URL = '/animations/idle.vrma';
+
+function ensureVrmLookAtTarget(vrm: VRM): void {
+  if (!vrm.lookAt) {
+    return;
+  }
+  if (!vrm.lookAt.target) {
+    const fallback = new THREE.Object3D();
+    fallback.position.copy(FALLBACK_LOOK_AT_POSITION);
+    vrm.lookAt.target = fallback;
+  }
+}
+
+/**
+ * Loads a .vrma (or gltf animation) and returns a Three.js {@link THREE.AnimationClip}
+ * using the same rules as {@code CharacterAvatar.loadVRMAnimation}.
+ */
+export async function loadVRMAAnimationClipFromUrl(
+  animationUrl: string,
+  vrm: VRM,
+): Promise<{ clip: THREE.AnimationClip | null; duration: number }> {
+  const loader = new GLTFLoader();
+  loader.crossOrigin = 'anonymous';
+  loader.register((parser) => new VRMAnimationLoaderPlugin(parser));
+
+  const gltf = await loader.loadAsync(animationUrl);
+  const vrmAnimation = gltf.userData.vrmAnimations?.[0] || gltf.userData.vrmAnimation;
+
+  let clip: THREE.AnimationClip | null = null;
+
+  if (vrmAnimation) {
+    if (vrm.lookAt) {
+      ensureVrmLookAtTarget(vrm);
+      clip = createVRMAnimationClip(vrmAnimation, vrm as any);
+    }
+    if (!clip && gltf.animations?.length) {
+      clip = gltf.animations[0];
+    }
+  } else if (gltf.animations?.length) {
+    clip = gltf.animations[0];
+  }
+
+  return { clip, duration: clip?.duration ?? 0 };
+}
+
+/** Whether {@code animationUrl} points at {@link DEFAULT_IDLE_VRMA_URL}-style idle VRMA. */
+export function isIdleVrmaUrl(animationUrl: string): boolean {
+  const pathOnly = animationUrl.split('?')[0] ?? animationUrl;
+  return pathOnly.endsWith('/idle.vrma') || pathOnly.endsWith('idle.vrma');
+}

--- a/frontend/src/lib/vrm-utils.ts
+++ b/frontend/src/lib/vrm-utils.ts
@@ -56,8 +56,79 @@ export class VRMUtils {
     'leftShoulder', 'leftUpperArm', 'leftLowerArm', 'leftHand',
     'rightShoulder', 'rightUpperArm', 'rightLowerArm', 'rightHand',
     'leftUpperLeg', 'leftLowerLeg', 'leftFoot',
-    'rightUpperLeg', 'rightLowerLeg', 'rightFoot'
+    'rightUpperLeg', 'rightLowerLeg', 'rightFoot',
   ];
+
+  /**
+   * Hips translation track as produced by {@code createVRMAnimationClip}:
+   * {@code `${hipsNode.name}.position`}.
+   */
+  static findHipsVectorPositionTrack(
+    clip: THREE.AnimationClip,
+    vrm: VRM,
+  ): THREE.VectorKeyframeTrack | null {
+    const humanoid = vrm.humanoid;
+    if (!humanoid) {
+      return null;
+    }
+    const hips = humanoid.getNormalizedBoneNode('hips' as never);
+    if (!hips?.name) {
+      return null;
+    }
+    const trackName = `${hips.name}.position`;
+    const track = clip.tracks.find((t) => t.name === trackName);
+    return track instanceof THREE.VectorKeyframeTrack ? track : null;
+  }
+
+  /** Samples hips `.position` keyframes at {@code time} (expects VectorKeyframeTrack). */
+  static sampleHipsPositionXZAtTime(
+    clip: THREE.AnimationClip,
+    vrm: VRM,
+    time: number,
+  ): { x: number; z: number } | null {
+    const track = VRMUtils.findHipsVectorPositionTrack(clip, vrm);
+    if (!track) {
+      return null;
+    }
+    const interpolant = new THREE.LinearInterpolant(track.times, track.values, 3);
+    const out = interpolant.evaluate(time) as Float32Array | number[];
+    return { x: out[0], z: out[2] };
+  }
+
+  /**
+   * Re-bases hips horizontal translation so t=0 matches {@code refIdleXZ}:
+   * {@code p'(t) = p(t) + (refIdle - refOther)} on X and Z; Y keys unchanged.
+   */
+  static rebaseHipsHorizontalInClip(
+    clip: THREE.AnimationClip,
+    vrm: VRM,
+    refIdleXZ: { x: number; z: number },
+    refOtherXZ: { x: number; z: number },
+  ): THREE.AnimationClip {
+    const target = VRMUtils.findHipsVectorPositionTrack(clip, vrm);
+    if (!target) {
+      return clip;
+    }
+    const dx = refIdleXZ.x - refOtherXZ.x;
+    const dz = refIdleXZ.z - refOtherXZ.z;
+    if (Math.abs(dx) < 1e-9 && Math.abs(dz) < 1e-9) {
+      return clip;
+    }
+    const hipsTrackName = target.name;
+    const newTracks = clip.tracks.map((tr) => {
+      if (tr.name !== hipsTrackName || !(tr instanceof THREE.VectorKeyframeTrack)) {
+        return tr;
+      }
+      const cloned = tr.clone();
+      const { values } = cloned;
+      for (let i = 0; i < values.length; i += 3) {
+        values[i] += dx;
+        values[i + 2] += dz;
+      }
+      return cloned;
+    });
+    return new THREE.AnimationClip(clip.name, clip.duration, newTracks);
+  }
 
   // VRM Loading
   static async loadVRM(


### PR DESCRIPTION
## 概要
Closes / 対応: #743

VRM 再生時に VRMA の hips translation 起因でキャラが横方向にずれて見える問題に対し、`idle.vrma`（`EmotionMapping.DEFAULT_ANIMATION` に対応）を golden baseline として、**他クリップの hips 位置トラック X/Z を t=0 で揃えてから再生**するようにしました。

## 変更内容
- `vrm-animation-clip.ts`: クリップロード共通化、`DEFAULT_IDLE_VRMA_URL`、`normalizeVrmaAssetPath` / `isDefaultIdleVrmaRequest`（待機アニメは EmotionMapping 連動・パス正規化比較）
- `vrm-utils.ts`: hips `.position` の検出・サンプル・水平リベース
- `CharacterAvatar.tsx`: `idleHipsBaselineRef`、`loadVRMAnimation` でのリベース適用・ライフサイクルクリア
- `CharacterSettings.tsx`: デフォルト VRMA を`DEFAULT_IDLE_VRMA_URL` に統一

## レビュー後の修正（コードレビュー反映）
- ファイル名 `endsWith('idle.vrma')` による判定をやめ、`EmotionMapping.DEFAULT_ANIMATION` 由来の URL と正規化パスの一致で待機クリップを判定

## 確認
- [ ] `pnpm lint && pnpm typecheck && pnpm build`（frontend）

## エビデンス
### 修正後thinking
<img width="1680" height="837" alt="修正後thinking" src="https://github.com/user-attachments/assets/0d06bba4-c401-4e65-8ec3-0f60638f3326" />

### 参考: 修正前thinking
<img width="1680" height="833" alt="修正前thinking" src="https://github.com/user-attachments/assets/8e5aea1c-5878-4819-a9fb-c1955d846354" />

### 参考: idle
<img width="1680" height="834" alt="idle" src="https://github.com/user-attachments/assets/9c0bc0da-da6c-4966-8d11-1528a822d10b" />

Made with [Cursor](https://cursor.com)