### PR TITLE
Post-alpha slide state and Cerebras speedups

### DIFF
--- a/backend/llm/README.md
+++ b/backend/llm/README.md
@@ -59,6 +59,13 @@ async def my_agent_node(state):
 | Gemini 2.5 Pro | `google/gemini-2.5-pro` | 高度な推論の安定版 fallback |
 | GPT-5.4 Nano | `openai/gpt-5.4-nano` | OpenAI 側の高速・低コスト候補 |
 
+## Cerebras fast primary
+
+`FAST_LLM_PRIMARY_PROVIDER=cerebras` と `CEREBRAS_API_KEY` が設定されている場合、
+`CEREBRAS_PRIMARY_USE_CASES` で許可された軽量レスポンス設定だけが Cerebras を先に試します。
+既定値は `qa_response,general_knowledge,event_info,facility_info` です。
+失敗時は既存の OpenRouter primary/fallback に戻ります。`none` で primary 利用を無効化できます。
+
 ## モデル設定
 
 用途別に事前設定されたコンフィグ:

--- a/backend/llm/model_resolve.py
+++ b/backend/llm/model_resolve.py
@@ -21,6 +21,14 @@ from backend.llm.models import SupportedModel
 logger = logging.getLogger(__name__)
 
 _DEFAULT_FAST_PRIMARY = SupportedModel.GEMINI_3_1_FLASH_LITE.value
+_DEFAULT_CEREBRAS_PRIMARY_USE_CASES = frozenset(
+    {
+        "qa_response",
+        "general_knowledge",
+        "event_info",
+        "facility_info",
+    }
+)
 
 
 def resolved_openrouter_model_slug(config: "ModelConfig", *, branch: str = "primary") -> str:
@@ -76,6 +84,38 @@ def fast_llm_enabled() -> bool:
     return raw not in {"0", "false", "no", "off"}
 
 
+def cerebras_primary_use_cases() -> frozenset[str] | None:
+    """
+    Use cases eligible for direct Cerebras primary.
+
+    None means all ModelConfig-level opt-ins are allowed. An empty set means
+    none are allowed. Unset defaults to lightweight response configs only.
+    """
+    raw = os.getenv("CEREBRAS_PRIMARY_USE_CASES")
+    if raw is None:
+        return _DEFAULT_CEREBRAS_PRIMARY_USE_CASES
+
+    values = frozenset(part.strip().lower() for part in raw.split(",") if part.strip())
+    if values & {"*", "all"}:
+        return None
+    if not values or values & {"0", "false", "no", "none", "off"}:
+        return frozenset()
+    return values
+
+
+def cerebras_primary_use_case_allowed(config: "ModelConfig") -> bool:
+    allowed = cerebras_primary_use_cases()
+    if allowed is None:
+        return True
+    if not allowed:
+        return False
+
+    use_case = getattr(config, "cerebras_primary_use_case", None)
+    if not use_case:
+        return False
+    return use_case.strip().lower() in allowed
+
+
 def cerebras_primary_enabled(config: "ModelConfig") -> bool:
     """Whether direct Cerebras should be attempted before OpenRouter for fast configs."""
     provider = os.getenv("FAST_LLM_PRIMARY_PROVIDER", "").strip().lower()
@@ -85,6 +125,7 @@ def cerebras_primary_enabled(config: "ModelConfig") -> bool:
         and provider == "cerebras"
         and bool(key)
         and bool(getattr(config, "allow_cerebras_primary", False))
+        and cerebras_primary_use_case_allowed(config)
         and is_fast_primary_config(config)
     )
 

--- a/backend/llm/models.py
+++ b/backend/llm/models.py
@@ -74,6 +74,7 @@ class ModelConfig:
         fallback_model: Backup model if primary fails (same OpenRouter API)
         timeout: Request timeout in seconds
         allow_cerebras_primary: Allow direct Cerebras before OpenRouter for lightweight answers
