### PR TITLE
fix(frontend): suppress iOS text selection on push-to-talk button (#768)

### DIFF
--- a/frontend/src/app/components/KioskBottomBar.tsx
+++ b/frontend/src/app/components/KioskBottomBar.tsx
@@ -129,6 +129,11 @@ export function KioskBottomBar({
             <button
               data-testid="kiosk-voice-button"
               type="button"
+              onTouchStart={(event) => {
+                if (isPushToTalk) {
+                  event.preventDefault();
+                }
+              }}
               onPointerDown={(event) => {
                 if (!isPushToTalk) {
                   return;
@@ -176,14 +181,17 @@ export function KioskBottomBar({
                 void handleKioskVoiceStart();
               }}
               className={cn(
-                'flex min-h-[72px] min-w-[min(100%,7rem)] flex-1 flex-col items-center justify-center gap-1 rounded-2xl px-3 py-3 shadow-md backdrop-blur-sm transition-transform sm:min-h-[80px] sm:flex-initial sm:px-5',
+                'flex min-h-[72px] min-w-[min(100%,7rem)] flex-1 flex-col items-center justify-center gap-1 rounded-2xl px-3 py-3 shadow-md backdrop-blur-sm transition-transform sm:min-h-[80px] sm:flex-initial sm:px-5 select-none touch-manipulation [-webkit-touch-callout:none]',
                 isVoiceCaptureActive
                   ? 'border border-emerald-300/70 bg-emerald-500/55 text-white shadow-lg'
                   : 'border border-white/35 bg-white/15 text-white hover:scale-[1.02]',
               )}
             >
-              <Mic className="size-6 shrink-0 sm:size-7" aria-hidden />
-              <span className="text-center text-xs font-semibold leading-tight sm:text-sm">
+              <Mic
+                className="pointer-events-none select-none touch-manipulation [-webkit-touch-callout:none] size-6 shrink-0 sm:size-7"
+                aria-hidden
+              />
+              <span className="pointer-events-none select-none touch-manipulation [-webkit-touch-callout:none] text-center text-xs font-semibold leading-tight sm:text-sm">
                 {voiceButtonLabel}
               </span>
             </button>


### PR DESCRIPTION
## Summary

Closes #768 (alpha-scope blocker、iOS で push-to-talk 押下中の text selection 発火問題)。

Kiosk のプッシュトークボタンで iOS Safari/Chrome の text selection / long-press menu を抑止。

## 主要変更

\`frontend/src/app/components/KioskBottomBar.tsx\` (1 file, +11/-3):
- Push-to-talk button および icon/label に \`select-none touch-manipulation [-webkit-touch-callout:none]\` 適用
- Push-to-talk 時のみ \`onTouchStart\` で \`event.preventDefault()\`
- icon/label inner span に \`pointer-events-none\` (タッチは button のみが受ける)

## Validation

- pnpm lint / typecheck / build pass (既存 MarpViewer hooks 警告のみ)
- Playwright voice-permission-denial.spec.ts (webkit-permissions): 4 passed

## Test plan

- [ ] CI green
- [ ] code-reviewer + Codex CLI 経路A
- [ ] develop merge
- [ ] iPhone Safari/Chrome 実機: push-to-talk 長押しで text selection / context menu が出ないこと
- [ ] 録音開始/終了が従来通り動作すること

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>