### PR TITLE
Fix EN diagnostic answer corruption

### DIFF
--- a/backend/agents/business_info_agent.py
+++ b/backend/agents/business_info_agent.py
@@ -603,10 +603,9 @@ Information: {context}
                     "受付でスタッフに声をかけてください。"
                 ),
                 "en": (
-                    "[relaxed]For your first visit, register at the 1F reception when "
-                    "you arrive. Please ask the reception staff for assistance. "
-                    "Registration is free, takes about 5 to 10 minutes, and staff "
-                    "can help you complete the web form."
+                    "[relaxed]Register at reception on arrival. Ask staff for assistance. "
+                    "It takes about 5 to 10 minutes and is completed with a web form. "
+                    "Online pre-registration is not available."
                 ),
                 "zh": (
                     "[relaxed]第一次来访时，请到一楼前台办理登记。登记免费，"
@@ -676,11 +675,11 @@ Information: {context}
                     "https://engineercafe.jp/ で、お問い合わせフォームも利用できます。"
                 ),
                 "en": (
-                    "[relaxed]You can contact Engineer Cafe by phone at 080-6742-7231 "
-                    "between 13:00 and 21:00. You can also use the official website, "
-                    "https://engineercafe.jp/, or its inquiry form. For second-floor "
-                    "meeting rooms, please use the separate inquiry path or ask at "
-                    "reception during opening hours."
+                    "[relaxed]Phone: 080-6742-7231 (13:00-21:00). "
+                    "Website: https://engineercafe.jp/. "
+                    "Contact form: https://engineercafe.jp/ja/contact. "
+                    "For second-floor meeting rooms, a separate inquiry may be needed. "
+                    "You can also visit reception in person during opening hours."
                 ),
                 "zh": (
                     "[relaxed]可以在13:00到21:00之间拨打080-6742-7231"

--- a/backend/agents/event_agent.py
+++ b/backend/agents/event_agent.py
@@ -377,10 +377,9 @@ class EventAgent:
                 "早めの申込をおすすめします。"
             ),
             "en": (
-                "[relaxed]Yes, you can check Engineer Cafe events on Connpass. "
-                "Event listings, details, and sign-up information are available at "
-                "https://engineercafe.connpass.com/. Many events are free, and when "
-                "capacity is limited, early sign-up is recommended."
+                "[relaxed]Yes. Event listings and sign-up information are available "
+                "on Connpass at https://engineercafe.connpass.com/. Most events are "
+                "free, and many are first-come, first-served."
             ),
             "zh": (
                 "[relaxed]可以在Connpass上查看工程师咖啡的活动信息。"

--- a/backend/tests/agents/test_business_info_agent.py
+++ b/backend/tests/agents/test_business_info_agent.py
@@ -78,12 +78,11 @@ class TestBusinessInfoAgent:
         )
 
         assert response is not None
-        assert "1F reception" in response["answer"]
+        assert "reception" in response["answer"]
         assert "5 to 10 minutes" in response["answer"]
         assert "web form" in response["answer"].lower()
         assert "staff" in response["answer"].lower()
-        assert "ask the reception staff" in response["answer"].lower()
-        assert "free" in response["answer"].lower()
+        assert "online pre-registration is not available" in response["answer"].lower()
 
     def test_first_time_visitor_canonical_response(self):
         """Hyphenated first-time visitor phrasing must not fall back."""
@@ -94,8 +93,8 @@ class TestBusinessInfoAgent:
         assert response is not None
         assert response["metadata"]["confidence"] >= 0.7
         assert response["metadata"]["sources"] == ["enhanced_rag"]
-        assert "1F reception" in response["answer"]
-        assert "free" in response["answer"].lower()
+        assert "reception" in response["answer"]
+        assert "staff" in response["answer"].lower()
         assert "5 to 10 minutes" in response["answer"]
 
     def test_opening_hours_canonical_response_japanese(self):
@@ -244,9 +243,9 @@ class TestBusinessInfoAgent:
 
         assert response is not None
         assert "080-6742-7231" in response["answer"]
-        assert "13:00 and 21:00" in response["answer"]
+        assert "13:00-21:00" in response["answer"]
         assert "https://engineercafe.jp/" in response["answer"]
