### PR TITLE
fix: keep alpha canonical answers ahead of stale RAG cache

### DIFF
--- a/backend/agents/business_info_agent.py
+++ b/backend/agents/business_info_agent.py
@@ -124,22 +124,15 @@ class BusinessInfoAgent:
             language,
         )
 
-        # requestTypeをcategoryにマッピング
-        category = self._map_request_type_to_category(request_type)
-
-        cached = state_context if state_context else None
-        canonical_allowed = not cached or (
-            cached.get("success") and cached.get("category") == category
-        )
-        canonical = (
-            self._get_canonical_response(query, request_type, language)
-            if canonical_allowed
-            else None
-        )
+        canonical = self._get_canonical_response(query, request_type, language)
         if canonical:
             return canonical
 
+        # requestTypeをcategoryにマッピング
+        category = self._map_request_type_to_category(request_type)
+
         # Check cached RAG results
+        cached = state_context if state_context else None
         if cached and cached.get("success") and cached.get("category") == category:
             context = cached.get("context_string", "")
             logger.info("Using cached RAG results for %s", category)
@@ -855,14 +848,14 @@ Information: {context}
                     "You can also visit reception in person during opening hours."
                 ),
                 "zh": (
-                    "[relaxed]可以在13:00到21:00之间拨打080-6742-7231"
-                    "联系工程师咖啡，也可以查看官网 https://engineercafe.jp/ "
-                    "或使用联系表单。"
+                    "[relaxed]电话：080-6742-7231（13:00-21:00）。"
+                    "官网：https://engineercafe.jp/。"
+                    "联系表单：https://engineercafe.jp/ja/contact。"
                 ),
                 "ko": (
-                    "[relaxed]엔지니어 카페에는 13시부터 21시 사이에 "
-                    "080-6742-7231로 전화하실 수 있습니다. 공식 사이트 "
-                    "https://engineercafe.jp/ 와 문의 양식도 이용할 수 있어요."
+                    "[relaxed]전화는 080-6742-7231(13:00-21:00)입니다. "
+                    "공식 사이트는 https://engineercafe.jp/ 이고 "
+                    "문의 폼은 https://engineercafe.jp/ja/contact 입니다."
                 ),
             }
             return self._canonical_result(answers.get(language, answers["ja"]), request_type)

--- a/backend/tests/agents/test_business_info_agent.py
+++ b/backend/tests/agents/test_business_info_agent.py
@@ -261,6 +261,34 @@ class TestBusinessInfoAgent:
         self.agent.enhanced_rag.search.assert_not_called()
         self.agent.llm_provider.generate.assert_not_called()
 
