### PR TITLE
fix(audio): extend mobile audio timeouts to 15s for Android >1MB decode (#698)

### DIFF
--- a/frontend/src/lib/audio/mobile-audio-service.ts
+++ b/frontend/src/lib/audio/mobile-audio-service.ts
@@ -82,7 +82,7 @@ export function shouldResetWebAudioPlayerForDevice(): boolean {
 }
 
 export class MobileAudioService {
-  private static readonly PLAYBACK_START_TIMEOUT_MS = 8000;
+  private static readonly PLAYBACK_START_TIMEOUT_MS = 15000;
   private webAudioPlayer: WebAudioPlayer | null = null;
   private htmlAudioElement: HTMLAudioElement | null = null;
   private htmlAudioUrl: string | null = null;

--- a/frontend/src/lib/audio/web-audio-player.ts
+++ b/frontend/src/lib/audio/web-audio-player.ts
@@ -20,7 +20,7 @@ import {
 } from './audio-user-interaction-gate';
 
 export class WebAudioPlayer {
-  private static readonly DEFAULT_DECODE_TIMEOUT_MS = 8000;
+  private static readonly DEFAULT_DECODE_TIMEOUT_MS = 15000;
   private audioContext: AudioContext | null = null;
   private audioBuffer: AudioBuffer | null = null;
   private source: AudioBufferSourceNode | null = null;


### PR DESCRIPTION
## Summary

Closes #698 (alpha-scope blocker のうち実装ギャップ部分)。

Android Chrome/WebView の \`decodeAudioData()\` が >1MB 大型 audio で hang/slow-resolve する既知 corner case 対策として、2 つの timeout 定数を \`8000ms\` → \`15000ms\` に延長。

## 変更箇所

- \`frontend/src/lib/audio/web-audio-player.ts:23\` \`DEFAULT_DECODE_TIMEOUT_MS\` \`8000\` → \`15000\`
- \`frontend/src/lib/audio/mobile-audio-service.ts:76\` \`PLAYBACK_START_TIMEOUT_MS\` \`8000\` → \`15000\`

## 動機
- alpha live verification の Cloud Run logs で /api/voice 応答が \`1.45MB 最大\` の base64 audio を返却するケース頻発
- 短時間 timeout で fallback / silent fail に流れるリスク
- issue #698 修正方針「PLAYBACK_START_TIMEOUT_MS を 15000ms に延長」の最小実装

## Validation (Codex 経路C 報告)
- pnpm lint pass / pnpm typecheck pass / pnpm build pass
- 該当 unit test 8/8 pass

## Test plan
- [ ] CI green
- [ ] code-reviewer + Codex CLI 経路A
- [ ] develop merge
- [ ] Vercel Production deploy 反映確認
- [ ] Pixel 実機で >1MB audio 再生 (#585 onsite proof)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>