-        assert "inquiry form" in response["answer"].lower()
+        assert "contact form" in response["answer"].lower()
         assert "second-floor meeting rooms" in response["answer"].lower()
 
     def test_closed_days_canonical_precedes_hours(self):

--- a/backend/tests/agents/test_event_agent.py
+++ b/backend/tests/agents/test_event_agent.py
@@ -97,7 +97,7 @@ class TestEventAgent:
         assert "sign-up" in response["answer"].lower()
         assert "https://engineercafe.connpass.com/" in response["answer"]
         assert "free" in response["answer"].lower()
-        assert "early sign-up" in response["answer"].lower()
+        assert "first-come, first-served" in response["answer"].lower()
         assert response["metadata"]["sources"] == ["connpass"]
 
     def test_connpass_canonical_response_japanese_mentions_recruitment(self):

--- a/backend/tests/utils/test_pii_scanner.py
+++ b/backend/tests/utils/test_pii_scanner.py
@@ -82,6 +82,12 @@ class TestScanAndMaskPhone:
         masked, items = scan_and_mask(text)
         assert "[REDACTED_PHONE]" in masked
 
+    def test_public_engineer_cafe_phone_is_not_masked(self):
+        text = "Phone: 080-6742-7231 (13:00-21:00)."
+        masked, items = scan_and_mask(text)
+        assert masked == text
+        assert items == []
+
 
 class TestScanAndMaskCreditCard:
     """クレジットカード番号の検出・マスキング"""
@@ -307,6 +313,9 @@ class TestContainsPii:
 
     def test_with_phone(self):
         assert contains_pii("電話: 090-1234-5678") is True
+
+    def test_with_public_engineer_cafe_phone(self):
+        assert contains_pii("Phone: 080-6742-7231 (13:00-21:00).") is False
 
     def test_with_credit_card(self):
         assert contains_pii("カード: 4111-1111-1111-1111") is True

--- a/backend/tests/workflows/test_main_workflow.py
+++ b/backend/tests/workflows/test_main_workflow.py
@@ -1425,6 +1425,42 @@ class TestResponseTranslation:
 
     @pytest.mark.asyncio
     @patch("backend.workflows.main_workflow.OrchestratorAgent")
+    async def test_format_response_skips_translation_for_english_answer(
+        self, mock_orchestrator_class
+    ):
+        """Canonical English answers must not pass through the JA->EN model."""
+        from backend.workflows.main_workflow import MainWorkflow
+
+        mock_orchestrator_class.return_value = AsyncMock()
+
+        with (
+            patch("backend.utils.memory_helper.get_memory_helper") as mock_get_helper,
+            patch("backend.services.translation_service.get_translation_service") as mock_get_ts,
+        ):
+            mock_helper = AsyncMock()
+            mock_helper.store_message = AsyncMock()
+            mock_get_helper.return_value = mock_helper
+
+            workflow = MainWorkflow()
+            answer = (
+                "Phone: 080-6742-7231 (13:00-21:00). "
+                "Website: https://engineercafe.jp/. "
+                "Contact form: https://engineercafe.jp/ja/contact."
+            )
+            state = {
+                "query": "How can I contact Engineer Cafe?",
+                "answer": answer,
+                "session_id": "test-session",
+                "language": "en",
+            }
+
+            result = await workflow._format_response_node(state, _mock_runtime())
+
+            mock_get_ts.assert_not_called()
+            assert result["messages"][-1].content == answer
+
+    @pytest.mark.asyncio
+    @patch("backend.workflows.main_workflow.OrchestratorAgent")
     async def test_format_response_skips_translation_for_ja(self, mock_orchestrator_class):
         """language='ja' の場合、翻訳をスキップすることを確認"""
         from backend.workflows.main_workflow import MainWorkflow

--- a/backend/utils/pii_scanner.py
+++ b/backend/utils/pii_scanner.py
@@ -25,6 +25,22 @@ from typing import Dict, List, Tuple
 # 各パターンは (pattern_name, compiled_regex) のタプル
 # pattern_name はマスキング時の置換ラベルに使用される
 
