### PR TITLE
fix(frontend): iOS-specific error message for microphone NotFoundError (#766)

### DIFF
--- a/frontend/src/__tests__/error-messages.test.ts
+++ b/frontend/src/__tests__/error-messages.test.ts
@@ -47,3 +47,78 @@ test("formatError maps backend timeout to a voice warmup message", () => {
     /warming up/,
   );
 });
+
+test("formatError uses MIC_NOT_FOUND_IOS copy on iOS for NotFoundError", () => {
+  const prev = globalThis.navigator;
+  Object.defineProperty(globalThis, "navigator", {
+    value: {
+      userAgent:
+        "Mozilla/5.0 (iPhone; CPU iPhone OS 17_0 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.0 Mobile/15E148 Safari/604.1",
+      maxTouchPoints: 5,
+    },
+    configurable: true,
+  });
+  try {
+    assert.match(
+      formatError(Object.assign(new Error("missing"), { name: "NotFoundError" }), "ja"),
+      /画面録画/,
+    );
+    assert.match(
+      formatError(Object.assign(new Error("missing"), { name: "NotFoundError" }), "en"),
+      /Settings → Safari/,
+    );
+  } finally {
+    if (prev === undefined) {
+      Reflect.deleteProperty(globalThis, "navigator");
+    } else {
+      Object.defineProperty(globalThis, "navigator", {
+        value: prev,
+        configurable: true,
+        writable: true,
+      });
+    }
+  }
+});
+
+test("formatError keeps MIC_NOT_FOUND on Android and desktop for NotFoundError", () => {
+  const prev = globalThis.navigator;
+  const cases = [
+    {
+      userAgent:
+        "Mozilla/5.0 (Linux; Android 13; Pixel 7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Mobile Safari/537.36",
+      maxTouchPoints: 5,
+    },
+    {
+      userAgent:
+        "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36",
+      maxTouchPoints: 0,
+    },
+  ];
+  for (const nav of cases) {
+    Object.defineProperty(globalThis, "navigator", {
+      value: nav,
+      configurable: true,
+    });
+    try {
+      assert.match(
+        formatError(Object.assign(new Error("missing"), { name: "NotFoundError" }), "ja"),
+        /ケーブル/,
+      );
+      assert.match(
+        formatError(Object.assign(new Error("missing"), { name: "NotFoundError" }), "en"),
+        /Bluetooth/,
+      );
+    } finally {
+      if (prev === undefined) {
+        Reflect.deleteProperty(globalThis, "navigator");
+      } else {
+        Object.defineProperty(globalThis, "navigator", {
+          value: prev,
+          configurable: true,
+          writable: true,
+        });
+      }
+    }
+  }
+});
+

--- a/frontend/src/lib/error-messages.ts
+++ b/frontend/src/lib/error-messages.ts
@@ -25,6 +25,12 @@ export const ERROR_MESSAGES: Record<string, ErrorMessage> = {
     en:
       'No microphone was found. Check your cable or Bluetooth connection, make sure no other app is using the mic, then try again.',
   },
+  MIC_NOT_FOUND_IOS: {
+    ja:
+      '画面録画中、別アプリで通話中、または Safari の Web サイト設定でマイクが拒否されている可能性があります。画面録画を停止し、設定 → Safari → Web サイト → マイクで「許可」になっているか確認してから、もう一度お試しください。',
+    en:
+      'iPhone may be screen recording, another app is using the microphone, or Safari has blocked microphone access. Stop screen recording and check Settings → Safari → Websites → Microphone, then try again.',
+  },
   MIC_INVALID_STATE: {
     ja:
       'マイクの状態が不正です（録音パイプラインの競合など）。タブを開き直すかページを再読み込みしてから、もう一度マイクボタンを押してください。',
@@ -145,6 +151,19 @@ export const ERROR_MESSAGES: Record<string, ErrorMessage> = {
   },
 };
 
+/** True when running on iPhone/iPad/iPod Safari or iPad-as-desktop (Mac UA + touch). */
+export function isIOSUserAgent(): boolean {
+  if (typeof navigator === 'undefined') {
+    return false;
+  }
+  const ua =
+    typeof navigator.userAgent === 'string' ? navigator.userAgent : '';
+  return (
+    /iPad|iPhone|iPod/.test(ua) ||
+    (ua.includes('Mac') && navigator.maxTouchPoints > 1)
+  );
+}
+
 /**
  * Get error message in specified language
  */
@@ -177,7 +196,10 @@ export function formatError(
       case 'notfounderror':
       case 'devicesnotfounderror':
       case 'overconstrainederror':
-        return getErrorMessage('MIC_NOT_FOUND', language);
+        return getErrorMessage(
+          isIOSUserAgent() ? 'MIC_NOT_FOUND_IOS' : 'MIC_NOT_FOUND',
+          language,
+        );
       case 'notreadableerror':
       case 'trackstarterror':
         return getErrorMessage('MICROPHONE_IN_USE', language);


### PR DESCRIPTION
## Summary

Closes #766 (alpha-scope blocker、iPhone Safari の「マイクが見つかりません」誤誘導エラー)。

iPhone Safari/Chrome で getUserMedia NotFoundError 発生時に、現状の「ケーブルや Bluetooth の接続を確認」(物理デバイス前提) を **iOS 専用文言**に分岐。画面録画 / 別アプリ占有 / Safari 設定での mic 拒否を案内。

## 主要変更

\`frontend/src/lib/error-messages.ts\` および \`frontend/src/__tests__/error-messages.test.ts\` (2 files, +98/-1):
- \`MIC_NOT_FOUND_IOS\` (ja/en) 新規追加: 画面録画停止 + Safari Web サイト設定で mic 許可を案内
- \`isIOSUserAgent()\` helper 追加 (navigator 未定義 / userAgent 非文字列に安全)
- \`formatError()\` の \`notfounderror\` / \`devicesnotfounderror\` / \`overconstrainederror\` 分岐で iOS UA なら \`MIC_NOT_FOUND_IOS\`、それ以外は従来 \`MIC_NOT_FOUND\` を返す
- 既存 \`MIC_NOT_FOUND\` (desktop / Android 用) は文言維持

unit test 追加:
- iPhone UA mock で MIC_NOT_FOUND_IOS が返る test
- Android / Windows Chrome UA で MIC_NOT_FOUND が返る test

## Validation

- pnpm lint / typecheck / build pass
- error-messages.test.ts: 5/5 pass

## Test plan

- [ ] CI green
- [ ] code-reviewer + Codex CLI 経路A
- [ ] develop merge
- [ ] iPhone Safari 実機: 画面録画中に push-to-talk → iOS 専用文言が表示
- [ ] Android / desktop で従来文言が regression なし

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>