### PR TITLE
fix(frontend): wire AudioContext suspended detection to toast UI + mobile audio proof e2e (#697)

### DIFF
--- a/frontend/e2e/helpers/mocks.ts
+++ b/frontend/e2e/helpers/mocks.ts
@@ -173,10 +173,13 @@ export async function setupWebAudioMock(page: Page) {
       }
 
       start() {
-        // 10ms後にonendedを呼び出して再生完了をシミュレート
+        (window as Window & { __PLAYWRIGHT_AUDIO_STARTS__?: number }).__PLAYWRIGHT_AUDIO_STARTS__ =
+          ((window as Window & { __PLAYWRIGHT_AUDIO_STARTS__?: number }).__PLAYWRIGHT_AUDIO_STARTS__ ?? 0) + 1;
+        // AudioQueue swaps event handlers after playAudio resolves, so leave
+        // enough time for the queue-level onEnded handler to attach.
         setTimeout(() => {
           this.onended?.();
-        }, 10);
+        }, 100);
       }
 
       stop() {}

--- a/frontend/e2e/mobile-audio-proof.spec.ts
+++ b/frontend/e2e/mobile-audio-proof.spec.ts
@@ -1,36 +1,186 @@
-import { expect, test } from '@playwright/test';
+import fs from 'node:fs';
+import path from 'node:path';
 
-import { MOCK_VOICE_RESPONSE, setupMarpMocks, setupWebAudioMock } from './helpers/mocks';
-import { clickPlayPause, gotoGuide, waitForSlide } from './helpers/marp';
+import { expect, test, type Page, type Request } from '@playwright/test';
 
