### PR TITLE
Post-alpha voice hardening

### DIFF
--- a/backend/agents/stt_agent.py
+++ b/backend/agents/stt_agent.py
@@ -30,6 +30,7 @@ import logging
 import math
 import numpy as np
 import os
+import re
 import time
 import uuid
 import wave
@@ -272,6 +273,10 @@ class HedgedFallback(Exception):
 
 class RejectedVoskFallback(Exception):
     """Vosk fallback produced a transcript too risky to treat as user intent."""
+
+
+class RejectedQwenPrimary(Exception):
+    """Qwen primary produced a transcript too risky to treat as user intent."""
 
 
 def _parse_qwen_stt_hedge_delay(
@@ -539,6 +544,104 @@ def _vosk_fallback_transcript_suspicious(
     particle_ratio = sum(1 for token in tokens if token in ja_particles) / len(tokens)
     content_tokens = [token for token in tokens if token not in ja_particles and len(token) > 1]
     return particle_ratio >= 0.30 and len(content_tokens) <= 3
+
+
+_QWEN_SHORT_COMMANDS = {
+    "はい",
+    "いいえ",
+    "うん",
+    "お願い",
+    "お願いします",
+    "キャンセル",
+    "戻る",
+    "終了",
+    "予約",
+    "料金",
+    "無料",
+    "受付",
+    "yes",
+    "no",
+    "ok",
+    "okay",
+    "cancel",
+    "stop",
+    "back",
+    "help",
+    "thanks",
+    "hello",
+    "hi",
+}
+
+_QWEN_SHORT_NOISE = {
+    "あ",
+    "あー",
+    "ああ",
+    "あああ",
+    "え",
+    "えー",
+    "ええ",
+    "えええ",
+    "う",
+    "うー",
+    "ん",
+    "んー",
+    "えっと",
+    "えと",
+    "まあ",
+    "uh",
+    "um",
+    "umm",
+    "mmm",
+    "hmm",
+}
+
+
+def _qwen_primary_transcript_suspicious(
+    transcript: str,
+    language: Optional[str],
+    confidence: Optional[float],
+) -> bool:
+    """Identify short/noisy Qwen output that should not drive chat intent.
+
+    Qwen generally returns less segmented text than Vosk, so this gate focuses
+    on empty, punctuation-only, repeated-character, and low-confidence short
+    fragments while preserving known high-confidence short commands.
+    """
+
+    normalized = " ".join((transcript or "").split())
+    compact = "".join(normalized.split())
+    if not compact:
+        return True
+
+    compact_lower = compact.lower()
+    if _vosk_transcript_trusted_for_early_return(normalized, language):
+        return False
+
+    if compact_lower in _QWEN_SHORT_COMMANDS:
+        return confidence is not None and confidence < 0.60
+
+    if compact_lower in _QWEN_SHORT_NOISE:
+        return confidence is None or confidence < 0.95
+
+    if re.fullmatch(r"[\W_]+", compact, flags=re.UNICODE):
+        return True
+
+    if len(compact) >= 3 and len(set(compact_lower)) == 1:
+        return confidence is None or confidence < 0.95
+
+    tokens = [token for token in normalized.split() if token]
+    if len(tokens) >= 3:
+        single_char_ratio = sum(1 for token in tokens if len(token) == 1) / len(tokens)
+        if single_char_ratio >= 0.60 and (confidence is None or confidence < 0.85):
+            return True
+
+    if len(compact) <= 2:
+        return confidence is None or confidence < 0.85
+
+    if len(compact) <= 4 and (confidence is None or confidence < 0.70):
+        return True
+
+    return False
 
 
 def _env_flag(name: str, default: bool = False) -> bool:
@@ -1761,6 +1864,57 @@ class STTAgent:
                 raise
             return await _run_vosk()
 
+        def _remaining_latency_budget() -> float | None:
+            if self._qwen_latency_budget is None:
+                return None
+            return self._qwen_latency_budget - (time.perf_counter() - overall_started_at)
+
+        def _reject_suspicious_qwen_result(
+            result: TranscriptionResult,
+        ) -> RejectedQwenPrimary | None:
+            if not _qwen_primary_transcript_suspicious(
+                result.text,
+                result.language,
+                result.confidence,
+            ):
+                return None
+            log_stt_event(
+                event="stt_qwen_rejected",
+                stt_trace_id=stt_trace_id,
+                provider="qwen-primary",
+                language=result.language,
+                success=False,
+                transcript_chars=len(result.text),
+                confidence=result.confidence,
+                stt_overall_duration_ms=_duration_ms(overall_started_at),
+                rejection_reason="suspicious_transcript",
+            )
+            return RejectedQwenPrimary("Rejected suspicious Qwen primary transcript")
+
+        async def _await_qwen_after_vosk_failure() -> TranscriptionResult:
+            remaining_budget = _remaining_latency_budget()
+            if remaining_budget is None:
+                return await qwen_task
+            if remaining_budget <= 0:
+                raise asyncio.TimeoutError("Qwen exceeded configured STT latency budget")
+            try:
+                return await asyncio.wait_for(
+                    asyncio.shield(qwen_task),
+                    timeout=remaining_budget,
+                )
+            except asyncio.TimeoutError:
+                log_stt_event(
+                    event="stt_qwen_latency_budget_complete",
+                    stt_trace_id=stt_trace_id,
+                    provider="qwen-primary",
+                    language=language,
+                    success=False,
+                    error_type="TimeoutError",
+                    latency_budget_s=self._qwen_latency_budget,
+                    stt_qwen_duration_ms=_duration_ms(overall_started_at),
+                )
+                raise
+
         qwen_task = asyncio.create_task(_run_qwen())
         vosk_task = asyncio.create_task(_run_vosk_after_qwen_failure())
 
@@ -1837,12 +1991,9 @@ class STTAgent:
                             and not vosk_trusted
                         ):
                             remaining_budget = self._qwen_hedge_grace
-                            if self._qwen_latency_budget is not None:
-                                remaining_budget = min(
-                                    remaining_budget,
-                                    self._qwen_latency_budget
-                                    - (time.perf_counter() - overall_started_at),
-                                )
+                            latency_budget_remaining = _remaining_latency_budget()
+                            if latency_budget_remaining is not None:
+                                remaining_budget = min(remaining_budget, latency_budget_remaining)
                             if remaining_budget <= 0:
                                 log_stt_event(
                                     event="stt_qwen_hedge_grace_skipped",
@@ -1893,27 +2044,32 @@ class STTAgent:
                     qwen_error_for_log = exc
 
             if isinstance(qwen_result, TranscriptionResult):
-                if not vosk_task.done():
-                    vosk_task.cancel()
-                    await asyncio.gather(vosk_task, return_exceptions=True)
-                log_stt_event(
-                    event="stt_winner",
-                    stt_trace_id=stt_trace_id,
-                    stt_winner="qwen",
-                    provider="qwen-primary",
-                    language=qwen_result.language,
-                    success=True,
-                    stt_overall_duration_ms=_duration_ms(overall_started_at),
-                    hedge_grace_s=self._qwen_hedge_grace,
-                    qwen_postprocess_enabled=qwen_postprocess_enabled,
-                )
-                return {
-                    "success": True,
-                    "transcript": qwen_result.text,
-                    "confidence": qwen_result.confidence,
-                    "language": qwen_result.language,
-                    "provider": "qwen-primary",
-                }
+                qwen_rejection = _reject_suspicious_qwen_result(qwen_result)
+                if qwen_rejection is not None:
+                    qwen_result = qwen_rejection
+                    qwen_error_for_log = qwen_rejection
+                else:
+                    if not vosk_task.done():
+                        vosk_task.cancel()
+                        await asyncio.gather(vosk_task, return_exceptions=True)
+                    log_stt_event(
+                        event="stt_winner",
+                        stt_trace_id=stt_trace_id,
+                        stt_winner="qwen",
+                        provider="qwen-primary",
+                        language=qwen_result.language,
+                        success=True,
+                        stt_overall_duration_ms=_duration_ms(overall_started_at),
+                        hedge_grace_s=self._qwen_hedge_grace,
+                        qwen_postprocess_enabled=qwen_postprocess_enabled,
+                    )
+                    return {
+                        "success": True,
+                        "transcript": qwen_result.text,
+                        "confidence": qwen_result.confidence,
+                        "language": qwen_result.language,
+                        "provider": "qwen-primary",
+                    }
 
             # Qwen failed or exceeded the hedge latency budget -> Vosk fallback
             if qwen_error_for_log is None:
@@ -1959,30 +2115,38 @@ class STTAgent:
                 and not qwen_task.done()
             ):
                 try:
-                    qwen_result = await qwen_task
+                    qwen_result = await _await_qwen_after_vosk_failure()
+                except asyncio.TimeoutError as exc:
+                    qwen_result = HedgedFallback(str(exc))
+                    qwen_error_for_log = qwen_result
                 except Exception as exc:
                     qwen_result = exc
                     qwen_error_for_log = exc
                 if isinstance(qwen_result, TranscriptionResult):
-                    log_stt_event(
-                        event="stt_winner",
-                        stt_trace_id=stt_trace_id,
-                        stt_winner="qwen",
-                        provider="qwen-primary",
-                        language=qwen_result.language,
-                        success=True,
-                        stt_overall_duration_ms=_duration_ms(overall_started_at),
-                        hedge_grace_s=self._qwen_hedge_grace,
-                        qwen_postprocess_enabled=qwen_postprocess_enabled,
-                        vosk_error_type=type(vosk_result).__name__,
-                    )
-                    return {
-                        "success": True,
-                        "transcript": qwen_result.text,
-                        "confidence": qwen_result.confidence,
-                        "language": qwen_result.language,
-                        "provider": "qwen-primary",
-                    }
+                    qwen_rejection = _reject_suspicious_qwen_result(qwen_result)
+                    if qwen_rejection is not None:
+                        qwen_result = qwen_rejection
+                        qwen_error_for_log = qwen_rejection
+                    else:
+                        log_stt_event(
+                            event="stt_winner",
+                            stt_trace_id=stt_trace_id,
+                            stt_winner="qwen",
+                            provider="qwen-primary",
+                            language=qwen_result.language,
+                            success=True,
+                            stt_overall_duration_ms=_duration_ms(overall_started_at),
+                            hedge_grace_s=self._qwen_hedge_grace,
+                            qwen_postprocess_enabled=qwen_postprocess_enabled,
+                            vosk_error_type=type(vosk_result).__name__,
+                        )
+                        return {
+                            "success": True,
+                            "transcript": qwen_result.text,
+                            "confidence": qwen_result.confidence,
+                            "language": qwen_result.language,
+                            "provider": "qwen-primary",
+                        }
 
             if isinstance(vosk_result, TranscriptionResult):
                 transcript = vosk_result.text

--- a/backend/agents/voice_agent.py
+++ b/backend/agents/voice_agent.py
@@ -255,6 +255,7 @@ def clean_text_for_tts(text: str) -> str:
 # -----------------------------------------------------------------------------
 
 DEFAULT_TTS_MAX_BYTES = 900
+MIN_CACHEABLE_TTS_AUDIO_BASE64_CHARS = 100
 
 
 def get_tts_max_bytes() -> int:
@@ -461,7 +462,21 @@ class VoiceVoxClient:
         """
         self.api_url = api_url.rstrip("/")
         self._initialized_speakers: set[int] = set()
+        self._client: Optional[httpx.AsyncClient] = None
         logger.info("VoiceVoxClient initialized: %s", self.api_url)
+
+    def _get_client(self) -> httpx.AsyncClient:
+        if self._client is None or self._client.is_closed:
+            self._client = httpx.AsyncClient(timeout=30)
+        return self._client
+
+    async def close(self) -> None:
+        if self._client is not None and not self._client.is_closed:
+            await self._client.aclose()
+        self._client = None
+
+    async def aclose(self) -> None:
+        await self.close()
 
     async def _ensure_speaker_initialized(self, client: httpx.AsyncClient, speaker_id: int) -> None:
         """初回遅延回避のためスピーカーを事前初期化 (公式推奨)"""
@@ -488,41 +503,39 @@ class VoiceVoxClient:
             speaker_id = self.DEFAULT_SPEAKER_JA if lang == "ja" else self.DEFAULT_SPEAKER_EN
 
         try:
-            async with httpx.AsyncClient(timeout=30) as client:
-                # Step 0: スピーカー初期化 (初回のみ、公式推奨)
-                await self._ensure_speaker_initialized(client, speaker_id)
+            client = self._get_client()
+            # Step 0: スピーカー初期化 (初回のみ、公式推奨)
+            await self._ensure_speaker_initialized(client, speaker_id)
 
-                # Step 1: Query 作成
-                query_url = f"{self.api_url}/audio_query"
-                query_response = await client.post(
-                    query_url,
-                    params={"text": text, "speaker": speaker_id},
-                )
+            # Step 1: Query 作成
+            query_url = f"{self.api_url}/audio_query"
+            query_response = await client.post(
+                query_url,
+                params={"text": text, "speaker": speaker_id},
+            )
 
-                if query_response.status_code >= 400:
-                    raise RuntimeError(f"VoiceVox audio_query failed: {query_response.status_code}")
+            if query_response.status_code >= 400:
+                raise RuntimeError(f"VoiceVox audio_query failed: {query_response.status_code}")
 
-                query_data = query_response.json()
+            query_data = query_response.json()
 
-                # Step 2: 音声合成
-                synthesis_url = f"{self.api_url}/synthesis"
-                synthesis_response = await client.post(
-                    synthesis_url,
-                    params={"speaker": speaker_id},
-                    json=query_data,
-                    headers={"Content-Type": "application/json"},
-                )
+            # Step 2: 音声合成
+            synthesis_url = f"{self.api_url}/synthesis"
+            synthesis_response = await client.post(
+                synthesis_url,
+                params={"speaker": speaker_id},
+                json=query_data,
+                headers={"Content-Type": "application/json"},
+            )
 
-                if synthesis_response.status_code >= 400:
-                    raise RuntimeError(
-                        f"VoiceVox synthesis failed: {synthesis_response.status_code}"
-                    )
+            if synthesis_response.status_code >= 400:
+                raise RuntimeError(f"VoiceVox synthesis failed: {synthesis_response.status_code}")
 
-                wav_data = synthesis_response.content
-                wav_b64 = base64.b64encode(wav_data).decode("utf-8")
+            wav_data = synthesis_response.content
+            wav_b64 = base64.b64encode(wav_data).decode("utf-8")
 
-                logger.info("VoiceVox synthesis success: text_len=%d", len(text))
-                return wav_b64
+            logger.info("VoiceVox synthesis success: text_len=%d", len(text))
+            return wav_b64
 
         except httpx.TimeoutException as e:
             logger.error("VoiceVox timeout: %s", e)
@@ -619,7 +632,21 @@ class PiperPlusTTSClient:
 
     def __init__(self, api_url: str = "http://localhost:8090"):
         self.api_url = api_url.rstrip("/")
+        self._client: Optional[httpx.AsyncClient] = None
         logger.info("PiperPlusTTSClient initialized: %s", self.api_url)
+
+    def _get_client(self) -> httpx.AsyncClient:
+        if self._client is None or self._client.is_closed:
+            self._client = httpx.AsyncClient(timeout=30)
+        return self._client
+
+    async def close(self) -> None:
+        if self._client is not None and not self._client.is_closed:
+            await self._client.aclose()
+        self._client = None
+
+    async def aclose(self) -> None:
+        await self.close()
 
     async def synthesize_wav_base64(
         self, text: str, lang: str, speaker_id: Optional[int] = None
@@ -640,20 +667,20 @@ class PiperPlusTTSClient:
             payload["speaker_id"] = speaker_id
 
         try:
-            async with httpx.AsyncClient(timeout=30) as client:
-                response = await client.post(
-                    f"{self.api_url}/synthesize",
-                    json=payload,
+            client = self._get_client()
+            response = await client.post(
+                f"{self.api_url}/synthesize",
+                json=payload,
+            )
+
+            if response.status_code >= 400:
+                raise RuntimeError(
+                    f"PiperPlus TTS API Error {response.status_code}: {response.text}"
                 )
 
-                if response.status_code >= 400:
-                    raise RuntimeError(
-                        f"PiperPlus TTS API Error {response.status_code}: {response.text}"
-                    )
-
-                wav_b64 = base64.b64encode(response.content).decode("utf-8")
-                logger.info("PiperPlus TTS synthesis success: text_len=%d", len(text))
-                return wav_b64
+            wav_b64 = base64.b64encode(response.content).decode("utf-8")
+            logger.info("PiperPlus TTS synthesis success: text_len=%d", len(text))
+            return wav_b64
 
         except httpx.TimeoutException as e:
             logger.error("PiperPlus TTS timeout: %s", e)
@@ -732,10 +759,51 @@ class VoiceAgent:
 
         self._tts_cache: TTLCache = TTLCache(maxsize=200, ttl=3600)
 
+    async def close(self) -> None:
+        """Close reusable TTS clients owned by this agent."""
+        clients = [
+            getattr(self, "tts_client", None),
+            getattr(self, "kokoro_client", None),
+            getattr(self, "voicevox_fallback_client", None),
+        ]
+        seen: set[int] = set()
+        for client in clients:
+            if client is None:
+                continue
+            client_id = id(client)
+            if client_id in seen:
+                continue
+            seen.add(client_id)
+            close = getattr(client, "close", None)
+            if callable(close):
+                result = close()
+                if asyncio.iscoroutine(result):
+                    await result
+                continue
+            aclose = getattr(client, "aclose", None)
+            if callable(aclose):
+                result = aclose()
+                if asyncio.iscoroutine(result):
+                    await result
+
+    async def aclose(self) -> None:
+        await self.close()
+
     @staticmethod
     def _tts_cache_key(text: str, language: str, provider: str, emotion: str) -> str:
         raw = f"{text}|{language}|{provider}|{emotion or 'neutral'}"
         return hashlib.sha256(raw.encode("utf-8")).hexdigest()
+
+    def _ensure_tts_cache(self) -> TTLCache:
+        cache_store = getattr(self, "_tts_cache", None)
+        if cache_store is None:
+            cache_store = TTLCache(maxsize=200, ttl=3600)
+            self._tts_cache = cache_store
+        return cache_store
+
+    @staticmethod
+    def _is_cacheable_audio(audio_b64: Any) -> bool:
+        return isinstance(audio_b64, str) and len(audio_b64) > MIN_CACHEABLE_TTS_AUDIO_BASE64_CHARS
 
     def _tts_audio_format(self, language: str) -> str:
         if self.tts_provider == "piper" or language == "en" or self.tts_provider == "voicevox":
@@ -828,33 +896,33 @@ class VoiceAgent:
             processed = truncate_by_bytes(processed, max_tts_bytes)
             logger.warning("Text truncated to %d bytes for TTS", max_tts_bytes)
 
-        cache_store = getattr(self, "_tts_cache", None)
-        if cache_store is None:
-            cache_store = TTLCache(maxsize=200, ttl=3600)
-            self._tts_cache = cache_store
-
+        cache_store = self._ensure_tts_cache()
         cache_key = self._tts_cache_key(processed, language, self.tts_provider, vrm_emotion)
         cached_audio = cache_store.get(cache_key)
         if cached_audio is not None:
-            log_tts_cache_event(hit=True, cache_key=cache_key, language=language)
-            log_tts_event(
-                event="tts_complete",
-                provider=self.tts_provider,
-                language=language,
-                success=True,
-                tts_cache_hit=True,
-                tts_overall_duration_ms=int((time.perf_counter() - tts_started_at) * 1000),
-            )
-            return {
-                "success": True,
-                "audioResponse": cached_audio,
-                "emotion": vrm_emotion,
-                "cleanText": processed,
-                "format": self._tts_audio_format(language),
-                "language": language,
-                "ambiguity_resolved": False,
-                "tts_cache_hit": True,
-            }
+            if not self._is_cacheable_audio(cached_audio):
+                cache_store.pop(cache_key, None)
+                logger.warning("Ignored invalid TTS cache entry: cache_key=%s", cache_key)
+            else:
+                log_tts_cache_event(hit=True, cache_key=cache_key, language=language)
+                log_tts_event(
+                    event="tts_complete",
+                    provider=self.tts_provider,
+                    language=language,
+                    success=True,
+                    tts_cache_hit=True,
+                    tts_overall_duration_ms=int((time.perf_counter() - tts_started_at) * 1000),
+                )
+                return {
+                    "success": True,
+                    "audioResponse": cached_audio,
+                    "emotion": vrm_emotion,
+                    "cleanText": processed,
+                    "format": self._tts_audio_format(language),
+                    "language": language,
+                    "ambiguity_resolved": False,
+                    "tts_cache_hit": True,
+                }
 
         log_tts_cache_event(hit=False, cache_key=cache_key, language=language)
 
@@ -884,7 +952,7 @@ class VoiceAgent:
                 )
                 audio_format = "audio/mpeg"
 
-            if audio_b64 and len(audio_b64) > 100:
+            if self._is_cacheable_audio(audio_b64):
                 cache_store[cache_key] = audio_b64
 
             log_tts_event(

--- a/backend/main.py
+++ b/backend/main.py
@@ -225,6 +225,12 @@ async def lifespan(app: FastAPI):
         logger.warning("Error closing store on shutdown: %s", e)
 
     try:
+        await _close_voice_agents()
+        logger.info("Voice agents closed on shutdown")
+    except Exception as e:
+        logger.warning("Error closing voice agents on shutdown: %s", e)
+
+    try:
         session_task_manager = get_session_task_manager()
         await session_task_manager.shutdown()
         logger.info("Session task manager shutdown complete")
@@ -1035,6 +1041,40 @@ _ALLOWED_TTS_PROVIDERS = frozenset({"voicevox", "piper", "google"})
 _stt_agent: Optional[Any] = None  # STTAgent (lazy-loaded)
 _slide_agent: Optional[Any] = None  # SlideAgent (lazy-loaded)
 _session_task_manager: Optional[Any] = None
+
+
+async def _close_voice_agents() -> None:
+    """Close cached VoiceAgent instances and clear the singletons."""
+    global _voice_agent, _voice_agents_by_provider
+
+    agents = []
+    if _voice_agent is not None:
+        agents.append(_voice_agent)
+    agents.extend(_voice_agents_by_provider.values())
+
+    seen: set[int] = set()
+    try:
+        for agent in agents:
+            agent_id = id(agent)
+            if agent_id in seen:
+                continue
+            seen.add(agent_id)
+
+            close = getattr(agent, "close", None)
+            if callable(close):
+                result = close()
+                if asyncio.iscoroutine(result):
+                    await result
+                continue
+
+            aclose = getattr(agent, "aclose", None)
+            if callable(aclose):
+                result = aclose()
+                if asyncio.iscoroutine(result):
+                    await result
+    finally:
+        _voice_agent = None
+        _voice_agents_by_provider = {}
 
 
 def _get_stm():

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -39,6 +39,9 @@ dependencies = [
     "psycopg-pool>=3.1.0",
     "tavily-python>=0.5.0",
     "slowapi>=0.1.9",
+    "cachetools>=5.3.0",
+    "ctranslate2>=4.0.0",
+    "sentencepiece>=0.2.0",
 ]
 
 [project.optional-dependencies]
@@ -76,6 +79,7 @@ python = "^3.11"
 langgraph = ">=1.0,<1.2"
 langchain = "^0.3.0"
 langchain-openai = "^0.2.0"
+langchain-text-splitters = "^0.3.0"
 langsmith = "^0.3.12"
 pydantic = "^2.0.0"
 pydantic-settings = "^2.0.0"
@@ -95,6 +99,9 @@ psycopg = {extras = ["binary"], version = "^3.1.0"}
 psycopg-pool = "^3.1.0"
 tavily-python = "^0.5.0"
 slowapi = ">=0.1.9"
+cachetools = ">=5.3.0"
+ctranslate2 = ">=4.0.0"
+sentencepiece = ">=0.2.0"
 
 [tool.poetry.group.audio.dependencies]
 vosk = "^0.3.45"

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -1,4 +1,4 @@
-langgraph>=0.2.0
+langgraph>=1.0,<1.2
 langchain>=0.3.0
 langchain-openai>=0.2.0
 langchain-text-splitters>=0.3.0
@@ -30,6 +30,7 @@ vosk>=0.3.45
 soundfile>=0.12.1
 pydub>=0.25.1
 qwen-asr>=0.0.6
+cachetools>=5.3.0
 
 # Translation (CTranslate2 + Helsinki-NLP/opus-mt)
 ctranslate2>=4.0.0
@@ -40,4 +41,3 @@ pytest>=8.0.0
 pytest-asyncio>=0.23.0
 pytest-cov>=4.1.0
 pytest-timeout>=2.3.0
-cachetools>=5.3.0

--- a/backend/tests/agents/test_stt_agent.py
+++ b/backend/tests/agents/test_stt_agent.py
@@ -24,6 +24,7 @@ from backend.agents.stt_agent import (
     STAGE_GRAMMARS,
     VALID_STAGES,
     _normalize_vosk_route_transcript,
+    _qwen_primary_transcript_suspicious,
     _vosk_fallback_transcript_suspicious,
     _vosk_transcript_trusted_for_early_return,
 )
@@ -1129,6 +1130,18 @@ class TestSTTAgent:
             "en",
             0.80,
         )
+
+    def test_qwen_primary_rejects_short_noisy_transcripts(self):
+        """Qwen should not accept low-confidence filler as user intent."""
+        assert _qwen_primary_transcript_suspicious("え", "ja", 0.40)
+        assert _qwen_primary_transcript_suspicious("???", "en", 0.99)
+        assert _qwen_primary_transcript_suspicious("あ あ あ", "ja", 0.80)
+
+    def test_qwen_primary_preserves_high_confidence_short_commands(self):
+        """Legitimate short confirmations must keep working."""
+        assert not _qwen_primary_transcript_suspicious("はい", "ja", 0.95)
+        assert not _qwen_primary_transcript_suspicious("OK", "en", 0.95)
+        assert not _qwen_primary_transcript_suspicious("予約", "ja", 0.80)
 
     def test_vosk_route_transcript_normalizes_hours_confusion(self):
         """Known Vosk brand/hour confusions become route-stable hours queries."""
@@ -2660,6 +2673,82 @@ class TestQwenPrimaryFallback:
             if record.name == "backend.observability.stt"
         ]
         assert "stt_qwen_hedge_grace_complete" in events
+
+    @pytest.mark.asyncio
+    async def test_suspicious_qwen_primary_falls_back_to_vosk(self, caplog):
+        """Short/noisy Qwen output should not beat a usable Vosk fallback."""
+        caplog.set_level(logging.INFO, logger="backend.observability.stt")
+
+        mock_qwen = MagicMock()
+        mock_qwen.transcribe = AsyncMock(
+            return_value=TranscriptionResult(text="え", confidence=0.40, language="ja")
+        )
+        mock_vosk = MagicMock(spec=LocalSTTClient)
+        mock_vosk.transcribe = AsyncMock(
+            return_value=TranscriptionResult(
+                text="エンジニア カフェ の 営業 時間 教え て ください",
+                confidence=0.80,
+                language="ja",
+            )
+        )
+
+        agent = self._make_agent(mock_qwen, mock_vosk)
+        agent._qwen_hedge_delay = 0.50
+        result = await agent.speech_to_text(b"audio", language="ja")
+
+        assert result["success"] is True
+        assert result["provider"] == "vosk-fallback"
+        assert "営業" in result["transcript"]
+
+        events = [
+            getattr(record, "event", None)
+            for record in caplog.records
+            if record.name == "backend.observability.stt"
+        ]
+        assert "stt_qwen_rejected" in events
+        winner = next(
+            record for record in caplog.records if getattr(record, "event", None) == "stt_winner"
+        )
+        assert winner.stt_winner == "vosk"
+        assert winner.qwen_error_type == "RejectedQwenPrimary"
+
+    @pytest.mark.asyncio
+    async def test_vosk_failure_does_not_wait_past_qwen_latency_budget(self, caplog):
+        """A configured UX budget caps late Qwen wait after fallback failure."""
+        caplog.set_level(logging.INFO, logger="backend.observability.stt")
+
+        async def too_late_qwen(*args, **kwargs):
+            await asyncio.sleep(0.30)
+            return TranscriptionResult(text="late qwen", confidence=0.90, language="ja")
+
+        async def failing_vosk(*args, **kwargs):
+            await asyncio.sleep(0.01)
+            raise RuntimeError("Vosk model missing")
+
+        mock_qwen = MagicMock()
+        mock_qwen.transcribe = too_late_qwen
+        mock_vosk = MagicMock(spec=LocalSTTClient)
+        mock_vosk.transcribe = AsyncMock(side_effect=failing_vosk)
+
+        agent = self._make_agent(mock_qwen, mock_vosk)
+        agent._qwen_timeout = 10.0
+        agent._qwen_hedge_delay = 0.01
+        agent._qwen_hedge_grace = 0.20
+        agent._qwen_latency_budget = 0.05
+
+        loop = asyncio.get_running_loop()
+        started_at = loop.time()
+        with pytest.raises(RuntimeError, match="Both Qwen and Vosk STT failed"):
+            await agent.speech_to_text(b"audio", language="ja")
+        elapsed = loop.time() - started_at
+
+        assert elapsed < 0.15
+        events = [
+            getattr(record, "event", None)
+            for record in caplog.records
+            if record.name == "backend.observability.stt"
+        ]
+        assert "stt_qwen_latency_budget_complete" in events
 
     @pytest.mark.asyncio
     async def test_low_confidence_fragmented_vosk_fallback_is_rejected(self, caplog):

--- a/backend/tests/agents/test_voice_agent.py
+++ b/backend/tests/agents/test_voice_agent.py
@@ -1,5 +1,6 @@
 from unittest.mock import AsyncMock
 
+import httpx
 import pytest
 from cachetools import TTLCache
 
@@ -11,7 +12,9 @@ from backend.agents.voice_agent import (
     get_tts_max_bytes,
     truncate_by_bytes,
     map_vrm_to_tts_emotion,
+    PiperPlusTTSClient,
     VoiceAgent,
+    VoiceVoxClient,
 )
 
 
@@ -24,6 +27,19 @@ class FakeTimer:
 
     def advance(self, seconds: float) -> None:
         self.current += seconds
+
+
+class FakeTTSHTTPResponse:
+    def __init__(
+        self, *, status_code: int = 200, content: bytes = b"", json_data=None, text: str = ""
+    ):
+        self.status_code = status_code
+        self.content = content
+        self._json_data = json_data if json_data is not None else {}
+        self.text = text
+
+    def json(self):
+        return self._json_data
 
 
 def test_parse_emotion_tags_removes_tags_and_maps_alias():
@@ -136,6 +152,107 @@ def test_map_vrm_to_tts_emotion():
     assert map_vrm_to_tts_emotion("happy") == "happy"
     assert map_vrm_to_tts_emotion("sad") == "sad"
     assert map_vrm_to_tts_emotion("angry") == "angry"
+
+
+@pytest.mark.asyncio
+async def test_piper_client_reuses_async_client_and_closes(monkeypatch):
+    class FakeAsyncClient:
+        instances = []
+
+        def __init__(self, timeout):
+            self.timeout = timeout
+            self.is_closed = False
+            self.posts = []
+            FakeAsyncClient.instances.append(self)
+
+        async def post(self, url, **kwargs):
+            self.posts.append((url, kwargs))
+            return FakeTTSHTTPResponse(content=b"wav-data")
+
+        async def aclose(self):
+            self.is_closed = True
+
+    monkeypatch.setattr("backend.agents.voice_agent.httpx.AsyncClient", FakeAsyncClient)
+    client = PiperPlusTTSClient(api_url="http://piper")
+
+    await client.synthesize_wav_base64("こんにちは", "ja")
+    await client.synthesize_wav_base64("Hello", "en", speaker_id=2)
+
+    assert len(FakeAsyncClient.instances) == 1
+    instance = FakeAsyncClient.instances[0]
+    assert instance.timeout == 30
+    assert len(instance.posts) == 2
+    assert instance.posts[0][0] == "http://piper/synthesize"
+    assert instance.posts[0][1]["json"] == {"text": "こんにちは", "language": "ja"}
+    assert instance.posts[1][1]["json"] == {"text": "Hello", "language": "en", "speaker_id": 2}
+
+    await client.close()
+
+    assert instance.is_closed is True
+    assert client._client is None
+
+
+@pytest.mark.asyncio
+async def test_voicevox_client_reuses_async_client_and_closes(monkeypatch):
+    class FakeAsyncClient:
+        instances = []
+
+        def __init__(self, timeout):
+            self.timeout = timeout
+            self.is_closed = False
+            self.posts = []
+            FakeAsyncClient.instances.append(self)
+
+        async def post(self, url, **kwargs):
+            self.posts.append((url, kwargs))
+            if url.endswith("/audio_query"):
+                return FakeTTSHTTPResponse(json_data={"query": "ok"})
+            return FakeTTSHTTPResponse(content=b"voicevox-wav")
+
+        async def aclose(self):
+            self.is_closed = True
+
+    monkeypatch.setattr("backend.agents.voice_agent.httpx.AsyncClient", FakeAsyncClient)
+    client = VoiceVoxClient(api_url="http://voicevox")
+
+    await client.synthesize_wav_base64("こんにちは", "ja")
+    await client.synthesize_wav_base64("こんばんは", "ja")
+
+    assert len(FakeAsyncClient.instances) == 1
+    instance = FakeAsyncClient.instances[0]
+    assert instance.timeout == 30
+    assert [url for url, _kwargs in instance.posts] == [
+        "http://voicevox/initialize_speaker",
+        "http://voicevox/audio_query",
+        "http://voicevox/synthesis",
+        "http://voicevox/audio_query",
+        "http://voicevox/synthesis",
+    ]
+
+    await client.aclose()
+
+    assert instance.is_closed is True
+    assert client._client is None
+
+
+@pytest.mark.asyncio
+async def test_piper_client_preserves_timeout_error(monkeypatch):
+    class TimeoutAsyncClient:
+        def __init__(self, timeout):
+            self.timeout = timeout
+            self.is_closed = False
+
+        async def post(self, url, **kwargs):
+            raise httpx.TimeoutException("request timed out")
+
+        async def aclose(self):
+            self.is_closed = True
+
+    monkeypatch.setattr("backend.agents.voice_agent.httpx.AsyncClient", TimeoutAsyncClient)
+    client = PiperPlusTTSClient(api_url="http://piper")
+
+    with pytest.raises(RuntimeError, match="PiperPlus TTS connection timeout"):
+        await client.synthesize_wav_base64("こんにちは", "ja")
 
 
 @pytest.mark.asyncio

--- a/backend/tests/agents/test_voice_agent_cache.py
+++ b/backend/tests/agents/test_voice_agent_cache.py
@@ -65,6 +65,26 @@ async def test_text_to_speech_cache_hit_returns_cached_audio_without_tts(monkeyp
 
 
 @pytest.mark.asyncio
+async def test_text_to_speech_ignores_invalid_cached_audio(monkeypatch):
+    agent, calls = _make_new_voice_agent(audio_b64="D" * 128)
+    agent._tts_cache = TTLCache(maxsize=200, ttl=3600)
+    cache_key = _cache_key(agent, "こんにちは")
+    agent._tts_cache[cache_key] = "short-audio"
+    log_tts_cache_event = Mock()
+
+    monkeypatch.setattr(voice_agent_module, "log_tts_cache_event", log_tts_cache_event)
+
+    result = await agent.text_to_speech(text="こんにちは", language="ja")
+
+    assert result["success"] is True
+    assert result["audioResponse"] == "D" * 128
+    assert result["tts_cache_hit"] is False
+    assert calls["count"] == 1
+    assert agent._tts_cache[cache_key] == "D" * 128
+    log_tts_cache_event.assert_called_once_with(hit=False, cache_key=cache_key, language="ja")
+
+
+@pytest.mark.asyncio
 async def test_text_to_speech_does_not_cache_short_audio():
     agent, calls = _make_new_voice_agent(audio_b64="short-audio")
 

--- a/backend/tests/test_main_endpoints.py
+++ b/backend/tests/test_main_endpoints.py
@@ -162,12 +162,49 @@ class TestLifespan:
             patch("backend.utils.checkpointer.prewarm_checkpointer", new=AsyncMock()) as prewarm,
             patch("backend.utils.checkpointer.close_checkpointer", new=AsyncMock()),
             patch("backend.utils.store.close_store", new=AsyncMock()),
+            patch("backend.main._close_voice_agents", new=AsyncMock()) as close_voice_agents,
         ):
             async with main_mod.lifespan(app):
                 prewarm.assert_awaited_once()
                 session_task_manager.initialize.assert_awaited_once()
 
+        close_voice_agents.assert_awaited_once()
         session_task_manager.shutdown.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_close_voice_agents_closes_cached_agents_once_and_resets(self, monkeypatch):
+        import backend.main as main_mod
+
+        class CloseAgent:
+            def __init__(self):
+                self.close = AsyncMock()
+
+        class AcloseAgent:
+            def __init__(self):
+                self.aclose = AsyncMock()
+
+        default_agent = CloseAgent()
+        provider_agent = CloseAgent()
+        aclose_agent = AcloseAgent()
+
+        monkeypatch.setattr(main_mod, "_voice_agent", default_agent)
+        monkeypatch.setattr(
+            main_mod,
+            "_voice_agents_by_provider",
+            {
+                "piper": default_agent,
+                "voicevox": provider_agent,
+                "google": aclose_agent,
+            },
+        )
+
+        await main_mod._close_voice_agents()
+
+        default_agent.close.assert_awaited_once()
+        provider_agent.close.assert_awaited_once()
+        aclose_agent.aclose.assert_awaited_once()
+        assert main_mod._voice_agent is None
+        assert main_mod._voice_agents_by_provider == {}
 
 
 class TestChatEndpoint:

--- a/docs/plans/comprehensive-refactoring-plan-2026-05-05.md
+++ b/docs/plans/comprehensive-refactoring-plan-2026-05-05.md
@@ -1,7 +1,7 @@
 # Engineer Cafe Navigator — 総合リファクタリング計画（ドキュメントのみ）
 
 **作成日**: 2026-05-05  
-**更新**: 2026-05-05 — §3A を追加し、`main.py` / `main_workflow.py` のファイル単位・PR 粒度まで具体化。  
+**更新**: 2026-05-08 — Post-alpha 実行注記を追加。2026-05-05 — §3A を追加し、`main.py` / `main_workflow.py` のファイル単位・PR 粒度まで具体化。
 **スコープ**: 現行実装を **変更しない** 前提での調査結果と、今後の改善計画の整理  
 **正本との関係**: 運用上の優先判断は引き続き [`docs/STATUS.md`](../STATUS.md)、[ADR 018](../adr/018-alpha-fast-response-and-assistant-profile-routing.md)、および実装コードを優先する。
 
@@ -18,6 +18,12 @@
 
 - 機能追加・プロンプト改変・RAG 品質そのものの「改善」（別Issue／Remediation と連動）。
 - 本番環境の無検証デプロイや、`--set-env-vars` による Cloud Run 全上書き。
+
+### 1.3 Post-alpha 実行注記（2026-05-08）
+
+- 別ロードマップ上の Phase 2 新機能／外部連携拡張は、現時点では優先度を下げる。
+- 当面の実行範囲は、既存の voice / STT / TTS / OCR / RAG 品質の hardening と、安全なリファクタリング hygiene に限定する。
+- 本書 §5 の Phase 2（`backend/main.py` 分割）は、新機能追加ではなく既存挙動を保つ機械的整理として扱う。
 
 ---
 

--- a/frontend/e2e/voice-filler.spec.ts
+++ b/frontend/e2e/voice-filler.spec.ts
@@ -6,10 +6,17 @@ import { expect, test } from '@playwright/test';
 async function dismissInitialModal(page: import('@playwright/test').Page) {
   const modal = page.getByRole('dialog');
   const closeButton = page.getByTestId('initial-settings-close');
-  if (await closeButton.isVisible({ timeout: 3_000 }).catch(() => false)) {
-    await closeButton.click({ force: true }).catch(() => {});
-    await expect(modal).toBeHidden({ timeout: 10_000 });
-  }
+  await expect
+    .poll(async () => {
+      if (await modal.isHidden().catch(() => true)) {
+        return true;
+      }
+      if (await closeButton.isVisible({ timeout: 1_000 }).catch(() => false)) {
+        await closeButton.click({ force: true }).catch(() => {});
+      }
+      return modal.isHidden().catch(() => true);
+    }, { timeout: 10_000 })
+    .toBe(true);
   await expect(page.getByRole('button', { name: 'Welcome' })).toBeVisible({ timeout: 5_000 });
 }
 

--- a/frontend/e2e/welcome-voice-first.spec.ts
+++ b/frontend/e2e/welcome-voice-first.spec.ts
@@ -10,10 +10,17 @@ interface MediaRequestCounts {
 async function dismissInitialModal(page: import('@playwright/test').Page) {
   const modal = page.getByRole('dialog');
   const closeButton = page.getByTestId('initial-settings-close');
-  if (await closeButton.isVisible({ timeout: 3_000 }).catch(() => false)) {
-    await closeButton.click({ force: true }).catch(() => {});
-    await expect(modal).toBeHidden({ timeout: 10_000 });
-  }
+  await expect
+    .poll(async () => {
+      if (await modal.isHidden().catch(() => true)) {
+        return true;
+      }
+      if (await closeButton.isVisible({ timeout: 1_000 }).catch(() => false)) {
+        await closeButton.click({ force: true }).catch(() => {});
+      }
+      return modal.isHidden().catch(() => true);
+    }, { timeout: 10_000 })
+    .toBe(true);
   await expect(page.getByRole('button', { name: 'Welcome' })).toBeVisible({ timeout: 5_000 });
 }
 

--- a/frontend/src/__tests__/api-character-route.test.ts
+++ b/frontend/src/__tests__/api-character-route.test.ts
@@ -5,13 +5,19 @@ import path from 'node:path';
 import { afterEach, test } from 'node:test';
 import { NextRequest } from 'next/server';
 
-import { GET } from '../app/api/character/route';
-
 const originalCwd = process.cwd();
+const originalBackendApiUrl = process.env.BACKEND_API_URL;
+const originalBackendApiKey = process.env.BACKEND_API_KEY;
+const originalFetch = global.fetch;
 let tempDir: string | null = null;
+
+process.env.BACKEND_API_URL = originalBackendApiUrl ?? 'https://backend.example.com';
 
 afterEach(async () => {
   process.chdir(originalCwd);
+  process.env.BACKEND_API_URL = originalBackendApiUrl ?? 'https://backend.example.com';
+  process.env.BACKEND_API_KEY = originalBackendApiKey;
+  global.fetch = originalFetch;
 
   if (tempDir) {
     await rm(tempDir, { recursive: true, force: true });
@@ -20,6 +26,7 @@ afterEach(async () => {
 });
 
 test('returns supported feature arrays when manifest is missing', async () => {
+  const { GET } = await import('../app/api/character/route');
   const response = await GET(
     new NextRequest('https://example.com/api/character?action=supported_features')
   );
@@ -44,6 +51,7 @@ test('returns manifest animations when a character animation manifest exists', a
 
   process.chdir(tempDir);
 
+  const { GET } = await import('../app/api/character/route');
   const response = await GET(
     new NextRequest('https://example.com/api/character?action=supported_features')
   );
@@ -57,6 +65,7 @@ test('returns manifest animations when a character animation manifest exists', a
 });
 
 test('keeps the default GET health payload for other actions', async () => {
+  const { GET } = await import('../app/api/character/route');
   const response = await GET(
     new NextRequest('https://example.com/api/character?action=current_state')
   );
@@ -65,4 +74,79 @@ test('keeps the default GET health payload for other actions', async () => {
   assert.deepEqual(await response.json(), {
     status: 'ok',
   });
+});
+
+test(
+  'POST action auto forwards to backend character auto endpoint without action field',
+  { concurrency: false },
+  async () => {
+    process.env.BACKEND_API_URL = 'https://backend.example.com';
+    process.env.BACKEND_API_KEY = 'k';
+
+    let requestUrl = '';
+    let postedBody = '';
+    global.fetch = (async (input: RequestInfo | URL, init?: RequestInit) => {
+      requestUrl = String(input);
+      postedBody = String(init?.body ?? '');
+      return new Response(
+        JSON.stringify({
+          success: true,
+          vrmControl: { name: 'thinking', duration: 800, keyframes: [] },
+        }),
+        { status: 200, headers: { 'Content-Type': 'application/json' } },
+      );
+    }) as typeof fetch;
+
+    const { POST } = await import('../app/api/character/route');
+    const response = await POST(
+      new NextRequest('https://example.com/api/character', {
+        method: 'POST',
+        body: JSON.stringify({
+          action: 'auto',
+          cleanText: 'こんにちは',
+          emotion: 'happy',
+        }),
+        headers: { 'Content-Type': 'application/json' },
+      }),
+    );
+
+    assert.equal(response.status, 200);
+    assert.equal(requestUrl, 'https://backend.example.com/api/character/auto');
+    assert.deepEqual(JSON.parse(postedBody), {
+      cleanText: 'こんにちは',
+      emotion: 'happy',
+    });
+    assert.deepEqual(await response.json(), {
+      success: true,
+      vrmControl: { name: 'thinking', duration: 800, keyframes: [] },
+    });
+  },
+);
+
+test('POST with an empty body forwards to the default backend character endpoint', async () => {
+  process.env.BACKEND_API_URL = 'https://backend.example.com';
+  process.env.BACKEND_API_KEY = 'k';
+
+  let requestUrl = '';
+  let postedBody = '';
+  global.fetch = (async (input: RequestInfo | URL, init?: RequestInit) => {
+    requestUrl = String(input);
+    postedBody = String(init?.body ?? '');
+    return new Response(JSON.stringify({ success: true }), {
+      status: 200,
+      headers: { 'Content-Type': 'application/json' },
+    });
+  }) as typeof fetch;
+
+  const { POST } = await import('../app/api/character/route');
+  const response = await POST(
+    new NextRequest('https://example.com/api/character', {
+      method: 'POST',
+    }),
+  );
+
+  assert.equal(response.status, 200);
+  assert.equal(requestUrl, 'https://backend.example.com/api/character');
+  assert.deepEqual(JSON.parse(postedBody), {});
+  assert.deepEqual(await response.json(), { success: true });
 });

--- a/frontend/src/app/api/character/route.ts
+++ b/frontend/src/app/api/character/route.ts
@@ -70,9 +70,18 @@ async function getSupportedAnimations() {
 
 export async function POST(request: NextRequest) {
   try {
-    const body = await request.json();
+    const rawBody = await request.text();
+    const body =
+      rawBody.trim().length > 0
+        ? (JSON.parse(rawBody) as Record<string, unknown>)
+        : {};
+    const action = typeof body?.action === 'string' ? body.action : null;
+    const backendPath = action === 'auto' ? '/api/character/auto' : '/api/character';
+    if (action === 'auto') {
+      delete body.action;
+    }
 
-    const response = await backendFetch('/api/character', {
+    const response = await backendFetch(backendPath, {
       body,
     });
 

--- a/frontend/src/app/components/KioskBottomBar.tsx
+++ b/frontend/src/app/components/KioskBottomBar.tsx
@@ -47,6 +47,10 @@ export function KioskBottomBar({
   setOcrMode: (mode: 'member_card' | 'handwriting') => void;
 }) {
   const isVoiceCaptureActive = kioskPhase === 'voice' && kioskVoiceLocked;
+  const controlsLocked = voice.uiLockState === 'locked';
+  const controlsInterruptible = voice.uiLockState === 'interruptible';
+  const welcomeDisabled = controlsLocked || controlsInterruptible || welcomeCooldown;
+  const nonWelcomeDisabled = controlsLocked;
   const isPushToTalk = micInputMode === 'push_to_talk';
   const pushToTalkPointerActiveRef = useRef(false);
   const voiceButtonLabel = isPushToTalk
@@ -58,10 +62,16 @@ export function KioskBottomBar({
       : labels.kioskVoice;
 
   const handleKioskVoiceStart = async () => {
+    if (controlsLocked) {
+      return;
+    }
     if (voice.unlockAudioPlayback()) {
       return;
     }
 
+    if (controlsInterruptible) {
+      voice.cancelSession();
+    }
     unlockAudioForUserGesture();
     clearReturnToIdleTimer();
     setWelcomeMemberOcrOpen(false);
@@ -86,6 +96,13 @@ export function KioskBottomBar({
     voice.cancelSession();
   };
 
+  const interruptActiveVoiceTurn = () => {
+    if (controlsInterruptible) {
+      setKioskVoiceLocked(false);
+      voice.cancelSession();
+    }
+  };
+
   const statusEnabled =
     kioskPhase === 'voice' || kioskPhase === 'idle' || kioskPhase === 'notice';
 
@@ -105,17 +122,17 @@ export function KioskBottomBar({
           sessionState={voice.sessionState}
         />
         <div className="flex w-full flex-row flex-wrap items-stretch justify-center gap-2 sm:gap-3">
-            {showKioskScreenChrome && (
+          {showKioskScreenChrome && (
             <button
               type="button"
               onClick={() => {
                 unlockAudioForUserGesture();
                 void onPlayWelcome();
               }}
-              disabled={isVoiceCaptureActive || voice.isLoading || welcomeCooldown}
+              disabled={welcomeDisabled}
               className={cn(
                 'flex min-h-[72px] min-w-[min(100%,7rem)] flex-1 flex-col items-center justify-center gap-1 rounded-2xl px-3 py-3 shadow-md backdrop-blur-sm transition-transform sm:min-h-[80px] sm:flex-initial sm:px-5',
-                isVoiceCaptureActive || voice.isLoading || welcomeCooldown
+                welcomeDisabled
                   ? 'cursor-not-allowed border border-slate-500/40 bg-slate-600/40 text-slate-300'
                   : 'border border-white/35 bg-white/15 text-white hover:scale-[1.02]',
               )}
@@ -125,140 +142,152 @@ export function KioskBottomBar({
                 {labels.kioskWelcome}
               </span>
             </button>
-            )}
-            <button
-              data-testid="kiosk-voice-button"
-              type="button"
-              onTouchStart={(event) => {
-                if (isPushToTalk) {
-                  event.preventDefault();
-                }
-              }}
-              onPointerDown={(event) => {
-                if (!isPushToTalk) {
-                  return;
-                }
+          )}
+          <button
+            data-testid="kiosk-voice-button"
+            type="button"
+            onTouchStart={(event) => {
+              if (isPushToTalk) {
                 event.preventDefault();
-                event.currentTarget.setPointerCapture(event.pointerId);
-                pushToTalkPointerActiveRef.current = true;
-                if (!isVoiceCaptureActive) {
-                  void handleKioskVoiceStart();
-                }
-              }}
-              onPointerUp={(event) => {
-                if (!isPushToTalk) {
-                  return;
-                }
-                if (event.currentTarget.hasPointerCapture(event.pointerId)) {
-                  event.currentTarget.releasePointerCapture(event.pointerId);
-                }
-                if (pushToTalkPointerActiveRef.current) {
-                  pushToTalkPointerActiveRef.current = false;
-                  handleKioskVoiceStop();
-                }
-              }}
-              onPointerCancel={(event) => {
-                if (!isPushToTalk) {
-                  return;
-                }
-                if (event.currentTarget.hasPointerCapture(event.pointerId)) {
-                  event.currentTarget.releasePointerCapture(event.pointerId);
-                }
-                if (pushToTalkPointerActiveRef.current) {
-                  pushToTalkPointerActiveRef.current = false;
-                  handleKioskVoiceStop();
-                }
-              }}
-              onClick={(event) => {
-                if (isPushToTalk) {
-                  event.preventDefault();
-                  return;
-                }
-                if (isVoiceCaptureActive) {
-                  handleKioskVoiceStop();
-                  return;
-                }
+              }
+            }}
+            onPointerDown={(event) => {
+              if (!isPushToTalk) {
+                return;
+              }
+              if (nonWelcomeDisabled && !isVoiceCaptureActive) {
+                return;
+              }
+              event.preventDefault();
+              event.currentTarget.setPointerCapture(event.pointerId);
+              pushToTalkPointerActiveRef.current = true;
+              if (!isVoiceCaptureActive) {
                 void handleKioskVoiceStart();
-              }}
-              className={cn(
-                'flex min-h-[72px] min-w-[min(100%,7rem)] flex-1 flex-col items-center justify-center gap-1 rounded-2xl px-3 py-3 shadow-md backdrop-blur-sm transition-transform sm:min-h-[80px] sm:flex-initial sm:px-5 select-none touch-manipulation [-webkit-touch-callout:none]',
-                isVoiceCaptureActive
-                  ? 'border border-emerald-300/70 bg-emerald-500/55 text-white shadow-lg'
-                  : 'border border-white/35 bg-white/15 text-white hover:scale-[1.02]',
-              )}
-            >
-              <Mic
-                className="pointer-events-none select-none touch-manipulation [-webkit-touch-callout:none] size-6 shrink-0 sm:size-7"
-                aria-hidden
-              />
-              <span className="pointer-events-none select-none touch-manipulation [-webkit-touch-callout:none] text-center text-xs font-semibold leading-tight sm:text-sm">
-                {voiceButtonLabel}
-              </span>
-            </button>
-            <button
-              type="button"
-              onClick={() => {
-                unlockAudioForUserGesture();
-                setWelcomeMemberOcrOpen(false);
-                setOcrMode('member_card');
-                setKioskPhase('ocr');
-              }}
-              disabled={isVoiceCaptureActive}
-              className={cn(
-                'flex min-h-[72px] min-w-[min(100%,7rem)] flex-1 flex-col items-center justify-center gap-1 rounded-2xl px-3 py-3 shadow-md backdrop-blur-sm transition-transform sm:min-h-[80px] sm:flex-initial sm:px-5',
-                isVoiceCaptureActive
+              }
+            }}
+            onPointerUp={(event) => {
+              if (!isPushToTalk) {
+                return;
+              }
+              if (event.currentTarget.hasPointerCapture(event.pointerId)) {
+                event.currentTarget.releasePointerCapture(event.pointerId);
+              }
+              if (pushToTalkPointerActiveRef.current) {
+                pushToTalkPointerActiveRef.current = false;
+                handleKioskVoiceStop();
+              }
+            }}
+            onPointerCancel={(event) => {
+              if (!isPushToTalk) {
+                return;
+              }
+              if (event.currentTarget.hasPointerCapture(event.pointerId)) {
+                event.currentTarget.releasePointerCapture(event.pointerId);
+              }
+              if (pushToTalkPointerActiveRef.current) {
+                pushToTalkPointerActiveRef.current = false;
+                handleKioskVoiceStop();
+              }
+            }}
+            onClick={(event) => {
+              if (isPushToTalk) {
+                event.preventDefault();
+                return;
+              }
+              if (nonWelcomeDisabled && !isVoiceCaptureActive) {
+                return;
+              }
+              if (isVoiceCaptureActive) {
+                handleKioskVoiceStop();
+                return;
+              }
+              void handleKioskVoiceStart();
+            }}
+            disabled={nonWelcomeDisabled && !isVoiceCaptureActive}
+            className={cn(
+              'flex min-h-[72px] min-w-[min(100%,7rem)] flex-1 touch-manipulation select-none flex-col items-center justify-center gap-1 rounded-2xl px-3 py-3 shadow-md backdrop-blur-sm transition-transform [-webkit-touch-callout:none] sm:min-h-[80px] sm:flex-initial sm:px-5',
+              isVoiceCaptureActive
+                ? 'border border-emerald-300/70 bg-emerald-500/55 text-white shadow-lg'
+                : nonWelcomeDisabled
                   ? 'cursor-not-allowed border border-slate-500/40 bg-slate-600/40 text-slate-300'
                   : 'border border-white/35 bg-white/15 text-white hover:scale-[1.02]',
-              )}
-            >
-              <Camera className="size-6 shrink-0 sm:size-7" aria-hidden />
-              <span className="text-center text-xs font-semibold leading-tight sm:text-sm">
-                {labels.kioskOcrMember}
-              </span>
-            </button>
-            <button
-              type="button"
-              onClick={() => {
-                unlockAudioForUserGesture();
-                setWelcomeMemberOcrOpen(false);
-                setOcrMode('handwriting');
-                setKioskPhase('ocr');
-              }}
-              disabled={isVoiceCaptureActive}
-              className={cn(
-                'flex min-h-[72px] min-w-[min(100%,7rem)] flex-1 flex-col items-center justify-center gap-1 rounded-2xl px-3 py-3 shadow-md backdrop-blur-sm transition-transform sm:min-h-[80px] sm:flex-initial sm:px-5',
-                isVoiceCaptureActive
-                  ? 'cursor-not-allowed border border-slate-500/40 bg-slate-600/40 text-slate-300'
-                  : 'border border-white/35 bg-white/15 text-white hover:scale-[1.02]',
-              )}
-            >
-              <PenLine className="size-6 shrink-0 sm:size-7" aria-hidden />
-              <span className="text-center text-xs font-semibold leading-tight sm:text-sm">
-                {labels.kioskOcrHandwriting}
-              </span>
-            </button>
-            <button
-              data-testid="kiosk-slides-button"
-              type="button"
-              onClick={() => {
-                unlockAudioForUserGesture();
-                setWelcomeMemberOcrOpen(false);
-                onStartPresentation();
-              }}
-              disabled={isVoiceCaptureActive}
-              className={cn(
-                'flex min-h-[72px] min-w-[min(100%,7rem)] flex-1 flex-col items-center justify-center gap-1 rounded-2xl px-3 py-3 shadow-md backdrop-blur-sm transition-transform sm:min-h-[80px] sm:flex-initial sm:px-5',
-                isVoiceCaptureActive
-                  ? 'cursor-not-allowed border border-slate-500/40 bg-slate-600/40 text-slate-300'
-                  : 'border border-white/35 bg-white/15 text-white hover:scale-[1.02]',
-              )}
-            >
-              <Presentation className="size-6 shrink-0 sm:size-7" aria-hidden />
-              <span className="text-center text-xs font-semibold leading-tight sm:text-sm">
-                {labels.kioskSlides}
-              </span>
-            </button>
-          </div>
+            )}
+          >
+            <Mic
+              className="pointer-events-none size-6 shrink-0 touch-manipulation select-none [-webkit-touch-callout:none] sm:size-7"
+              aria-hidden
+            />
+            <span className="pointer-events-none touch-manipulation select-none text-center text-xs font-semibold leading-tight [-webkit-touch-callout:none] sm:text-sm">
+              {voiceButtonLabel}
+            </span>
+          </button>
+          <button
+            type="button"
+            onClick={() => {
+              interruptActiveVoiceTurn();
+              unlockAudioForUserGesture();
+              setWelcomeMemberOcrOpen(false);
+              setOcrMode('member_card');
+              setKioskPhase('ocr');
+            }}
+            disabled={nonWelcomeDisabled}
+            className={cn(
+              'flex min-h-[72px] min-w-[min(100%,7rem)] flex-1 flex-col items-center justify-center gap-1 rounded-2xl px-3 py-3 shadow-md backdrop-blur-sm transition-transform sm:min-h-[80px] sm:flex-initial sm:px-5',
+              nonWelcomeDisabled
+                ? 'cursor-not-allowed border border-slate-500/40 bg-slate-600/40 text-slate-300'
+                : 'border border-white/35 bg-white/15 text-white hover:scale-[1.02]',
+            )}
+          >
+            <Camera className="size-6 shrink-0 sm:size-7" aria-hidden />
+            <span className="text-center text-xs font-semibold leading-tight sm:text-sm">
+              {labels.kioskOcrMember}
+            </span>
+          </button>
+          <button
+            type="button"
+            onClick={() => {
+              interruptActiveVoiceTurn();
+              unlockAudioForUserGesture();
+              setWelcomeMemberOcrOpen(false);
+              setOcrMode('handwriting');
+              setKioskPhase('ocr');
+            }}
+            disabled={nonWelcomeDisabled}
+            className={cn(
+              'flex min-h-[72px] min-w-[min(100%,7rem)] flex-1 flex-col items-center justify-center gap-1 rounded-2xl px-3 py-3 shadow-md backdrop-blur-sm transition-transform sm:min-h-[80px] sm:flex-initial sm:px-5',
+              nonWelcomeDisabled
+                ? 'cursor-not-allowed border border-slate-500/40 bg-slate-600/40 text-slate-300'
+                : 'border border-white/35 bg-white/15 text-white hover:scale-[1.02]',
+            )}
+          >
+            <PenLine className="size-6 shrink-0 sm:size-7" aria-hidden />
+            <span className="text-center text-xs font-semibold leading-tight sm:text-sm">
+              {labels.kioskOcrHandwriting}
+            </span>
+          </button>
+          <button
+            data-testid="kiosk-slides-button"
+            type="button"
+            onClick={() => {
+              interruptActiveVoiceTurn();
+              unlockAudioForUserGesture();
+              setWelcomeMemberOcrOpen(false);
+              onStartPresentation();
+            }}
+            disabled={nonWelcomeDisabled}
+            className={cn(
+              'flex min-h-[72px] min-w-[min(100%,7rem)] flex-1 flex-col items-center justify-center gap-1 rounded-2xl px-3 py-3 shadow-md backdrop-blur-sm transition-transform sm:min-h-[80px] sm:flex-initial sm:px-5',
+              nonWelcomeDisabled
+                ? 'cursor-not-allowed border border-slate-500/40 bg-slate-600/40 text-slate-300'
+                : 'border border-white/35 bg-white/15 text-white hover:scale-[1.02]',
+            )}
+          >
+            <Presentation className="size-6 shrink-0 sm:size-7" aria-hidden />
+            <span className="text-center text-xs font-semibold leading-tight sm:text-sm">
+              {labels.kioskSlides}
+            </span>
+          </button>
+        </div>
       </div>
     </div>
   );

--- a/frontend/src/app/components/KioskOcrOverlay.tsx
+++ b/frontend/src/app/components/KioskOcrOverlay.tsx
@@ -32,10 +32,16 @@ export function KioskOcrOverlay({
   return (
     <div
       data-testid="kiosk-ocr-overlay"
-      className="absolute inset-0 z-40 overflow-y-auto bg-black/60 p-4"
+      className="absolute inset-0 z-40 grid min-h-0 place-items-center overflow-y-auto bg-black/60"
+      style={{
+        paddingTop: 'max(1rem, env(safe-area-inset-top))',
+        paddingRight: 'max(1rem, env(safe-area-inset-right))',
+        paddingBottom: 'max(1rem, env(safe-area-inset-bottom))',
+        paddingLeft: 'max(1rem, env(safe-area-inset-left))',
+      }}
       onPointerDownCapture={bumpUserActivity}
     >
-      <div className="mx-auto max-w-lg rounded-[28px] border border-white/15 bg-white/95 p-5 shadow-xl md:p-8">
+      <div className="mx-auto max-h-full w-full max-w-lg overflow-y-auto rounded-[28px] border border-white/15 bg-white/95 p-5 shadow-xl md:p-8">
         <h3
           data-testid="kiosk-ocr-overlay-title"
           className="mb-4 text-center text-lg font-semibold text-slate-900"

--- a/frontend/src/app/components/VoiceInterface.tsx
+++ b/frontend/src/app/components/VoiceInterface.tsx
@@ -45,6 +45,7 @@ export type VoiceSessionState = 'idle' | 'listening' | 'processing' | 'speaking'
 
 /** Semantic loading stage for kiosk UI; avoids coupling to localized loadingMessage strings. */
 export type VoiceLoadingPhase = 'mic' | 'stt' | 'llm' | 'tts' | null;
+export type VoiceUiLockState = 'normal' | 'locked' | 'interruptible';
 
 export interface VoiceInterfaceMetadata {
   clarification?: {
@@ -53,7 +54,7 @@ export interface VoiceInterfaceMetadata {
   };
   clarification_options?: string[];
   requires_followup?: boolean;
-   reception_type?: string;
+  reception_type?: string;
   vrm_control?: CharacterAnimationData | null;
   [key: string]: unknown;
 }
@@ -69,6 +70,7 @@ export interface VoiceInterfaceRenderProps {
   isLoading: boolean;
   loadingMessage: string;
   loadingPhase: VoiceLoadingPhase;
+  uiLockState: VoiceUiLockState;
   currentLanguage: 'ja' | 'en';
   volume: number;
   isMuted: boolean;
@@ -181,6 +183,7 @@ const FAST_FILLER_TEXT = {
   ja: '確認しています。',
   en: 'Let me check.',
 } as const;
+const AUTO_VRM_PLAYBACK_WAIT_MS = 180;
 
 /** UUID v4 を生成する。crypto.randomUUID が無い環境（HTTP や古いブラウザ）用のフォールバック付き。 */
 const generateUuid = (): string => {
@@ -305,6 +308,7 @@ export default function VoiceInterface({
   const [isLoading, setIsLoading] = useState(false);
   const [loadingMessage, setLoadingMessage] = useState('');
   const [loadingPhase, setLoadingPhase] = useState<VoiceLoadingPhase>(null);
+  const [exclusiveUiLock, setExclusiveUiLock] = useState(false);
   const [mediaStream, setMediaStream] = useState<MediaStream | null>(null);
 
   const sessionIdRef = useRef(createSessionId());
@@ -376,6 +380,28 @@ export default function VoiceInterface({
     requestAbortRef.current?.abort();
     requestAbortRef.current = null;
   }, []);
+
+  const requestBackendInterrupt = useCallback(() => {
+    const sessionId = sessionIdRef.current;
+    if (!sessionId) {
+      return;
+    }
+
+    void fetch('/api/voice', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({
+        action: 'interrupt',
+        sessionId,
+        language: currentLanguage,
+      }),
+      keepalive: true,
+    }).catch(() => {
+      /* best-effort interrupt */
+    });
+  }, [currentLanguage]);
 
   const cancelFastFiller = useCallback(() => {
     if (fastFillerTimerRef.current !== null) {
@@ -501,6 +527,7 @@ export default function VoiceInterface({
     setIsLoading(false);
     setLoadingMessage('');
     setLoadingPhase(null);
+    setExclusiveUiLock(false);
     voiceController.notifySpeakingComplete(true);
     return true;
   }, [cleanupAudioPlayback, currentLanguage, voiceController]);
@@ -513,6 +540,7 @@ export default function VoiceInterface({
     setIsLoading(false);
     setLoadingMessage('');
     setLoadingPhase(null);
+    setExclusiveUiLock(false);
     sessionIdRef.current = createSessionId();
   }, []);
 
@@ -676,6 +704,48 @@ export default function VoiceInterface({
     ],
   );
 
+  const fetchAutoVrmControl = useCallback(
+    async (
+      cleanText: string,
+      emotion: string | null | undefined,
+      signal: AbortSignal,
+    ): Promise<Record<string, unknown> | null> => {
+      try {
+        const response = await fetch('/api/character', {
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json',
+          },
+          body: JSON.stringify({
+            action: 'auto',
+            cleanText,
+            emotion: emotion?.trim() || 'neutral',
+          }),
+          signal,
+        });
+        if (!response.ok) {
+          return null;
+        }
+        return (await response.json()) as Record<string, unknown>;
+      } catch {
+        return null;
+      }
+    },
+    [],
+  );
+
+  const resolveAutoVrmControlForPlayback = useCallback(
+    async (vrmTask: Promise<Record<string, unknown> | null>) => {
+      return Promise.race([
+        vrmTask,
+        new Promise<null>((resolve) => {
+          window.setTimeout(resolve, AUTO_VRM_PLAYBACK_WAIT_MS, null);
+        }),
+      ]);
+    },
+    [],
+  );
+
   const unlockAudioPlayback = useCallback((): boolean => {
     if (sessionState === 'listening') {
       return false;
@@ -815,11 +885,15 @@ export default function VoiceInterface({
           text: preprocessTTS(cleanAnswer, responseLanguage),
           language: responseLanguage,
           sessionId: sessionIdRef.current,
-          includeVrmControl: true,
         };
         if (typeof qaResult.emotion === 'string' && qaResult.emotion.trim()) {
           ttsBody.emotion = qaResult.emotion.trim();
         }
+        const vrmTask = fetchAutoVrmControl(
+          cleanAnswer,
+          typeof qaResult.emotion === 'string' ? qaResult.emotion : null,
+          signal,
+        );
 
         const ttsResponse = await fetch('/api/voice', {
           method: 'POST',
@@ -844,7 +918,11 @@ export default function VoiceInterface({
         // Filler runs in parallel; do not await — slow filler must not delay main TTS enqueue.
         void fillerTask.catch(() => {});
 
-        const playbackMetadata = mergePlaybackMetadataWithTtsVrmControl(qaMeta, ttsResult);
+        const vrmResult = await resolveAutoVrmControlForPlayback(vrmTask);
+        const playbackMetadata = mergePlaybackMetadataWithTtsVrmControl(
+          qaMeta,
+          vrmResult ?? ttsResult,
+        );
 
         if (isMuted) {
           cancelFastFiller();
@@ -946,9 +1024,11 @@ export default function VoiceInterface({
       onVoiceTurnAssistantSpeakingVisual,
       onVoiceTurnThinkingVisual,
       playAssistantAudio,
+      resolveAutoVrmControlForPlayback,
       scheduleLipSyncFrames,
       skipAssistantTurnAutoResume,
       deferForIOSAudioUnlock,
+      fetchAutoVrmControl,
       stopPlayback,
       volume,
       voiceController,
@@ -1024,11 +1104,15 @@ export default function VoiceInterface({
           text: preprocessTTS(cleanAnswer, responseLanguage),
           language: responseLanguage,
           sessionId: sessionIdRef.current,
-          includeVrmControl: true,
         };
         if (typeof qaResult.emotion === 'string' && qaResult.emotion.trim()) {
           ttsBody.emotion = qaResult.emotion.trim();
         }
+        const vrmTask = fetchAutoVrmControl(
+          cleanAnswer,
+          typeof qaResult.emotion === 'string' ? qaResult.emotion : null,
+          abortController.signal,
+        );
 
         const ttsResponse = await fetch('/api/voice', {
           method: 'POST',
@@ -1049,7 +1133,11 @@ export default function VoiceInterface({
           throw ttsError;
         }
 
-        const playbackMetadata = mergePlaybackMetadataWithTtsVrmControl(qaMeta, ttsResult);
+        const vrmResult = await resolveAutoVrmControlForPlayback(vrmTask);
+        const playbackMetadata = mergePlaybackMetadataWithTtsVrmControl(
+          qaMeta,
+          vrmResult ?? ttsResult,
+        );
 
         if (typeof ttsResult.audioResponse === 'string' && ttsResult.audioResponse.length > 0) {
           await playAssistantAudio(ttsResult.audioResponse, playbackMetadata);
@@ -1075,6 +1163,7 @@ export default function VoiceInterface({
         setIsLoading(false);
         setLoadingMessage('');
         setLoadingPhase(null);
+        setExclusiveUiLock(false);
       }
     },
     [
@@ -1082,8 +1171,10 @@ export default function VoiceInterface({
       cancelFastFiller,
       currentLanguage,
       ensureVisitorId,
+      fetchAutoVrmControl,
       onSlideAgentResponse,
       playAssistantAudio,
+      resolveAutoVrmControlForPlayback,
       scheduleFastFiller,
       skipAssistantTurnAutoResume,
       stopPlayback,
@@ -1100,6 +1191,7 @@ export default function VoiceInterface({
 
       cancelPendingRequest();
       stopPlayback(false);
+      setExclusiveUiLock(true);
       setError(null);
       setTranscript('');
 
@@ -1124,11 +1216,15 @@ export default function VoiceInterface({
           text: preprocessTTS(cleanAnswer, responseLanguage),
           language: responseLanguage,
           sessionId: sessionIdRef.current,
-          includeVrmControl: true,
         };
         if (parsedAnswer.primaryEmotion) {
           ttsBody.emotion = parsedAnswer.primaryEmotion;
         }
+        const vrmTask = fetchAutoVrmControl(
+          cleanAnswer,
+          parsedAnswer.primaryEmotion,
+          abortController.signal,
+        );
 
         const ttsResponse = await fetch('/api/voice', {
           method: 'POST',
@@ -1147,9 +1243,10 @@ export default function VoiceInterface({
           );
         }
 
+        const vrmResult = await resolveAutoVrmControlForPlayback(vrmTask);
         const playbackMetadata = mergePlaybackMetadataWithTtsVrmControl(
           metadataForPlayback ?? null,
-          ttsResult,
+          vrmResult ?? ttsResult,
         );
 
         if (typeof ttsResult.audioResponse === 'string' && ttsResult.audioResponse.length > 0) {
@@ -1174,12 +1271,15 @@ export default function VoiceInterface({
         setIsLoading(false);
         setLoadingMessage('');
         setLoadingPhase(null);
+        setExclusiveUiLock(false);
       }
     },
     [
       cancelPendingRequest,
       currentLanguage,
+      fetchAutoVrmControl,
       playAssistantAudio,
+      resolveAutoVrmControlForPlayback,
       skipAssistantTurnAutoResume,
       stopPlayback,
       voiceController,
@@ -1198,6 +1298,7 @@ export default function VoiceInterface({
       setIsLoading(true);
       setLoadingMessage(LOADING_LABELS[currentLanguage].recognize);
       setLoadingPhase('stt');
+      scheduleFastFiller();
 
       const abortController = new AbortController();
       requestAbortRef.current = abortController;
@@ -1232,6 +1333,7 @@ export default function VoiceInterface({
           return;
         }
 
+        cancelFastFiller();
         setError(formatError(recordingError, currentLanguage));
         voiceController.notifySpeakingComplete(true);
       } finally {
@@ -1243,7 +1345,14 @@ export default function VoiceInterface({
         setLoadingPhase(null);
       }
     },
-    [cancelPendingRequest, currentLanguage, processVoiceTurnWithParallelFiller, voiceController],
+    [
+      cancelPendingRequest,
+      cancelFastFiller,
+      currentLanguage,
+      processVoiceTurnWithParallelFiller,
+      scheduleFastFiller,
+      voiceController,
+    ],
   );
 
   const ensureRecorder = useCallback(async () => {
@@ -1406,6 +1515,7 @@ export default function VoiceInterface({
     isReplayingPendingIOSAudioRef.current = false;
     cancelSttWarmup();
     cancelFastFiller();
+    requestBackendInterrupt();
     cancelPendingRequest();
     stopPlayback(false);
     shouldDiscardNextAudioRef.current = true;
@@ -1413,10 +1523,12 @@ export default function VoiceInterface({
     setIsLoading(false);
     setLoadingMessage('');
     setLoadingPhase(null);
+    setExclusiveUiLock(false);
     voiceController.endManualSession();
   }, [
     cancelFastFiller,
     cancelPendingRequest,
+    requestBackendInterrupt,
     stopPlayback,
     stopRecorderCapture,
     voiceController,
@@ -1467,6 +1579,24 @@ export default function VoiceInterface({
     });
   }, [currentLanguage]);
 
+  const uiLockState = useMemo<VoiceUiLockState>(() => {
+    if (exclusiveUiLock) {
+      return 'locked';
+    }
+    if (sessionState === 'listening' || loadingPhase === 'mic' || loadingPhase === 'stt') {
+      return 'locked';
+    }
+    if (
+      sessionState === 'processing' ||
+      sessionState === 'speaking' ||
+      loadingPhase === 'llm' ||
+      loadingPhase === 'tts'
+    ) {
+      return 'interruptible';
+    }
+    return 'normal';
+  }, [exclusiveUiLock, loadingPhase, sessionState]);
+
   useEffect(() => {
     return () => {
       pendingIOSPlaybackRef.current = null;
@@ -1492,6 +1622,7 @@ export default function VoiceInterface({
       isLoading,
       loadingMessage,
       loadingPhase,
+      uiLockState,
       currentLanguage,
       volume,
       isMuted,
@@ -1524,6 +1655,7 @@ export default function VoiceInterface({
       isMuted,
       loadingMessage,
       loadingPhase,
+      uiLockState,
       metadata,
       response,
       sendMessage,

--- a/frontend/src/components/reception/OcrCameraView.tsx
+++ b/frontend/src/components/reception/OcrCameraView.tsx
@@ -47,7 +47,7 @@ const STATE_LABELS: Record<OcrCameraState, string> = {
 
 const MODE_LABELS: Record<OcrMode, string> = {
   member_card: '会員証を読み取り範囲に映してください',
-  handwriting: '文字を読み取り範囲に映してください',
+  handwriting: '紙やボードに書いた文字をカメラの読み取り範囲に映してください',
 };
 
 export function OcrCameraView({
@@ -107,15 +107,15 @@ export function OcrCameraView({
   const statusTitleClass = compact ? 'text-sm font-semibold' : 'text-lg font-medium';
   const modeHintClass = compact ? 'text-xs text-gray-500' : 'text-sm text-gray-500';
   const videoWrapClass = compact
-    ? 'relative w-full max-w-[200px] overflow-hidden rounded-md bg-black'
-    : 'relative w-full max-w-md overflow-hidden rounded-lg bg-black';
+    ? 'relative aspect-[4/3] w-full max-h-[min(24dvh,9.375rem)] max-w-[min(100%,12.5rem,32dvh)] overflow-hidden rounded-md bg-black'
+    : 'relative aspect-[4/3] w-full max-h-[min(42dvh,21rem)] max-w-[min(100%,28rem,56dvh)] overflow-hidden rounded-lg bg-black';
   const scanBoxClass = compact
-    ? 'h-24 w-36 rounded-md border-2 border-white/60'
-    : 'h-48 w-64 rounded-lg border-2 border-white/60';
+    ? 'h-[min(6rem,70%)] w-[min(9rem,78%)] rounded-md border-2 border-white/60'
+    : 'h-[min(12rem,70%)] w-[min(16rem,78%)] rounded-lg border-2 border-white/60';
   const spinnerClass = compact ? 'size-6 border-2' : 'size-8 border-4';
 
   return (
-    <div className={cn('flex flex-col items-center', compact ? 'gap-2' : 'gap-4')}>
+    <div className={cn('flex min-h-0 w-full flex-col items-center', compact ? 'gap-2' : 'gap-4')}>
       {/* Status */}
       <div className="text-center">
         <p className={statusTitleClass}>{STATE_LABELS[state]}</p>
@@ -129,7 +129,7 @@ export function OcrCameraView({
           autoPlay
           playsInline
           muted
-          className="w-full"
+          className="h-full w-full object-contain"
         />
 
         {/* Scanning overlay */}

--- a/scripts/stt-postdeploy-logging-check.sh
+++ b/scripts/stt-postdeploy-logging-check.sh
@@ -1,0 +1,248 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Summarize post-deploy STT structured logs from Cloud Logging.
+#
+# Usage:
+#   scripts/stt-postdeploy-logging-check.sh --since 2026-05-08T10:00:00+09:00
+#   scripts/stt-postdeploy-logging-check.sh --since 2026-05-08T01:00:00Z --revision engineer-cafe-backend-00099-abc --dry-run
+
+PROJECT_ID="${STT_LOG_CHECK_PROJECT:-aipartner-426616}"
+SERVICE_NAME="${STT_LOG_CHECK_SERVICE:-engineer-cafe-backend}"
+REGION="${STT_LOG_CHECK_REGION:-asia-northeast1}"
+LIMIT=1000
+SINCE=""
+UNTIL=""
+REVISION=""
+DRY_RUN=0
+
+usage() {
+  sed -n '4,9p' "$0"
+  cat <<'EOF'
+
+Options:
+  --since RFC3339      Required start timestamp. Accepts UTC (Z), offsets, or JST suffix.
+  --until RFC3339      Optional end timestamp. Accepts UTC (Z), offsets, or JST suffix.
+  --project ID         GCP project (default: aipartner-426616)
+  --service NAME       Cloud Run service (default: engineer-cafe-backend)
+  --region REGION      Cloud Run region (default: asia-northeast1)
+  --revision NAME      Optional Cloud Run revision filter
+  --limit N            Max log rows to read (default: 1000)
+  --dry-run            Print the Cloud Logging filter without reading logs
+  -h, --help           Show this usage
+
+Reports:
+  - stt_winner counts
+  - stt_overall_duration_ms p50/p90/max
+  - stt_qwen_rejected count
+EOF
+  exit "${1:-0}"
+}
+
+die() {
+  echo "Error: $*" >&2
+  exit 2
+}
+
+require_cmd() {
+  if ! command -v "$1" >/dev/null 2>&1; then
+    die "required command not found: $1"
+  fi
+}
+
+is_positive_int() {
+  [[ "${1:-}" =~ ^[1-9][0-9]*$ ]]
+}
+
+normalize_timestamp() {
+  python3 - "$1" <<'PY'
+from __future__ import annotations
+
+from datetime import datetime, timezone
+import re
+import sys
+
+raw = sys.argv[1].strip()
+if not raw or '"' in raw or "\n" in raw or "\r" in raw:
+    raise SystemExit(2)
+
+value = re.sub(r"\s+JST$", "+09:00", raw, flags=re.IGNORECASE)
+value = value.replace(" ", "T")
+if value.endswith("Z"):
+    value = value[:-1] + "+00:00"
+
+try:
+    parsed = datetime.fromisoformat(value)
+except ValueError as exc:
+    raise SystemExit(f"invalid timestamp {raw!r}: {exc}")
+
+if parsed.tzinfo is None:
+    raise SystemExit(f"timestamp must include timezone, Z, offset, or JST suffix: {raw!r}")
+
+print(parsed.astimezone(timezone.utc).isoformat().replace("+00:00", "Z"))
+PY
+}
+
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --since) [ "$#" -ge 2 ] || die "--since requires a value"; SINCE="$2"; shift 2 ;;
+    --until) [ "$#" -ge 2 ] || die "--until requires a value"; UNTIL="$2"; shift 2 ;;
+    --project) [ "$#" -ge 2 ] || die "--project requires a value"; PROJECT_ID="$2"; shift 2 ;;
+    --service) [ "$#" -ge 2 ] || die "--service requires a value"; SERVICE_NAME="$2"; shift 2 ;;
+    --region) [ "$#" -ge 2 ] || die "--region requires a value"; REGION="$2"; shift 2 ;;
+    --revision) [ "$#" -ge 2 ] || die "--revision requires a value"; REVISION="$2"; shift 2 ;;
+    --limit) [ "$#" -ge 2 ] || die "--limit requires a value"; LIMIT="$2"; shift 2 ;;
+    --dry-run) DRY_RUN=1; shift ;;
+    -h|--help) usage 0 ;;
+    *) echo "Unknown arg: $1" >&2; usage 1 ;;
+  esac
+done
+
+[[ -n "$PROJECT_ID" ]] || die "project must not be empty"
+[[ -n "$SERVICE_NAME" ]] || die "service must not be empty"
+[[ -n "$REGION" ]] || die "region must not be empty"
+[[ -n "$SINCE" ]] || die "--since is required"
+is_positive_int "$LIMIT" || die "--limit must be a positive integer"
+require_cmd python3
+
+SINCE_UTC="$(normalize_timestamp "$SINCE")"
+UNTIL_UTC=""
+if [ -n "$UNTIL" ]; then
+  UNTIL_UTC="$(normalize_timestamp "$UNTIL")"
+fi
+
+FILTER='resource.type="cloud_run_revision"'
+FILTER="$FILTER AND resource.labels.service_name=\"$SERVICE_NAME\""
+FILTER="$FILTER AND resource.labels.location=\"$REGION\""
+if [ -n "$REVISION" ]; then
+  [[ "$REVISION" != *'"'* && "$REVISION" != *$'\n'* && "$REVISION" != *$'\r'* ]] || die "--revision must not contain quotes or newlines"
+  FILTER="$FILTER AND resource.labels.revision_name=\"$REVISION\""
+fi
+FILTER="$FILTER AND timestamp >= \"$SINCE_UTC\""
+if [ -n "$UNTIL_UTC" ]; then
+  FILTER="$FILTER AND timestamp <= \"$UNTIL_UTC\""
+fi
+FILTER="$FILTER AND (jsonPayload.event=\"stt_winner\" OR jsonPayload.event=\"stt_qwen_rejected\")"
+
+if [ "$DRY_RUN" = "1" ]; then
+  echo "Dry run: no gcloud logging read calls will be executed."
+  echo "Project: $PROJECT_ID"
+  echo "Service: $SERVICE_NAME"
+  echo "Region: $REGION"
+  echo "Revision: ${REVISION:-all revisions}"
+  echo "Since UTC: $SINCE_UTC"
+  echo "Until UTC: ${UNTIL_UTC:-none}"
+  echo "Limit: $LIMIT"
+  echo "Filter: $FILTER"
+  exit 0
+fi
+
+require_cmd gcloud
+LOG_JSON="$(mktemp)"
+trap 'rm -f "$LOG_JSON"' EXIT
+
+gcloud logging read "$FILTER" \
+  --project "$PROJECT_ID" \
+  --limit "$LIMIT" \
+  --format=json > "$LOG_JSON"
+
+python3 - "$LOG_JSON" "$PROJECT_ID" "$SERVICE_NAME" "$REGION" "$REVISION" "$SINCE_UTC" "${UNTIL_UTC:-}" "$LIMIT" <<'PY'
+from __future__ import annotations
+
+from collections import Counter
+import json
+import math
+import sys
+from typing import Any
+
+log_json, project, service, region, revision, since_utc, until_utc, limit_raw = sys.argv[1:9]
+limit = int(limit_raw)
+
+with open(log_json, encoding="utf-8") as fh:
+    entries = json.load(fh)
+if not isinstance(entries, list):
+    entries = []
+
+
+def percentile(values: list[float], ratio: float) -> float | None:
+    if not values:
+        return None
+    ordered = sorted(values)
+    if len(ordered) == 1:
+        return ordered[0]
+    pos = (len(ordered) - 1) * ratio
+    lower = math.floor(pos)
+    upper = math.ceil(pos)
+    if lower == upper:
+        return ordered[lower]
+    return ordered[lower] + (ordered[upper] - ordered[lower]) * (pos - lower)
+
+
+def fmt_ms(value: float | None) -> str:
+    return "n/a" if value is None else f"{value:.0f}"
+
+
+winner_counts: Counter[str] = Counter()
+latencies: list[float] = []
+qwen_rejected_count = 0
+event_counts: Counter[str] = Counter()
+
+for entry in entries:
+    payload = entry.get("jsonPayload")
+    if not isinstance(payload, dict):
+        continue
+    event = payload.get("event")
+    if not isinstance(event, str):
+        continue
+    event_counts[event] += 1
+    if event == "stt_qwen_rejected":
+        qwen_rejected_count += 1
+        continue
+    if event != "stt_winner":
+        continue
+
+    winner = payload.get("stt_winner") or payload.get("provider") or "unknown"
+    winner_counts[str(winner)] += 1
+    duration = payload.get("stt_overall_duration_ms")
+    try:
+        latencies.append(float(duration))
+    except (TypeError, ValueError):
+        pass
+
+print("# STT Post-Deploy Logging Check")
+print()
+print(f"- Project: `{project}`")
+print(f"- Service: `{service}` / `{region}`")
+print(f"- Revision: `{revision or 'all revisions'}`")
+print(f"- Window UTC: `{since_utc}` to `{until_utc or 'now'}`")
+print(f"- Rows read: `{len(entries)}`")
+if len(entries) >= limit:
+    print(f"- Limit warning: read hit the configured limit `{limit}`; rerun with a larger --limit if needed.")
+print()
+print("## Events")
+print()
+print("| Event | Count |")
+print("| --- | ---: |")
+for event in ("stt_winner", "stt_qwen_rejected"):
+    print(f"| {event} | {event_counts.get(event, 0)} |")
+print()
+print("## Winners")
+print()
+print("| stt_winner | Count |")
+print("| --- | ---: |")
+if winner_counts:
+    for winner, count in sorted(winner_counts.items()):
+        print(f"| {winner} | {count} |")
+else:
+    print("| n/a | 0 |")
+print()
+print("## Latency")
+print()
+print("| Metric | Value ms |")
+print("| --- | ---: |")
+print(f"| p50 | {fmt_ms(percentile(latencies, 0.50))} |")
+print(f"| p90 | {fmt_ms(percentile(latencies, 0.90))} |")
+print(f"| max | {fmt_ms(max(latencies) if latencies else None)} |")
+print()
+print(f"stt_qwen_rejected count: `{qwen_rejected_count}`")
+PY


### PR DESCRIPTION
## Summary
- Harden STT fallback: reject suspicious Qwen transcripts, cap Qwen wait after Vosk miss, and add post-deploy Cloud Logging STT telemetry checker.
- Improve voice turn UX: lock only during mic/STT capture, keep LLM/TTS interruptible, send best-effort backend interrupt, start fast filler during STT, and decouple VRM auto-control from TTS latency.
- Improve TTS reliability: reuse provider HTTP clients, reject invalid cached audio, and close voice agents during FastAPI lifespan shutdown.
- Fix portrait OCR/handwriting layout and clarify handwriting camera copy.
- Align runtime dependencies and record post-alpha execution notes.

## Verification
- `python -m pytest backend/tests/test_main_endpoints.py backend/tests/agents/test_stt_agent.py backend/tests/agents/test_voice_agent.py backend/tests/agents/test_voice_agent_cache.py -q` (201 passed)
- `python -m ruff check backend/agents/stt_agent.py backend/agents/voice_agent.py backend/main.py backend/tests/test_main_endpoints.py backend/tests/agents/test_stt_agent.py backend/tests/agents/test_voice_agent.py backend/tests/agents/test_voice_agent_cache.py`
- `python -m black --check backend/agents/stt_agent.py backend/agents/voice_agent.py backend/main.py backend/tests/test_main_endpoints.py backend/tests/agents/test_stt_agent.py backend/tests/agents/test_voice_agent.py backend/tests/agents/test_voice_agent_cache.py`
- `pnpm exec tsc --noEmit --pretty false`
- `pnpm lint` (passes with existing `ReceptionPdfGuide.tsx` exhaustive-deps warning)
- `pnpm exec tsx --test src/__tests__/api-character-route.test.ts src/__tests__/tts-vrm-metadata.test.ts src/__tests__/voice-filler-playback.test.ts` (12 passed)
- `pnpm build` (passes with existing Browserslist staleness notice and existing `ReceptionPdfGuide.tsx` warning)
- `PLAYWRIGHT_BASE_URL=http://127.0.0.1:3028 PLAYWRIGHT_VIDEO=off pnpm exec playwright test e2e/voice-filler.spec.ts e2e/welcome-voice-first.spec.ts e2e/reception-pdf-guide.spec.ts --project=chromium --workers=1` (8 passed)
- Portrait OCR smoke on production Next server: 390x844 and 320x568 for member-card and handwriting overlays all fit viewport/title bounds
- `bash -n scripts/stt-postdeploy-logging-check.sh && shellcheck scripts/stt-postdeploy-logging-check.sh && scripts/stt-postdeploy-logging-check.sh --dry-run --since '2026-05-08 00:00:00 JST'`
- `git diff --check`

## Live gate
Do not close the related issues on PR merge alone. After merge/deploy, verify the new Cloud Run revision and run live endpoint/log checks, then close/update issues only after production behavior is confirmed.

Related: #781, #529, #611, #584, #569, #763
