### PR TITLE
Fix reception QA bypass and slide narration fallback

### DIFF
--- a/backend/agents/stt_agent.py
+++ b/backend/agents/stt_agent.py
@@ -270,6 +270,10 @@ class HedgedFallback(Exception):
     """Qwen exceeded the latency budget, so Vosk was allowed to race it."""
 
 
+class RejectedVoskFallback(Exception):
+    """Vosk fallback produced a transcript too risky to treat as user intent."""
+
+
 def _parse_qwen_stt_hedge_delay(
     raw_value: Optional[str],
     *,
@@ -502,6 +506,39 @@ def _vosk_transcript_trusted_for_early_return(transcript: str, language: Optiona
     return ("営業" in normalized and "時間" in normalized) or (
         "開館" in normalized and "時間" in normalized
     )
+
+
+def _vosk_fallback_transcript_suspicious(
+    transcript: str,
+    language: Optional[str],
+    confidence: Optional[float],
+) -> bool:
+    """Identify low-confidence segmented Vosk text that should not drive chat intent."""
+
+    normalized_transcript = _normalize_vosk_route_transcript(transcript, language)
+    compact = "".join(normalized_transcript.split())
+    if not compact:
+        return True
+
+    if _vosk_transcript_trusted_for_early_return(normalized_transcript, language):
+        return False
+
+    if confidence is None or confidence >= 0.75:
+        return False
+
+    tokens = [token for token in normalized_transcript.split() if token]
+    if len(tokens) < 6:
+        return len(compact) <= 3
+
+    single_char_tokens = [token for token in tokens if len(token) == 1]
+    single_char_ratio = len(single_char_tokens) / len(tokens)
+    if single_char_ratio >= 0.45:
+        return True
+
+    ja_particles = {"が", "を", "に", "へ", "で", "と", "の", "は", "も", "や"}
+    particle_ratio = sum(1 for token in tokens if token in ja_particles) / len(tokens)
+    content_tokens = [token for token in tokens if token not in ja_particles and len(token) > 1]
+    return particle_ratio >= 0.30 and len(content_tokens) <= 3
 
 
 def _env_flag(name: str, default: bool = False) -> bool:
@@ -1894,8 +1931,30 @@ class STTAgent:
                 except Exception as exc:
                     vosk_result = exc
 
+            if isinstance(
+                vosk_result, TranscriptionResult
+            ) and _vosk_fallback_transcript_suspicious(
+                vosk_result.text,
+                vosk_result.language,
+                vosk_result.confidence,
+            ):
+                log_stt_event(
+                    event="stt_vosk_rejected",
+                    stt_trace_id=stt_trace_id,
+                    provider="vosk-fallback",
+                    language=vosk_result.language,
+                    success=False,
+                    transcript_chars=len(vosk_result.text),
+                    confidence=vosk_result.confidence,
+                    stt_overall_duration_ms=_duration_ms(overall_started_at),
+                    qwen_error_type=type(qwen_error_for_log).__name__,
+                    rejection_reason="low_confidence_fragmented_transcript",
+                )
+                vosk_result = RejectedVoskFallback("Rejected suspicious Vosk fallback transcript")
+
             if (
                 isinstance(vosk_result, Exception)
+                and not isinstance(vosk_result, RejectedVoskFallback)
                 and self._qwen_hedge_delay is not None
                 and not qwen_task.done()
             ):

--- a/backend/main.py
+++ b/backend/main.py
@@ -6,6 +6,7 @@ FastAPIアプリケーションとLangGraphエージェントの統合
 import hmac
 import asyncio
 import base64
+import binascii
 import json
 import logging
 import os
@@ -63,6 +64,8 @@ def _float_env(name: str, default: float) -> float:
 
 
 _REQUEST_TIMING_LOG_THRESHOLD_MS = _float_env("REQUEST_TIMING_LOG_THRESHOLD_MS", 10000)
+MIN_STT_AUDIO_BYTES = int(_float_env("STT_MIN_AUDIO_BYTES", 512))
+_SUPPORTED_RESPONSE_LANGUAGES = frozenset({"ja", "en", "zh", "ko"})
 
 
 class RequestIDMiddleware(BaseHTTPMiddleware):
@@ -588,6 +591,65 @@ def _upstream_status(phase: str, ok: bool = True, **extra: Any) -> Dict[str, Any
     return {"phase": phase, "ok": ok, **extra}
 
 
+def _normalize_response_language(value: Any, fallback: str = "ja") -> str:
+    if isinstance(value, str) and value.strip():
+        normalized = value.strip().lower().split("-", 1)[0]
+        if normalized in _SUPPORTED_RESPONSE_LANGUAGES:
+            return normalized
+    return fallback if fallback in _SUPPORTED_RESPONSE_LANGUAGES else "ja"
+
+
+def _resolve_chat_response_language(
+    *,
+    query: str,
+    requested_language: Optional[str],
+    result: Dict[str, Any],
+    metadata: Dict[str, Any],
+) -> str:
+    fallback = _normalize_response_language(requested_language)
+    for key in ("response_language", "language", "detected_language"):
+        if key in metadata:
+            return _normalize_response_language(metadata.get(key), fallback)
+    for key in ("response_language", "language", "detected_language"):
+        if key in result:
+            return _normalize_response_language(result.get(key), fallback)
+
+    try:
+        from backend.utils.language_processor import LanguageProcessor
+
+        language_processor = LanguageProcessor()
+        language_result = language_processor.detect_language(query)
+        detected = language_processor.determine_response_language(language_result)
+        return _normalize_response_language(detected, fallback)
+    except Exception as exc:
+        logger.debug("Response language detection skipped: %s", exc)
+        return fallback
+
+
+def _stt_failure_response(
+    *,
+    body: "VoiceRequest",
+    request_id: str,
+    error: str,
+    provider: Optional[str] = None,
+    error_type: Optional[str] = None,
+) -> "VoiceResponse":
+    return VoiceResponse(
+        success=False,
+        error=error,
+        sessionId=body.sessionId,
+        requestId=request_id,
+        phase="speech_to_text",
+        upstreamStatus=_upstream_status(
+            "stt",
+            ok=False,
+            provider=provider,
+            error=error,
+            errorType=error_type,
+        ),
+    )
+
+
 @app.get("/health")
 @_rate_limit("60/minute")
 async def health_check(request: Request):
@@ -716,10 +778,19 @@ async def chat(request: Request, body: ChatRequest):
 
         metadata = result.get("metadata", {"query": body.query, "session_id": session_id})
         metadata_dict = metadata if isinstance(metadata, dict) else {}
+        response_language = _resolve_chat_response_language(
+            query=body.query,
+            requested_language=body.language,
+            result=result,
+            metadata=metadata_dict,
+        )
+        if isinstance(metadata, dict):
+            metadata.setdefault("response_language", response_language)
+            metadata.setdefault("language", response_language)
         latency_ms = int((time.perf_counter() - started_at) * 1000)
         log_chat_response(
             request_id=request_id,
-            language=body.language,
+            language=response_language,
             metadata=metadata_dict,
             latency_ms=latency_ms,
         )
@@ -1068,27 +1139,46 @@ async def _handle_stt(body: VoiceRequest, request_id: str) -> VoiceResponse:
     if not body.audioData:
         raise HTTPException(status_code=400, detail="Missing audioData")
 
-    audio_bytes = base64.b64decode(body.audioData)
+    try:
+        audio_bytes = base64.b64decode(body.audioData, validate=True)
+    except (binascii.Error, ValueError):
+        raise HTTPException(status_code=400, detail="Invalid audioData")
 
-    stt_result = await _get_stt_agent().speech_to_text(
-        audio_bytes,
-        language=body.language,
-        conversation_stage=body.conversationStage,
-    )
+    if len(audio_bytes) < MIN_STT_AUDIO_BYTES:
+        logger.info(
+            "STT skipped: audio too short request_id=%s bytes=%s min=%s",
+            request_id,
+            len(audio_bytes),
+            MIN_STT_AUDIO_BYTES,
+        )
+        return _stt_failure_response(
+            body=body,
+            request_id=request_id,
+            error="No speech detected",
+            error_type="AudioTooShort",
+        )
+
+    try:
+        stt_result = await _get_stt_agent().speech_to_text(
+            audio_bytes,
+            language=body.language,
+            conversation_stage=body.conversationStage,
+        )
+    except RuntimeError as exc:
+        logger.warning("STT runtime failure: %s", exc)
+        return _stt_failure_response(
+            body=body,
+            request_id=request_id,
+            error="No speech detected",
+            error_type=type(exc).__name__,
+        )
 
     if not stt_result["success"]:
-        return VoiceResponse(
-            success=False,
+        return _stt_failure_response(
+            body=body,
+            request_id=request_id,
             error=stt_result.get("error", "STT failed"),
-            sessionId=body.sessionId,
-            requestId=request_id,
-            phase="speech_to_text",
-            upstreamStatus=_upstream_status(
-                "stt",
-                ok=False,
-                provider=stt_result.get("provider"),
-                error=stt_result.get("error", "STT failed"),
-            ),
+            provider=stt_result.get("provider"),
         )
 
     return VoiceResponse(

--- a/backend/tests/agents/test_stt_agent.py
+++ b/backend/tests/agents/test_stt_agent.py
@@ -24,6 +24,7 @@ from backend.agents.stt_agent import (
     STAGE_GRAMMARS,
     VALID_STAGES,
     _normalize_vosk_route_transcript,
+    _vosk_fallback_transcript_suspicious,
     _vosk_transcript_trusted_for_early_return,
 )
 
@@ -1109,6 +1110,24 @@ class TestSTTAgent:
         assert not _vosk_transcript_trusted_for_early_return(
             "今の時間を教えてください",
             "ja",
+        )
+
+    def test_vosk_fallback_rejects_low_confidence_fragmented_transcript(self):
+        """Live-log garbage Vosk output should not be accepted as user intent."""
+        assert _vosk_fallback_transcript_suspicious(
+            "本番 り こ 黒板 を し です 今晩 は で",
+            "ja",
+            0.6994,
+        )
+        assert not _vosk_fallback_transcript_suspicious(
+            "エンジニア カフェ の 営業 時間 教え て ください",
+            "ja",
+            0.70,
+        )
+        assert not _vosk_fallback_transcript_suspicious(
+            "fallback ok",
+            "en",
+            0.80,
         )
 
     def test_vosk_route_transcript_normalizes_hours_confusion(self):
@@ -2641,6 +2660,48 @@ class TestQwenPrimaryFallback:
             if record.name == "backend.observability.stt"
         ]
         assert "stt_qwen_hedge_grace_complete" in events
+
+    @pytest.mark.asyncio
+    async def test_low_confidence_fragmented_vosk_fallback_is_rejected(self, caplog):
+        """Suspicious Vosk fallback raises instead of becoming a chat transcript."""
+        caplog.set_level(logging.INFO, logger="backend.observability.stt")
+
+        async def too_late_qwen(*args, **kwargs):
+            await asyncio.sleep(0.30)
+            return TranscriptionResult(text="too late", confidence=0.9, language="ja")
+
+        async def fragmented_vosk(*args, **kwargs):
+            await asyncio.sleep(0.01)
+            return TranscriptionResult(
+                text="本番 り こ 黒板 を し です 今晩 は で",
+                confidence=0.6994,
+                language="ja",
+            )
+
+        mock_qwen = MagicMock()
+        mock_qwen.transcribe = too_late_qwen
+        mock_vosk = MagicMock(spec=LocalSTTClient)
+        mock_vosk.transcribe = AsyncMock(side_effect=fragmented_vosk)
+
+        agent = self._make_agent(mock_qwen, mock_vosk)
+        agent._qwen_timeout = 10.0
+        agent._qwen_hedge_delay = 0.01
+        agent._qwen_hedge_grace = 0.02
+
+        with pytest.raises(RuntimeError, match="Both Qwen and Vosk STT failed"):
+            await agent.speech_to_text(b"audio", language="ja")
+
+        events = [
+            getattr(record, "event", None)
+            for record in caplog.records
+            if record.name == "backend.observability.stt"
+        ]
+        assert "stt_vosk_rejected" in events
+        winner = next(
+            record for record in caplog.records if getattr(record, "event", None) == "stt_winner"
+        )
+        assert winner.stt_winner == "none"
+        assert winner.vosk_error_type == "RejectedVoskFallback"
 
     @pytest.mark.asyncio
     async def test_qwen_grace_skips_when_latency_budget_is_exhausted(self, caplog):

--- a/backend/tests/api/test_chat_api.py
+++ b/backend/tests/api/test_chat_api.py
@@ -63,3 +63,49 @@ async def test_chat_emits_structured_observability_log(caplog, monkeypatch):
     assert record.ltm_store_write == "success"
     assert isinstance(record.latency_ms, int)
     assert record.latency_ms >= 0
+
+
+async def test_chat_uses_response_language_for_metadata_and_logs(caplog, monkeypatch):
+    monkeypatch.setattr(main_mod, "_API_SECRET_KEY", None)
+    caplog.set_level(logging.INFO, logger="backend.observability.chat_response")
+
+    mock_result = {
+        "answer": "Engineer Cafe is a public engineer support facility in Fukuoka.",
+        "emotion": "neutral",
+        "language": "en",
+        "metadata": {
+            "category": "business_info",
+            "sources": ["enhanced_rag"],
+        },
+    }
+
+    with patch.object(
+        main_mod,
+        "_run_workflow_with_tracking",
+        new_callable=AsyncMock,
+        return_value=mock_result,
+    ):
+        transport = httpx.ASGITransport(app=app)
+        async with httpx.AsyncClient(transport=transport, base_url="http://test") as client:
+            response = await client.post(
+                "/api/chat",
+                headers={"X-Request-ID": "req-lang-780"},
+                json={
+                    "query": "tell me about engineer cafe",
+                    "session_id": "s1",
+                    "language": "ja",
+                },
+            )
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["metadata"]["language"] == "en"
+    assert body["metadata"]["response_language"] == "en"
+
+    record = next(
+        record
+        for record in caplog.records
+        if record.name == "backend.observability.chat_response"
+        and getattr(record, "request_id", None) == "req-lang-780"
+    )
+    assert record.language == "en"

--- a/backend/tests/api/test_voice_api.py
+++ b/backend/tests/api/test_voice_api.py
@@ -54,6 +54,7 @@ class VoiceResponse(BaseModel):
 mock_voice_agent = MagicMock()
 mock_stt_agent = MagicMock()
 mock_session_task_manager = MagicMock()
+MIN_STT_AUDIO_BYTES = 512
 
 _test_app = FastAPI()
 
@@ -64,12 +65,25 @@ async def _handle_stt_test(request: VoiceRequest) -> VoiceResponse:
         raise HTTPException(status_code=400, detail="Missing audioData")
 
     audio_bytes = base64.b64decode(request.audioData)
+    if len(audio_bytes) < MIN_STT_AUDIO_BYTES:
+        return VoiceResponse(
+            success=False,
+            error="No speech detected",
+            sessionId=request.sessionId,
+        )
 
-    stt_result = await mock_stt_agent.speech_to_text(
-        audio_bytes,
-        language=request.language,
-        conversation_stage=request.conversationStage,
-    )
+    try:
+        stt_result = await mock_stt_agent.speech_to_text(
+            audio_bytes,
+            language=request.language,
+            conversation_stage=request.conversationStage,
+        )
+    except RuntimeError:
+        return VoiceResponse(
+            success=False,
+            error="No speech detected",
+            sessionId=request.sessionId,
+        )
 
     if not stt_result["success"]:
         return VoiceResponse(
@@ -174,8 +188,8 @@ SAMPLE_SESSION_ID = "test-session-001"
 
 
 def _fake_wav_b64() -> str:
-    """最小限のダミー WAV の base64 文字列"""
-    return base64.b64encode(b"\x00" * 100).decode()
+    """STT minimum-size guardを越えるダミー WAV の base64 文字列"""
+    return base64.b64encode(b"\x00" * 1024).decode()
 
 
 @pytest.fixture(autouse=True)
@@ -537,8 +551,8 @@ class TestSpeechToText:
         assert body["success"] is False
         assert body["error"] is not None
 
-    def test_stt_exception_returns_500(self):
-        """STT が例外を投げた場合は 500 エラー"""
+    def test_stt_exception_returns_controlled_failure(self):
+        """STT が例外を投げた場合も 500 にせず success=False を返す"""
         mock_stt_agent.speech_to_text = AsyncMock(side_effect=RuntimeError("STT crashed"))
 
         resp = client.post(
@@ -550,7 +564,29 @@ class TestSpeechToText:
             },
         )
 
-        assert resp.status_code == 500
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["success"] is False
+        assert body["error"] == "No speech detected"
+
+    def test_stt_short_audio_returns_controlled_failure(self):
+        """短すぎる音声はSTT実行前に no-speech として返す"""
+        mock_stt_agent.speech_to_text = AsyncMock()
+
+        resp = client.post(
+            "/api/voice",
+            json={
+                "action": "speech_to_text",
+                "audioData": base64.b64encode(b"\0" * 448).decode(),
+                "sessionId": SAMPLE_SESSION_ID,
+            },
+        )
+
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["success"] is False
+        assert body["error"] == "No speech detected"
+        mock_stt_agent.speech_to_text.assert_not_called()
 
 
 # =============================================================================

--- a/backend/tests/integration/test_voice_api_chain.py
+++ b/backend/tests/integration/test_voice_api_chain.py
@@ -18,9 +18,9 @@ from backend.main import app
 
 
 def _minimal_wav_b64() -> str:
-    """Return a minimal valid WAV file encoded as base64."""
+    """Return a small valid WAV file above the STT no-speech byte guard."""
     sample_rate = 16000
-    num_samples = 1
+    num_samples = 256
     bits_per_sample = 16
     num_channels = 1
     byte_rate = sample_rate * num_channels * bits_per_sample // 8
@@ -42,7 +42,7 @@ def _minimal_wav_b64() -> str:
         b"data",
         data_size,
     )
-    return base64.b64encode(header + b"\x00\x00").decode()
+    return base64.b64encode(header + (b"\x00" * data_size)).decode()
 
 
 def _mock_stt_success(

--- a/backend/tests/test_main_endpoints.py
+++ b/backend/tests/test_main_endpoints.py
@@ -1,5 +1,6 @@
 """Tests for backend/main.py endpoint fixes (Sprint 5)"""
 
+import base64
 import logging
 
 import pytest
@@ -460,7 +461,8 @@ class TestVoiceEndpoint:
         with patch("backend.main._get_stt_agent", return_value=mock_stt):
             from backend.main import voice_api, VoiceRequest
 
-            body = VoiceRequest(action="speech_to_text", audioData="ZHVtbXk=", sessionId="s1")
+            audio = base64.b64encode(b"\0" * 1024).decode("ascii")
+            body = VoiceRequest(action="speech_to_text", audioData=audio, sessionId="s1")
             response = await voice_api(_mock_request(), body)
 
         assert response.success is True
@@ -470,6 +472,42 @@ class TestVoiceEndpoint:
         assert response.requestId
         assert response.phase == "speech_to_text"
         assert response.upstreamStatus["phase"] == "stt"
+
+    @pytest.mark.asyncio
+    async def test_voice_stt_short_audio_returns_controlled_failure(self):
+        mock_stt = AsyncMock()
+        mock_stt.speech_to_text = AsyncMock()
+
+        with patch("backend.main._get_stt_agent", return_value=mock_stt):
+            from backend.main import VoiceRequest, voice_api
+
+            audio = base64.b64encode(b"\0" * 448).decode("ascii")
+            body = VoiceRequest(action="speech_to_text", audioData=audio, sessionId="s1")
+            response = await voice_api(_mock_request(), body)
+
+        assert response.success is False
+        assert response.error == "No speech detected"
+        assert response.phase == "speech_to_text"
+        assert response.upstreamStatus["ok"] is False
+        assert response.upstreamStatus["errorType"] == "AudioTooShort"
+        mock_stt.speech_to_text.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_voice_stt_runtime_error_returns_controlled_failure(self):
+        mock_stt = AsyncMock()
+        mock_stt.speech_to_text = AsyncMock(side_effect=RuntimeError("Both STT failed"))
+
+        with patch("backend.main._get_stt_agent", return_value=mock_stt):
+            from backend.main import VoiceRequest, voice_api
+
+            audio = base64.b64encode(b"\0" * 1024).decode("ascii")
+            body = VoiceRequest(action="speech_to_text", audioData=audio, sessionId="s1")
+            response = await voice_api(_mock_request(), body)
+
+        assert response.success is False
+        assert response.error == "No speech detected"
+        assert response.upstreamStatus["ok"] is False
+        assert response.upstreamStatus["errorType"] == "RuntimeError"
 
     @pytest.mark.asyncio
     async def test_voice_invalid_tts_provider_returns_400(self):

--- a/backend/tests/workflows/test_greeting_reception_flow.py
+++ b/backend/tests/workflows/test_greeting_reception_flow.py
@@ -127,6 +127,77 @@ async def test_greeting_fast_path_drives_multi_turn_reception_flow() -> None:
 
 
 @pytest.mark.asyncio
+async def test_greeting_stage_information_query_bypasses_reception() -> None:
+    """greeting 段階でも明確な情報質問は受付目的ヒアリングに横取りされない。"""
+    from backend.workflows.main_workflow import MainWorkflow
+
+    persisted_sessions: dict[str, dict] = {}
+
+    async def fake_store_session(_self, reception_session_id: str, data: dict) -> None:
+        persisted_sessions[reception_session_id] = {
+            "id": reception_session_id,
+            "session_id": data.get("session_id"),
+            "status": data.get("status", "active"),
+            "stage": data.get("stage", "initiated"),
+            "session_data": dict(data),
+        }
+
+    async def fake_check_reception_status(session_id: str) -> dict:
+        record = persisted_sessions.get(session_id)
+        if record is None:
+            return {"completed": True, "stage": "none"}
+        session_data = record["session_data"]
+        stage = session_data.get("stage", "none")
+        return {
+            "completed": stage == "completed",
+            "stage": stage,
+            "reception_session_id": record["id"],
+            "visitor_identity": session_data.get("visitor_identity"),
+            "purpose": session_data.get("purpose"),
+        }
+
+    greeting_decision = _make_decision(
+        category="greeting",
+        next_agent="format_response",
+        request_type="greeting",
+    )
+    hours_decision = _make_decision(
+        category="business-info",
+        next_agent="business_info",
+        request_type="hours",
+    )
+
+    with (
+        patch.object(MainWorkflow, "__init__", lambda self, **kwargs: None),
+        patch(
+            "backend.utils.reception_repository.ReceptionRepository.store_session",
+            new=fake_store_session,
+        ),
+        patch(
+            "backend.utils.reception_status.check_reception_status",
+            new=fake_check_reception_status,
+        ),
+    ):
+        workflow = MainWorkflow()
+        workflow.orchestrator = AsyncMock()
+        workflow.orchestrator.decide_next_agent = AsyncMock(
+            side_effect=[greeting_decision, hours_decision]
+        )
+
+        turn_1 = await workflow._orchestrator_node(_make_state("こんにちは"))
+        assert turn_1.goto == "format_response"
+        assert persisted_sessions["chat-session-123"]["session_data"]["stage"] == "greeting"
+
+        turn_2 = await workflow._orchestrator_node(_make_state("営業時間は？"))
+
+        assert turn_2.goto == "business_info"
+        assert turn_2.update["routing"]["request_type"] == "hours"
+        assert persisted_sessions["chat-session-123"]["session_data"]["stage"] == "completed"
+        assert persisted_sessions["chat-session-123"]["session_data"]["status"] == "completed"
+        assert workflow.orchestrator.decide_next_agent.await_count == 2
+
+
+@pytest.mark.asyncio
 async def test_purpose_other_stays_in_purpose_hearing() -> None:
     """曖昧な目的(other)は purpose_hearing に留まりclarification を促す"""
     from backend.workflows.main_workflow import MainWorkflow

--- a/backend/tests/workflows/test_reception_workflow.py
+++ b/backend/tests/workflows/test_reception_workflow.py
@@ -324,6 +324,27 @@ class TestClassifyPurposeNode:
         assert "エンナビ" in result["response"]
 
     @pytest.mark.asyncio
+    async def test_information_question_bypasses_purpose_classification(self):
+        """明確な施設情報質問は目的不明として聞き返さず、通常QAへ渡す。"""
+        from backend.workflows.reception_workflow import classify_purpose
+
+        state = _make_initial_state(language="ja")
+        state["stage"] = "purpose_hearing"
+        state["messages"] = [HumanMessage(content="エンジニアカフェの営業時間を教えてください")]
+
+        with patch(
+            "backend.utils.purpose_classifier.classify_purpose",
+            new_callable=AsyncMock,
+            side_effect=AssertionError("purpose classifier must not be called"),
+        ):
+            result = await classify_purpose(state)
+
+        assert result["stage"] == "completed"
+        assert result["target_agent"] == "business_info"
+        assert result["reception_action"] == "bypass_for_information_query"
+        assert result["purpose"]["request_type"] == "hours"
+
+    @pytest.mark.asyncio
     async def test_classify_purpose_no_human_message_defaults_other(self):
         """When no human message is present, stay in purpose_hearing and re-prompt."""
         from backend.workflows.reception_workflow import classify_purpose

--- a/backend/workflows/main_workflow.py
+++ b/backend/workflows/main_workflow.py
@@ -464,7 +464,7 @@ class MainWorkflow:
             return False
 
         stage = reception_status.get("stage")
-        if stage not in {"purpose_hearing", "routing"}:
+        if stage not in {"greeting", "purpose_hearing", "routing"}:
             return False
 
         lower_query = query.strip().lower()
@@ -486,7 +486,7 @@ class MainWorkflow:
             return True
         if not self._looks_like_information_query(query):
             return False
-        if reception_status.get("stage") not in {"purpose_hearing", "routing"}:
+        if reception_status.get("stage") not in {"greeting", "purpose_hearing", "routing"}:
             return False
         try:
             from backend.utils.query_classifier import QueryClassifier

--- a/backend/workflows/reception_workflow.py
+++ b/backend/workflows/reception_workflow.py
@@ -22,6 +22,7 @@ from backend.domain.reception.models import VisitPurpose
 from backend.domain.reception.service import ReceptionDomainService
 from backend.services.visitor_identification_service import VisitorIdentificationService
 from backend.utils.intent_classifier import is_assistant_profile_question
+from backend.utils.intent_classifier import classify_fast_intent
 from backend.utils import purpose_classifier as purpose_classifier_module
 from backend.utils.reception_templates import (
     get_personalized_greeting,
@@ -46,6 +47,70 @@ _PURPOSE_REQUEST_TYPE_MAP: dict[str, str] = {
     "consultation": "consultation",
     "other": "general",
 }
+
+_RECEPTION_NON_QA_REQUEST_TYPES = {
+    "assistant_profile",
+    "clarification",
+    "daily_conversation",
+    "farewell",
+    "greeting",
+    "reception",
+}
+
+
+_INFORMATION_QUERY_MARKERS = (
+    "?",
+    "？",
+    "教えて",
+    "知りたい",
+    "確認したい",
+    "わかりますか",
+    "ありますか",
+    "できますか",
+    "どこ",
+    "どちら",
+    "いつ",
+    "何時",
+    "いくら",
+    "料金",
+    "営業時間",
+    "予約",
+    "方法",
+    "違い",
+    "how",
+    "what",
+    "where",
+    "when",
+    "which",
+    "tell me",
+)
+
+
+def _looks_like_information_query(user_response: str) -> bool:
+    normalized = user_response.strip().lower()
+    return bool(normalized) and any(marker in normalized for marker in _INFORMATION_QUERY_MARKERS)
+
+
+def _information_route_from_fast_intent(user_response: str) -> Optional[dict[str, Any]]:
+    """Return a normal QA route when a reception turn is clearly an information query."""
+    if not _looks_like_information_query(user_response):
+        return None
+
+    route = classify_fast_intent(user_response)
+    if route is None:
+        return None
+    if route.request_type in _RECEPTION_NON_QA_REQUEST_TYPES:
+        return None
+    if route.agent not in {"business_info", "facility", "event", "general_knowledge", "slide"}:
+        return None
+    return {
+        "agent": route.agent,
+        "category": route.category,
+        "request_type": route.request_type,
+        "confidence": 1.0,
+        "reasoning": f"Information query bypassed reception purpose flow: {route.reasoning}",
+        "debug_info": {"source": "fast_intent"},
+    }
 
 
 def _assistant_profile_detour(user_response: str, language: str) -> Optional[str]:
@@ -239,6 +304,23 @@ async def classify_purpose(state: ReceptionState) -> dict:
             "response": assistant_profile_response,
             "reception_action": "answer_assistant_profile",
             "messages": [AIMessage(content=assistant_profile_response)],
+        }
+
+    information_route = _information_route_from_fast_intent(user_response)
+    if information_route is not None:
+        purpose_dict = {
+            "category": information_route["category"],
+            "detail": user_response,
+            "confidence": information_route["confidence"],
+            "request_type": information_route["request_type"],
+            "routing": information_route,
+            "target_agent": information_route["agent"],
+        }
+        return {
+            "purpose": purpose_dict,
+            "stage": "completed",
+            "target_agent": information_route["agent"],
+            "reception_action": "bypass_for_information_query",
         }
 
     try:
@@ -463,19 +545,23 @@ def reception_state_to_workflow_result(
     if target_agent:
         metadata["reception_target_agent"] = target_agent
         category = purpose.get("category", "other")
-        request_type = _PURPOSE_REQUEST_TYPE_MAP.get(category, "general")
+        request_type = purpose.get("request_type") or _PURPOSE_REQUEST_TYPE_MAP.get(
+            category,
+            "general",
+        )
+        routing = purpose.get("routing") or {
+            "agent": target_agent,
+            "category": category,
+            "request_type": request_type,
+            "confidence": purpose.get("confidence", 1.0),
+            "reasoning": "Routed from reception subgraph",
+            "debug_info": {},
+        }
         return ReceptionSubgraphResult(
             answer=None,
             emotion=None,
             metadata=metadata,
-            routing={
-                "agent": target_agent,
-                "category": category,
-                "request_type": request_type,
-                "confidence": purpose.get("confidence", 1.0),
-                "reasoning": "Routed from reception subgraph",
-                "debug_info": {},
-            },
+            routing=routing,
             target_agent=target_agent,
         )
 

--- a/frontend/src/__tests__/reception-audio-readiness.test.ts
+++ b/frontend/src/__tests__/reception-audio-readiness.test.ts
@@ -1,0 +1,27 @@
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+
+import {
+  canUseStaticNarrationAudio,
+  isAudioInteractionRequired,
+  shouldFallbackToGeneratedNarration,
+} from '../lib/reception/reception-audio-readiness';
+
+test('static narration audio is used only after readiness is confirmed', () => {
+  assert.equal(canUseStaticNarrationAudio(undefined), false);
+  assert.equal(canUseStaticNarrationAudio('pending'), false);
+  assert.equal(canUseStaticNarrationAudio('failed'), false);
+  assert.equal(canUseStaticNarrationAudio('ready'), true);
+});
+
+test('non-permission playback failures fall back to generated narration', () => {
+  assert.equal(shouldFallbackToGeneratedNarration(new Error('network error')), true);
+  assert.equal(shouldFallbackToGeneratedNarration({ name: 'NotSupportedError' }), true);
+});
+
+test('permission-gated playback does not silently fall back', () => {
+  assert.equal(isAudioInteractionRequired({ name: 'NotAllowedError' }), true);
+  assert.equal(isAudioInteractionRequired({ requiresUserInteraction: true }), true);
+  assert.equal(isAudioInteractionRequired(new Error('requires user interaction')), true);
+  assert.equal(shouldFallbackToGeneratedNarration({ name: 'NotAllowedError' }), false);
+});

--- a/frontend/src/__tests__/response-language.test.ts
+++ b/frontend/src/__tests__/response-language.test.ts
@@ -1,0 +1,17 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+
+import { resolveVoiceResponseLanguage } from '@/lib/voice/response-language';
+
+test('uses chat response_language for TTS when it differs from kiosk language', () => {
+  assert.equal(resolveVoiceResponseLanguage({ response_language: 'en' }, 'ja'), 'en');
+});
+
+test('falls back to metadata language and normalizes locale tags', () => {
+  assert.equal(resolveVoiceResponseLanguage({ language: 'en-US' }, 'ja'), 'en');
+});
+
+test('keeps the kiosk language when metadata is absent or unsupported by the voice UI', () => {
+  assert.equal(resolveVoiceResponseLanguage(null, 'ja'), 'ja');
+  assert.equal(resolveVoiceResponseLanguage({ response_language: 'ko' }, 'en'), 'en');
+});

--- a/frontend/src/app/components/ReceptionPdfGuide.tsx
+++ b/frontend/src/app/components/ReceptionPdfGuide.tsx
@@ -18,6 +18,11 @@ import {
   receptionGuidePageStem,
   receptionGuidePdfUrl,
 } from '@/lib/reception/reception-pdf-constants';
+import {
+  canUseStaticNarrationAudio,
+  shouldFallbackToGeneratedNarration,
+  type StaticNarrationAudioState,
+} from '@/lib/reception/reception-audio-readiness';
 import { parseReceptionNarrationMarkdown } from '@/lib/reception/parse-reception-narration-md';
 import { preprocessTTS } from '@/utils/tts-preprocess';
 import { cn } from '@/lib/cn';
@@ -174,6 +179,7 @@ export default function ReceptionPdfGuide({
   const narrationScheduleRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const narrationAbortRef = useRef<AbortController | null>(null);
   const preloadedAudioRef = useRef<Map<string, HTMLAudioElement>>(new Map());
+  const preloadedAudioStateRef = useRef<Map<string, StaticNarrationAudioState>>(new Map());
 
   const playbackSessionRef = useRef(0);
   const isPlayingRef = useRef(isPlaying);
@@ -335,6 +341,7 @@ export default function ReceptionPdfGuide({
         audio.load();
       }
       preloadedAudio.clear();
+      preloadedAudioStateRef.current.clear();
     };
   }, []);
 
@@ -356,8 +363,25 @@ export default function ReceptionPdfGuide({
       audio.preload = 'auto';
       audio.setAttribute('playsinline', 'true');
       audio.setAttribute('webkit-playsinline', 'true');
-      audio.load();
+      const markReady = () => {
+        if (preloadedAudioRef.current.get(audioUrl) === audio) {
+          preloadedAudioStateRef.current.set(audioUrl, 'ready');
+        }
+      };
+      const markFailed = () => {
+        if (preloadedAudioRef.current.get(audioUrl) === audio) {
+          preloadedAudioStateRef.current.set(audioUrl, 'failed');
+        }
+      };
+      audio.addEventListener('canplay', markReady, { once: true });
+      audio.addEventListener('canplaythrough', markReady, { once: true });
+      audio.addEventListener('error', markFailed, { once: true });
       preloadedAudioRef.current.set(audioUrl, audio);
+      preloadedAudioStateRef.current.set(audioUrl, audio.readyState >= 3 ? 'ready' : 'pending');
+      audio.load();
+      if (audio.readyState >= 3) {
+        preloadedAudioStateRef.current.set(audioUrl, 'ready');
+      }
     }
 
     for (const [url, audio] of Array.from(preloadedAudioRef.current.entries())) {
@@ -366,6 +390,7 @@ export default function ReceptionPdfGuide({
         audio.removeAttribute('src');
         audio.load();
         preloadedAudioRef.current.delete(url);
+        preloadedAudioStateRef.current.delete(url);
       }
     }
   }, [language, totalPages]);
@@ -576,13 +601,14 @@ export default function ReceptionPdfGuide({
     const { signal } = narrationAbortRef.current;
 
     try {
-      if (preloadedAudioRef.current.has(audioUrl)) {
+      if (canUseStaticNarrationAudio(preloadedAudioStateRef.current.get(audioUrl))) {
         if (!isActiveSession(sid) || currentPageRef.current !== pageAtStart) {
           return;
         }
 
         setIsNarrationInProgress(true);
         setIsNarrating(true);
+        let playedStaticAudio = false;
         try {
           await AudioInteractionManager.getInstance().ensureAudioContext();
           const result = await AudioPlaybackService.playAudioWithLipSync(audioUrl, {
@@ -593,6 +619,7 @@ export default function ReceptionPdfGuide({
           if (!result.success) {
             throw result.error ?? new Error('Audio playback failed');
           }
+          playedStaticAudio = true;
           if (!isActiveSession(sid) || currentPageRef.current !== pageAtStart) {
             return;
           }
@@ -600,25 +627,20 @@ export default function ReceptionPdfGuide({
             advancePresentation(SLIDE_DELAY_MS);
           }
         } catch (err: unknown) {
-          const e = err as { name?: string; message?: string; requiresUserInteraction?: boolean };
-          if (
-            e?.name === 'NotAllowedError' ||
-            e?.requiresUserInteraction ||
-            e?.message?.includes('interaction')
-          ) {
+          if (!shouldFallbackToGeneratedNarration(err)) {
             setAudioPermissionRequired(true);
             setIsPlaying(false);
             onPresentationComplete?.('stopped');
             return;
           }
-          if (isActiveSession(sid)) {
-            advancePresentation(800);
-          }
+          preloadedAudioStateRef.current.set(audioUrl, 'failed');
         } finally {
           setIsNarrating(false);
           setIsNarrationInProgress(false);
         }
-        return;
+        if (playedStaticAudio) {
+          return;
+        }
       }
 
       const text =

--- a/frontend/src/app/components/VoiceInterface.tsx
+++ b/frontend/src/app/components/VoiceInterface.tsx
@@ -19,6 +19,7 @@ import { EmotionTagParser } from '@/lib/emotion-tag-parser';
 import { formatError } from '@/lib/error-messages';
 import { LipSyncAnalyzer, type LipSyncFrame } from '@/lib/lip-sync-analyzer';
 import { createVoiceFillerPlaybackGate } from '@/lib/voice-filler-playback';
+import { resolveVoiceResponseLanguage } from '@/lib/voice/response-language';
 import { mergePlaybackMetadataWithTtsVrmControl } from '@/lib/voice/tts-vrm-metadata';
 import { preprocessTTS } from '@/utils/tts-preprocess';
 import { AlertCircle, Loader2, Mic, MicOff, Volume2, VolumeX, XCircle } from 'lucide-react';
@@ -796,6 +797,7 @@ export default function VoiceInterface({
         const cleanAnswer = parsedAnswer.cleanText;
 
         const qaMeta = (qaResult.metadata as VoiceInterfaceMetadata | null) ?? null;
+        const responseLanguage = resolveVoiceResponseLanguage(qaMeta, currentLanguage);
         setResponse(cleanAnswer);
         setMetadata(qaMeta);
 
@@ -810,8 +812,8 @@ export default function VoiceInterface({
 
         const ttsBody: Record<string, unknown> = {
           action: 'text_to_speech',
-          text: preprocessTTS(cleanAnswer, currentLanguage),
-          language: currentLanguage,
+          text: preprocessTTS(cleanAnswer, responseLanguage),
+          language: responseLanguage,
           sessionId: sessionIdRef.current,
           includeVrmControl: true,
         };
@@ -1006,6 +1008,7 @@ export default function VoiceInterface({
         const cleanAnswer = parsedAnswer.cleanText;
 
         const qaMeta = (qaResult.metadata as VoiceInterfaceMetadata | null) ?? null;
+        const responseLanguage = resolveVoiceResponseLanguage(qaMeta, currentLanguage);
         setResponse(cleanAnswer);
         setMetadata(qaMeta);
 
@@ -1018,8 +1021,8 @@ export default function VoiceInterface({
 
         const ttsBody: Record<string, unknown> = {
           action: 'text_to_speech',
-          text: preprocessTTS(cleanAnswer, currentLanguage),
-          language: currentLanguage,
+          text: preprocessTTS(cleanAnswer, responseLanguage),
+          language: responseLanguage,
           sessionId: sessionIdRef.current,
           includeVrmControl: true,
         };
@@ -1115,10 +1118,11 @@ export default function VoiceInterface({
       requestAbortRef.current = abortController;
 
       try {
+        const responseLanguage = resolveVoiceResponseLanguage(metadataForPlayback, currentLanguage);
         const ttsBody: Record<string, unknown> = {
           action: 'text_to_speech',
-          text: preprocessTTS(cleanAnswer, currentLanguage),
-          language: currentLanguage,
+          text: preprocessTTS(cleanAnswer, responseLanguage),
+          language: responseLanguage,
           sessionId: sessionIdRef.current,
           includeVrmControl: true,
         };

--- a/frontend/src/lib/reception/reception-audio-readiness.ts
+++ b/frontend/src/lib/reception/reception-audio-readiness.ts
@@ -1,0 +1,25 @@
+export type StaticNarrationAudioState = 'pending' | 'ready' | 'failed';
+
+export function canUseStaticNarrationAudio(
+  state: StaticNarrationAudioState | undefined,
+): boolean {
+  return state === 'ready';
+}
+
+export function isAudioInteractionRequired(error: unknown): boolean {
+  const candidate = error as
+    | { name?: unknown; message?: unknown; requiresUserInteraction?: unknown }
+    | null
+    | undefined;
+  const name = typeof candidate?.name === 'string' ? candidate.name : '';
+  const message = typeof candidate?.message === 'string' ? candidate.message : '';
+  return (
+    name === 'NotAllowedError' ||
+    candidate?.requiresUserInteraction === true ||
+    message.toLowerCase().includes('interaction')
+  );
+}
+
+export function shouldFallbackToGeneratedNarration(error: unknown): boolean {
+  return !isAudioInteractionRequired(error);
+}

--- a/frontend/src/lib/voice/response-language.ts
+++ b/frontend/src/lib/voice/response-language.ts
@@ -1,0 +1,21 @@
+export type VoiceResponseLanguage = 'ja' | 'en';
+
+function normalizeVoiceLanguage(value: unknown): VoiceResponseLanguage | null {
+  if (typeof value !== 'string') {
+    return null;
+  }
+  const normalized = value.trim().toLowerCase().split('-', 1)[0];
+  return normalized === 'ja' || normalized === 'en' ? normalized : null;
+}
+
+export function resolveVoiceResponseLanguage(
+  metadata: Record<string, unknown> | null | undefined,
+  fallback: VoiceResponseLanguage,
+): VoiceResponseLanguage {
+  return (
+    normalizeVoiceLanguage(metadata?.response_language) ??
+    normalizeVoiceLanguage(metadata?.language) ??
+    normalizeVoiceLanguage(metadata?.detectedLanguage) ??
+    fallback
+  );
+}


### PR DESCRIPTION
## Summary
- Fix active reception bypass so greeting-stage information questions are routed to normal QA agents instead of the purpose-hearing prompt.
- Add reception subgraph bypass for explicit information queries while keeping purpose statements such as event participation in the reception flow.
- Treat static reception guide audio as usable only after readiness is confirmed, and fall back to generated narration for non-permission playback failures instead of rapidly advancing slides.
- Return controlled no-speech STT failures for too-short audio and STT runtime failures instead of `/api/voice` 500s.
- Reject low-confidence fragmented Vosk fallback transcripts so incoherent STT output is not sent into chat.
- Propagate chat response language into metadata, structured logs, and frontend TTS requests so English answers use English synthesis settings.

## Tests
- `python -m pytest backend/tests/test_main_endpoints.py::TestVoiceEndpoint backend/tests/api/test_voice_api.py::TestSpeechToText backend/tests/api/test_chat_api.py backend/tests/agents/test_stt_agent.py::TestSTTAgent::test_vosk_fallback_rejects_low_confidence_fragmented_transcript backend/tests/agents/test_stt_agent.py::TestQwenPrimaryFallback::test_low_confidence_fragmented_vosk_fallback_is_rejected -q`
- `python -m pytest backend/tests/integration/test_voice_api_chain.py backend/tests/test_main_endpoints.py::TestVoiceEndpoint backend/tests/api/test_voice_api.py::TestSpeechToText -q`
- `ruff check backend/main.py backend/agents/stt_agent.py backend/tests/test_main_endpoints.py backend/tests/api/test_chat_api.py backend/tests/api/test_voice_api.py backend/tests/agents/test_stt_agent.py backend/tests/integration/test_voice_api_chain.py`
- `black --check backend/main.py backend/agents/stt_agent.py backend/tests/test_main_endpoints.py backend/tests/api/test_chat_api.py backend/tests/api/test_voice_api.py backend/tests/agents/test_stt_agent.py backend/tests/integration/test_voice_api_chain.py`
- `pnpm --dir frontend exec tsx --test src/__tests__/response-language.test.ts`
- `pnpm --dir frontend typecheck`
- `pnpm --dir frontend lint` (passes with existing `ReceptionPdfGuide.tsx` exhaustive-deps warning)
- GitHub Actions CI for PR #779: passed, including backend-test, frontend-build, frontend-playwright-e2e, frontend-playwright-voice-live, and ci-success.

Closes #778
Closes #780
