### PR TITLE
test: align live C gate JA target

### DIFF
--- a/backend/evaluation/run_live_api_eval.py
+++ b/backend/evaluation/run_live_api_eval.py
@@ -68,7 +68,7 @@ TRACKED_METRICS = (
 )
 
 TARGETS: Dict[str, float] = {
-    "ja": 0.85,
+    "ja": 0.81,
     "en": 0.75,
     "zh": 0.65,
     "ko": 0.65,
@@ -1104,6 +1104,9 @@ def _format_report(
     case_suite: str,
 ) -> str:
     """Format a human-readable report."""
+    target_summary = ", ".join(
+        f"{lang} >= {TARGETS[lang]:.2f}" for lang in ("ja", "en", "zh", "ko")
+    )
     lines = [
         "=" * 60,
         "RAGAS Live API Evaluation Report",
@@ -1111,7 +1114,7 @@ def _format_report(
         "=" * 60,
         "",
         f"Case suite: {case_suite}",
-        "Targets: ja >= 0.85, en >= 0.75, zh >= 0.65, ko >= 0.65",
+        f"Targets: {target_summary}",
         "RAGAS contexts: golden_dataset references, not live retrieved chunks",
         f"Live source metadata gate: {'enabled' if check_live_sources else 'disabled'}",
         "",

--- a/backend/tests/evaluation/test_ragas_live_case_suites.py
+++ b/backend/tests/evaluation/test_ragas_live_case_suites.py
@@ -13,7 +13,9 @@ from backend.evaluation.run_live_api_eval import (
     CASE_SUITE_DIAGNOSTIC_29,
     EVENT_SOURCE_REQUIREMENT,
     LOCAL_KNOWLEDGE_SOURCE_REQUIREMENT,
+    TARGETS,
     _call_chat_api,
+    _format_report,
     _load_case_suite_config,
     _required_live_sources,
     _source_requirement_ok,
@@ -85,6 +87,50 @@ def test_alpha_127_coverage_requires_all_languages_and_all_cases():
     assert full["passed"] is True
     assert partial_languages["passed"] is False
     assert short_count["passed"] is False
+
+
+def test_alpha_live_gate_uses_phase1_japanese_answer_target():
+    assert TARGETS["ja"] == 0.81
+
+    report = _format_report(
+        {
+            "ja": {
+                "metrics": {"answer_correctness": 0.81},
+                "requested_case_count": 1,
+                "collected_case_count": 1,
+                "evaluated_case_count": 1,
+                "collection_error_count": 0,
+                "ragas_error_count": 0,
+            }
+        },
+        {
+            "per_language": {
+                "ja": {
+                    "answer_correctness": {"actual": 0.81, "target": 0.81},
+                    "answer_target_passed": True,
+                    "evaluation_complete": {
+                        "requested": 1,
+                        "collected": 1,
+                        "evaluated": 1,
+                        "collection_errors": 0,
+                        "ragas_errors": 0,
+                        "passed": True,
+                    },
+                    "collection_errors": 0,
+                    "ragas_errors": 0,
+                    "source_failures": 0,
+                }
+            },
+            "failed_targets": [],
+            "failed_source_cases": [],
+            "all_targets_met": True,
+        },
+        ("ja",),
+        check_live_sources=True,
+        case_suite=CASE_SUITE_ALPHA_127,
+    )
+
+    assert "Targets: ja >= 0.81, en >= 0.75, zh >= 0.65, ko >= 0.65" in report
 
 
 def test_alpha_source_requirements_allow_live_metadata_aliases():


### PR DESCRIPTION
## Summary
- align the live C/RAGAS gate Japanese answer_correctness target with the alpha Phase 1 decision (0.81)
- generate the human-readable target summary from the same TARGETS constant
- add regression coverage so the live gate/report cannot drift from the intended JA threshold again

## Verification
- mise exec -- python -m pytest backend/tests/evaluation/test_ragas_live_case_suites.py backend/tests/evaluation/test_multilingual_ragas.py -q
- mise exec -- ruff check backend/evaluation/run_live_api_eval.py backend/tests/evaluation/test_ragas_live_case_suites.py backend/tests/evaluation/test_multilingual_ragas.py
- mise exec -- black --check backend/evaluation/run_live_api_eval.py backend/tests/evaluation/test_ragas_live_case_suites.py backend/tests/evaluation/test_multilingual_ragas.py
- git diff --check

## Notes
- This fixes the gate threshold wiring only. The latest C-127 run on #758 scored JA 0.8056, so a rerun may still miss the explicit 0.81 target by a narrow margin.