+_PUBLIC_CONTACT_ALLOWLIST = {
+    "080-6742-7231",
+    "080 6742 7231",
+    "08067427231",
+}
+
+
+def _normalize_public_contact_candidate(value: str) -> str:
+    return re.sub(r"[\s\-]", "", value)
+
+
+_PUBLIC_CONTACT_ALLOWLIST_NORMALIZED = {
+    _normalize_public_contact_candidate(value) for value in _PUBLIC_CONTACT_ALLOWLIST
+}
+
+
 _PII_PATTERNS: List[Tuple[str, re.Pattern[str]]] = [
     # --- メールアドレス ---
     (
@@ -174,6 +190,12 @@ def scan_and_mask(text: str) -> Tuple[str, List[Dict[str, str]]]:
 
     for pattern_name, pattern in _PII_PATTERNS:
         for match in pattern.finditer(text):
+            if (
+                pattern_name == "PHONE"
+                and _normalize_public_contact_candidate(match.group())
+                in _PUBLIC_CONTACT_ALLOWLIST_NORMALIZED
+            ):
+                continue
             all_matches.append((match.start(), match.end(), pattern_name, match.group()))
 
     if not all_matches:
@@ -224,8 +246,14 @@ def contains_pii(text: str) -> bool:
     if not text:
         return False
 
-    for _pattern_name, pattern in _PII_PATTERNS:
-        if pattern.search(text):
+    for pattern_name, pattern in _PII_PATTERNS:
+        for match in pattern.finditer(text):
+            if (
+                pattern_name == "PHONE"
+                and _normalize_public_contact_candidate(match.group())
+                in _PUBLIC_CONTACT_ALLOWLIST_NORMALIZED
+            ):
+                continue
             return True
 
     return False

--- a/backend/workflows/main_workflow.py
+++ b/backend/workflows/main_workflow.py
@@ -1276,7 +1276,7 @@ class MainWorkflow:
         # zh/ko: rely on LLM's native multilingual output (LANGUAGE_INSTRUCTION)
         # CTranslate2 only supports en<->ja, so no translation for zh/ko
         language = state.get("language", "ja")
-        if language == "en":
+        if language == "en" and self._should_translate_answer_to_english(answer):
             try:
                 from backend.services.translation_service import (
                     get_translation_service,
@@ -1504,6 +1504,15 @@ class MainWorkflow:
                 AIMessage(content=answer),
             ],
         }
+
+    @staticmethod
+    def _should_translate_answer_to_english(answer: str) -> bool:
+        """Return true only when an English turn still has Japanese text."""
+        if not answer:
+            return False
+        return any(
+            ("\u3040" <= char <= "\u30ff") or ("\u4e00" <= char <= "\u9fff") for char in answer
+        )
 
     def _decode_image_data(self, image_data: Any) -> Any:
         """Convert base64 image string to np.ndarray for VisionAgent.


### PR DESCRIPTION
## Summary
- skip JA->EN response translation when the workflow answer is already English, preventing canonical EN answers with URLs/phone numbers from being corrupted
- allowlist Engineer Cafe's public phone number in output PII masking so contact answers preserve the required channel
- align EN diagnostic canonical answers for first-visit registration, Connpass, and contact with the golden facts

## Verification
- mise exec -- python -m pytest backend/tests/agents/test_business_info_agent.py backend/tests/agents/test_event_agent.py backend/tests/utils/test_pii_scanner.py backend/tests/workflows/test_main_workflow.py::TestResponseTranslation -q
- mise exec -- ruff check backend/workflows/main_workflow.py backend/utils/pii_scanner.py backend/agents/business_info_agent.py backend/agents/event_agent.py backend/tests/workflows/test_main_workflow.py backend/tests/utils/test_pii_scanner.py backend/tests/agents/test_business_info_agent.py backend/tests/agents/test_event_agent.py
- mise exec -- black --check backend/workflows/main_workflow.py backend/utils/pii_scanner.py backend/agents/business_info_agent.py backend/agents/event_agent.py backend/tests/workflows/test_main_workflow.py backend/tests/utils/test_pii_scanner.py backend/tests/agents/test_business_info_agent.py backend/tests/agents/test_event_agent.py
- git diff --check

Refs #583 #670