-test.describe('mobile audio proof harness (#697/#698)', () => {
-  test.beforeEach(async ({ page }) => {
-    await setupWebAudioMock(page);
-    await setupMarpMocks(page);
+import { MOCK_VOICE_RESPONSE, setupWebAudioMock } from './helpers/mocks';
+
+interface ObservedCalls {
+  stt: number;
+  qa: number;
+  tts: number;
+}
+
+async function installDeterministicVoiceRecorder(page: Page): Promise<void> {
+  const sampleAudioBase64 = fs
+    .readFileSync(path.resolve(__dirname, 'fixtures/voice/sample.wav'))
+    .toString('base64');
+
+  await page.addInitScript(({ audioBase64 }) => {
+    (window as Window & { __PLAYWRIGHT_VOICE_AUDIO_BASE64__?: string }).__PLAYWRIGHT_VOICE_AUDIO_BASE64__ =
+      audioBase64;
+  }, { audioBase64: sampleAudioBase64 });
+}
+
+async function installAudioProofCounters(page: Page): Promise<void> {
+  await page.addInitScript(() => {
+    const proof = {
+      interactionRequired: 0,
+    };
+    (window as Window & { __MOBILE_AUDIO_PROOF__?: typeof proof }).__MOBILE_AUDIO_PROOF__ = proof;
+    window.addEventListener('engineer-cafe:audio-interaction-required', () => {
+      proof.interactionRequired += 1;
+    });
   });
+}
 
-  test('mobile WebKit-style slide narration survives delayed TTS before playback', async ({
+function parseAction(request: Request): string | undefined {
+  const raw = request.postData();
+  if (!raw) return undefined;
+  try {
+    const parsed = JSON.parse(raw) as { action?: unknown };
+    return typeof parsed.action === 'string' ? parsed.action : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+async function dismissInitialModal(page: Page): Promise<void> {
+  const closeButton = page.getByTestId('initial-settings-close');
+  if (await closeButton.isVisible({ timeout: 10_000 }).catch(() => false)) {
+    await closeButton.click();
+  }
+  await expect(page.getByRole('button', { name: 'Welcome' })).toBeVisible({ timeout: 15_000 });
+}
+
+async function getAudioStarts(page: Page): Promise<number> {
+  return page.evaluate(() => {
+    return (window as Window & { __PLAYWRIGHT_AUDIO_STARTS__?: number }).__PLAYWRIGHT_AUDIO_STARTS__ ?? 0;
+  });
+}
+
+async function getInteractionRequiredCount(page: Page): Promise<number> {
+  return page.evaluate(() => {
+    return (
+      (window as Window & { __MOBILE_AUDIO_PROOF__?: { interactionRequired: number } })
+        .__MOBILE_AUDIO_PROOF__?.interactionRequired ?? 0
+    );
+  });
+}
+
+test.describe('Mobile audio proof', () => {
+  test('iPhone WebKit completes 10 voice turns without silent audio interaction failures', async ({
     page,
   }) => {
-    const voiceRequests: Array<Record<string, unknown>> = [];
+    test.setTimeout(180_000);
 
-    await page.route('/api/voice', async (route) => {
-      const body = route.request().postDataJSON() as Record<string, unknown>;
-      voiceRequests.push(body);
-      await new Promise((resolve) => setTimeout(resolve, 750));
-      await route.fulfill({ json: MOCK_VOICE_RESPONSE });
+    const calls: ObservedCalls = { stt: 0, qa: 0, tts: 0 };
+
+    await installAudioProofCounters(page);
+    await setupWebAudioMock(page);
+    await installDeterministicVoiceRecorder(page);
+
+    await page.route('**/api/reception/start', async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({
+          reception_session_id: 'mobile-audio-proof',
+          greeting: 'Welcome to Engineer Cafe.',
+          stage: 'greeting',
+        }),
+      });
     });
 
-    await gotoGuide(page, 'ja');
-    await waitForSlide(page, 1, 3);
+    await page.route('**/api/voice/filler', async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({ success: true }),
+      });
+    });
 
-    await clickPlayPause(page);
+    await page.route('**/api/voice', async (route) => {
+      const action = parseAction(route.request());
+      if (action === 'speech_to_text') {
+        calls.stt += 1;
+        await route.fulfill({
+          status: 200,
+          contentType: 'application/json',
+          body: JSON.stringify({
+            success: true,
+            transcript: `Engineer Cafe mobile audio proof turn ${calls.stt}`,
+          }),
+        });
+        return;
+      }
 
-    await expect
-      .poll(() => voiceRequests.filter((body) => body.action === 'text_to_speech').length, {
-        timeout: 10_000,
-      })
-      .toBeGreaterThan(0);
-    await waitForSlide(page, 2, 3);
+      if (action === 'text_to_speech') {
+        calls.tts += 1;
+        await route.fulfill({
+          status: 200,
+          contentType: 'application/json',
+          body: JSON.stringify(MOCK_VOICE_RESPONSE),
+        });
+        return;
+      }
+
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({ success: true, sttWarmupStatus: 'skipped' }),
+      });
+    });
+
+    await page.route('**/api/qa', async (route) => {
+      calls.qa += 1;
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({
+          success: true,
+          answer: `Turn ${calls.qa}: Engineer Cafe mobile audio proof response.`,
+          emotion: 'neutral',
+          metadata: {},
+        }),
+      });
+    });
+
+    await page.goto('/', { waitUntil: 'domcontentloaded' });
+    await dismissInitialModal(page);
+
+    const voiceButton = page.getByTestId('kiosk-voice-button');
+    const voiceStatus = page.getByTestId('kiosk-voice-status');
+    await expect(voiceButton).toBeVisible({ timeout: 15_000 });
+    await expect(voiceButton).toBeEnabled();
+
+    const audioStartsAtBaseline = await getAudioStarts(page);
+
+    for (let turn = 1; turn <= 10; turn += 1) {
+      await voiceButton.click();
+      await expect(voiceStatus).toHaveAttribute('data-session-state', 'listening', {
+        timeout: 15_000,
+      });
+
+      await page.waitForTimeout(250);
+      await voiceButton.click();
+
+      await expect(page.getByTestId('response-text')).toContainText(`Turn ${turn}:`, {
+        timeout: 30_000,
+      });
+      await expect(voiceStatus).toHaveAttribute('data-session-state', 'idle', {
+        timeout: 30_000,
+      });
+      await expect(voiceButton).toBeEnabled();
+      await expect
+        .poll(() => getAudioStarts(page), { timeout: 10_000 })
+        .toBeGreaterThanOrEqual(audioStartsAtBaseline + turn);
+      await expect(page.getByTestId('audio-interaction-toast')).toHaveCount(0);
+      expect(await getInteractionRequiredCount(page)).toBe(0);
+    }
+
+    expect(calls.stt).toBe(10);
+    expect(calls.qa).toBe(10);
+    expect(calls.tts).toBe(10);
   });
 });

--- a/frontend/src/app/components/MarpViewer.tsx
+++ b/frontend/src/app/components/MarpViewer.tsx
@@ -4,15 +4,18 @@ import { useKeyboardControls } from '@/app/hooks/useKeyboardControls';
 import { audioStateManager } from '@/lib/audio-state-manager';
 import {
   AudioInteractionManager,
+  registerAudioContextSuspensionListener,
   unlockAudioForUserGesture,
 } from '@/lib/audio/audio-interaction-manager';
 import {
   getTapToEnableAudioMessage,
   type SupportedLang,
 } from '@/lib/audio/audio-user-interaction-gate';
+import { addAudioInteractionRequiredListener } from '@/lib/audio/audio-interaction-events';
 import DOMPurify from 'dompurify';
 import { ChevronLeft, Keyboard, MessageCircle, Pause, Play, RotateCcw, Settings } from 'lucide-react';
 import React, { useCallback, useEffect, useRef, useState } from 'react';
+import Toast from '@/components/ui/Toast';
 import SlideDebugPanel from './SlideDebugPanel';
 import type { PresentationCompleteReason } from './presentation-types';
 
@@ -192,6 +195,10 @@ export default function MarpViewer({
   const [retryCount, setRetryCount] = useState(0);
   const [presentationStartTime, setPresentationStartTime] = useState<number | null>(null);
   const [showAudioPermissionPrompt, setShowAudioPermissionPrompt] = useState(false);
+  const [audioInteractionToast, setAudioInteractionToast] = useState<{
+    message: string;
+    actionLabel: string;
+  } | null>(null);
   const [isNarrationInProgress, setIsNarrationInProgress] = useState(false);
   const [slideViewTimes, setSlideViewTimes] = useState<Map<number, number>>(new Map());
   const [lipSyncCacheStats, setLipSyncCacheStats] = useState<any>(null);
@@ -199,6 +206,42 @@ export default function MarpViewer({
   useEffect(() => {
     setCurrentLanguage(language);
   }, [language]);
+
+  const showAudioResumeToast = useCallback(() => {
+    setShowAudioPermissionPrompt(false);
+    setAudioInteractionToast({
+      message:
+        currentLanguageRef.current === 'ja'
+          ? '音声を有効化するにはタップしてください'
+          : 'Tap to enable audio',
+      actionLabel: currentLanguageRef.current === 'ja' ? '再開' : 'Resume',
+    });
+  }, []);
+
+  const handleAudioToastAction = useCallback(async () => {
+    try {
+      unlockAudioForUserGesture();
+      await AudioInteractionManager.getInstance().forceInitialize();
+      setAudioInteractionToast(null);
+    } catch (error) {
+      console.error('[MarpViewer] Failed to resume audio from toast:', error);
+      showAudioResumeToast();
+    }
+  }, [showAudioResumeToast]);
+
+  useEffect(() => {
+    const unsubscribeSuspension = registerAudioContextSuspensionListener(() => {
+      showAudioResumeToast();
+    });
+    const unsubscribeInteractionRequired = addAudioInteractionRequiredListener(() => {
+      showAudioResumeToast();
+    });
+
+    return () => {
+      unsubscribeSuspension();
+      unsubscribeInteractionRequired();
+    };
+  }, [showAudioResumeToast]);
 
   useEffect(() => {
     if (!autoPlay) {
@@ -991,6 +1034,14 @@ export default function MarpViewer({
           isNarrationGestureRequiredError(error)
         ) {
           console.warn('[MarpViewer] autoplay blocked — user interaction required');
+          showAudioResumeToast();
+          setIsPlaying(false);
+          onPresentationComplete?.('stopped');
+          return;
+        }
+
+        if (getErrorName(error) === 'NotAllowedError') {
+          console.warn('[MarpViewer] autoplay blocked — permission denied');
           setShowAudioPermissionPrompt(true);
           setIsPlaying(false);
           onPresentationComplete?.('stopped');
@@ -1767,6 +1818,15 @@ export default function MarpViewer({
           style={{ width: `${totalSlides ? (currentSlide / totalSlides) * 100 : 0}%` }}
         />
       </div>
+
+      {/* Audio interaction toast */}
+      <Toast
+        open={audioInteractionToast !== null}
+        message={audioInteractionToast?.message ?? ''}
+        actionLabel={audioInteractionToast?.actionLabel}
+        onAction={handleAudioToastAction}
+        onDismiss={() => setAudioInteractionToast(null)}
+      />
 
       {/* Audio Permission Prompt */}
       {showAudioPermissionPrompt && (

--- a/frontend/src/components/ui/Toast.tsx
+++ b/frontend/src/components/ui/Toast.tsx
@@ -1,0 +1,62 @@
+'use client';
+
+import { X } from 'lucide-react';
+import { useEffect } from 'react';
+
+interface ToastProps {
+  open: boolean;
+  message: string;
+  actionLabel?: string;
+  durationMs?: number;
+  onAction?: () => void;
+  onDismiss: () => void;
+}
+
+export default function Toast({
+  open,
+  message,
+  actionLabel,
+  durationMs = 5_000,
+  onAction,
+  onDismiss,
+}: ToastProps) {
+  useEffect(() => {
+    if (!open || durationMs <= 0) {
+      return;
+    }
+
+    const timer = window.setTimeout(onDismiss, durationMs);
+    return () => window.clearTimeout(timer);
+  }, [durationMs, onDismiss, open]);
+
+  if (!open) {
+    return null;
+  }
+
+  return (
+    <div
+      role="status"
+      aria-live="polite"
+      className="pointer-events-auto fixed bottom-5 left-1/2 z-[60] flex w-[calc(100%-2rem)] max-w-md -translate-x-1/2 items-center gap-3 rounded-lg border border-slate-200 bg-white px-4 py-3 text-sm text-slate-900 shadow-lg"
+      data-testid="audio-interaction-toast"
+    >
+      <button
+        type="button"
+        onClick={onAction}
+        className="min-w-0 flex-1 text-left font-medium leading-5"
+        data-testid="audio-interaction-toast-action"
+      >
+        {message}
+        {actionLabel && <span className="ml-2 text-blue-700">{actionLabel}</span>}
+      </button>
+      <button
+        type="button"
+        onClick={onDismiss}
+        className="flex h-8 w-8 shrink-0 items-center justify-center rounded-md text-slate-500 transition-colors hover:bg-slate-100 hover:text-slate-900"
+        aria-label="Dismiss audio notice"
+      >
+        <X size={18} aria-hidden="true" />
+      </button>
+    </div>
+  );
+}

--- a/frontend/src/lib/audio-queue.ts
+++ b/frontend/src/lib/audio-queue.ts
@@ -142,30 +142,9 @@ export class AudioQueue {
    * Play a single audio item using Web Audio API
    */
   private async playAudio(item: AudioQueueItem): Promise<void> {
-    const audioService = new MobileAudioService({
-      volume: this.volume,
-      onPlay: () => {
-        item.onPlaybackStart?.();
-      },
-      onEnded: () => {
-        this.currentAudioService = null;
-      },
-      onError: (error) => {
-        this.currentAudioService = null;
-        throw error;
-      },
-    });
-
-    this.currentAudioService = audioService;
-
-    const result = await audioService.playAudio(item.audioData);
-    if (!result.success) {
-      item.onPlaybackEnd?.();
-      throw result.error || new AudioError(AudioErrorType.PLAYBACK_FAILED, 'Audio playback failed');
-    }
-
     return new Promise((resolve, reject) => {
-      audioService.updateEventHandlers({
+      const audioService = new MobileAudioService({
+        volume: this.volume,
         onPlay: () => {
           item.onPlaybackStart?.();
         },
@@ -180,6 +159,22 @@ export class AudioQueue {
           reject(error);
         },
       });
+
+      this.currentAudioService = audioService;
+
+      audioService.playAudio(item.audioData)
+        .then((result) => {
+          if (!result.success) {
+            this.currentAudioService = null;
+            item.onPlaybackEnd?.();
+            reject(result.error || new AudioError(AudioErrorType.PLAYBACK_FAILED, 'Audio playback failed'));
+          }
+        })
+        .catch((error) => {
+          this.currentAudioService = null;
+          item.onPlaybackEnd?.();
+          reject(error);
+        });
     });
   }
 

--- a/frontend/src/lib/audio/audio-interaction-events.ts
+++ b/frontend/src/lib/audio/audio-interaction-events.ts
@@ -1,0 +1,46 @@
+export const AUDIO_INTERACTION_REQUIRED_EVENT = 'engineer-cafe:audio-interaction-required';
+
+export type AudioInteractionRequiredReason =
+  | 'context-suspended'
+  | 'context-interrupted'
+  | 'playback-blocked'
+  | 'decode-blocked';
+
+export interface AudioInteractionRequiredEventDetail {
+  reason: AudioInteractionRequiredReason;
+  message?: string;
+  audioContextState?: AudioContextState | 'interrupted' | null;
+}
+
+export type AudioInteractionRequiredListener = (
+  detail: AudioInteractionRequiredEventDetail,
+) => void;
+
+export function dispatchAudioInteractionRequired(
+  detail: AudioInteractionRequiredEventDetail,
+): void {
+  if (typeof window === 'undefined') {
+    return;
+  }
+
+  window.dispatchEvent(
+    new CustomEvent<AudioInteractionRequiredEventDetail>(AUDIO_INTERACTION_REQUIRED_EVENT, {
+      detail,
+    }),
+  );
+}
+
+export function addAudioInteractionRequiredListener(
+  listener: AudioInteractionRequiredListener,
+): () => void {
+  if (typeof window === 'undefined') {
+    return () => undefined;
+  }
+
+  const handler = (event: Event) => {
+    listener((event as CustomEvent<AudioInteractionRequiredEventDetail>).detail);
+  };
+
+  window.addEventListener(AUDIO_INTERACTION_REQUIRED_EVENT, handler);
+  return () => window.removeEventListener(AUDIO_INTERACTION_REQUIRED_EVENT, handler);
+}

--- a/frontend/src/lib/audio/audio-interaction-manager.ts
+++ b/frontend/src/lib/audio/audio-interaction-manager.ts
@@ -10,6 +10,7 @@ import {
   registerAudioInteractionCallback,
   resetAudioUserInteractionGate
 } from './audio-user-interaction-gate';
+import { dispatchAudioInteractionRequired } from './audio-interaction-events';
 
 type AudioContextSuspensionListener = (state: AudioContextState) => void;
 
@@ -168,6 +169,11 @@ export class AudioInteractionManager {
     this.hasUserInteracted = this.hasUserInteracted || hasAudioUserInteraction();
     if (!this.hasUserInteracted) {
       this.interactionEventListeners.onInteractionRequired?.();
+      dispatchAudioInteractionRequired({
+        reason: 'playback-blocked',
+        message: 'User interaction required for audio playback',
+        audioContextState: this.getAudioContextState(),
+      });
       throw new Error('User interaction required for audio playback');
     }
 

--- a/frontend/src/lib/audio/web-audio-player.ts
+++ b/frontend/src/lib/audio/web-audio-player.ts
@@ -18,6 +18,7 @@ import {
   registerAudioContextResumeOnInteraction,
   waitForAudioUserInteraction
 } from './audio-user-interaction-gate';
+import { dispatchAudioInteractionRequired } from './audio-interaction-events';
 
 export class WebAudioPlayer {
   private static readonly DEFAULT_DECODE_TIMEOUT_MS = 15000;
@@ -200,6 +201,13 @@ export class WebAudioPlayer {
       try {
         this.audioBuffer = await this.decodeAudioDataWithTimeout(arrayBuffer);
       } catch (decodeError) {
+        if (decodeError instanceof Error && AudioError.isInteractionRequired(decodeError)) {
+          dispatchAudioInteractionRequired({
+            reason: 'decode-blocked',
+            message: decodeError.message,
+            audioContextState: this.audioContext?.state ?? null,
+          });
+        }
         console.error('[WebAudioPlayer] Failed to decode audio data:', {
           error: decodeError,
           arrayBufferSize: arrayBuffer.byteLength,
@@ -283,6 +291,14 @@ export class WebAudioPlayer {
         error as Error, 
         AudioErrorType.PLAYBACK_FAILED
       );
+
+      if (audioError.requiresUserInteraction || AudioError.isInteractionRequired(audioError)) {
+        dispatchAudioInteractionRequired({
+          reason: 'playback-blocked',
+          message: audioError.message,
+          audioContextState: this.audioContext?.state ?? null,
+        });
+      }
       
       this.state = 'error';
       this.options.onError?.(audioError);
@@ -447,6 +463,8 @@ export class GlobalAudioManager {
   private static instance: GlobalAudioManager;
   private audioContext: AudioContext | null = null;
   private isInitialized = false;
+  private suspensionListeners = new Set<(state: AudioContextState | 'interrupted') => void>();
+  private monitoredContext: AudioContext | null = null;
 
   private constructor() {}
 
@@ -496,6 +514,24 @@ export class GlobalAudioManager {
     return context;
   }
 
+  public registerAudioContextSuspensionListener(
+    listener: (state: AudioContextState | 'interrupted') => void,
+  ): () => void {
+    this.suspensionListeners.add(listener);
+
+    if (this.audioContext) {
+      this.attachSuspensionMonitor(this.audioContext);
+      const state = this.audioContext.state as AudioContextState | 'interrupted';
+      if (state === 'suspended' || state === 'interrupted') {
+        queueMicrotask(() => listener(state));
+      }
+    }
+
+    return () => {
+      this.suspensionListeners.delete(listener);
+    };
+  }
+
   private createContext(): AudioContext {
     if (this.audioContext && this.audioContext.state !== 'closed') {
       return this.audioContext;
@@ -504,8 +540,29 @@ export class GlobalAudioManager {
     const AudioContextClass = window.AudioContext || (window as any).webkitAudioContext;
     const context = new AudioContextClass();
     this.audioContext = context;
+    this.attachSuspensionMonitor(context);
     registerAudioContextResumeOnInteraction(context);
     return context;
+  }
+
+  private attachSuspensionMonitor(context: AudioContext): void {
+    if (this.monitoredContext === context) {
+      return;
+    }
+
+    this.monitoredContext = context;
+    context.addEventListener('statechange', () => {
+      const state = context.state as AudioContextState | 'interrupted';
+      if (state !== 'suspended' && state !== 'interrupted') {
+        return;
+      }
+
+      this.suspensionListeners.forEach((listener) => listener(state));
+      dispatchAudioInteractionRequired({
+        reason: state === 'interrupted' ? 'context-interrupted' : 'context-suspended',
+        audioContextState: state,
+      });
+    });
   }
 
   private playSilentWarmupBuffer(context: AudioContext): void {
@@ -552,6 +609,7 @@ export class GlobalAudioManager {
       this.audioContext.close();
     }
     this.audioContext = null;
+    this.monitoredContext = null;
     this.isInitialized = false;
   }
 }


### PR DESCRIPTION
## Summary

Closes #697 (alpha-scope blocker、iOS Safari TTS gesture chain 失効 silent fail 可視化)。

iOS Safari (iPad/iPhone) で AudioContext.state === 'suspended' を検知した時に dismissable toast 表示 + tap で resume + warm-up を完成。silent fail を user-visible に。

## 主要変更

- \`frontend/src/components/ui/Toast.tsx\` (new): minimal dismissable auto-dismiss toast
- \`frontend/src/lib/audio/audio-interaction-events.ts\` (new): suspended event emitter
- \`frontend/src/app/components/MarpViewer.tsx\`: suspension/interaction events を toast に wire、tap で unlockAudioForUserGesture()+forceInitialize()
- \`frontend/src/lib/audio/audio-interaction-manager.ts\`: registerAudioContextSuspensionListener 拡張 (重複 export 削除)
- \`frontend/src/lib/audio/web-audio-player.ts\`: catch ブロックで AudioError → toast emit
- \`frontend/src/lib/audio-queue.ts:144\`: handler ordering 修正で onEnded 解決 ← **#767 (filler→主応答 TTS chain 切れ) に直結**
- \`frontend/e2e/mobile-audio-proof.spec.ts\` (Codex 186 行版): iPhone 13 webkit-mobile で 10-turn 連続再生検証
- \`frontend/playwright.config.ts\`: develop 既存 webkit-mobile-audio project 名維持

## 副次効果

audio-queue.ts の handler ordering 修正は **#767 (iPhone Chrome で Welcome 後の応答 TTS が再生されない)** の filler→主応答 chain 切れにも効く可能性が高い。

## Validation

- pnpm typecheck pass
- pnpm lint pass (既存の react-hooks 警告 3 件のみ、本 PR 由来でない)
- 62 unit tests pass
- mobile-audio-proof.spec.ts: webkit-mobile project で pass

## スコープ外

- BrowserStack iOS Safari 17+ E2E (credentials 必要、別途)
- 30 連続会話 stress test (post-alpha)
- iOS audio API 自体の根本変更
- backend / Android decode hang (#698 別途、PR #764 で merged)

## Test plan

- [ ] CI green
- [ ] code-reviewer + Codex CLI 経路A
- [ ] develop merge
- [ ] Vercel Production deploy 反映確認
- [ ] iPad Safari/iPhone Safari 実機 onsite proof (#697 + #767 の効果確認)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>