### PR TITLE
fix(backend): correct PostgREST filter syntax + tolerant reception UUID lookup (#662)

### DIFF
--- a/backend/api/reception.py
+++ b/backend/api/reception.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 
 import logging
 import time
+import uuid
 from collections import OrderedDict
 from datetime import datetime
 from typing import TYPE_CHECKING, Any, Literal, Optional
@@ -149,6 +150,14 @@ def _parse_datetime(value: Any) -> datetime | None:
     return None
 
 
+def _is_uuid(value: str) -> bool:
+    try:
+        uuid.UUID(value)
+    except (TypeError, ValueError):
+        return False
+    return True
+
+
 def _deserialize_session(record: dict[str, Any]) -> ReceptionSession:
     session_data = record.get("session_data") or {}
 
@@ -222,24 +231,28 @@ async def _persist_session(session: ReceptionSession, *, status: str = "active")
 async def _load_session(
     reception_session_id: str, *, allow_completed: bool = False
 ) -> Optional[ReceptionSession]:
-    try:
-        record = await _get_session_repository().get_session_record(
-            reception_session_id,
-            include_completed=allow_completed,
-        )
-    except Exception as exc:
-        logger.warning("Reception persistence read failed; using in-memory fallback: %s", exc)
-        record = None
+    record = None
+    if _is_uuid(reception_session_id):
+        try:
+            record = await _get_session_repository().get_session_record(
+                reception_session_id,
+                include_completed=allow_completed,
+            )
+        except Exception as exc:
+            logger.warning("Reception persistence read failed; using in-memory fallback: %s", exc)
+            record = None
+    else:
+        logger.debug("Skipping reception persistence UUID lookup for non-UUID reception_session_id")
 
     if record is not None:
-        session = _deserialize_session(record)
-        _store_session(session)
-        return session
+        persisted_session = _deserialize_session(record)
+        _store_session(persisted_session)
+        return persisted_session
 
-    session = _active_sessions.get(reception_session_id)
-    if session is not None:
+    cached_session = _active_sessions.get(reception_session_id)
+    if cached_session is not None:
         _active_sessions.move_to_end(reception_session_id)
-    return session
+    return cached_session
 
 
 # ---------------------------------------------------------------------------

--- a/backend/tests/api/test_reception_api.py
+++ b/backend/tests/api/test_reception_api.py
@@ -360,6 +360,35 @@ class TestReceptionStatus:
         assert data["visitor_type"] is None
         assert data["purpose"] is None
 
+    def test_status_non_uuid_reception_session_id_uses_memory_without_db(self, caplog):
+        synthetic_id = "alpha-a-20260502_020830-a-A2-EN-002"
+        fake_repo = AsyncMock()
+        fake_repo.get_session_record.side_effect = AssertionError(
+            "non-UUID reception_session_id should not query persistence"
+        )
+        reception_module._session_repository = fake_repo
+
+        session = reception_module.ReceptionSession(
+            id=synthetic_id,
+            session_id="sess-alpha",
+            stage="greeting",
+            language="en",
+            trigger_type="button_press",
+        )
+        reception_module._store_session(session)
+
+        with caplog.at_level("DEBUG", logger="backend.api.reception"):
+            response = client.get(
+                f"/api/reception/status/{synthetic_id}",
+                params={"session_id": "sess-alpha"},
+            )
+
+        assert response.status_code == 200
+        assert response.json()["stage"] == "greeting"
+        fake_repo.get_session_record.assert_not_awaited()
+        assert "invalid input syntax for type uuid" not in caplog.text
+        assert not [record for record in caplog.records if record.levelname in {"WARNING", "ERROR"}]
+
     def test_status_reflects_advanced_stage(self):
         start = _start_session(session_id="s1")
         rid = start["reception_session_id"]

--- a/backend/tests/tools/test_enhanced_rag.py
+++ b/backend/tests/tools/test_enhanced_rag.py
@@ -5,8 +5,10 @@ RAG検索のクエリ拡張、スコアリング、テキストフォールバ�
 エンベディング生成のロジックを検証する。
 """
 
-import pytest
+import inspect
 from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
 
 from backend.tools.enhanced_rag import (
     DEFAULT_EMBEDDING_DIMENSIONS,
@@ -589,6 +591,13 @@ class TestSearchIntegration:
 class TestTextFallbackSearch:
     """テキストフォールバック検索のテスト"""
 
+    def test_text_fallback_uses_valid_postgrest_null_filter_syntax(self):
+        """content_embedding null filter should use valid PostgREST syntax."""
+        source = inspect.getsource(EnhancedRAGSearch._text_fallback_search)
+
+        assert '.filter("content_embedding", "not.is", None)' not in source
+        assert '.not_.is_("content_embedding", "null")' in source
+
     @pytest.mark.asyncio
     async def test_text_fallback_with_category_match(self, rag_search, mock_supabase):
         """カテゴリ一致でテキストフォールバックが結果を返す"""
@@ -611,14 +620,14 @@ class TestTextFallbackSearch:
         mock_eq_lang.limit.return_value = mock_result
         mock_eq_cat = MagicMock()
         mock_eq_cat.eq.return_value = mock_eq_lang
-        # PR #546 (#541): _text_fallback_search now chains
-        # .filter("content_embedding", "not.is", None) after .select(...)
-        # before the category/language .eq(...) calls, so the mock chain
-        # must route through a filter node before reaching category eq.
+        # _text_fallback_search filters to rows with embeddings before
+        # category/language predicates.
         mock_filter = MagicMock()
         mock_filter.eq.return_value = mock_eq_cat
+        mock_not = MagicMock()
+        mock_not.is_.return_value = mock_filter
         mock_select = MagicMock()
-        mock_select.filter.return_value = mock_filter
+        mock_select.not_ = mock_not
         mock_select.eq.return_value = mock_eq_cat
         mock_table = MagicMock()
         mock_table.select.return_value = mock_select
@@ -634,6 +643,7 @@ class TestTextFallbackSearch:
         # カテゴリ一致＋テキストマッチがあるので結果が返る
         assert len(results) > 0
         assert results[0]["similarity"] > 0
+        mock_not.is_.assert_called_once_with("content_embedding", "null")
 
     @pytest.mark.asyncio
     async def test_text_fallback_handles_error(self, rag_search, mock_supabase):

--- a/backend/tools/enhanced_rag.py
+++ b/backend/tools/enhanced_rag.py
@@ -607,7 +607,7 @@ class EnhancedRAGSearch:
             query_builder = (
                 self.supabase.table("knowledge_base")
                 .select("id, content, category, subcategory, language, source, metadata")
-                .filter("content_embedding", "not.is", None)
+                .not_.is_("content_embedding", "null")
             )
 
             # カテゴリフィルタ（generalカテゴリ以外の場合）
@@ -630,7 +630,7 @@ class EnhancedRAGSearch:
                 result = (
                     self.supabase.table("knowledge_base")
                     .select("id, content, category, subcategory, language, source, metadata")
-                    .filter("content_embedding", "not.is", None)
+                    .not_.is_("content_embedding", "null")
                     .eq("language", "ja")
                     .limit(max_results)
                     .execute()


### PR DESCRIPTION
## Summary

Closes #662 (alpha-scope blocker、Cloud Run logs noise 解消)。

alpha live verification 中に観測された 2 件の backend warning/error を修正:

### Bug 1: Supabase PostgREST filter parse error
- ログ: \`failed to parse filter (not.is.None)\` (PGRST100)
- 場所: \`backend/tools/enhanced_rag.py\` (2 か所)
- 修正: 無効な \`not.is.None\` を有効な PostgREST 文法に置換

### Bug 2: Reception session lookup non-UUID input crash
- ログ: \`invalid input syntax for type uuid: \"alpha-a-...\"\` (22P02)
- 場所: \`backend/api/reception.py:231\` \`_load_session()\`
- 修正: 非 UUID session ID で persistence lookup を skip、debug log に降格、in-memory fallback パスへ

## 変更概要 (Codex 経路C 報告)

- enhanced_rag.py: PostgREST filter 構文修正
- reception.py:231: \`_load_session\` 非 UUID 早期 return
- backend/tests/tools/test_enhanced_rag.py:594: regression test
- backend/tests/api/test_reception_api.py:363: regression test

## Validation

- \`black --check backend/\`: pass
- \`pytest backend/tests/tools/ backend/tests/api/ -q\`: 385 passed
- \`ruff check\` on touched files: pass

## スコープ外
- enhanced_rag の他のロジック (embedding、reranker、cache 等)
- reception session schema 変更
- Migration / RLS policy
- frontend / /api/voice / LangGraph workflow

## Test plan

- [ ] CI green
- [ ] code-reviewer + Codex CLI 経路A
- [ ] develop merge
- [ ] backend-deploy-staging で Cloud Run 新 revision deploy 確認
- [ ] alpha-live-verification で当該 error が log window に出ないことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>