+        cerebras_primary_use_case: Stable use-case name for env allowlist checks
     """
 
     model_id: SupportedModel
@@ -83,6 +84,7 @@ class ModelConfig:
     fallback_model: Optional[SupportedModel] = None
     timeout: float = 30.0
     allow_cerebras_primary: bool = False
+    cerebras_primary_use_case: Optional[str] = None
 
     input_cost_per_1k: float = field(default=0.0, repr=False)
     output_cost_per_1k: float = field(default=0.0, repr=False)
@@ -116,6 +118,7 @@ MODEL_CONFIGS: dict[str, ModelConfig] = {
         max_tokens=1024,
         fallback_model=SupportedModel.GEMINI_2_5_FLASH_LITE,
         allow_cerebras_primary=True,
+        cerebras_primary_use_case="qa_response",
         input_cost_per_1k=0.0001,
         output_cost_per_1k=0.0004,
     ),
@@ -133,6 +136,7 @@ MODEL_CONFIGS: dict[str, ModelConfig] = {
         max_tokens=1024,
         fallback_model=SupportedModel.GEMINI_2_5_FLASH_LITE,
         allow_cerebras_primary=True,
+        cerebras_primary_use_case="general_knowledge",
         input_cost_per_1k=0.0001,
         output_cost_per_1k=0.0004,
     ),
@@ -150,6 +154,8 @@ MODEL_CONFIGS: dict[str, ModelConfig] = {
         temperature=0.4,
         max_tokens=512,
         fallback_model=SupportedModel.GEMINI_2_5_FLASH_LITE,
+        allow_cerebras_primary=True,
+        cerebras_primary_use_case="event_info",
         input_cost_per_1k=0.0001,
         output_cost_per_1k=0.0004,
     ),
@@ -158,6 +164,8 @@ MODEL_CONFIGS: dict[str, ModelConfig] = {
         temperature=0.5,
         max_tokens=768,
         fallback_model=SupportedModel.GEMINI_2_5_FLASH_LITE,
+        allow_cerebras_primary=True,
+        cerebras_primary_use_case="facility_info",
         input_cost_per_1k=0.0001,
         output_cost_per_1k=0.0004,
     ),

--- a/backend/tests/llm/test_model_resolve.py
+++ b/backend/tests/llm/test_model_resolve.py
@@ -1,0 +1,102 @@
+"""
+Tests for LLM model/provider routing resolution.
+"""
+
+import pytest
+
+from backend.llm.model_resolve import (
+    cerebras_primary_enabled,
+    cerebras_primary_use_cases,
+)
+from backend.llm.models import MODEL_CONFIGS
+from backend.llm.models import ModelConfig, SupportedModel
+
+
+def _enable_cerebras_primary_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("FAST_LLM_ENABLED", "true")
+    monkeypatch.setenv("FAST_LLM_PRIMARY_PROVIDER", "cerebras")
+    monkeypatch.setenv("CEREBRAS_API_KEY", "test_cerebras_key")
+
+
+@pytest.mark.parametrize(
+    "use_case",
+    ["qa_response", "general_knowledge", "event_info", "facility_info"],
+)
+def test_default_cerebras_primary_use_cases_include_lightweight_responses(
+    monkeypatch: pytest.MonkeyPatch, use_case: str
+):
+    _enable_cerebras_primary_env(monkeypatch)
+    monkeypatch.delenv("CEREBRAS_PRIMARY_USE_CASES", raising=False)
+
+    assert cerebras_primary_enabled(MODEL_CONFIGS[use_case]) is True
+
+
+@pytest.mark.parametrize("use_case", ["router", "clarification", "deep_reasoning", "vision"])
+def test_cerebras_primary_does_not_apply_to_non_response_configs(
+    monkeypatch: pytest.MonkeyPatch, use_case: str
+):
+    _enable_cerebras_primary_env(monkeypatch)
+    monkeypatch.delenv("CEREBRAS_PRIMARY_USE_CASES", raising=False)
+
+    assert cerebras_primary_enabled(MODEL_CONFIGS[use_case]) is False
+
+
+def test_cerebras_primary_use_cases_can_narrow_response_surface(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    _enable_cerebras_primary_env(monkeypatch)
+    monkeypatch.setenv("CEREBRAS_PRIMARY_USE_CASES", "qa_response,general_knowledge")
+
+    assert cerebras_primary_enabled(MODEL_CONFIGS["qa_response"]) is True
+    assert cerebras_primary_enabled(MODEL_CONFIGS["general_knowledge"]) is True
+    assert cerebras_primary_enabled(MODEL_CONFIGS["event_info"]) is False
+    assert cerebras_primary_enabled(MODEL_CONFIGS["facility_info"]) is False
+
+
+@pytest.mark.parametrize("raw_value", ["none", "off", "false", ""])
+def test_cerebras_primary_use_cases_can_disable_primary(
+    monkeypatch: pytest.MonkeyPatch, raw_value: str
+):
+    _enable_cerebras_primary_env(monkeypatch)
+    monkeypatch.setenv("CEREBRAS_PRIMARY_USE_CASES", raw_value)
+
+    assert cerebras_primary_use_cases() == frozenset()
+    assert cerebras_primary_enabled(MODEL_CONFIGS["qa_response"]) is False
+
+
+def test_cerebras_primary_requires_fast_llm_flag(monkeypatch: pytest.MonkeyPatch):
+    _enable_cerebras_primary_env(monkeypatch)
+    monkeypatch.setenv("FAST_LLM_ENABLED", "false")
+
+    assert cerebras_primary_enabled(MODEL_CONFIGS["facility_info"]) is False
+
+
+def test_cerebras_primary_requires_api_key(monkeypatch: pytest.MonkeyPatch):
+    _enable_cerebras_primary_env(monkeypatch)
+    monkeypatch.setenv("CEREBRAS_API_KEY", "")
+
+    assert cerebras_primary_enabled(MODEL_CONFIGS["event_info"]) is False
+
+
+def test_cerebras_primary_requires_named_use_case_by_default(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    _enable_cerebras_primary_env(monkeypatch)
+    config = ModelConfig(
+        model_id=SupportedModel.GEMINI_3_1_FLASH_LITE,
+        fallback_model=SupportedModel.GEMINI_2_5_FLASH_LITE,
+        allow_cerebras_primary=True,
+    )
+
+    assert cerebras_primary_enabled(config) is False
+
+
+def test_cerebras_primary_allows_explicit_all_for_opted_in_configs(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    _enable_cerebras_primary_env(monkeypatch)
+    monkeypatch.setenv("CEREBRAS_PRIMARY_USE_CASES", "all")
+
+    assert cerebras_primary_use_cases() is None
+    assert cerebras_primary_enabled(MODEL_CONFIGS["facility_info"]) is True
+    assert cerebras_primary_enabled(MODEL_CONFIGS["router"]) is False

--- a/backend/tests/llm/test_models.py
+++ b/backend/tests/llm/test_models.py
@@ -110,6 +110,8 @@ class TestModelConfig:
         assert config.top_p == 0.9
         assert config.fallback_model is None
         assert config.timeout == 30.0
+        assert config.allow_cerebras_primary is False
+        assert config.cerebras_primary_use_case is None
         assert config.input_cost_per_1k == 0.0
         assert config.output_cost_per_1k == 0.0
 
@@ -310,6 +312,23 @@ class TestModelConfigs:
         config = MODEL_CONFIGS["general_knowledge"]
         assert config.model_id == SupportedModel.GEMINI_3_1_FLASH_LITE
         assert config.fallback_model == SupportedModel.GEMINI_2_5_FLASH_LITE
+
+    @pytest.mark.parametrize(
+        "use_case",
+        ["qa_response", "general_knowledge", "event_info", "facility_info"],
+    )
+    def test_lightweight_response_configs_allow_cerebras_primary(self, use_case: str):
+        """低遅延レスポンス用途だけが Cerebras primary opt-in を持つこと"""
+        config = MODEL_CONFIGS[use_case]
+        assert config.allow_cerebras_primary is True
+        assert config.cerebras_primary_use_case == use_case
+
+    @pytest.mark.parametrize("use_case", ["router", "clarification", "deep_reasoning", "vision"])
+    def test_non_response_configs_do_not_allow_cerebras_primary(self, use_case: str):
+        """routing/vision/deep reasoning は Cerebras primary に自動波及させないこと"""
+        config = MODEL_CONFIGS[use_case]
+        assert config.allow_cerebras_primary is False
+        assert config.cerebras_primary_use_case is None
 
     def test_deep_reasoning_keeps_gemini_pro(self):
         """deep_reasoning は明示 keyword 用に Pro モデルを保持すること"""

--- a/backend/tests/llm/test_openrouter.py
+++ b/backend/tests/llm/test_openrouter.py
@@ -166,6 +166,7 @@ class TestOpenRouterProvider:
             model_id=SupportedModel.GEMINI_3_1_FLASH_LITE,
             fallback_model=SupportedModel.GEMINI_2_5_FLASH_LITE,
             allow_cerebras_primary=True,
+            cerebras_primary_use_case="qa_response",
         )
 
         with (
@@ -199,6 +200,7 @@ class TestOpenRouterProvider:
             model_id=SupportedModel.GEMINI_3_1_FLASH_LITE,
             fallback_model=SupportedModel.GEMINI_2_5_FLASH_LITE,
             allow_cerebras_primary=True,
+            cerebras_primary_use_case="qa_response",
         )
 
         mock_response = MagicMock()

--- a/frontend/e2e/reception-pdf-guide.spec.ts
+++ b/frontend/e2e/reception-pdf-guide.spec.ts
@@ -38,6 +38,24 @@ async function mockReceptionApis(page: import('@playwright/test').Page) {
   });
 }
 
+async function dragOnSlidePanel(
+  page: import('@playwright/test').Page,
+  deltaX: number,
+  deltaY: number,
+) {
+  const box = await page.getByTestId('reception-pdf-landscape-panel').boundingBox();
+  expect(box).not.toBeNull();
+  if (!box) {
+    return;
+  }
+  const startX = box.x + box.width / 2;
+  const startY = box.y + box.height / 2;
+  await page.mouse.move(startX, startY);
+  await page.mouse.down();
+  await page.mouse.move(startX + deltaX, startY + deltaY, { steps: 6 });
+  await page.mouse.up();
+}
+
 test.describe('Reception PDF guide', () => {
   test.beforeEach(async ({ page }) => {
     await mockReceptionApis(page);
@@ -67,6 +85,7 @@ test.describe('Reception PDF guide', () => {
     await expect(page.getByTestId('reception-pdf-play')).toHaveAttribute('data-state', 'playing', {
       timeout: 15_000,
     });
+    await expect(page.getByTestId('kiosk-settings-button')).toHaveCount(0);
   });
 
   test('close slides returns to Welcome', async ({ page }) => {
@@ -87,6 +106,36 @@ test.describe('Reception PDF guide', () => {
     await expect(page.getByTestId('reception-pdf-counter')).toHaveText('1 / 5', {
       timeout: 15_000,
     });
-    await expect(page.getByText('Auto-advance')).toBeVisible();
+    await expect(page.getByTestId('reception-pdf-controls')).toBeVisible();
+    await expect(page.getByText('Auto-advance')).toHaveCount(0);
+  });
+
+  test('horizontal swipes navigate slides while short or vertical drags are ignored', async ({
+    page,
+  }) => {
+    await page.setViewportSize({ width: 960, height: 540 });
+    await page.getByTestId('kiosk-slides-button').click();
+    await page.getByTestId('slide-language-ja').click();
+
+    await expect(page.getByTestId('reception-pdf-counter')).toHaveText('1 / 5', {
+      timeout: 15_000,
+    });
+    await expect(page.getByTestId('reception-pdf-play')).toHaveAttribute('data-state', 'playing', {
+      timeout: 15_000,
+    });
+    await page.getByTestId('reception-pdf-play').click();
+    await expect(page.getByTestId('reception-pdf-play')).toHaveAttribute('data-state', 'paused');
+
+    await dragOnSlidePanel(page, -180, 8);
+    await expect(page.getByTestId('reception-pdf-counter')).toHaveText('2 / 5');
+
+    await dragOnSlidePanel(page, -32, 0);
+    await expect(page.getByTestId('reception-pdf-counter')).toHaveText('2 / 5');
+
+    await dragOnSlidePanel(page, -180, 170);
+    await expect(page.getByTestId('reception-pdf-counter')).toHaveText('2 / 5');
+
+    await dragOnSlidePanel(page, 180, 6);
+    await expect(page.getByTestId('reception-pdf-counter')).toHaveText('1 / 5');
   });
 });

--- a/frontend/e2e/slide-pdf-narration.spec.ts
+++ b/frontend/e2e/slide-pdf-narration.spec.ts
@@ -1,5 +1,160 @@
 import { expect, test } from '@playwright/test';
-import { setupWebAudioMock } from './helpers/mocks';
+import { MOCK_VOICE_RESPONSE, setupWebAudioMock } from './helpers/mocks';
+
+declare global {
+  interface Window {
+    __SLIDE_AUDIO_COUNTERS__?: {
+      active: number;
+      starts: number;
+      maxActive: number;
+    };
+    __PLAYWRIGHT_AUDIO_STARTS__?: number;
+  }
+}
+
+async function setupSlideAudioElementMock(
+  page: import('@playwright/test').Page,
+  options: { staticAudioReady: boolean } = { staticAudioReady: true },
+) {
+  await page.addInitScript(({ staticAudioReady }) => {
+    type Listener = {
+      callback: EventListenerOrEventListenerObject;
+      once: boolean;
+    };
+
+    const counters = {
+      active: 0,
+      starts: 0,
+      maxActive: 0,
+    };
+    Object.defineProperty(window, '__SLIDE_AUDIO_COUNTERS__', {
+      configurable: true,
+      value: counters,
+    });
+
+    const isSlideAudio = (url: string) => url.includes('/reception/audio/');
+
+    class MockAudioElement extends EventTarget {
+      public preload = '';
+      public volume = 1;
+      public paused = true;
+      public ended = false;
+      public currentTime = 0;
+      public duration = 30;
+      public readyState = staticAudioReady ? 4 : 0;
+      public src = '';
+      private readonly listeners = new Map<string, Set<Listener>>();
+
+      constructor(url?: string) {
+        super();
+        this.src = url ?? '';
+      }
+
+      setAttribute() {}
+
+      removeAttribute(name: string) {
+        if (name === 'src') {
+          this.src = '';
+        }
+      }
+
+      load() {
+        if (!staticAudioReady) {
+          return;
+        }
+        this.readyState = 4;
+        setTimeout(() => {
+          this.emit('canplay');
+          this.emit('canplaythrough');
+        }, 0);
+      }
+
+      async play() {
+        if (!this.paused) {
+          return;
+        }
+        this.paused = false;
+        this.ended = false;
+        if (isSlideAudio(this.src)) {
+          counters.active += 1;
+          counters.starts += 1;
+          counters.maxActive = Math.max(counters.maxActive, counters.active);
+        }
+        this.emit('play');
+      }
+
+      pause() {
+        if (this.paused) {
+          return;
+        }
+        this.paused = true;
+        if (isSlideAudio(this.src) && !this.ended) {
+          counters.active = Math.max(0, counters.active - 1);
+        }
+        this.emit('pause');
+      }
+
+      addEventListener(
+        event: string,
+        callback: EventListenerOrEventListenerObject,
+        options?: boolean | AddEventListenerOptions,
+      ) {
+        const listeners = this.listeners.get(event) ?? new Set<Listener>();
+        listeners.add({ callback, once: typeof options === 'object' && options.once === true });
+        this.listeners.set(event, listeners);
+      }
+
+      removeEventListener(event: string, callback: EventListenerOrEventListenerObject) {
+        const listeners = this.listeners.get(event);
+        if (!listeners) {
+          return;
+        }
+        for (const listener of Array.from(listeners)) {
+          if (listener.callback === callback) {
+            listeners.delete(listener);
+          }
+        }
+      }
+
+      private emit(event: string) {
+        const listeners = this.listeners.get(event);
+        if (!listeners) {
+          return;
+        }
+        const evt = new Event(event);
+        for (const listener of Array.from(listeners)) {
+          if (typeof listener.callback === 'function') {
+            listener.callback.call(this, evt);
+          } else {
+            listener.callback.handleEvent(evt);
+          }
+          if (listener.once) {
+            listeners.delete(listener);
+          }
+        }
+      }
+    }
+
+    Object.defineProperty(window, 'Audio', {
+      configurable: true,
+      value: MockAudioElement,
+    });
+  }, options);
+}
+
+async function mockReceptionStart(page: import('@playwright/test').Page, sessionId: string) {
+  await page.route('**/api/reception/start', async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({
+        reception_session_id: sessionId,
+        greeting: 'テストです。',
+        stage: 'greeting',
+      }),
+    });
+  });
+}
 
 async function dismissInitialModal(page: import('@playwright/test').Page) {
   const modal = page.getByRole('dialog');
@@ -28,17 +183,8 @@ async function dismissInitialModal(page: import('@playwright/test').Page) {
 test.describe('Slide PDF narration deck (#624)', () => {
   test('autoplay uses static slide audio and does not call Piper TTS', async ({ page }) => {
     await setupWebAudioMock(page);
-    await page.route('**/api/reception/start', async (route) => {
-      await route.fulfill({
-        status: 200,
-        contentType: 'application/json',
-        body: JSON.stringify({
-          reception_session_id: 'mock-slide-narration',
-          greeting: 'テストです。',
-          stage: 'greeting',
-        }),
-      });
-    });
+    await setupSlideAudioElementMock(page, { staticAudioReady: true });
+    await mockReceptionStart(page, 'mock-slide-narration');
 
     let piperHits = 0;
 
@@ -82,5 +228,91 @@ test.describe('Slide PDF narration deck (#624)', () => {
 
     await page.waitForTimeout(3_000);
     expect(piperHits).toBe(0);
+  });
+
+  test('rapid slide changes stop current narration before another slide can play', async ({ page }) => {
+    await setupWebAudioMock(page);
+    await setupSlideAudioElementMock(page, { staticAudioReady: true });
+    await mockReceptionStart(page, 'mock-rapid-slide-narration');
+    await page.route('**/api/voice', async (route) => {
+      await route.fulfill({ status: 200, contentType: 'application/json', body: '{}' });
+    });
+
+    await page.goto('/', { waitUntil: 'domcontentloaded' });
+    await dismissInitialModal(page);
+
+    await page.setViewportSize({ width: 960, height: 540 });
+    await page.getByTestId('kiosk-slides-button').click();
+    await page.getByTestId('slide-language-ja').click();
+
+    await expect(page.getByTestId('reception-pdf-counter')).toHaveText('1 / 5', {
+      timeout: 15_000,
+    });
+    await page.waitForFunction(() => window.__SLIDE_AUDIO_COUNTERS__?.active === 1);
+
+    await page.getByTestId('reception-pdf-next').click();
+    await expect(page.getByTestId('reception-pdf-counter')).toHaveText('2 / 5');
+    await page.waitForFunction(() => window.__SLIDE_AUDIO_COUNTERS__?.active === 0);
+    await expect(page.getByTestId('reception-pdf-play')).toHaveAttribute('data-state', 'paused');
+
+    await page.getByTestId('reception-pdf-next').click();
+    await expect(page.getByTestId('reception-pdf-counter')).toHaveText('3 / 5');
+    await page.getByTestId('reception-pdf-play').click();
+    await page.waitForFunction(() => window.__SLIDE_AUDIO_COUNTERS__?.active === 1);
+
+    const counters = await page.evaluate(() => window.__SLIDE_AUDIO_COUNTERS__);
+    expect(counters?.starts).toBe(2);
+    expect(counters?.maxActive).toBe(1);
+  });
+
+  test('closing slides during pending generated narration prevents stale audio playback', async ({ page }) => {
+    await setupWebAudioMock(page);
+    await setupSlideAudioElementMock(page, { staticAudioReady: false });
+    await mockReceptionStart(page, 'mock-close-pending-narration');
+    let ttsRequests = 0;
+    await page.route('**/api/voice', async (route) => {
+      const req = route.request();
+      if (req.method() === 'POST') {
+        let body: Record<string, unknown> = {};
+        try {
+          body = req.postDataJSON() as Record<string, unknown>;
+        } catch {
+          body = {};
+        }
+        if (body.action === 'text_to_speech') {
+          ttsRequests += 1;
+          await new Promise((resolve) => setTimeout(resolve, 900));
+          await route.fulfill({
+            status: 200,
+            contentType: 'application/json',
+            body: JSON.stringify(MOCK_VOICE_RESPONSE),
+          });
+          return;
+        }
+      }
+      await route.fulfill({ status: 200, contentType: 'application/json', body: '{}' });
+    });
+
+    await page.goto('/', { waitUntil: 'domcontentloaded' });
+    await dismissInitialModal(page);
+
+    await page.setViewportSize({ width: 960, height: 540 });
+    await page.getByTestId('kiosk-slides-button').click();
+    await page.getByTestId('slide-language-ja').click();
+
+    await expect(page.getByTestId('reception-pdf-counter')).toHaveText('1 / 5', {
+      timeout: 15_000,
+    });
+    await expect.poll(() => ttsRequests, { timeout: 5_000 }).toBe(1);
+
+    await page.getByRole('button', { name: /スライドを閉じる|Close slides/ }).click();
+    await expect(page.getByRole('button', { name: 'Welcome' })).toBeVisible({ timeout: 5_000 });
+    await page.waitForTimeout(1_200);
+
+    const staticAudioCounters = await page.evaluate(() => window.__SLIDE_AUDIO_COUNTERS__);
+    const webAudioStarts = await page.evaluate(() => window.__PLAYWRIGHT_AUDIO_STARTS__ ?? 0);
+    expect(staticAudioCounters?.active).toBe(0);
+    expect(staticAudioCounters?.maxActive).toBe(0);
+    expect(webAudioStarts).toBe(0);
   });
 });

--- a/frontend/src/__tests__/mobile-audio-service.test.ts
+++ b/frontend/src/__tests__/mobile-audio-service.test.ts
@@ -344,3 +344,65 @@ test("playAudioWithLipSync skips analyzer for blob audio URLs", async () => {
   assert.equal(result.method, "html-audio");
   assert.equal(audioContextConstructed, false);
 });
+
+test("playAudioWithLipSync reports aborted playback as cancelled", async () => {
+  class MockAudioElement {
+    public preload = "";
+    public volume = 1;
+    public paused = true;
+    public ended = false;
+    private listeners = new Map<string, Set<() => void>>();
+
+    constructor(public readonly url: string) {}
+
+    setAttribute() {}
+    removeAttribute() {}
+    load() {}
+    pause() {
+      if (this.paused) {
+        return;
+      }
+      this.paused = true;
+      this.listeners.get("pause")?.forEach((listener) => listener());
+    }
+    addEventListener(event: string, listener: () => void) {
+      const listeners = this.listeners.get(event) ?? new Set<() => void>();
+      listeners.add(listener);
+      this.listeners.set(event, listeners);
+    }
+    removeEventListener(event: string, listener: () => void) {
+      this.listeners.get(event)?.delete(listener);
+    }
+    async play() {
+      this.paused = false;
+      this.listeners.get("play")?.forEach((listener) => listener());
+    }
+  }
+
+  Object.defineProperty(globalThis, "window", {
+    configurable: true,
+    value: { innerWidth: 390, setTimeout, clearTimeout },
+  });
+  Object.defineProperty(globalThis, "document", {
+    configurable: true,
+    value: {
+      addEventListener() {},
+      removeEventListener() {},
+    },
+  });
+  Object.defineProperty(globalThis, "Audio", {
+    configurable: true,
+    value: MockAudioElement,
+  });
+
+  const controller = new AbortController();
+  const playback = AudioPlaybackService.playAudioWithLipSync("blob:playback-audio", {
+    signal: controller.signal,
+  });
+
+  controller.abort();
+
+  const result = await playback;
+  assert.equal(result.success, false);
+  assert.equal(result.method, "cancelled");
+});

--- a/frontend/src/__tests__/slide-agent-metadata.test.ts
+++ b/frontend/src/__tests__/slide-agent-metadata.test.ts
@@ -1,0 +1,18 @@
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+
+import { isSlideAgentMetadata } from '@/lib/voice/slide-agent-metadata';
+
+test('detects current SlideAgent metadata variants used by voice and kiosk flows', () => {
+  assert.equal(isSlideAgentMetadata({ agent: 'SlideAgent' }), true);
+  assert.equal(isSlideAgentMetadata({ route: 'slide' }), true);
+  assert.equal(isSlideAgentMetadata({ reception_target_agent: 'slide_agent' }), true);
+  assert.equal(isSlideAgentMetadata({ reception_target_agent: 'SlideAgent' }), true);
+});
+
+test('does not classify absent or unrelated metadata as SlideAgent output', () => {
+  assert.equal(isSlideAgentMetadata(null), false);
+  assert.equal(isSlideAgentMetadata(undefined), false);
+  assert.equal(isSlideAgentMetadata({ agent: 'FacilityAgent', route: 'facility' }), false);
+  assert.equal(isSlideAgentMetadata({ route: 'slides' }), false);
+});

--- a/frontend/src/app/components/ReceptionPdfGuide.tsx
+++ b/frontend/src/app/components/ReceptionPdfGuide.tsx
@@ -7,11 +7,12 @@
  */
 import { useKeyboardControls } from '@/app/hooks/useKeyboardControls';
 import { audioStateManager } from '@/lib/audio-state-manager';
-import { AudioPlaybackService } from '@/lib/audio/audio-playback-service';
 import {
   AudioInteractionManager,
   unlockAudioForUserGesture,
 } from '@/lib/audio/audio-interaction-manager';
+import { MobileAudioService } from '@/lib/audio/mobile-audio-service';
+import type { AudioDataInput, AudioOperationResult } from '@/lib/audio/audio-interfaces';
 import {
   RECEPTION_GUIDE_AUDIO_EXT,
   receptionGuideAudioPrefix,
@@ -26,6 +27,7 @@ import {
 import { parseReceptionNarrationMarkdown } from '@/lib/reception/parse-reception-narration-md';
 import { preprocessTTS } from '@/utils/tts-preprocess';
 import { cn } from '@/lib/cn';
+import { slideEventManager } from '@/lib/slide-events';
 import { ChevronLeft, ChevronRight, Pause, Play, RotateCw, RotateCcw } from 'lucide-react';
 import React, { useCallback, useEffect, useLayoutEffect, useRef, useState } from 'react';
 import type { PDFDocumentProxy } from 'pdfjs-dist';
@@ -33,6 +35,16 @@ import type { PresentationCompleteReason } from './presentation-types';
 
 const SLIDE_DELAY_MS = 500;
 const NARRATION_GAP_MS = 300;
+
+type NarrationRun = {
+  id: number;
+  playbackSessionId: number;
+  page: number;
+  controller: AbortController;
+  audioService: MobileAudioService | null;
+};
+const SWIPE_MIN_DISTANCE_PX = 64;
+const SWIPE_HORIZONTAL_DOMINANCE = 1.35;
 
 function toSameOriginUrl(path: string): string {
   if (typeof window === 'undefined') {
@@ -177,9 +189,15 @@ export default function ReceptionPdfGuide({
 
   const autoPlayTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const narrationScheduleRef = useRef<ReturnType<typeof setTimeout> | null>(null);
-  const narrationAbortRef = useRef<AbortController | null>(null);
+  const activeNarrationRunRef = useRef<NarrationRun | null>(null);
+  const narrationRunSeqRef = useRef(0);
   const preloadedAudioRef = useRef<Map<string, HTMLAudioElement>>(new Map());
   const preloadedAudioStateRef = useRef<Map<string, StaticNarrationAudioState>>(new Map());
+  const swipeStartRef = useRef<{
+    pointerId: number | null;
+    x: number;
+    y: number;
+  } | null>(null);
 
   const playbackSessionRef = useRef(0);
   const isPlayingRef = useRef(isPlaying);
@@ -329,6 +347,7 @@ export default function ReceptionPdfGuide({
 
   useEffect(() => {
     const preloadedAudio = preloadedAudioRef.current;
+    const preloadedAudioState = preloadedAudioStateRef.current;
     return () => {
       try {
         window.speechSynthesis?.cancel();
@@ -341,7 +360,7 @@ export default function ReceptionPdfGuide({
         audio.load();
       }
       preloadedAudio.clear();
-      preloadedAudioStateRef.current.clear();
+      preloadedAudioState.clear();
     };
   }, []);
 
@@ -438,8 +457,20 @@ export default function ReceptionPdfGuide({
         clearTimeout(narrationScheduleRef.current);
         narrationScheduleRef.current = null;
       }
-      narrationAbortRef.current?.abort();
-      narrationAbortRef.current = null;
+      const run = activeNarrationRunRef.current;
+      if (run) {
+        run.controller.abort();
+        run.audioService?.stop();
+        run.audioService?.dispose();
+        run.audioService = null;
+        slideEventManager.emitNarrationComplete(run.page, {
+          sessionId: String(run.playbackSessionId),
+          narrationRunId: run.id,
+        });
+        activeNarrationRunRef.current = null;
+      }
+      isNarratingRef.current = false;
+      isNarrationInProgressRef.current = false;
       setIsNarrating(false);
       setIsNarrationInProgress(false);
       try {
@@ -497,7 +528,36 @@ export default function ReceptionPdfGuide({
     };
   }, [currentPage, totalPages, containerBounds]);
 
+  const setNarrationFlags = useCallback((active: boolean) => {
+    isNarratingRef.current = active;
+    isNarrationInProgressRef.current = active;
+    setIsNarrating(active);
+    setIsNarrationInProgress(active);
+  }, []);
+
+  const stopActiveNarration = useCallback(
+    (resetUi = true) => {
+      const run = activeNarrationRunRef.current;
+      if (run) {
+        run.controller.abort();
+        run.audioService?.stop();
+        run.audioService?.dispose();
+        run.audioService = null;
+        slideEventManager.emitNarrationComplete(run.page, {
+          sessionId: String(run.playbackSessionId),
+          narrationRunId: run.id,
+        });
+        activeNarrationRunRef.current = null;
+      }
+      if (resetUi) {
+        setNarrationFlags(false);
+      }
+    },
+    [setNarrationFlags],
+  );
+
   const startPlaybackSession = () => {
+    stopActiveNarration();
     playbackSessionRef.current += 1;
     isPlayingRef.current = true;
     return playbackSessionRef.current;
@@ -512,9 +572,132 @@ export default function ReceptionPdfGuide({
   const isActiveSession = (id: number) =>
     playbackSessionRef.current === id && isPlayingRef.current;
 
+  const isActiveNarrationRun = useCallback(
+    (run: NarrationRun) =>
+      activeNarrationRunRef.current === run &&
+      !run.controller.signal.aborted &&
+      playbackSessionRef.current === run.playbackSessionId &&
+      isPlayingRef.current &&
+      currentPageRef.current === run.page,
+    [],
+  );
+
+  const beginNarrationRun = useCallback(
+    (playbackSessionId: number, page: number): NarrationRun => {
+      stopActiveNarration(false);
+      const run: NarrationRun = {
+        id: narrationRunSeqRef.current + 1,
+        playbackSessionId,
+        page,
+        controller: new AbortController(),
+        audioService: null,
+      };
+      narrationRunSeqRef.current = run.id;
+      activeNarrationRunRef.current = run;
+      setNarrationFlags(true);
+      slideEventManager.emitNarrationStart(page, {
+        sessionId: String(playbackSessionId),
+        narrationRunId: run.id,
+      });
+      return run;
+    },
+    [setNarrationFlags, stopActiveNarration],
+  );
+
+  const finishNarrationRun = useCallback(
+    (run: NarrationRun) => {
+      if (activeNarrationRunRef.current !== run) {
+        return;
+      }
+      run.audioService?.dispose();
+      run.audioService = null;
+      activeNarrationRunRef.current = null;
+      setNarrationFlags(false);
+      slideEventManager.emitNarrationComplete(run.page, {
+        sessionId: String(run.playbackSessionId),
+        narrationRunId: run.id,
+      });
+    },
+    [setNarrationFlags],
+  );
+
+  const playNarrationAudio = useCallback(
+    async (
+      audioData: AudioDataInput,
+      run: NarrationRun,
+    ): Promise<AudioOperationResult> => {
+      if (!isActiveNarrationRun(run)) {
+        return { success: false, method: 'cancelled' };
+      }
+
+      return new Promise<AudioOperationResult>((resolve) => {
+        let settled = false;
+        let service: MobileAudioService | null = null;
+
+        const settle = (result: AudioOperationResult) => {
+          if (settled) {
+            return;
+          }
+          settled = true;
+          run.controller.signal.removeEventListener('abort', onAbort);
+          if (run.audioService === service) {
+            run.audioService = null;
+          }
+          service?.dispose();
+          resolve(result);
+        };
+
+        const stopAsCancelled = () => {
+          service?.stop();
+          settle({ success: false, method: 'cancelled' });
+        };
+
+        const onAbort = () => {
+          stopAsCancelled();
+        };
+
+        service = new MobileAudioService({
+          volume: volume / 100,
+          onPlay: () => {
+            if (!isActiveNarrationRun(run)) {
+              stopAsCancelled();
+            }
+          },
+          onEnded: () => {
+            onVisemeControl?.('Closed', 0);
+            settle({ success: true, method: service?.getCurrentMethod() ?? undefined });
+          },
+          onError: (error) => {
+            settle({ success: false, error, method: service?.getCurrentMethod() ?? undefined });
+          },
+        });
+        run.audioService = service;
+        run.controller.signal.addEventListener('abort', onAbort, { once: true });
+
+        service
+          .playAudio(audioData)
+          .then((result) => {
+            if (!isActiveNarrationRun(run)) {
+              stopAsCancelled();
+              return;
+            }
+            if (!result.success) {
+              settle(result);
+            }
+          })
+          .catch(() => {
+            settle({
+              success: false,
+              method: service?.getCurrentMethod() ?? undefined,
+            });
+          });
+      });
+    },
+    [isActiveNarrationRun, onVisemeControl, volume],
+  );
+
   const clearPlaybackWork = useCallback(() => {
-    narrationAbortRef.current?.abort();
-    narrationAbortRef.current = null;
+    stopActiveNarration();
     try {
       window.speechSynthesis?.cancel();
     } catch {
@@ -528,17 +711,21 @@ export default function ReceptionPdfGuide({
       clearTimeout(narrationScheduleRef.current);
       narrationScheduleRef.current = null;
     }
-    setIsNarrating(false);
-    setIsNarrationInProgress(false);
     audioStateManager.stopAll();
     onVisemeControl?.('Closed', 0);
     onExpressionControl?.('neutral', 1.0);
-  }, [onExpressionControl, onVisemeControl]);
+  }, [onExpressionControl, onVisemeControl, stopActiveNarration]);
 
-  const setPageState = (p: number) => {
+  const setPageState = useCallback((p: number) => {
+    slideEventManager.emitSlideTransitionStart(p, {
+      sessionId: String(playbackSessionRef.current),
+    });
     currentPageRef.current = p;
     setCurrentPage(p);
-  };
+    slideEventManager.emitSlideTransitionComplete(p, {
+      sessionId: String(playbackSessionRef.current),
+    });
+  }, []);
 
   const advancePresentation = useCallback(
     (delayMs = SLIDE_DELAY_MS) => {
@@ -580,7 +767,7 @@ export default function ReceptionPdfGuide({
         step();
       }, delayMs);
     },
-    [onPresentationComplete]
+    [onPresentationComplete, setPageState]
   );
 
   const narrateCurrentSlide = useCallback(async () => {
@@ -593,40 +780,38 @@ export default function ReceptionPdfGuide({
     }
     const sid = playbackSessionRef.current;
     const pageAtStart = currentPageRef.current;
+    const run = beginNarrationRun(sid, pageAtStart);
     const stem = receptionGuidePageStem(pageAtStart);
     const audioPrefix = receptionGuideAudioPrefix(language);
     const audioUrl = toSameOriginUrl(`${audioPrefix}/${stem}.${RECEPTION_GUIDE_AUDIO_EXT}`);
-
-    narrationAbortRef.current = new AbortController();
-    const { signal } = narrationAbortRef.current;
+    const { signal } = run.controller;
 
     try {
       if (canUseStaticNarrationAudio(preloadedAudioStateRef.current.get(audioUrl))) {
-        if (!isActiveSession(sid) || currentPageRef.current !== pageAtStart) {
+        if (!isActiveNarrationRun(run)) {
           return;
         }
 
-        setIsNarrationInProgress(true);
-        setIsNarrating(true);
         let playedStaticAudio = false;
         try {
-          await AudioInteractionManager.getInstance().ensureAudioContext();
-          const result = await AudioPlaybackService.playAudioWithLipSync(audioUrl, {
-            volume: volume / 100,
-            enableLipSync: settings.enableLipSync,
-            onVisemeUpdate: onVisemeControl || undefined,
-          });
+          const result = await playNarrationAudio(audioUrl, run);
+          if (!isActiveNarrationRun(run)) {
+            return;
+          }
           if (!result.success) {
             throw result.error ?? new Error('Audio playback failed');
           }
           playedStaticAudio = true;
-          if (!isActiveSession(sid) || currentPageRef.current !== pageAtStart) {
+          if (!isActiveNarrationRun(run)) {
             return;
           }
           if (settings.autoAdvance) {
             advancePresentation(SLIDE_DELAY_MS);
           }
         } catch (err: unknown) {
+          if (!isActiveNarrationRun(run)) {
+            return;
+          }
           if (!shouldFallbackToGeneratedNarration(err)) {
             setAudioPermissionRequired(true);
             setIsPlaying(false);
@@ -634,9 +819,6 @@ export default function ReceptionPdfGuide({
             return;
           }
           preloadedAudioStateRef.current.set(audioUrl, 'failed');
-        } finally {
-          setIsNarrating(false);
-          setIsNarrationInProgress(false);
         }
         if (playedStaticAudio) {
           return;
@@ -646,87 +828,84 @@ export default function ReceptionPdfGuide({
       const text =
         narrationTexts[pageAtStart - 1]?.trim() ?? '';
       if (!text) {
-        if (isActiveSession(sid)) {
+        if (isActiveNarrationRun(run)) {
           advancePresentation(400);
         }
         return;
       }
-      if (!isActiveSession(sid) || currentPageRef.current !== pageAtStart) {
+      if (!isActiveNarrationRun(run)) {
         return;
       }
-      setIsNarrationInProgress(true);
-      setIsNarrating(true);
-      try {
-        let playedPiper = false;
-        const sidTrim = sessionId.trim();
-        if (sidTrim.length > 0) {
-          try {
-            const res = await fetch('/api/voice', {
-              method: 'POST',
-              headers: {
-                'Content-Type': 'application/json',
-              },
-              body: JSON.stringify({
-                action: 'text_to_speech',
-                text: preprocessTTS(text, language),
-                language,
-                sessionId: sidTrim,
-                includeVrmControl: false,
-              }),
-              signal,
-            });
-            const data = (await res.json()) as Record<string, unknown>;
-            if (
-              res.ok &&
-              data.success &&
-              typeof data.audioResponse === 'string' &&
-              data.audioResponse.length > 0
-            ) {
-              const raw = Uint8Array.from(atob(data.audioResponse), (c) => c.charCodeAt(0));
-              const buf = raw.buffer.slice(raw.byteOffset, raw.byteOffset + raw.byteLength);
-              await AudioInteractionManager.getInstance().ensureAudioContext();
-              const result = await AudioPlaybackService.playAudioWithLipSync(buf, {
-                volume: volume / 100,
-                enableLipSync: settings.enableLipSync,
-                onVisemeUpdate: onVisemeControl || undefined,
-              });
-              playedPiper = result.success;
+      let playedPiper = false;
+      const sidTrim = sessionId.trim();
+      if (sidTrim.length > 0) {
+        try {
+          const res = await fetch('/api/voice', {
+            method: 'POST',
+            headers: {
+              'Content-Type': 'application/json',
+            },
+            body: JSON.stringify({
+              action: 'text_to_speech',
+              text: preprocessTTS(text, language),
+              language,
+              sessionId: sidTrim,
+              includeVrmControl: false,
+            }),
+            signal,
+          });
+          const data = (await res.json()) as Record<string, unknown>;
+          if (
+            res.ok &&
+            data.success &&
+            typeof data.audioResponse === 'string' &&
+            data.audioResponse.length > 0
+          ) {
+            const raw = Uint8Array.from(atob(data.audioResponse), (c) => c.charCodeAt(0));
+            const buf = raw.buffer.slice(raw.byteOffset, raw.byteOffset + raw.byteLength);
+            if (!isActiveNarrationRun(run)) {
+              return;
             }
-          } catch {
-            playedPiper = false;
+            const result = await playNarrationAudio(buf, run);
+            playedPiper = result.success;
           }
+        } catch {
+          if (!isActiveNarrationRun(run)) {
+            return;
+          }
+          playedPiper = false;
         }
-        if (!playedPiper) {
-          await speakNarrationText(text, language, signal);
-        }
-        if (!isActiveSession(sid) || currentPageRef.current !== pageAtStart) {
-          return;
-        }
-        if (settings.autoAdvance) {
-          advancePresentation(SLIDE_DELAY_MS);
-        }
-      } finally {
-        setIsNarrating(false);
-        setIsNarrationInProgress(false);
+      }
+      if (!playedPiper) {
+        await speakNarrationText(text, language, signal);
+      }
+      if (!isActiveNarrationRun(run)) {
+        return;
+      }
+      if (settings.autoAdvance) {
+        advancePresentation(SLIDE_DELAY_MS);
       }
     } catch (e) {
       if (e instanceof Error && e.name === 'AbortError') {
         return;
       }
-      if (isActiveSession(sid)) {
+      if (isActiveNarrationRun(run)) {
         advancePresentation(400);
       }
+    } finally {
+      finishNarrationRun(run);
     }
   }, [
     advancePresentation,
+    beginNarrationRun,
+    finishNarrationRun,
+    isActiveNarrationRun,
     language,
     narrationTexts,
     onPresentationComplete,
-    onVisemeControl,
+    playNarrationAudio,
     sessionId,
     settings.autoAdvance,
-    settings.enableLipSync,
-    volume,
   ]);
 
   const narrateWithRetryRef = useRef<(retries?: number) => Promise<void>>(async () => {});
@@ -774,11 +953,11 @@ export default function ReceptionPdfGuide({
     };
   }, [isPlaying, totalPages, landscapeReady, language]);
 
-  const stopAutoPlay = () => {
+  const stopAutoPlay = useCallback(() => {
     pendingAutoStartRef.current = false;
     invalidatePlaybackSession();
     clearPlaybackWork();
-  };
+  }, [clearPlaybackWork]);
 
   const toggleAutoPlay = () => {
     if (isPlaying) {
@@ -815,7 +994,7 @@ export default function ReceptionPdfGuide({
     setIsPlaying(true);
   };
 
-  const previousSlide = () => {
+  const previousSlide = useCallback(() => {
     if (currentPage > 1) {
       const was = isPlayingRef.current;
       stopAutoPlay();
@@ -825,9 +1004,9 @@ export default function ReceptionPdfGuide({
       }
       setPageState(currentPage - 1);
     }
-  };
+  }, [currentPage, onPresentationComplete, setPageState, stopAutoPlay]);
 
-  const nextSlide = () => {
+  const nextSlide = useCallback(() => {
     if (currentPage < totalPages) {
       const was = isPlayingRef.current;
       stopAutoPlay();
@@ -837,9 +1016,9 @@ export default function ReceptionPdfGuide({
       }
       setPageState(currentPage + 1);
     }
-  };
+  }, [currentPage, onPresentationComplete, setPageState, stopAutoPlay, totalPages]);
 
-  const gotoSlide = (n: number) => {
+  const gotoSlide = useCallback((n: number) => {
     if (n >= 1 && n <= totalPages) {
       const was = isPlayingRef.current;
       if (was) {
@@ -848,6 +1027,53 @@ export default function ReceptionPdfGuide({
         onPresentationComplete?.('stopped');
       }
       setPageState(n);
+    }
+  }, [onPresentationComplete, setPageState, stopAutoPlay, totalPages]);
+
+  const handleSwipeDelta = useCallback(
+    (deltaX: number, deltaY: number) => {
+      const absX = Math.abs(deltaX);
+      const absY = Math.abs(deltaY);
+      if (
+        absX < SWIPE_MIN_DISTANCE_PX ||
+        absX < absY * SWIPE_HORIZONTAL_DOMINANCE
+      ) {
+        return;
+      }
+      if (deltaX < 0) {
+        nextSlide();
+      } else {
+        previousSlide();
+      }
+    },
+    [nextSlide, previousSlide],
+  );
+
+  const onSlidePointerDown = (event: React.PointerEvent<HTMLDivElement>) => {
+    if (!event.isPrimary || event.button !== 0) {
+      return;
+    }
+    swipeStartRef.current = {
+      pointerId: event.pointerId,
+      x: event.clientX,
+      y: event.clientY,
+    };
+    event.currentTarget.setPointerCapture?.(event.pointerId);
+  };
+
+  const onSlidePointerUp = (event: React.PointerEvent<HTMLDivElement>) => {
+    const start = swipeStartRef.current;
+    if (!start || start.pointerId !== event.pointerId) {
+      return;
+    }
+    swipeStartRef.current = null;
+    event.currentTarget.releasePointerCapture?.(event.pointerId);
+    handleSwipeDelta(event.clientX - start.x, event.clientY - start.y);
+  };
+
+  const onSlidePointerCancel = (event: React.PointerEvent<HTMLDivElement>) => {
+    if (swipeStartRef.current?.pointerId === event.pointerId) {
+      swipeStartRef.current = null;
     }
   };
 
@@ -908,85 +1134,77 @@ export default function ReceptionPdfGuide({
       data-testid="reception-pdf-guide"
       className={cn('relative flex h-full min-h-0 flex-col', className)}
     >
-      <div className="absolute left-2 right-12 top-2 z-20 flex flex-wrap items-center justify-between gap-1.5 rounded-xl border border-white/70 bg-white/85 px-2 py-1.5 shadow-lg backdrop-blur-md sm:left-3 sm:right-14 sm:top-3 sm:gap-2 sm:px-3 sm:py-2">
-        <div className="flex items-center gap-2">
-          <button
-            type="button"
-            data-testid="reception-pdf-prev"
-            onClick={previousSlide}
-            disabled={currentPage === 1}
-            className="rounded bg-blue-500 p-1.5 text-white disabled:bg-gray-300 sm:p-2"
-          >
-            <ChevronLeft className="h-4 w-4" />
-          </button>
-          <button
-            type="button"
-            data-testid="reception-pdf-next"
-            onClick={nextSlide}
-            disabled={currentPage >= totalPages}
-            className="rounded bg-blue-500 p-1.5 text-white disabled:bg-gray-300 sm:p-2"
-          >
-            <ChevronRight className="h-4 w-4" />
-          </button>
-          <span data-testid="reception-pdf-counter" className="text-sm font-medium text-gray-700">
-            {totalPages > 0 ? `${currentPage} / ${totalPages}` : '—'}
-          </span>
-        </div>
-        <div className="flex flex-wrap items-center gap-2">
-          <button
-            type="button"
-            data-testid="reception-pdf-play"
-            onClick={toggleAutoPlay}
-            aria-pressed={isPlaying}
-            data-state={isPlaying ? 'playing' : 'paused'}
-            className={cn(
-              'rounded p-1.5 text-white sm:p-2',
-              isPlaying ? 'bg-red-500' : 'bg-green-500'
-            )}
-          >
-            {isPlaying ? <Pause className="h-4 w-4" /> : <Play className="h-4 w-4" />}
-          </button>
-          {isNarrating ? (
-            <span className="hidden text-xs text-blue-700 sm:inline">
-              {language === 'ja' ? 'ナレーション中…' : 'Narrating…'}
-            </span>
-          ) : null}
-          <button
-            type="button"
-            data-testid="reception-pdf-reset"
-            onClick={() => gotoSlide(1)}
-            className="rounded bg-gray-500 p-1.5 text-white sm:p-2"
-          >
-            <RotateCcw className="h-4 w-4" />
-          </button>
-          <label className="flex items-center gap-1 text-xs text-gray-600">
-            <input
-              type="checkbox"
-              checked={settings.enableLipSync}
-              onChange={(e) =>
-                setSettings((s) => ({ ...s, enableLipSync: e.target.checked }))
-              }
-            />
-            <span className="hidden sm:inline">{language === 'ja' ? 'リップ' : 'Lip'}</span>
-          </label>
-          <label className="flex items-center gap-1 text-xs text-gray-600">
-            <input
-              type="checkbox"
-              checked={settings.autoAdvance}
-              onChange={(e) =>
-                setSettings((s) => ({ ...s, autoAdvance: e.target.checked }))
-              }
-            />
-            <span className="hidden sm:inline">{language === 'ja' ? '自動送り' : 'Auto-advance'}</span>
-          </label>
-        </div>
-      </div>
       <div
         ref={wrapRef}
         data-testid="reception-pdf-landscape-panel"
-        className="relative flex min-h-0 flex-1 items-center justify-center overflow-hidden bg-slate-100 p-0.5 sm:p-1"
+        onPointerDown={onSlidePointerDown}
+        onPointerUp={onSlidePointerUp}
+        onPointerCancel={onSlidePointerCancel}
+        className="relative flex min-h-0 flex-1 touch-pan-y items-center justify-center overflow-hidden bg-slate-100 p-0.5 sm:p-1"
       >
         <canvas ref={canvasRef} className="max-h-full max-w-full shadow-lg" data-testid="reception-pdf-canvas" />
+      </div>
+      <div
+        data-testid="reception-pdf-controls"
+        className="absolute bottom-2 left-1/2 z-20 flex -translate-x-1/2 items-center gap-1.5 rounded-lg border border-white/70 bg-slate-950/75 px-2 py-1.5 text-white shadow-lg backdrop-blur-md sm:bottom-3 sm:gap-2 sm:px-3 sm:py-2"
+      >
+        <button
+          type="button"
+          data-testid="reception-pdf-prev"
+          onClick={previousSlide}
+          disabled={currentPage === 1}
+          aria-label={language === 'ja' ? '前のスライド' : 'Previous slide'}
+          className="inline-flex size-9 items-center justify-center rounded bg-white/15 text-white transition-colors hover:bg-white/25 disabled:bg-white/5 disabled:text-white/35 sm:size-10"
+        >
+          <ChevronLeft className="h-4 w-4" aria-hidden />
+        </button>
+        <button
+          type="button"
+          data-testid="reception-pdf-play"
+          onClick={toggleAutoPlay}
+          aria-label={
+            isPlaying
+              ? language === 'ja'
+                ? '一時停止'
+                : 'Pause'
+              : language === 'ja'
+                ? '再生'
+                : 'Play'
+          }
+          aria-pressed={isPlaying}
+          data-state={isPlaying ? 'playing' : 'paused'}
+          className={cn(
+            'inline-flex size-9 items-center justify-center rounded text-white transition-colors sm:size-10',
+            isPlaying ? 'bg-red-500 hover:bg-red-600' : 'bg-emerald-600 hover:bg-emerald-700',
+          )}
+        >
+          {isPlaying ? <Pause className="h-4 w-4" aria-hidden /> : <Play className="h-4 w-4" aria-hidden />}
+        </button>
+        <span
+          data-testid="reception-pdf-counter"
+          className="min-w-14 text-center text-sm font-semibold tabular-nums text-white"
+        >
+          {totalPages > 0 ? `${currentPage} / ${totalPages}` : '—'}
+        </span>
+        <button
+          type="button"
+          data-testid="reception-pdf-reset"
+          onClick={() => gotoSlide(1)}
+          aria-label={language === 'ja' ? '最初のスライドへ' : 'Reset to first slide'}
+          className="inline-flex size-9 items-center justify-center rounded bg-white/15 text-white transition-colors hover:bg-white/25 sm:size-10"
+        >
+          <RotateCcw className="h-4 w-4" aria-hidden />
+        </button>
+        <button
+          type="button"
+          data-testid="reception-pdf-next"
+          onClick={nextSlide}
+          disabled={currentPage >= totalPages}
+          aria-label={language === 'ja' ? '次のスライド' : 'Next slide'}
+          className="inline-flex size-9 items-center justify-center rounded bg-white/15 text-white transition-colors hover:bg-white/25 disabled:bg-white/5 disabled:text-white/35 sm:size-10"
+        >
+          <ChevronRight className="h-4 w-4" aria-hidden />
+        </button>
       </div>
       {audioPermissionRequired ? (
         <div className="absolute inset-0 z-30 flex items-center justify-center bg-black/45 p-4">

--- a/frontend/src/app/components/VoiceInterface.tsx
+++ b/frontend/src/app/components/VoiceInterface.tsx
@@ -20,6 +20,7 @@ import { formatError } from '@/lib/error-messages';
 import { LipSyncAnalyzer, type LipSyncFrame } from '@/lib/lip-sync-analyzer';
 import { createVoiceFillerPlaybackGate } from '@/lib/voice-filler-playback';
 import { resolveVoiceResponseLanguage } from '@/lib/voice/response-language';
+import { isSlideAgentMetadata } from '@/lib/voice/slide-agent-metadata';
 import { mergePlaybackMetadataWithTtsVrmControl } from '@/lib/voice/tts-vrm-metadata';
 import { preprocessTTS } from '@/utils/tts-preprocess';
 import { AlertCircle, Loader2, Mic, MicOff, Volume2, VolumeX, XCircle } from 'lucide-react';
@@ -131,18 +132,6 @@ interface VoiceInterfaceProps {
 
 const DEFAULT_WAKE_WORDS = ['すみません', 'hello'];
 const VISITOR_ID_STORAGE_KEY = 'engineer_cafe_visitor_id';
-
-function isSlideAgentMetadata(metadata: VoiceInterfaceMetadata | null): boolean {
-  if (!metadata) {
-    return false;
-  }
-  return (
-    metadata.agent === 'SlideAgent' ||
-    metadata.route === 'slide' ||
-    metadata.reception_target_agent === 'slide_agent' ||
-    metadata.reception_target_agent === 'SlideAgent'
-  );
-}
 
 const STATUS_LABELS: Record<'ja' | 'en', Record<VoiceSessionState, string>> = {
   ja: {

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -246,6 +246,7 @@ export default function Home() {
   useEffect(() => {
     if (kioskPhase === 'slides') {
       setWelcomeMemberOcrOpen(false);
+      setShowSettingsPanel(false);
     }
   }, [kioskPhase]);
 
@@ -320,18 +321,6 @@ export default function Home() {
     returnToIdle();
   }, [returnToIdle]);
 
-  const isSlideAgentMetadata = useCallback((metadata: VoiceInterfaceMetadata | null): boolean => {
-    if (!metadata) {
-      return false;
-    }
-    return (
-      metadata.agent === 'SlideAgent' ||
-      metadata.route === 'slide' ||
-      metadata.reception_target_agent === 'slide_agent' ||
-      metadata.reception_target_agent === 'SlideAgent'
-    );
-  }, []);
-
   return (
     <>
       <InitialSettingsModal
@@ -355,9 +344,6 @@ export default function Home() {
         showDefaultUI={false}
         onMetadataChange={(metadata) => {
           setLatestMetadata(metadata);
-          if (isSlideAgentMetadata(metadata)) {
-            startPresentation(currentLanguage);
-          }
         }}
         onSlideAgentResponse={() => {
           startPresentation(currentLanguage);
@@ -555,34 +541,36 @@ export default function Home() {
                   />
                 </div>
 
-                <div className="pointer-events-none absolute inset-0 z-30">
-                  <div
-                  className="pointer-events-none absolute"
-                  style={{
-                    top: screenPadding.paddingTop,
-                    left: screenPadding.paddingLeft,
-                  }}
-                >
-                  <ClockBadge language={voice.currentLanguage} />
-                </div>
-                <div
-                    className="pointer-events-auto absolute"
-                    style={{
-                      top: screenPadding.paddingTop,
-                      right: screenPadding.paddingRight,
-                    }}
-                  >
-                    <button
-                      data-testid="kiosk-settings-button"
-                      type="button"
-                      onClick={() => setShowSettingsPanel(true)}
-                      aria-label={voice.currentLanguage === 'ja' ? '設定' : 'Settings'}
-                      className="inline-flex size-11 shrink-0 items-center justify-center rounded-full border border-white/15 bg-black/45 text-white shadow-lg backdrop-blur-md transition-transform duration-200 ease-out hover:scale-105"
+                {!showSlideMode ? (
+                  <div className="pointer-events-none absolute inset-0 z-30">
+                    <div
+                      className="pointer-events-none absolute"
+                      style={{
+                        top: screenPadding.paddingTop,
+                        left: screenPadding.paddingLeft,
+                      }}
                     >
-                      <Settings className="size-5" />
-                    </button>
+                      <ClockBadge language={voice.currentLanguage} />
+                    </div>
+                    <div
+                      className="pointer-events-auto absolute"
+                      style={{
+                        top: screenPadding.paddingTop,
+                        right: screenPadding.paddingRight,
+                      }}
+                    >
+                      <button
+                        data-testid="kiosk-settings-button"
+                        type="button"
+                        onClick={() => setShowSettingsPanel(true)}
+                        aria-label={voice.currentLanguage === 'ja' ? '設定' : 'Settings'}
+                        className="inline-flex size-11 shrink-0 items-center justify-center rounded-full border border-white/15 bg-black/45 text-white shadow-lg backdrop-blur-md transition-transform duration-200 ease-out hover:scale-105"
+                      >
+                        <Settings className="size-5" />
+                      </button>
+                    </div>
                   </div>
-                </div>
+                ) : null}
 
                 <KioskWelcomeOverlay
                   open={welcomeMemberOcrOpen}
@@ -596,7 +584,7 @@ export default function Home() {
                   onMemberOcrEnd={handleWelcomeMemberOcrEndSilent}
                 />
 
-                {showSettingsPanel && settingsPanelProps ? (
+                {showSettingsPanel && settingsPanelProps && !showSlideMode ? (
                   <div
                     className="absolute inset-0 z-40 pointer-events-none"
                     aria-hidden={!showSettingsPanel}

--- a/frontend/src/lib/audio-state-manager.ts
+++ b/frontend/src/lib/audio-state-manager.ts
@@ -146,6 +146,13 @@ export class AudioStateManager {
     this.activeAudioServices.add(audioService);
     // Volume settings will be applied when creating the service
   }
+
+  unregisterAudioService(audioService: MobileAudioService) {
+    this.activeAudioServices.delete(audioService);
+    if (this.currentAudioService === audioService) {
+      this.currentAudioService = null;
+    }
+  }
   
   setVolume(vol: number) {
     this.globalVolume = Math.max(0, Math.min(1, vol));

--- a/frontend/src/lib/audio/audio-playback-service.ts
+++ b/frontend/src/lib/audio/audio-playback-service.ts
@@ -9,6 +9,7 @@
  */
 
 import { AudioDataProcessor } from './audio-data-processor';
+import { audioStateManager } from '../audio-state-manager';
 import {
   AudioError,
   AudioErrorType,
@@ -35,6 +36,7 @@ export interface AudioPlaybackOptions {
   onError?: (error: AudioError) => void;
   /** Skip analyzer when frames are pre-baked (e.g. public/reception/lipsync). */
   precomputedLipSync?: LipSyncData | null;
+  signal?: AbortSignal;
 }
 
 async function analyzeLipSyncFromAudioData(
@@ -204,11 +206,62 @@ export class AudioPlaybackService {
             safeReject(audioError);
           }
         });
+        audioStateManager.registerAudioService(audioService);
+
+        const cleanup = () => {
+          isPlaying = false;
+          audioStateManager.unregisterAudioService(audioService);
+          audioService.dispose();
+          if (options.onVisemeUpdate) {
+            options.onVisemeUpdate('Closed', 0);
+          }
+        };
+        const onAbort = () => {
+          audioService.stop();
+          cleanup();
+          safeResolve({ success: false, method: 'cancelled' });
+        };
+        if (options.signal?.aborted) {
+          onAbort();
+          return;
+        }
+        options.signal?.addEventListener('abort', onAbort, { once: true });
+
+        audioService.updateEventHandlers({
+          onPlay: () => {
+            isPlaying = true;
+            playbackStartTime = performance.now();
+            if (lipSyncData && options.onVisemeUpdate) {
+              updateLipSync();
+            }
+          },
+          onEnded: () => {
+            cleanup();
+            options.signal?.removeEventListener('abort', onAbort);
+            options.onPlaybackEnd?.();
+            safeResolve({ success: true, method: playbackMethod });
+          },
+          onError: (error) => {
+            cleanup();
+            options.signal?.removeEventListener('abort', onAbort);
+            const audioError = error instanceof AudioError
+              ? error
+              : new AudioError(
+                  AudioErrorType.PLAYBACK_FAILED,
+                  (error as Error)?.message || 'Audio playback failed'
+                );
+            console.error('[AudioPlayback] Playback failed:', audioError);
+            options.onError?.(audioError);
+            safeReject(audioError);
+          }
+        });
         
         // Start audio playback
         audioService.playAudio(audioData)
           .then((result) => {
             if (!result.success) {
+              cleanup();
+              options.signal?.removeEventListener('abort', onAbort);
               const audioError = result.error ?? new AudioError(
                 AudioErrorType.PLAYBACK_FAILED,
                 'Audio playback failed'
@@ -221,6 +274,8 @@ export class AudioPlaybackService {
             // Don't resolve here - wait for onEnded callback
           })
           .catch((error) => {
+            cleanup();
+            options.signal?.removeEventListener('abort', onAbort);
             const audioError = AudioError.fromError(error as Error, AudioErrorType.PLAYBACK_FAILED);
             options.onError?.(audioError);
             safeReject(audioError);

--- a/frontend/src/lib/slide-events.ts
+++ b/frontend/src/lib/slide-events.ts
@@ -1,25 +1,43 @@
+export interface SlideEventDetail {
+  slideNumber: number;
+  sessionId?: string;
+  narrationRunId?: number;
+}
+
 export class SlideEventManager extends EventTarget {
-  emitSlideTransitionStart(slideNumber: number): void {
-    this.dispatchEvent(new CustomEvent('slideTransitionStart', {
-      detail: { slideNumber }
+  emitSlideTransitionStart(
+    slideNumber: number,
+    detail: Omit<SlideEventDetail, 'slideNumber'> = {},
+  ): void {
+    this.dispatchEvent(new CustomEvent<SlideEventDetail>('slideTransitionStart', {
+      detail: { slideNumber, ...detail }
     }));
   }
-  
-  emitSlideTransitionComplete(slideNumber: number): void {
-    this.dispatchEvent(new CustomEvent('slideTransitionComplete', {
-      detail: { slideNumber }
+
+  emitSlideTransitionComplete(
+    slideNumber: number,
+    detail: Omit<SlideEventDetail, 'slideNumber'> = {},
+  ): void {
+    this.dispatchEvent(new CustomEvent<SlideEventDetail>('slideTransitionComplete', {
+      detail: { slideNumber, ...detail }
     }));
   }
-  
-  emitNarrationStart(slideNumber: number): void {
-    this.dispatchEvent(new CustomEvent('narrationStart', {
-      detail: { slideNumber }
+
+  emitNarrationStart(
+    slideNumber: number,
+    detail: Omit<SlideEventDetail, 'slideNumber'> = {},
+  ): void {
+    this.dispatchEvent(new CustomEvent<SlideEventDetail>('narrationStart', {
+      detail: { slideNumber, ...detail }
     }));
   }
-  
-  emitNarrationComplete(slideNumber: number): void {
-    this.dispatchEvent(new CustomEvent('narrationComplete', {
-      detail: { slideNumber }
+
+  emitNarrationComplete(
+    slideNumber: number,
+    detail: Omit<SlideEventDetail, 'slideNumber'> = {},
+  ): void {
+    this.dispatchEvent(new CustomEvent<SlideEventDetail>('narrationComplete', {
+      detail: { slideNumber, ...detail }
     }));
   }
 }

--- a/frontend/src/lib/voice/slide-agent-metadata.ts
+++ b/frontend/src/lib/voice/slide-agent-metadata.ts
@@ -1,0 +1,13 @@
+export function isSlideAgentMetadata(metadata: unknown): boolean {
+  if (!metadata || typeof metadata !== 'object') {
+    return false;
+  }
+  const candidate = metadata as Record<string, unknown>;
+
+  return (
+    candidate.agent === 'SlideAgent' ||
+    candidate.route === 'slide' ||
+    candidate.reception_target_agent === 'slide_agent' ||
+    candidate.reception_target_agent === 'SlideAgent'
+  );
+}


### PR DESCRIPTION
## Summary\n- add horizontal swipe slide navigation and remove slide-mode top chrome/settings controls\n- make slide narration lifecycle cancellable by session/page/run so rapid navigation and close cannot leave stale audio\n- dedupe SlideAgent presentation trigger and share SlideAgent metadata detection\n- expand optional Cerebras primary routing to lightweight event/facility response configs behind allowlist/fallbacks\n\n## Verification\n- pnpm lint\n- rm -rf .next && pnpm build && pnpm exec tsc --noEmit --pretty false\n- PLAYWRIGHT_BASE_URL=http://127.0.0.1:3031 PLAYWRIGHT_VIDEO=off pnpm exec playwright test --config=playwright.config.ts e2e/reception-pdf-guide.spec.ts e2e/slide-pdf-narration.spec.ts --project=chromium --workers=1\n- pnpm test:node\n- python -m pytest backend/tests/llm/test_models.py backend/tests/llm/test_model_resolve.py backend/tests/llm/test_openrouter.py -q\n- python -m ruff check backend/llm/models.py backend/llm/model_resolve.py backend/tests/llm/test_models.py backend/tests/llm/test_model_resolve.py backend/tests/llm/test_openrouter.py\n- python -m black --check backend/llm/models.py backend/llm/model_resolve.py backend/tests/llm/test_models.py backend/tests/llm/test_model_resolve.py backend/tests/llm/test_openrouter.py\n- git diff --check