+    @pytest.mark.asyncio
+    async def test_answer_business_query_canonical_ignores_stale_state_context(self):
+        """Known alpha-gate canonical answers must not be suppressed by stale RAG cache."""
+        self.agent.enhanced_rag.search = AsyncMock(
+            side_effect=AssertionError("reservation canonical must skip stale cache fallback")
+        )
+        self.agent.llm_provider.generate = AsyncMock(
+            side_effect=AssertionError("reservation canonical must skip LLM")
+        )
+
+        response = await self.agent.answer_business_query(
+            "Can I use Engineer Cafe without a reservation?",
+            "reception",
+            "en",
+            "q-biz-en-003",
+            state_context={
+                "success": True,
+                "category": "general",
+                "context_string": "stale general cache",
+                "results": [],
+                "query": "stale",
+            },
+        )
+
+        assert "without a reservation" in response["answer"].lower()
+        self.agent.enhanced_rag.search.assert_not_called()
+        self.agent.llm_provider.generate.assert_not_called()
+
     def test_reception_request_type_alone_does_not_force_first_visit(self):
         """reception routingだけで初回登録回答へ倒さない"""
         response = self.agent._get_canonical_response(
@@ -304,6 +332,25 @@ class TestBusinessInfoAgent:
         assert "contact form" in response["answer"].lower()
         assert "official website" in response["answer"].lower()
         assert "second-floor meeting rooms" in response["answer"].lower()
+
+    def test_contact_canonical_response_zh_ko_includes_sources_and_form(self):
+        """gt-106/116: ZH/KO contact must avoid fallback and include contact form URL."""
+        zh = self.agent._get_canonical_response("如何联系工程师咖啡？", "contact", "zh")
+        ko = self.agent._get_canonical_response(
+            "엔지니어 카페에 어떻게 연락할 수 있나요?", "contact", "ko"
+        )
+
+        assert zh is not None
+        assert "080-6742-7231" in zh["answer"]
+        assert "https://engineercafe.jp/" in zh["answer"]
+        assert "https://engineercafe.jp/ja/contact" in zh["answer"]
+        assert zh["metadata"]["sources"] == ["enhanced_rag"]
+
+        assert ko is not None
+        assert "080-6742-7231" in ko["answer"]
+        assert "https://engineercafe.jp/" in ko["answer"]
+        assert "https://engineercafe.jp/ja/contact" in ko["answer"]
+        assert ko["metadata"]["sources"] == ["enhanced_rag"]
 
     def test_closed_days_canonical_precedes_hours(self):
         """休館日は営業時間の広い回答に倒さない"""

--- a/backend/tests/workflows/test_rag_cache.py
+++ b/backend/tests/workflows/test_rag_cache.py
@@ -266,18 +266,20 @@ class TestAgentCacheUsage:
                 }
             )
 
-            # カテゴリ不一致: キャッシュはgeneral、実際はconsultation
+            # カテゴリ不一致: キャッシュはhours、実際はgeneral。
+            # Known canonical questions intentionally bypass RAG regardless of cache state,
+            # so this uses a non-canonical business query to test fallback mechanics.
             state_context = {
                 "success": True,
-                "category": "general",
-                "context_string": "一般情報",
+                "category": "hours",
+                "context_string": "営業時間データ",
                 "results": [],
                 "query": "テスト",
             }
 
             await agent.answer_business_query(
-                query="コミュニティマネージャーに相談できることは？",
-                request_type="consultation",
+                query="テスト",
+                request_type=None,
                 language="ja",
                 state_context=state_context,
             )
@@ -310,15 +312,15 @@ class TestAgentCacheUsage:
             # キャッシュが失敗状態
             state_context = {
                 "success": False,
-                "category": "consultation",
+                "category": "general",
                 "context_string": "",
                 "results": [],
                 "query": "テスト",
             }
 
             await agent.answer_business_query(
-                query="コミュニティマネージャーに相談できることは？",
-                request_type="consultation",
+                query="テスト",
+                request_type=None,
                 language="ja",
                 state_context=state_context,
             )


### PR DESCRIPTION
## Summary
- restore BusinessInfo canonical answers so alpha-gate questions are not suppressed by stale/mismatched RAG cache context
- adjust RAG cache fallback unit tests to use non-canonical business queries for fallback mechanics
- tighten ZH/KO contact canonical text so gt-106/gt-116 keep enhanced_rag sources and contact-form facts

## Why
Post-PR #753 live run https://github.com/EngineerCafeJP/engineercafe-navigator/actions/runs/25290921827 still failed because canonical answers were bypassed whenever prefetched cache category mismatched. That preserved cache tests, but weakened live alpha answers.

## Validation
- mise exec -- python -m pytest backend/tests/agents/test_business_info_agent.py backend/tests/workflows/test_rag_cache.py::TestAgentCacheUsage::test_business_agent_falls_back_on_category_mismatch backend/tests/workflows/test_rag_cache.py::TestAgentCacheUsage::test_agent_falls_back_on_cache_failure -q
- mise exec -- ruff check backend/agents/business_info_agent.py backend/tests/agents/test_business_info_agent.py backend/tests/workflows/test_rag_cache.py
- mise exec -- black --check backend/agents/business_info_agent.py backend/tests/agents/test_business_info_agent.py backend/tests/workflows/test_rag_cache.py
- git diff --check

Refs #583 #653 #672