### PR TITLE
Fix post-alpha voice routing and slide narration bugs

### DIFF
--- a/backend/agents/orchestrator_agent.py
+++ b/backend/agents/orchestrator_agent.py
@@ -17,7 +17,7 @@ LangGraph の Supervisor Agent パターンに従い、クエリを適切なエ�
 import json
 import logging
 import os
-from dataclasses import dataclass, field
+from dataclasses import dataclass, field, replace
 from typing import Optional
 
 from langchain_core.messages import HumanMessage, SystemMessage
@@ -25,15 +25,15 @@ from langgraph.graph import END
 
 from backend.config.routing_constants import (
     AGENT_DESCRIPTIONS,
-    CATEGORY_TO_AGENT_MAP,
     MEMORY_EXCLUSION_BUSINESS,
     MEMORY_EXCLUSION_FACILITY,
     MEMORY_KEYWORDS,
     RoutingTarget,
     extract_request_type,
     match_keywords,
+    normalize_agent_node,
 )
-from backend.llm.models import ModelConfig, SupportedModel
+from backend.llm.models import get_model_config
 from backend.llm.openrouter import OpenRouterProvider
 from backend.utils.input_sanitizer import (
     MAX_CONTEXT_LENGTH,
@@ -158,12 +158,9 @@ class OrchestratorAgent:
         if not isinstance(raw_decision, dict):
             raise ValueError("Response must be a JSON object")
 
-        next_agent = raw_decision.get("next_agent")
-        if not isinstance(next_agent, str):
+        raw_next_agent = raw_decision.get("next_agent")
+        if not isinstance(raw_next_agent, str):
             raise ValueError("next_agent must be a string")
-
-        if next_agent not in AGENT_DESCRIPTIONS:
-            next_agent = "general_knowledge"
 
         reasoning = str(raw_decision.get("reasoning", ""))[:200]
         category = str(raw_decision.get("category", "general"))[:50]
@@ -171,8 +168,17 @@ class OrchestratorAgent:
         if request_type is not None:
             request_type = str(request_type)[:50]
 
+        next_agent, resolution_source = normalize_agent_node(
+            raw_next_agent,
+            category=category,
+            request_type=request_type,
+            prefer_category=True,
+        )
+
         return {
             "next_agent": next_agent,
+            "raw_next_agent": raw_next_agent,
+            "agent_resolution_source": resolution_source,
             "reasoning": reasoning,
             "category": category,
             "request_type": request_type,
@@ -254,11 +260,10 @@ class OrchestratorAgent:
                 HumanMessage(content=user_message),
             ]
 
-            routing_config = ModelConfig(
-                model_id=SupportedModel.GEMINI_3_1_FLASH_LITE,
+            routing_config = replace(
+                get_model_config("router"),
                 temperature=0.15,
                 max_tokens=200,
-                fallback_model=SupportedModel.GEMINI_2_5_FLASH_LITE,
             )
 
             response_content = await self.provider.generate(
@@ -279,6 +284,8 @@ class OrchestratorAgent:
                     fast_path=False,
                     language_result=language_result,
                     llm_response_length=len(response_content),
+                    raw_next_agent=decision["raw_next_agent"],
+                    agent_resolution_source=decision["agent_resolution_source"],
                 ),
             )
 
@@ -286,13 +293,19 @@ class OrchestratorAgent:
             logger.warning("LLM routing failed: %s", e, exc_info=True)
 
             classification = await self.query_classifier.classify_with_details(sanitized_query)
-            next_agent = CATEGORY_TO_AGENT_MAP.get(classification.category, "general_knowledge")
+            request_type = extract_request_type(sanitized_query)
+            next_agent, resolution_source = normalize_agent_node(
+                None,
+                category=classification.category,
+                request_type=request_type,
+                prefer_category=True,
+            )
 
             return OrchestratorDecision(
                 next_agent=next_agent,
                 language=response_language,
                 category=classification.category,
-                request_type=extract_request_type(sanitized_query),
+                request_type=request_type,
                 confidence=classification.confidence,
                 reasoning="Fallback to QueryClassifier",
                 debug_info=self._create_debug_info(
@@ -300,6 +313,7 @@ class OrchestratorAgent:
                     language_result=language_result,
                     fallback=True,
                     error_type=type(e).__name__,
+                    agent_resolution_source=resolution_source,
                 ),
             )
 
@@ -310,6 +324,8 @@ class OrchestratorAgent:
         llm_response_length: Optional[int] = None,
         fallback: bool = False,
         error_type: Optional[str] = None,
+        raw_next_agent: Optional[str] = None,
+        agent_resolution_source: Optional[str] = None,
     ) -> dict:
         """デバッグ情報を作成（本番環境では最小限）"""
         if self._is_production:
@@ -331,6 +347,12 @@ class OrchestratorAgent:
 
         if error_type:
             info["error_type"] = error_type
+
+        if raw_next_agent:
+            info["raw_next_agent"] = raw_next_agent
+
+        if agent_resolution_source:
+            info["agent_resolution_source"] = agent_resolution_source
 
         return info
 

--- a/backend/agents/voice_agent.py
+++ b/backend/agents/voice_agent.py
@@ -24,7 +24,7 @@ import os
 import re
 import time
 from dataclasses import dataclass
-from typing import Any, Dict, List, Optional
+from typing import Any, Awaitable, Dict, List, Optional
 
 import httpx
 from cachetools import TTLCache
@@ -256,6 +256,12 @@ def clean_text_for_tts(text: str) -> str:
 
 DEFAULT_TTS_MAX_BYTES = 900
 MIN_CACHEABLE_TTS_AUDIO_BASE64_CHARS = 100
+_DEFAULT_TTS_TIMEOUTS: Dict[str, float] = {
+    "piper": 2.5,
+    "kokoro": 3.0,
+    "voicevox": 4.0,
+    "google": 6.0,
+}
 
 
 def get_tts_max_bytes() -> int:
@@ -268,6 +274,38 @@ def get_tts_max_bytes() -> int:
         logger.warning("Invalid TTS_MAX_BYTES=%r; using %d", raw, DEFAULT_TTS_MAX_BYTES)
         return DEFAULT_TTS_MAX_BYTES
     return max(200, value)
+
+
+def get_tts_timeout_seconds(provider: str, role: str = "primary") -> float:
+    """Soft timeout for one TTS provider attempt.
+
+    HTTP clients keep their larger socket timeouts, but the voice turn should
+    move to the next recovery path quickly when a local TTS server is wedged.
+    """
+
+    provider_key = (provider or "").strip().lower()
+    role_key = (role or "primary").strip().upper()
+    env_names = [
+        f"TTS_{provider_key.upper()}_{role_key}_TIMEOUT_SECONDS",
+        f"TTS_{role_key}_TIMEOUT_SECONDS",
+        f"TTS_{provider_key.upper()}_TIMEOUT_SECONDS",
+    ]
+    default = _DEFAULT_TTS_TIMEOUTS.get(provider_key, 4.0)
+
+    for name in env_names:
+        raw = os.getenv(name)
+        if raw is None or raw.strip() == "":
+            continue
+        try:
+            value = float(raw)
+        except (TypeError, ValueError):
+            logger.warning("Invalid %s=%r; using %.1fs", name, raw, default)
+            return default
+        if value <= 0:
+            logger.warning("Invalid %s=%r; using %.1fs", name, raw, default)
+            return default
+        return max(0.05, value)
+    return default
 
 
 def truncate_by_bytes(text: str, max_bytes: int = 5000) -> str:
@@ -805,10 +843,40 @@ class VoiceAgent:
     def _is_cacheable_audio(audio_b64: Any) -> bool:
         return isinstance(audio_b64, str) and len(audio_b64) > MIN_CACHEABLE_TTS_AUDIO_BASE64_CHARS
 
+    @staticmethod
+    def _cached_audio_from_entry(cache_entry: Any) -> Optional[str]:
+        if isinstance(cache_entry, str):
+            return cache_entry
+        if isinstance(cache_entry, dict):
+            audio = cache_entry.get("audioResponse")
+            return audio if isinstance(audio, str) else None
+        return None
+
+    @staticmethod
+    def _require_audio_response(audio_b64: Any, provider: str) -> str:
+        if isinstance(audio_b64, str) and audio_b64.strip():
+            return audio_b64
+        raise RuntimeError(f"{provider} TTS returned empty audio response")
+
     def _tts_audio_format(self, language: str) -> str:
+        if self.tts_provider == "google":
+            return "audio/mpeg"
         if self.tts_provider == "piper" or language == "en" or self.tts_provider == "voicevox":
             return "audio/wav"
         return "audio/mpeg"
+
+    async def _await_tts_attempt(
+        self,
+        awaitable: Awaitable[str],
+        *,
+        provider: str,
+        role: str,
+    ) -> str:
+        timeout_s = get_tts_timeout_seconds(provider, role)
+        try:
+            return await asyncio.wait_for(awaitable, timeout=timeout_s)
+        except asyncio.TimeoutError as exc:
+            raise RuntimeError(f"{provider} TTS {role} timed out after {timeout_s:.2f}s") from exc
 
     def _detect_category(self, text: str, language: str) -> Optional[ClarificationCategory]:
         """
@@ -898,12 +966,18 @@ class VoiceAgent:
 
         cache_store = self._ensure_tts_cache()
         cache_key = self._tts_cache_key(processed, language, self.tts_provider, vrm_emotion)
-        cached_audio = cache_store.get(cache_key)
-        if cached_audio is not None:
+        cached_entry = cache_store.get(cache_key)
+        if cached_entry is not None:
+            cached_audio = self._cached_audio_from_entry(cached_entry)
             if not self._is_cacheable_audio(cached_audio):
                 cache_store.pop(cache_key, None)
                 logger.warning("Ignored invalid TTS cache entry: cache_key=%s", cache_key)
             else:
+                cached_format = (
+                    cached_entry.get("format")
+                    if isinstance(cached_entry, dict)
+                    else self._tts_audio_format(language)
+                )
                 log_tts_cache_event(hit=True, cache_key=cache_key, language=language)
                 log_tts_event(
                     event="tts_complete",
@@ -918,42 +992,79 @@ class VoiceAgent:
                     "audioResponse": cached_audio,
                     "emotion": vrm_emotion,
                     "cleanText": processed,
-                    "format": self._tts_audio_format(language),
+                    "format": cached_format or self._tts_audio_format(language),
                     "language": language,
                     "ambiguity_resolved": False,
                     "tts_cache_hit": True,
+                    "fallback_used": (
+                        cached_entry.get("fallback_used")
+                        if isinstance(cached_entry, dict)
+                        else False
+                    ),
+                    "fallback_provider": (
+                        cached_entry.get("fallback_provider")
+                        if isinstance(cached_entry, dict)
+                        else None
+                    ),
                 }
 
         log_tts_cache_event(hit=False, cache_key=cache_key, language=language)
 
+        primary_attempt_provider: Optional[str] = None
         try:
             # ステップ5: 言語に基づいてTTSエンジンを選択
             if self.tts_provider == "piper":
                 # piper-plus: 日本語・英語両対応（単一エンジン）
-                audio_b64 = await self.tts_client.synthesize_wav_base64(processed, language)
+                primary_attempt_provider = "piper"
+                audio_b64 = await self._await_tts_attempt(
+                    self.tts_client.synthesize_wav_base64(processed, language),
+                    provider="piper",
+                    role="primary",
+                )
                 audio_format = "audio/wav"
-            elif language == "en":
+            elif language == "en" and self.kokoro_client:
                 # 英語 → Kokoro TTS (voicevox/google の場合)
-                if self.kokoro_client:
-                    audio_b64 = await self.kokoro_client.synthesize_wav_base64(processed, language)
-                else:
-                    # Kokoro unavailable, fall through to main client (limited English support)
-                    audio_b64 = await self.tts_client.synthesize_wav_base64(processed, language)
+                primary_attempt_provider = "kokoro"
+                audio_b64 = await self._await_tts_attempt(
+                    self.kokoro_client.synthesize_wav_base64(processed, language),
+                    provider="kokoro",
+                    role="primary",
+                )
                 audio_format = "audio/wav"
-            elif self.tts_provider == "voicevox":
-                # 日本語 → VoiceVox
-                audio_b64 = await self.tts_client.synthesize_wav_base64(processed, language)
-                audio_format = "audio/wav"
-            else:  # google
-                # Google TTS（既存のロジック）
+            elif self.tts_provider == "google":
+                # Google TTS supports both ja/en; without Kokoro it must not
+                # fall through to a WAV-only method that GoogleTTSClient lacks.
+                primary_attempt_provider = "google"
                 tts_emotion = map_vrm_to_tts_emotion(vrm_emotion)
-                audio_b64 = await self.tts_client.synthesize_mp3_base64(
-                    processed, language, tts_emotion
+                audio_b64 = await self._await_tts_attempt(
+                    self.tts_client.synthesize_mp3_base64(processed, language, tts_emotion),
+                    provider="google",
+                    role="primary",
                 )
                 audio_format = "audio/mpeg"
+            elif self.tts_provider == "voicevox":
+                # 日本語 → VoiceVox（英語は最後のローカルWAV fallbackとしても使う）
+                primary_attempt_provider = "voicevox"
+                audio_b64 = await self._await_tts_attempt(
+                    self.tts_client.synthesize_wav_base64(processed, language),
+                    provider="voicevox",
+                    role="primary",
+                )
+                audio_format = "audio/wav"
+            else:
+                raise RuntimeError(f"No TTS route for provider={self.tts_provider}")
 
+            audio_b64 = self._require_audio_response(
+                audio_b64,
+                primary_attempt_provider or self.tts_provider,
+            )
             if self._is_cacheable_audio(audio_b64):
-                cache_store[cache_key] = audio_b64
+                cache_store[cache_key] = {
+                    "audioResponse": audio_b64,
+                    "format": audio_format,
+                    "fallback_used": False,
+                    "fallback_provider": None,
+                }
 
             log_tts_event(
                 event="tts_complete",
@@ -983,8 +1094,10 @@ class VoiceAgent:
                         logger.warning("piper failed, falling back to Kokoro for en")
                         if self.kokoro_client:
                             fallback_provider = "kokoro"
-                            audio_b64 = await self.kokoro_client.synthesize_wav_base64(
-                                processed, language
+                            audio_b64 = await self._await_tts_attempt(
+                                self.kokoro_client.synthesize_wav_base64(processed, language),
+                                provider="kokoro",
+                                role="fallback",
                             )
                         else:
                             raise RuntimeError(
@@ -999,8 +1112,12 @@ class VoiceAgent:
                         logger.warning("piper failed, falling back to VoiceVox for %s", language)
                         if self.voicevox_fallback_client:
                             fallback_provider = "voicevox"
-                            audio_b64 = await self.voicevox_fallback_client.synthesize_wav_base64(
-                                processed, language
+                            audio_b64 = await self._await_tts_attempt(
+                                self.voicevox_fallback_client.synthesize_wav_base64(
+                                    processed, language
+                                ),
+                                provider="voicevox",
+                                role="fallback",
                             )
                         else:
                             raise RuntimeError(
@@ -1008,29 +1125,65 @@ class VoiceAgent:
                             )
                     audio_format = "audio/wav"
                 elif language == "en":
-                    # 英語フォールバック → Kokoro TTS
-                    if self.kokoro_client:
-                        fallback_provider = "kokoro"
-                        audio_b64 = await self.kokoro_client.synthesize_wav_base64(
-                            processed, language
+                    # 英語フォールバック: 同じ失敗 provider の即時再試行は避ける。
+                    if self.tts_provider == "google" and primary_attempt_provider != "google":
+                        fallback_provider = "google"
+                        audio_b64 = await self._await_tts_attempt(
+                            self.tts_client.synthesize_mp3_base64(processed, language, "sad"),
+                            provider="google",
+                            role="fallback",
                         )
+                        audio_format = "audio/mpeg"
+                    elif self.kokoro_client and primary_attempt_provider != "kokoro":
+                        fallback_provider = "kokoro"
+                        audio_b64 = await self._await_tts_attempt(
+                            self.kokoro_client.synthesize_wav_base64(processed, language),
+                            provider="kokoro",
+                            role="fallback",
+                        )
+                        audio_format = "audio/wav"
+                    elif self.tts_provider == "voicevox" and primary_attempt_provider != "voicevox":
+                        fallback_provider = "voicevox"
+                        audio_b64 = await self._await_tts_attempt(
+                            self.tts_client.synthesize_wav_base64(processed, language),
+                            provider="voicevox",
+                            role="fallback",
+                        )
+                        audio_format = "audio/wav"
                     else:
                         raise RuntimeError(
-                            "English TTS failed and Kokoro not configured for fallback"
+                            "English TTS failed and no alternate fallback provider is configured"
                         )
-                    audio_format = "audio/wav"
                 elif self.tts_provider == "voicevox":
                     # 日本語フォールバック → VoiceVox
                     fallback_provider = "voicevox"
-                    audio_b64 = await self.tts_client.synthesize_wav_base64(processed, language)
+                    audio_b64 = await self._await_tts_attempt(
+                        self.tts_client.synthesize_wav_base64(processed, language),
+                        provider="voicevox",
+                        role="fallback",
+                    )
                     audio_format = "audio/wav"
                 else:
                     # Google TTSフォールバック
                     fallback_provider = "google"
-                    audio_b64 = await self.tts_client.synthesize_mp3_base64(
-                        processed, language, "sad"
+                    audio_b64 = await self._await_tts_attempt(
+                        self.tts_client.synthesize_mp3_base64(processed, language, "sad"),
+                        provider="google",
+                        role="fallback",
                     )
                     audio_format = "audio/mpeg"
+
+                audio_b64 = self._require_audio_response(
+                    audio_b64,
+                    fallback_provider or "fallback",
+                )
+                if self._is_cacheable_audio(audio_b64):
+                    cache_store[cache_key] = {
+                        "audioResponse": audio_b64,
+                        "format": audio_format,
+                        "fallback_used": True,
+                        "fallback_provider": fallback_provider,
+                    }
 
                 log_tts_event(
                     event="tts_complete",

--- a/backend/config/routing_constants.py
+++ b/backend/config/routing_constants.py
@@ -8,7 +8,7 @@ Note: このモジュールはリーフ依存（他のエージェントモジ�
 """
 
 import re
-from typing import Dict, List, Literal, Optional
+from typing import Dict, List, Literal, Optional, TypeAlias, cast
 
 # =============================================================================
 # エージェントノード名の型定義
@@ -22,6 +22,17 @@ AgentNodeName = Literal[
     "slide",
     "farewell",
 ]
+
+EXECUTABLE_AGENT_NODES: frozenset[AgentNodeName] = frozenset(
+    (
+        "business_info",
+        "facility",
+        "event",
+        "general_knowledge",
+        "slide",
+        "farewell",
+    )
+)
 
 RoutingTarget = Literal[
     "business_info",
@@ -837,19 +848,25 @@ AGENT_DESCRIPTIONS: Dict[str, str] = {
 }
 
 CATEGORY_TO_AGENT_MAP: Dict[str, AgentNodeName] = {
+    "business-hours": "business_info",
     "facility-info": "facility",
+    "basement-facility": "facility",
     "saino-cafe": "business_info",
     "calendar": "event",
     "events": "event",
     "current-time": "general_knowledge",
+    "current_info": "general_knowledge",
+    "assistant_profile": "general_knowledge",
+    "daily_conversation": "general_knowledge",
     "general": "general_knowledge",
     "memory": "general_knowledge",
-    "consultation": "general_knowledge",
+    "consultation": "business_info",
     "community": "business_info",
     "cafe-clarification-needed": "general_knowledge",
     "meeting-room-clarification-needed": "general_knowledge",
     "event-clarification-needed": "general_knowledge",
     "space-clarification-needed": "general_knowledge",
+    "general-clarification-needed": "general_knowledge",
     # query_classifier._detect_specific_category が返すカテゴリ
     "pricing": "business_info",
     "facilities": "facility",
@@ -868,7 +885,122 @@ CATEGORY_TO_AGENT_MAP: Dict[str, AgentNodeName] = {
     "lost_found": "facility",
     "greeting": "business_info",
     "farewell": "farewell",
+    "slide": "slide",
 }
+
+_BROAD_ROUTING_CATEGORIES = frozenset(
+    (
+        "general",
+        "general-clarification-needed",
+        "cafe-clarification-needed",
+        "meeting-room-clarification-needed",
+        "event-clarification-needed",
+        "space-clarification-needed",
+    )
+)
+
+_AGENT_NODE_ALIASES: dict[str, AgentNodeName] = {
+    "businessinfoagent": "business_info",
+    "business_info_agent": "business_info",
+    "business-info": "business_info",
+    "business info": "business_info",
+    "facilityagent": "facility",
+    "facility_agent": "facility",
+    "eventagent": "event",
+    "event_agent": "event",
+    "generalknowledgeagent": "general_knowledge",
+    "general_knowledge_agent": "general_knowledge",
+    "general-knowledge": "general_knowledge",
+    "general knowledge": "general_knowledge",
+    "gka": "general_knowledge",
+    "timeagent": "general_knowledge",
+    "time_agent": "general_knowledge",
+    "slideagent": "slide",
+    "slide_agent": "slide",
+    "farewellagent": "farewell",
+    "farewell_agent": "farewell",
+}
+
+REQUEST_TYPE_TO_AGENT_MAP: dict[str, AgentNodeName] = {
+    "hours": "business_info",
+    "price": "business_info",
+    "pricing": "business_info",
+    "contact": "business_info",
+    "reception": "business_info",
+    "consultation": "business_info",
+    "community": "business_info",
+    "wifi": "facility",
+    "lost_found": "facility",
+    "basement": "facility",
+    "facility": "facility",
+    "meeting_room": "facility",
+    "meeting-room": "facility",
+    "access": "facility",
+    "location": "facility",
+    "building": "facility",
+    "parking": "facility",
+    "bicycle": "facility",
+    "smoking": "facility",
+    "food_drink": "facility",
+    "floor_layout": "facility",
+    "nearby": "facility",
+    "exclusive_rental": "facility",
+    "toilet": "facility",
+    "accessibility": "facility",
+    "photography": "facility",
+    "children_noise": "facility",
+    "temporary_exit": "facility",
+    "pets": "facility",
+    "emergency": "facility",
+    "event": "event",
+    "slide": "slide",
+    "farewell": "farewell",
+    "memory": "general_knowledge",
+    "assistant_profile": "general_knowledge",
+    "daily_conversation": "general_knowledge",
+    "current_info": "general_knowledge",
+}
+
+AgentResolutionSource: TypeAlias = Literal["request_type", "category", "agent", "alias", "fallback"]
+
+
+def normalize_agent_node(
+    raw_agent: object,
+    *,
+    category: Optional[str] = None,
+    request_type: Optional[str] = None,
+    fallback: AgentNodeName = "general_knowledge",
+    prefer_category: bool = False,
+) -> tuple[AgentNodeName, AgentResolutionSource]:
+    """Resolve routing output to an executable LangGraph agent node.
+
+    LLMs and integration layers can return display class names
+    (``BusinessInfoAgent``), inline pseudo-targets (``greeting``), or stale
+    defaults. LangGraph ``Command.goto`` must receive one of the concrete node
+    names, so this helper is the single normalization point for routing and
+    state-transition code.
+    """
+    request_type_agent = REQUEST_TYPE_TO_AGENT_MAP.get(request_type or "")
+    if prefer_category and request_type_agent:
+        return request_type_agent, "request_type"
+
+    category_agent = CATEGORY_TO_AGENT_MAP.get(category or "")
+    if prefer_category and category_agent and category not in _BROAD_ROUTING_CATEGORIES:
+        return category_agent, "category"
+
+    if isinstance(raw_agent, str):
+        normalized = raw_agent.strip()
+        if normalized in EXECUTABLE_AGENT_NODES:
+            return cast(AgentNodeName, normalized), "agent"
+
+        alias = _AGENT_NODE_ALIASES.get(normalized.lower())
+        if alias:
+            return alias, "alias"
+
+    if category_agent:
+        return category_agent, "category"
+
+    return fallback, "fallback"
 
 
 # =============================================================================

--- a/backend/llm/model_resolve.py
+++ b/backend/llm/model_resolve.py
@@ -153,6 +153,27 @@ def cerebras_reasoning_effort() -> str | None:
     return raw if raw else None
 
 
+def cerebras_timeout_seconds(config: "ModelConfig") -> float:
+    """Bound direct Cerebras attempts so fast-path failures recover quickly."""
+
+    raw = (
+        os.getenv("CEREBRAS_TIMEOUT_SECONDS", "").strip()
+        or os.getenv("FAST_LLM_TIMEOUT_SECONDS", "").strip()
+    )
+    default = min(max(float(getattr(config, "timeout", 30.0) or 30.0), 0.1), 8.0)
+    if not raw:
+        return default
+    try:
+        value = float(raw)
+    except (TypeError, ValueError):
+        logger.warning("Invalid Cerebras timeout %r; using %.1fs", raw, default)
+        return default
+    if value <= 0:
+        logger.warning("Invalid Cerebras timeout %r; using %.1fs", raw, default)
+        return default
+    return max(0.1, value)
+
+
 def merge_gemini_openrouter_extra(payload: dict) -> None:
     """Merge JSON from GEMINI_OPENROUTER_EXTRA_JSON into the completion payload (optional)."""
     extra = os.getenv("GEMINI_OPENROUTER_EXTRA_JSON", "").strip()

--- a/backend/llm/openrouter.py
+++ b/backend/llm/openrouter.py
@@ -30,6 +30,7 @@ from .model_resolve import (
     cerebras_model_slug,
     cerebras_primary_enabled,
     cerebras_reasoning_effort,
+    cerebras_timeout_seconds,
     merge_gemini_openrouter_extra,
     resolved_openrouter_model_slug,
 )
@@ -174,7 +175,7 @@ class OpenRouterProvider(LLMProvider):
         if effort:
             body["reasoning_effort"] = effort
         async with httpx.AsyncClient(
-            timeout=max(config.timeout, 60.0),
+            timeout=cerebras_timeout_seconds(config),
             headers={"Authorization": f"Bearer {api_key}", "Content-Type": "application/json"},
         ) as cerebras_http:
             response = await cerebras_http.post(CEREBRAS_CHAT_URL, json=body)

--- a/backend/main.py
+++ b/backend/main.py
@@ -68,6 +68,10 @@ MIN_STT_AUDIO_BYTES = int(_float_env("STT_MIN_AUDIO_BYTES", 512))
 _SUPPORTED_RESPONSE_LANGUAGES = frozenset({"ja", "en", "zh", "ko"})
 
 
+def _voice_stt_request_timeout_seconds() -> float:
+    return _float_env("VOICE_STT_REQUEST_TIMEOUT_SECONDS", 12.0)
+
+
 class RequestIDMiddleware(BaseHTTPMiddleware):
     """X-Request-ID ヘッダーの生成/伝播"""
 
@@ -988,6 +992,40 @@ def _read_filler_audio(intent: str, language: str) -> str:
     return encoded
 
 
+def _read_filler_audio_with_static_fallback(
+    intent: str,
+    language: str,
+) -> tuple[str, str, str, bool]:
+    candidates: list[tuple[str, str]] = [(intent, language)]
+    for candidate in (("fallback", language), ("fallback", "ja")):
+        if candidate not in candidates:
+            candidates.append(candidate)
+
+    first_error: Exception | None = None
+    for candidate_intent, candidate_language in candidates:
+        try:
+            audio = _read_filler_audio(candidate_intent, candidate_language)
+            return (
+                audio,
+                candidate_intent,
+                candidate_language,
+                (candidate_intent, candidate_language) != (intent, language),
+            )
+        except Exception as exc:
+            if first_error is None:
+                first_error = exc
+            logger.warning(
+                "Filler audio unavailable: intent=%s language=%s error=%s",
+                candidate_intent,
+                candidate_language,
+                exc,
+            )
+
+    if first_error is not None:
+        raise first_error
+    raise FileNotFoundError(f"No filler audio candidates for {intent}_{language}")
+
+
 def _filler_text(intent: str, language: str) -> str:
     fallback = FILLER_TEXTS["fallback"]["ja"]
     return FILLER_TEXTS.get(intent, FILLER_TEXTS["fallback"]).get(language, fallback)
@@ -1012,12 +1050,17 @@ async def voice_filler_api(request: Request, body: FillerRequest):
     if intent not in FILLER_INTENTS:
         intent = "fallback"
 
+    actual_intent = intent
+    actual_language = body.language
+    fallback_used = False
     try:
-        audio = _read_filler_audio(intent, body.language)
+        audio, actual_intent, actual_language, fallback_used = (
+            _read_filler_audio_with_static_fallback(intent, body.language)
+        )
         ok = bool(audio)
     except Exception as exc:
         logger.warning(
-            "Filler audio unavailable: intent=%s language=%s error=%s",
+            "Filler audio unavailable after static fallback: intent=%s language=%s error=%s",
             intent,
             body.language,
             exc,
@@ -1031,7 +1074,14 @@ async def voice_filler_api(request: Request, body: FillerRequest):
         intent=intent,
         fillerText=_filler_text(intent, body.language),
         requestId=request_id,
-        upstreamStatus=_upstream_status("filler", ok=ok, latencyMs=latency_ms),
+        upstreamStatus=_upstream_status(
+            "filler",
+            ok=ok,
+            latencyMs=latency_ms,
+            fallbackUsed=fallback_used,
+            actualIntent=actual_intent,
+            actualLanguage=actual_language,
+        ),
     )
 
 
@@ -1199,10 +1249,28 @@ async def _handle_stt(body: VoiceRequest, request_id: str) -> VoiceResponse:
         )
 
     try:
-        stt_result = await _get_stt_agent().speech_to_text(
+        stt_call = _get_stt_agent().speech_to_text(
             audio_bytes,
             language=body.language,
             conversation_stage=body.conversationStage,
+        )
+        stt_timeout_s = _voice_stt_request_timeout_seconds()
+        if stt_timeout_s > 0:
+            stt_result = await asyncio.wait_for(stt_call, timeout=stt_timeout_s)
+        else:
+            stt_result = await stt_call
+    except asyncio.TimeoutError:
+        logger.warning(
+            "STT request timed out: request_id=%s timeout_s=%.2f",
+            request_id,
+            _voice_stt_request_timeout_seconds(),
+        )
+        return _stt_failure_response(
+            body=body,
+            request_id=request_id,
+            error="No speech detected",
+            provider=os.getenv("STT_PROVIDER"),
+            error_type="TimeoutError",
         )
     except RuntimeError as exc:
         logger.warning("STT runtime failure: %s", exc)

--- a/backend/tests/agents/test_orchestrator_fast_routing.py
+++ b/backend/tests/agents/test_orchestrator_fast_routing.py
@@ -24,6 +24,47 @@ class TestOrchestratorFastRouting:
         assert result["request_type"] == "food_drink", "rt-011 should be food_drink type"
         assert result["category"] == "facility-info", "rt-011 should be facility-info category"
 
+    def test_llm_agent_class_name_is_normalized_to_graph_node(self, orchestrator):
+        decision = orchestrator._parse_llm_response("""
+            {
+              "next_agent": "BusinessInfoAgent",
+              "reasoning": "営業時間の質問",
+              "category": "business-hours",
+              "request_type": "hours"
+            }
+            """)
+
+        assert decision["next_agent"] == "business_info"
+        assert decision["raw_next_agent"] == "BusinessInfoAgent"
+        assert decision["agent_resolution_source"] == "request_type"
+
+    def test_llm_specific_category_overrides_stale_default_agent(self, orchestrator):
+        decision = orchestrator._parse_llm_response("""
+            {
+              "next_agent": "GeneralKnowledgeAgent",
+              "reasoning": "料金カテゴリだがagentが古い既定値",
+              "category": "pricing",
+              "request_type": "price"
+            }
+            """)
+
+        assert decision["next_agent"] == "business_info"
+        assert decision["agent_resolution_source"] == "request_type"
+
+    def test_llm_request_type_overrides_wrong_facility_category(self, orchestrator):
+        decision = orchestrator._parse_llm_response("""
+            {
+              "next_agent": "FacilityAgent",
+              "reasoning": "施設全般カテゴリだが営業時間の質問",
+              "category": "facility-info",
+              "request_type": "hours"
+            }
+            """)
+
+        assert decision["next_agent"] == "business_info"
+        assert decision["raw_next_agent"] == "FacilityAgent"
+        assert decision["agent_resolution_source"] == "request_type"
+
     def test_rt_014_meeting_room_with_floor(self, orchestrator):
         """Test rt-014: 会議室+階情報 fast-path"""
         result = orchestrator._try_fast_routing("2階の会議室を借りたいのですが")

--- a/backend/tests/agents/test_voice_agent.py
+++ b/backend/tests/agents/test_voice_agent.py
@@ -1,6 +1,8 @@
+import asyncio
 from unittest.mock import AsyncMock
 
 import httpx
+import time
 import pytest
 from cachetools import TTLCache
 
@@ -342,6 +344,90 @@ async def test_text_to_speech_fallback_on_error(monkeypatch):
 
 
 @pytest.mark.asyncio
+async def test_text_to_speech_piper_timeout_falls_back_quickly(monkeypatch):
+    monkeypatch.setenv("TTS_PIPER_PRIMARY_TIMEOUT_SECONDS", "0.01")
+    agent = VoiceAgent(tts_provider="piper")
+
+    async def slow_piper(text, lang):
+        await asyncio.sleep(1)
+        return "TOO_LATE"
+
+    async def fake_voicevox_synth(text, lang, speaker_id=None):
+        return "VOICEVOX_FALLBACK_BASE64"
+
+    monkeypatch.setattr(agent.tts_client, "synthesize_wav_base64", slow_piper)
+    monkeypatch.setattr(
+        agent.voicevox_fallback_client, "synthesize_wav_base64", fake_voicevox_synth
+    )
+
+    started_at = time.perf_counter()
+    result = await agent.text_to_speech(text="こんにちは", language="ja")
+    elapsed = time.perf_counter() - started_at
+
+    assert elapsed < 0.25
+    assert result["success"] is True
+    assert result["fallback_used"] is True
+    assert result["fallback_provider"] == "voicevox"
+    assert result["audioResponse"] == "VOICEVOX_FALLBACK_BASE64"
+    assert "timed out" in result["error"]
+
+
+@pytest.mark.asyncio
+async def test_text_to_speech_caches_successful_fallback(monkeypatch):
+    monkeypatch.setenv("TTS_PIPER_PRIMARY_TIMEOUT_SECONDS", "0.01")
+    agent = VoiceAgent(tts_provider="piper")
+    calls = {"piper": 0, "voicevox": 0}
+    fallback_audio = "V" * 128
+
+    async def slow_piper(text, lang):
+        calls["piper"] += 1
+        await asyncio.sleep(1)
+        return "TOO_LATE"
+
+    async def fake_voicevox_synth(text, lang, speaker_id=None):
+        calls["voicevox"] += 1
+        return fallback_audio
+
+    monkeypatch.setattr(agent.tts_client, "synthesize_wav_base64", slow_piper)
+    monkeypatch.setattr(
+        agent.voicevox_fallback_client, "synthesize_wav_base64", fake_voicevox_synth
+    )
+
+    first = await agent.text_to_speech(text="こんにちは", language="ja")
+    second = await agent.text_to_speech(text="こんにちは", language="ja")
+
+    assert first["success"] is True
+    assert first["fallback_used"] is True
+    assert second["tts_cache_hit"] is True
+    assert second["fallback_used"] is True
+    assert second["fallback_provider"] == "voicevox"
+    assert second["audioResponse"] == fallback_audio
+    assert calls == {"piper": 1, "voicevox": 1}
+
+
+@pytest.mark.asyncio
+async def test_text_to_speech_empty_primary_audio_uses_fallback(monkeypatch):
+    agent = VoiceAgent(tts_provider="google")
+    state = {"n": 0}
+
+    async def fake_synth(text, lang, tts_emotion):
+        state["n"] += 1
+        if state["n"] == 1:
+            return ""
+        return "FALLBACK_BASE64"
+
+    monkeypatch.setattr(agent.tts_client, "synthesize_mp3_base64", fake_synth)
+
+    result = await agent.text_to_speech(text="こんにちは", language="ja")
+
+    assert result["success"] is True
+    assert result["fallback_used"] is True
+    assert result["fallback_provider"] == "google"
+    assert result["audioResponse"] == "FALLBACK_BASE64"
+    assert "empty audio response" in result["error"]
+
+
+@pytest.mark.asyncio
 async def test_text_to_speech_cache_hit_reuses_audio(monkeypatch):
     agent = VoiceAgent(tts_provider="google")
     calls = {"count": 0}
@@ -455,6 +541,59 @@ async def test_text_to_speech_routes_english_to_kokoro(monkeypatch):
     assert result["audioResponse"] == "KOKORO_BASE64_WAV"
     assert result["format"] == "audio/wav"
     assert result["language"] == "en"
+
+
+@pytest.mark.asyncio
+async def test_text_to_speech_google_english_without_kokoro_uses_google_mp3(monkeypatch):
+    monkeypatch.delenv("KOKORO_API_URL", raising=False)
+    agent = VoiceAgent(tts_provider="google")
+    google_called = {"called": False}
+
+    async def fake_google_synth(text, lang, tts_emotion):
+        google_called["called"] = True
+        return "GOOGLE_BASE64_MP3"
+
+    monkeypatch.setattr(agent.tts_client, "synthesize_mp3_base64", fake_google_synth)
+
+    result = await agent.text_to_speech(
+        text="Hello, how are you?",
+        language="en",
+    )
+
+    assert google_called["called"] is True
+    assert result["success"] is True
+    assert result["audioResponse"] == "GOOGLE_BASE64_MP3"
+    assert result["format"] == "audio/mpeg"
+    assert result["language"] == "en"
+
+
+@pytest.mark.asyncio
+async def test_text_to_speech_google_english_kokoro_failure_falls_back_to_google(
+    monkeypatch,
+):
+    monkeypatch.setenv("KOKORO_API_URL", "http://localhost:8880")
+    agent = VoiceAgent(tts_provider="google")
+
+    async def fake_kokoro_fail(text, lang, voice=None):
+        raise RuntimeError("kokoro down")
+
+    async def fake_google_synth(text, lang, tts_emotion):
+        return "GOOGLE_FALLBACK_MP3"
+
+    monkeypatch.setattr(agent.kokoro_client, "synthesize_wav_base64", fake_kokoro_fail)
+    monkeypatch.setattr(agent.tts_client, "synthesize_mp3_base64", fake_google_synth)
+
+    result = await agent.text_to_speech(
+        text="Hello, how are you?",
+        language="en",
+    )
+
+    assert result["success"] is True
+    assert result["audioResponse"] == "GOOGLE_FALLBACK_MP3"
+    assert result["format"] == "audio/mpeg"
+    assert result["fallback_used"] is True
+    assert result["fallback_provider"] == "google"
+    assert "kokoro down" in result["error"]
 
 
 @pytest.mark.asyncio

--- a/backend/tests/agents/test_voice_agent_cache.py
+++ b/backend/tests/agents/test_voice_agent_cache.py
@@ -32,6 +32,24 @@ def _cache_key(agent: VoiceAgent, text: str, language: str = "ja", emotion: str 
     return agent._tts_cache_key(text, language, agent.tts_provider, emotion)
 
 
+def _assert_cached_audio_entry(
+    agent: VoiceAgent,
+    cache_key: str,
+    *,
+    audio_b64: str,
+    audio_format: str = "audio/wav",
+    fallback_used: bool = False,
+    fallback_provider: str | None = None,
+) -> None:
+    cached = agent._tts_cache[cache_key]
+    assert cached == {
+        "audioResponse": audio_b64,
+        "format": audio_format,
+        "fallback_used": fallback_used,
+        "fallback_provider": fallback_provider,
+    }
+
+
 @pytest.mark.asyncio
 async def test_text_to_speech_lazy_inits_cache_for_new_bypass():
     agent, calls = _make_new_voice_agent()
@@ -80,7 +98,7 @@ async def test_text_to_speech_ignores_invalid_cached_audio(monkeypatch):
     assert result["audioResponse"] == "D" * 128
     assert result["tts_cache_hit"] is False
     assert calls["count"] == 1
-    assert agent._tts_cache[cache_key] == "D" * 128
+    _assert_cached_audio_entry(agent, cache_key, audio_b64="D" * 128)
     log_tts_cache_event.assert_called_once_with(hit=False, cache_key=cache_key, language="ja")
 
 
@@ -103,7 +121,7 @@ async def test_text_to_speech_caches_valid_audio():
     await agent.text_to_speech(text="こんにちは", language="ja")
 
     cache_key = _cache_key(agent, "こんにちは")
-    assert agent._tts_cache[cache_key] == "D" * 128
+    _assert_cached_audio_entry(agent, cache_key, audio_b64="D" * 128)
 
 
 @pytest.mark.asyncio

--- a/backend/tests/api/test_voice_filler_api.py
+++ b/backend/tests/api/test_voice_filler_api.py
@@ -1,3 +1,5 @@
+import asyncio
+import base64
 import time
 
 import httpx
@@ -114,3 +116,63 @@ async def test_voice_filler_accepts_wav_meeting_minimum_size(monkeypatch, tmp_pa
     body = response.json()
     assert body["upstreamStatus"]["ok"] is True
     assert len(body["audioResponse"]) > 0
+
+
+async def test_voice_filler_uses_static_fallback_clip_when_intent_clip_missing(
+    monkeypatch,
+    tmp_path,
+):
+    monkeypatch.setattr(main_mod, "_API_SECRET_KEY", "expected-key")
+    monkeypatch.setattr(main_mod, "_FILLER_DIR", tmp_path)
+    main_mod._filler_audio_cache.clear()
+
+    fallback_file = tmp_path / "fallback_ja.wav"
+    fallback_file.write_bytes(bytes([255]) * 9000)
+
+    transport = httpx.ASGITransport(app=app)
+    async with httpx.AsyncClient(transport=transport, base_url="http://test") as client:
+        response = await client.post(
+            "/api/voice/filler",
+            headers={"X-API-Key": "expected-key"},
+            json={"query": "WiFiのパスワードは？", "language": "ja"},
+        )
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["intent"] == "wifi"
+    assert body["audioResponse"]
+    assert body["upstreamStatus"]["ok"] is True
+    assert body["upstreamStatus"]["fallbackUsed"] is True
+    assert body["upstreamStatus"]["actualIntent"] == "fallback"
+    assert body["upstreamStatus"]["actualLanguage"] == "ja"
+
+
+async def test_handle_stt_times_out_and_returns_recoverable_failure(monkeypatch):
+    monkeypatch.setenv("VOICE_STT_REQUEST_TIMEOUT_SECONDS", "0.01")
+
+    class SlowSTTAgent:
+        async def speech_to_text(self, audio_data, language=None, conversation_stage=None):
+            await asyncio.sleep(1)
+            return {
+                "success": True,
+                "transcript": "too late",
+                "language": language or "ja",
+                "provider": "slow",
+            }
+
+    monkeypatch.setattr(main_mod, "_get_stt_agent", lambda: SlowSTTAgent())
+
+    body = main_mod.VoiceRequest(
+        action="speech_to_text",
+        audioData=base64.b64encode(b"\x00" * 1024).decode("ascii"),
+        language="ja",
+        sessionId="stt-timeout",
+    )
+
+    response = await main_mod._handle_stt(body, "req-stt-timeout")
+
+    assert response.success is False
+    assert response.error == "No speech detected"
+    assert response.requestId == "req-stt-timeout"
+    assert response.upstreamStatus["ok"] is False
+    assert response.upstreamStatus["errorType"] == "TimeoutError"

--- a/backend/tests/config/test_routing_constants.py
+++ b/backend/tests/config/test_routing_constants.py
@@ -7,6 +7,7 @@ import pytest
 from backend.config.routing_constants import (
     CATEGORY_TO_AGENT_MAP,
     extract_request_type,
+    normalize_agent_node,
 )
 
 
@@ -110,6 +111,58 @@ class TestNewRoutingKeywords:
     def test_pet_policy_keywords_avoid_substring_false_positives(self, query):
         """Pet policy should not catch bottle or English substring matches."""
         assert extract_request_type(query) != "pets"
+
+
+class TestAgentNodeNormalization:
+    """LangGraph node transition names are normalized from routing output."""
+
+    @pytest.mark.parametrize(
+        ("raw_agent", "category", "expected_agent", "expected_source"),
+        [
+            ("BusinessInfoAgent", None, "business_info", "alias"),
+            ("GeneralKnowledgeAgent", None, "general_knowledge", "alias"),
+            ("facility", None, "facility", "agent"),
+            ("greeting", "greeting", "business_info", "category"),
+            ("unknown", "pricing", "business_info", "category"),
+            ("unknown", None, "general_knowledge", "fallback"),
+        ],
+    )
+    def test_normalize_agent_node(self, raw_agent, category, expected_agent, expected_source):
+        agent, source = normalize_agent_node(raw_agent, category=category)
+
+        assert agent == expected_agent
+        assert source == expected_source
+
+    def test_specific_category_overrides_stale_agent_when_requested(self):
+        agent, source = normalize_agent_node(
+            "GeneralKnowledgeAgent",
+            category="pricing",
+            prefer_category=True,
+        )
+
+        assert agent == "business_info"
+        assert source == "category"
+
+    def test_request_type_overrides_broad_or_wrong_category_when_requested(self):
+        agent, source = normalize_agent_node(
+            "FacilityAgent",
+            category="facility-info",
+            request_type="hours",
+            prefer_category=True,
+        )
+
+        assert agent == "business_info"
+        assert source == "request_type"
+
+    def test_broad_category_does_not_override_explicit_agent(self):
+        agent, source = normalize_agent_node(
+            "FacilityAgent",
+            category="general",
+            prefer_category=True,
+        )
+
+        assert agent == "facility"
+        assert source == "alias"
 
 
 class TestReceptionRouting:

--- a/backend/tests/llm/test_openrouter.py
+++ b/backend/tests/llm/test_openrouter.py
@@ -236,6 +236,56 @@ class TestOpenRouterProvider:
         assert openrouter_mock.call_count == 1
 
     @pytest.mark.asyncio
+    async def test_cerebras_direct_call_uses_fast_timeout_env(self):
+        """Cerebras direct path should not inherit the old 60s minimum wait."""
+        messages = [HumanMessage(content="Test message")]
+        config = ModelConfig(
+            model_id=SupportedModel.GEMINI_3_1_FLASH_LITE,
+            fallback_model=SupportedModel.GEMINI_2_5_FLASH_LITE,
+            allow_cerebras_primary=True,
+            cerebras_primary_use_case="qa_response",
+            timeout=30.0,
+        )
+
+        class FakeCerebrasResponse:
+            def raise_for_status(self):
+                return None
+
+            def json(self):
+                return {"choices": [{"message": {"content": "fast cerebras"}}]}
+
+        class FakeAsyncClient:
+            timeouts = []
+
+            def __init__(self, *, timeout, headers):
+                self.timeouts.append(timeout)
+                self.headers = headers
+
+            async def __aenter__(self):
+                return self
+
+            async def __aexit__(self, exc_type, exc_val, exc_tb):
+                return None
+
+            async def post(self, url, json):
+                return FakeCerebrasResponse()
+
+        with (
+            patch.dict(
+                os.environ,
+                {
+                    "CEREBRAS_API_KEY": "test_cerebras_key",
+                    "CEREBRAS_TIMEOUT_SECONDS": "1.25",
+                },
+            ),
+            patch("backend.llm.openrouter.httpx.AsyncClient", FakeAsyncClient),
+        ):
+            response = await self.provider._cerebras_generate(messages, config)
+
+        assert response == "fast cerebras"
+        assert FakeAsyncClient.timeouts == [1.25]
+
+    @pytest.mark.asyncio
     async def test_cerebras_fast_primary_requires_config_opt_in(self):
         """施設・イベント系のfast configへCerebras primaryが波及しないこと"""
         messages = [HumanMessage(content="Test message")]

--- a/backend/tests/workflows/test_main_workflow.py
+++ b/backend/tests/workflows/test_main_workflow.py
@@ -991,6 +991,87 @@ class TestOrchestratorIntegration:
 
     @pytest.mark.asyncio
     @patch("backend.workflows.main_workflow.OrchestratorAgent")
+    async def test_orchestrator_node_normalizes_stale_agent_before_goto(
+        self, mock_orchestrator_class
+    ):
+        """routing category と実際の LangGraph 遷移先をずらさない。"""
+        from backend.workflows.main_workflow import MainWorkflow
+        from backend.agents.orchestrator_agent import OrchestratorDecision
+
+        mock_decision = OrchestratorDecision(
+            next_agent="GeneralKnowledgeAgent",
+            language="ja",
+            category="pricing",
+            request_type="price",
+            confidence=0.8,
+            reasoning="Fallback agent label was stale",
+            debug_info={},
+        )
+        mock_orchestrator = AsyncMock()
+        mock_orchestrator.decide_next_agent = AsyncMock(return_value=mock_decision)
+        mock_orchestrator_class.return_value = mock_orchestrator
+
+        workflow = MainWorkflow()
+
+        state = {
+            "query": "料金はいくらですか？",
+            "session_id": "test-session",
+            "language": "ja",
+            "context": {"memory": {}},
+        }
+
+        with patch("backend.utils.topic_guard.check_topic_adherence", return_value=(True, None)):
+            result = await workflow._orchestrator_node(state)
+
+        assert result.goto == "business_info"
+        assert result.update["routing"]["agent"] == "business_info"
+        assert result.update["routing"]["category"] == "pricing"
+        assert result.update["routing"]["request_type"] == "price"
+        assert result.update["routing"]["debug_info"]["raw_next_agent"] == "GeneralKnowledgeAgent"
+        assert result.update["routing"]["debug_info"]["agent_resolution_source"] == "request_type"
+
+    @pytest.mark.asyncio
+    @patch("backend.workflows.main_workflow.OrchestratorAgent")
+    async def test_orchestrator_node_uses_request_type_when_category_is_too_broad(
+        self, mock_orchestrator_class
+    ):
+        """facility-info + hours のような広いカテゴリでも営業時間は business_info へ送る。"""
+        from backend.workflows.main_workflow import MainWorkflow
+        from backend.agents.orchestrator_agent import OrchestratorDecision
+
+        mock_decision = OrchestratorDecision(
+            next_agent="facility",
+            language="ja",
+            category="facility-info",
+            request_type="hours",
+            confidence=0.8,
+            reasoning="Broad facility category with business-hours request type",
+            debug_info={},
+        )
+        mock_orchestrator = AsyncMock()
+        mock_orchestrator.decide_next_agent = AsyncMock(return_value=mock_decision)
+        mock_orchestrator_class.return_value = mock_orchestrator
+
+        workflow = MainWorkflow()
+
+        state = {
+            "query": "開館時間を教えてください",
+            "session_id": "test-session",
+            "language": "ja",
+            "context": {"memory": {}},
+        }
+
+        with patch("backend.utils.topic_guard.check_topic_adherence", return_value=(True, None)):
+            result = await workflow._orchestrator_node(state)
+
+        assert result.goto == "business_info"
+        assert result.update["routing"]["agent"] == "business_info"
+        assert result.update["routing"]["category"] == "facility-info"
+        assert result.update["routing"]["request_type"] == "hours"
+        assert result.update["routing"]["debug_info"]["agent_resolution_source"] == "request_type"
+
+    @pytest.mark.asyncio
+    @patch("backend.workflows.main_workflow.OrchestratorAgent")
     async def test_format_response_node(self, mock_orchestrator_class):
         """_format_response_nodeが正しくメッセージをフォーマットすることを確認"""
         from backend.workflows.main_workflow import MainWorkflow

--- a/backend/workflows/main_workflow.py
+++ b/backend/workflows/main_workflow.py
@@ -36,7 +36,7 @@ from backend.agents.orchestrator_agent import (
     RoutingTarget,
 )
 from backend.agents.orchestrator_agent import OrchestratorAgent as RoutingLogicAgent
-from backend.config.routing_constants import GREETING_KEYWORDS, match_keywords
+from backend.config.routing_constants import GREETING_KEYWORDS, match_keywords, normalize_agent_node
 from backend.services.memory_promoter import MemoryPromoter
 from backend.utils.postgres_sanitizer import sanitize_for_postgres
 from backend.utils.store import store_with_retry
@@ -611,7 +611,11 @@ class MainWorkflow:
         except Exception as guard_err:
             logger.debug("Pre-memory topic guard skipped: %s", guard_err)
 
-        fast_path_agent = fast_route["agent"]
+        fast_path_agent, resolution_source = normalize_agent_node(
+            fast_route.get("agent"),
+            category=fast_route.get("category"),
+            request_type=fast_route.get("request_type"),
+        )
         if fast_path_agent not in self._PRE_MEMORY_DIRECT_AGENTS:
             return {
                 "language": response_language,
@@ -625,11 +629,13 @@ class MainWorkflow:
             "routing": {
                 **state.get("routing", {}),
                 **fast_route,
+                "agent": fast_path_agent,
                 "pre_memory_fast_path_agent": fast_path_agent,
                 "confidence": 0.9,
                 "debug_info": {
                     "fast_path": True,
                     "path": "keyword_router",
+                    "agent_resolution_source": resolution_source,
                 },
             },
         }
@@ -1124,12 +1130,29 @@ class MainWorkflow:
                     self._store_reception_session,
                 )
                 if reception_result.get("target_agent"):
+                    routing = reception_result.get("routing") or {}
+                    target_agent, resolution_source = normalize_agent_node(
+                        reception_result["target_agent"],
+                        category=routing.get("category"),
+                        request_type=routing.get("request_type"),
+                    )
                     return Command(
-                        goto=cast(RoutingTarget, reception_result["target_agent"]),
+                        goto=cast(RoutingTarget, target_agent),
                         update={
                             "language": state.get("language", "ja"),
-                            "routing": reception_result["routing"],
-                            "metadata": reception_result["metadata"],
+                            "routing": {
+                                **routing,
+                                "agent": target_agent,
+                                "debug_info": {
+                                    **routing.get("debug_info", {}),
+                                    "raw_target_agent": reception_result["target_agent"],
+                                    "agent_resolution_source": resolution_source,
+                                },
+                            },
+                            "metadata": {
+                                **reception_result["metadata"],
+                                "reception_target_agent": target_agent,
+                            },
                         },
                     )
 
@@ -1150,6 +1173,17 @@ class MainWorkflow:
             session_id=session_id,
             memory_context=memory_context,
         )
+        next_agent, resolution_source = normalize_agent_node(
+            decision.next_agent,
+            category=decision.category,
+            request_type=decision.request_type,
+            prefer_category=True,
+        )
+        debug_info = {
+            **decision.debug_info,
+            "raw_next_agent": decision.next_agent,
+            "agent_resolution_source": resolution_source,
+        }
 
         for handler in (
             lambda current_state, current_decision: self._handle_emergency(
@@ -1175,13 +1209,16 @@ class MainWorkflow:
                 return cmd
 
         return Command(
-            goto=decision.next_agent,
+            goto=next_agent,
             update={
                 "language": decision.language,
-                "routing": self._build_routing_payload(
-                    decision,
-                    agent=decision.next_agent,
-                ),
+                "routing": {
+                    **self._build_routing_payload(
+                        decision,
+                        agent=next_agent,
+                    ),
+                    "debug_info": debug_info,
+                },
             },
         )
 
@@ -1725,14 +1762,27 @@ class MainWorkflow:
         Raises:
             ValueError: If the target agent is not a known node.
         """
-        target = handoff.target_agent
+        routing = handoff.workflow_state.get("routing", {})
+        target, resolution_source = normalize_agent_node(handoff.target_agent)
         node_attr = self._AGENT_NODE_MAP.get(target)
-        if node_attr is None:
+        if node_attr is None or resolution_source == "fallback":
             raise ValueError(
-                f"Unknown target agent '{target}'. Valid agents: {sorted(self._AGENT_NODE_MAP)}"
+                f"Unknown target agent '{handoff.target_agent}'. "
+                f"Valid agents: {sorted(self._AGENT_NODE_MAP)}"
             )
 
-        state = handoff.workflow_state
+        state = {
+            **handoff.workflow_state,
+            "routing": {
+                **(routing if isinstance(routing, dict) else {}),
+                "agent": target,
+                "debug_info": {
+                    **(routing.get("debug_info", {}) if isinstance(routing, dict) else {}),
+                    "raw_target_agent": handoff.target_agent,
+                    "agent_resolution_source": resolution_source,
+                },
+            },
+        }
         self._current_visitor_id = state.get("session_id", "anonymous")
 
         agent_node = getattr(self, node_attr)

--- a/frontend/e2e/mobile-audio-proof.spec.ts
+++ b/frontend/e2e/mobile-audio-proof.spec.ts
@@ -132,6 +132,14 @@ test.describe('Mobile audio proof', () => {
       });
     });
 
+    await page.route('**/api/character', async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({ success: true, vrm_control: null }),
+      });
+    });
+
     await page.route('**/api/qa', async (route) => {
       calls.qa += 1;
       await route.fulfill({
@@ -163,7 +171,7 @@ test.describe('Mobile audio proof', () => {
       });
 
       await page.waitForTimeout(250);
-      await voiceButton.click();
+      await voiceButton.dispatchEvent('click');
 
       await expect(page.getByTestId('response-text')).toContainText(`Turn ${turn}:`, {
         timeout: 30_000,
@@ -177,6 +185,9 @@ test.describe('Mobile audio proof', () => {
         .toBeGreaterThanOrEqual(audioStartsAtBaseline + turn);
       await expect(page.getByTestId('audio-interaction-toast')).toHaveCount(0);
       expect(await getInteractionRequiredCount(page)).toBe(0);
+      if (turn < 10) {
+        await page.waitForTimeout(500);
+      }
     }
 
     expect(calls.stt).toBe(10);

--- a/frontend/e2e/reception-flow.spec.ts
+++ b/frontend/e2e/reception-flow.spec.ts
@@ -352,6 +352,108 @@ test.describe('Reception flow — voice mode', () => {
   });
 });
 
+test.describe('Reception flow — voice locking and interruption', () => {
+  test('STT locks other actions, then LLM processing can be interrupted by opening slides', async ({
+    page,
+  }) => {
+    await installDeterministicVoiceRecorder(page);
+    await mockReceptionStart(page);
+
+    let releaseStt!: () => void;
+    const sttGate = new Promise<void>((resolve) => {
+      releaseStt = resolve;
+    });
+    let releaseQa!: () => void;
+    const qaGate = new Promise<void>((resolve) => {
+      releaseQa = resolve;
+    });
+
+    let sttRequests = 0;
+    let qaRequests = 0;
+    let interruptRequests = 0;
+    let ttsRequests = 0;
+
+    await page.route(`**${QA_CHAT_URL}`, async (route) => {
+      qaRequests += 1;
+      await qaGate;
+      await route
+        .fulfill({
+          status: 200,
+          contentType: 'application/json',
+          body: JSON.stringify({
+            success: true,
+            answer: '割り込みテスト応答です。',
+            emotion: 'neutral',
+            metadata: {},
+          }),
+        })
+        .catch(() => {});
+    });
+
+    await page.route('**/api/voice', async (route) => {
+      let body: Record<string, unknown> = {};
+      try {
+        body = route.request().postDataJSON() as Record<string, unknown>;
+      } catch {
+        body = {};
+      }
+
+      if (body.action === 'speech_to_text') {
+        sttRequests += 1;
+        await sttGate;
+        await route.fulfill({
+          status: 200,
+          contentType: 'application/json',
+          body: JSON.stringify({ success: true, transcript: 'スライド案内を見たいです' }),
+        });
+        return;
+      }
+
+      if (body.action === 'interrupt') {
+        interruptRequests += 1;
+      }
+      if (body.action === 'text_to_speech') {
+        ttsRequests += 1;
+      }
+
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({ success: true, sttWarmupStatus: 'ready' }),
+      });
+    });
+
+    await page.goto('/', { waitUntil: 'domcontentloaded' });
+    await dismissInitialModal(page);
+
+    const voiceButton = page.getByTestId('kiosk-voice-button');
+    const slidesButton = page.getByTestId('kiosk-slides-button');
+
+    await voiceButton.click();
+    await expect(page.getByTestId('kiosk-voice-status')).toHaveAttribute(
+      'data-session-state',
+      'listening',
+      { timeout: 8_000 },
+    );
+    await voiceButton.click();
+
+    await expect.poll(() => sttRequests, { timeout: 8_000 }).toBe(1);
+    await expect(slidesButton).toBeDisabled();
+
+    releaseStt();
+    await expect.poll(() => qaRequests, { timeout: 8_000 }).toBe(1);
+    await expect(slidesButton).toBeEnabled();
+
+    await slidesButton.click();
+    await expect(page.getByTestId('slide-language-ja')).toBeVisible({ timeout: 5_000 });
+    await expect.poll(() => interruptRequests, { timeout: 5_000 }).toBeGreaterThanOrEqual(1);
+
+    releaseQa();
+    await page.waitForTimeout(300);
+    expect(ttsRequests).toBe(0);
+  });
+});
+
 test.describe('Reception flow — microphone errors', () => {
   test.beforeEach(async ({ page }) => {
     await rejectMicrophonePermission(page);

--- a/frontend/e2e/slide-pdf-narration.spec.ts
+++ b/frontend/e2e/slide-pdf-narration.spec.ts
@@ -418,6 +418,35 @@ test.describe('Slide PDF narration deck (#624)', () => {
     expect(counters?.maxActive).toBe(1);
   });
 
+  test('closing slides during static narration stops the active slide audio', async ({ page }) => {
+    await setupWebAudioMock(page);
+    await setupSlideAudioElementMock(page, { staticAudioReady: true });
+    await mockReceptionStart(page, 'mock-close-static-narration');
+    await page.route('**/api/voice', async (route) => {
+      await route.fulfill({ status: 200, contentType: 'application/json', body: '{}' });
+    });
+
+    await page.goto('/', { waitUntil: 'domcontentloaded' });
+    await dismissInitialModal(page);
+
+    await page.setViewportSize({ width: 960, height: 540 });
+    await page.getByTestId('kiosk-slides-button').click();
+    await page.getByTestId('slide-language-ja').click();
+
+    await expect(page.getByTestId('reception-pdf-counter')).toHaveText('1 / 5', {
+      timeout: 15_000,
+    });
+    await page.waitForFunction(() => window.__SLIDE_AUDIO_COUNTERS__?.active === 1);
+
+    await page.getByRole('button', { name: /スライドを閉じる|Close slides/ }).click();
+    await expect(page.getByRole('button', { name: 'Welcome' })).toBeVisible({ timeout: 5_000 });
+
+    const counters = await page.evaluate(() => window.__SLIDE_AUDIO_COUNTERS__);
+    expect(counters?.active).toBe(0);
+    expect(counters?.starts).toBe(1);
+    expect(counters?.maxActive).toBe(1);
+  });
+
   test('autoplay waits for narration markdown instead of fast-advancing without audio', async ({
     page,
   }) => {

--- a/frontend/e2e/slide-pdf-narration.spec.ts
+++ b/frontend/e2e/slide-pdf-narration.spec.ts
@@ -14,9 +14,11 @@ declare global {
 
 async function setupSlideAudioElementMock(
   page: import('@playwright/test').Page,
-  options: { staticAudioReady: boolean } = { staticAudioReady: true },
+  options: { staticAudioReady: boolean; endAfterMs?: number; duration?: number } = {
+    staticAudioReady: true,
+  },
 ) {
-  await page.addInitScript(({ staticAudioReady }) => {
+  await page.addInitScript(({ staticAudioReady, endAfterMs, duration }) => {
     type Listener = {
       callback: EventListenerOrEventListenerObject;
       once: boolean;
@@ -40,10 +42,11 @@ async function setupSlideAudioElementMock(
       public paused = true;
       public ended = false;
       public currentTime = 0;
-      public duration = 30;
+      public duration = duration ?? 30;
       public readyState = staticAudioReady ? 4 : 0;
       public src = '';
       private readonly listeners = new Map<string, Set<Listener>>();
+      private endTimer: number | null = null;
 
       constructor(url?: string) {
         super();
@@ -73,6 +76,10 @@ async function setupSlideAudioElementMock(
         if (!this.paused) {
           return;
         }
+        if (this.endTimer !== null) {
+          clearTimeout(this.endTimer);
+          this.endTimer = null;
+        }
         this.paused = false;
         this.ended = false;
         if (isSlideAudio(this.src)) {
@@ -81,9 +88,27 @@ async function setupSlideAudioElementMock(
           counters.maxActive = Math.max(counters.maxActive, counters.active);
         }
         this.emit('play');
+        if (typeof endAfterMs === 'number') {
+          this.endTimer = window.setTimeout(() => {
+            this.endTimer = null;
+            if (this.paused) {
+              return;
+            }
+            this.paused = true;
+            this.ended = true;
+            if (isSlideAudio(this.src)) {
+              counters.active = Math.max(0, counters.active - 1);
+            }
+            this.emit('ended');
+          }, Math.max(0, endAfterMs));
+        }
       }
 
       pause() {
+        if (this.endTimer !== null) {
+          clearTimeout(this.endTimer);
+          this.endTimer = null;
+        }
         if (this.paused) {
           return;
         }
@@ -181,6 +206,8 @@ async function dismissInitialModal(page: import('@playwright/test').Page) {
 }
 
 test.describe('Slide PDF narration deck (#624)', () => {
+  test.describe.configure({ mode: 'serial' });
+
   test('autoplay uses static slide audio and does not call Piper TTS', async ({ page }) => {
     await setupWebAudioMock(page);
     await setupSlideAudioElementMock(page, { staticAudioReady: true });
@@ -230,6 +257,132 @@ test.describe('Slide PDF narration deck (#624)', () => {
     expect(piperHits).toBe(0);
   });
 
+  test('autoplay does not fast-forward while static audio and narration markdown are not ready', async ({ page }) => {
+    await setupWebAudioMock(page);
+    await setupSlideAudioElementMock(page, { staticAudioReady: false });
+    await mockReceptionStart(page, 'mock-pending-assets-narration');
+    await page.route('**/reception/engineer-cafe-narration-ja.md', async (route) => {
+      await new Promise((resolve) => setTimeout(resolve, 3_000));
+      await route.fulfill({
+        status: 200,
+        contentType: 'text/markdown',
+        body: '## スライド 1\n\nテスト案内です。\n',
+      });
+    });
+    await page.route('**/api/voice', async (route) => {
+      await route.fulfill({ status: 200, contentType: 'application/json', body: '{}' });
+    });
+
+    await page.goto('/', { waitUntil: 'domcontentloaded' });
+    await dismissInitialModal(page);
+
+    await page.setViewportSize({ width: 960, height: 540 });
+    await page.getByTestId('kiosk-slides-button').click();
+    await page.getByTestId('slide-language-ja').click();
+
+    await expect(page.getByTestId('reception-pdf-counter')).toHaveText('1 / 5', {
+      timeout: 15_000,
+    });
+    await expect(page.getByTestId('reception-pdf-play')).toHaveAttribute('data-state', 'playing', {
+      timeout: 15_000,
+    });
+
+    await page.waitForTimeout(2_000);
+    await expect(page.getByTestId('reception-pdf-counter')).toHaveText('1 / 5');
+  });
+
+  test('zero-duration static audio ending immediately does not cascade through slides', async ({ page }) => {
+    await setupWebAudioMock(page);
+    await setupSlideAudioElementMock(page, {
+      staticAudioReady: true,
+      duration: 0,
+      endAfterMs: 0,
+    });
+    await mockReceptionStart(page, 'mock-immediate-ended-narration');
+    await page.route('**/api/voice', async (route) => {
+      await route.fulfill({ status: 200, contentType: 'application/json', body: '{}' });
+    });
+
+    await page.goto('/', { waitUntil: 'domcontentloaded' });
+    await dismissInitialModal(page);
+
+    await page.setViewportSize({ width: 960, height: 540 });
+    await page.getByTestId('kiosk-slides-button').click();
+    await page.getByTestId('slide-language-ja').click();
+
+    await expect(page.getByTestId('reception-pdf-counter')).toHaveText('1 / 5', {
+      timeout: 15_000,
+    });
+    await page.waitForFunction(() => window.__SLIDE_AUDIO_COUNTERS__?.starts === 1);
+
+    await page.waitForTimeout(2_000);
+    await expect(page.getByTestId('reception-pdf-counter')).toHaveText('1 / 5');
+
+    const counters = await page.evaluate(() => window.__SLIDE_AUDIO_COUNTERS__);
+    expect(counters?.active).toBe(0);
+    expect(counters?.maxActive).toBe(1);
+  });
+
+  test('short generated narration audio does not fast-forward the deck', async ({ page }) => {
+    await setupWebAudioMock(page);
+    await setupSlideAudioElementMock(page, { staticAudioReady: false });
+    await mockReceptionStart(page, 'mock-short-generated-narration');
+    await page.route('**/reception/engineer-cafe-narration-ja.md', async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: 'text/markdown',
+        body: [
+          '# test',
+          '',
+          '## スライド1：テスト',
+          '',
+          '短い生成音声のテストナレーションです。',
+          '',
+          '---',
+          '',
+          '## スライド2：テスト',
+          '',
+          '二枚目のテストナレーションです。',
+        ].join('\n'),
+      });
+    });
+    await page.route('**/api/voice', async (route) => {
+      const req = route.request();
+      if (req.method() === 'POST') {
+        let body: Record<string, unknown> = {};
+        try {
+          body = req.postDataJSON() as Record<string, unknown>;
+        } catch {
+          body = {};
+        }
+        if (body.action === 'text_to_speech') {
+          await route.fulfill({
+            status: 200,
+            contentType: 'application/json',
+            body: JSON.stringify(MOCK_VOICE_RESPONSE),
+          });
+          return;
+        }
+      }
+      await route.fulfill({ status: 200, contentType: 'application/json', body: '{}' });
+    });
+
+    await page.goto('/', { waitUntil: 'domcontentloaded' });
+    await dismissInitialModal(page);
+
+    await page.setViewportSize({ width: 960, height: 540 });
+    await page.getByTestId('kiosk-slides-button').click();
+    await page.getByTestId('slide-language-ja').click();
+
+    await expect(page.getByTestId('reception-pdf-counter')).toHaveText('1 / 5', {
+      timeout: 15_000,
+    });
+    await page.waitForFunction(() => (window.__PLAYWRIGHT_AUDIO_STARTS__ ?? 0) >= 1);
+
+    await page.waitForTimeout(2_000);
+    await expect(page.getByTestId('reception-pdf-counter')).toHaveText('1 / 5');
+  });
+
   test('rapid slide changes stop current narration before another slide can play', async ({ page }) => {
     await setupWebAudioMock(page);
     await setupSlideAudioElementMock(page, { staticAudioReady: true });
@@ -263,6 +416,77 @@ test.describe('Slide PDF narration deck (#624)', () => {
     const counters = await page.evaluate(() => window.__SLIDE_AUDIO_COUNTERS__);
     expect(counters?.starts).toBe(2);
     expect(counters?.maxActive).toBe(1);
+  });
+
+  test('autoplay waits for narration markdown instead of fast-advancing without audio', async ({
+    page,
+  }) => {
+    await setupWebAudioMock(page);
+    await setupSlideAudioElementMock(page, { staticAudioReady: false });
+    await mockReceptionStart(page, 'mock-delayed-narration-assets');
+
+    let releaseNarration!: () => void;
+    const narrationGate = new Promise<void>((resolve) => {
+      releaseNarration = resolve;
+    });
+    await page.route('**/reception/engineer-cafe-narration-ja.md', async (route) => {
+      await narrationGate;
+      await route.fulfill({
+        status: 200,
+        contentType: 'text/markdown',
+        body: [
+          '# test',
+          '',
+          '## スライド1：テスト',
+          '',
+          'スライド一枚目のテストナレーションです。',
+          '',
+          '---',
+          '',
+          '## スライド2：テスト',
+          '',
+          'スライド二枚目のテストナレーションです。',
+        ].join('\n'),
+      });
+    });
+
+    let ttsRequests = 0;
+    await page.route('**/api/voice', async (route) => {
+      const req = route.request();
+      if (req.method() === 'POST') {
+        let body: Record<string, unknown> = {};
+        try {
+          body = req.postDataJSON() as Record<string, unknown>;
+        } catch {
+          body = {};
+        }
+        if (body.action === 'text_to_speech') {
+          ttsRequests += 1;
+        }
+      }
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify(MOCK_VOICE_RESPONSE),
+      });
+    });
+
+    await page.goto('/', { waitUntil: 'domcontentloaded' });
+    await dismissInitialModal(page);
+
+    await page.setViewportSize({ width: 960, height: 540 });
+    await page.getByTestId('kiosk-slides-button').click();
+    await page.getByTestId('slide-language-ja').click();
+
+    await expect(page.getByTestId('reception-pdf-counter')).toHaveText('1 / 5', {
+      timeout: 15_000,
+    });
+    await page.waitForTimeout(1_300);
+    await expect(page.getByTestId('reception-pdf-counter')).toHaveText('1 / 5');
+    expect(ttsRequests).toBe(0);
+
+    releaseNarration();
+    await expect.poll(() => ttsRequests, { timeout: 5_000 }).toBeGreaterThan(0);
   });
 
   test('closing slides during pending generated narration prevents stale audio playback', async ({ page }) => {

--- a/frontend/e2e/voice-permission-denial.spec.ts
+++ b/frontend/e2e/voice-permission-denial.spec.ts
@@ -1,3 +1,6 @@
+import fs from 'node:fs';
+import path from 'node:path';
+
 import { expect, test } from '@playwright/test';
 
 /**
@@ -16,17 +19,34 @@ async function dismissInitialModal(page: import('@playwright/test').Page) {
 
 async function installMicDenial(page: import('@playwright/test').Page, errorName: string) {
   await page.addInitScript((name: string) => {
-    const md = navigator.mediaDevices ?? {};
-    Object.defineProperty(navigator, 'mediaDevices', {
-      configurable: true,
-      value: {
-        ...md,
-        getUserMedia: async () => {
-          throw new DOMException('Playwright injected denial', name);
-        },
-      },
-    });
+    (window as Window & { __PLAYWRIGHT_VOICE_RECORDER_ERROR_NAME__?: string }).__PLAYWRIGHT_VOICE_RECORDER_ERROR_NAME__ =
+      name;
   }, errorName);
+}
+
+async function installDeterministicVoiceRecorder(page: import('@playwright/test').Page) {
+  const sampleAudioBase64 = fs
+    .readFileSync(path.resolve(__dirname, 'fixtures/voice/sample.wav'))
+    .toString('base64');
+
+  await page.addInitScript(({ audioBase64 }) => {
+    (window as Window & { __PLAYWRIGHT_VOICE_AUDIO_BASE64__?: string }).__PLAYWRIGHT_VOICE_AUDIO_BASE64__ =
+      audioBase64;
+  }, { audioBase64: sampleAudioBase64 });
+}
+
+async function installIOSUserAgent(page: import('@playwright/test').Page) {
+  await page.addInitScript(() => {
+    Object.defineProperty(navigator, 'userAgent', {
+      configurable: true,
+      value:
+        'Mozilla/5.0 (iPhone; CPU iPhone OS 17_0 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.0 Mobile/15E148 Safari/604.1',
+    });
+    Object.defineProperty(navigator, 'maxTouchPoints', {
+      configurable: true,
+      value: 5,
+    });
+  });
 }
 
 test.describe('Microphone permission denial (#638)', () => {
@@ -66,6 +86,101 @@ test.describe('Microphone permission denial (#638)', () => {
       timeout: 8_000,
     });
   }
+
+  test('NotFoundError while response-prep recovers to an enabled idle UI', async ({ page }) => {
+    await installIOSUserAgent(page);
+    await installDeterministicVoiceRecorder(page);
+
+    let releaseQa: (() => void) | null = null;
+    const qaRequested = new Promise<void>((resolve) => {
+      releaseQa = resolve;
+    });
+
+    await page.route('**/api/voice/filler', async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({ success: true }),
+      });
+    });
+
+    await page.route('**/api/voice', async (route) => {
+      const raw = route.request().postData();
+      const action = raw ? (JSON.parse(raw) as { action?: string }).action : '';
+      if (action === 'speech_to_text') {
+        await route.fulfill({
+          status: 200,
+          contentType: 'application/json',
+          body: JSON.stringify({
+            success: true,
+            transcript: 'Engineer Cafe の設備を教えてください。',
+          }),
+        });
+        return;
+      }
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({ success: true, sttWarmupStatus: 'ready' }),
+      });
+    });
+
+    await page.route('**/api/qa', async (route) => {
+      releaseQa?.();
+      await new Promise<void>((resolve) => {
+        releaseQa = resolve;
+      });
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({
+          success: true,
+          answer: 'Engineer Cafe の設備案内です。',
+          emotion: 'neutral',
+          metadata: {},
+        }),
+      }).catch(() => {});
+    });
+
+    await page.goto('/', { waitUntil: 'domcontentloaded' });
+    await dismissInitialModal(page);
+
+    const voiceButton = page.getByTestId('kiosk-voice-button');
+    const voiceStatus = page.getByTestId('kiosk-voice-status');
+    const welcomeButton = page.getByRole('button', { name: 'Welcome' });
+
+    await voiceButton.click();
+    await expect(voiceStatus).toHaveAttribute('data-session-state', 'listening', {
+      timeout: 8_000,
+    });
+    await voiceButton.dispatchEvent('click');
+    await qaRequested;
+
+    await expect(voiceStatus).toContainText(/応答を準備|Preparing an answer/, {
+      timeout: 8_000,
+    });
+    await expect(voiceButton).toBeEnabled();
+    await expect(welcomeButton).toBeEnabled();
+
+    await page.waitForTimeout(500);
+    await page.evaluate(() => {
+      (window as Window & { __PLAYWRIGHT_VOICE_RECORDER_ERROR_NAME__?: string }).__PLAYWRIGHT_VOICE_RECORDER_ERROR_NAME__ =
+        'NotFoundError';
+    });
+    await voiceButton.click();
+
+    await expect(voiceStatus).toContainText(/画面録画|Settings.*Safari|マイク|microphone/i, {
+      timeout: 8_000,
+    });
+    await expect(voiceStatus).toHaveAttribute('data-session-state', 'idle', {
+      timeout: 8_000,
+    });
+    await expect(voiceButton).toBeEnabled();
+    await expect(voiceButton).not.toContainText(/録音中|Recording/);
+    await expect(welcomeButton).toBeEnabled();
+
+    releaseQa?.();
+  });
 
   test('NotAllowedError shows guidance and clears recording affordance', async ({ page }) => {
     await installMicDenial(page, 'NotAllowedError');

--- a/frontend/src/__tests__/reception-narration-timing.test.ts
+++ b/frontend/src/__tests__/reception-narration-timing.test.ts
@@ -1,0 +1,41 @@
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+
+import {
+  RECEPTION_NARRATION_MIN_SLIDE_DWELL_MS,
+  getReceptionNarrationAdvanceDelay,
+} from '../lib/reception/reception-narration-timing';
+
+test('slide narration advance waits for minimum dwell after immediate completion', () => {
+  assert.equal(
+    getReceptionNarrationAdvanceDelay({
+      slideShownAtMs: 1_000,
+      nowMs: 1_100,
+      requestedDelayMs: 500,
+    }),
+    RECEPTION_NARRATION_MIN_SLIDE_DWELL_MS - 100,
+  );
+});
+
+test('slide narration advance keeps requested delay after minimum dwell is satisfied', () => {
+  assert.equal(
+    getReceptionNarrationAdvanceDelay({
+      slideShownAtMs: 1_000,
+      nowMs: 8_000,
+      requestedDelayMs: 500,
+    }),
+    500,
+  );
+});
+
+test('slide narration advance handles invalid timing values safely', () => {
+  assert.equal(
+    getReceptionNarrationAdvanceDelay({
+      slideShownAtMs: Number.NaN,
+      nowMs: 8_000,
+      requestedDelayMs: -1,
+      minimumDwellMs: 2_000,
+    }),
+    2_000,
+  );
+});

--- a/frontend/src/app/components/KioskBottomBar.tsx
+++ b/frontend/src/app/components/KioskBottomBar.tsx
@@ -5,7 +5,7 @@ import { cn } from '@/lib/cn';
 import { overlayLabels } from '@/lib/kiosk-labels';
 import type { KioskMicMode, KioskPhase } from '@/lib/kiosk-constants';
 import { Camera, Mic, PenLine, Presentation, Sparkles } from 'lucide-react';
-import { useRef } from 'react';
+import { useEffect, useRef } from 'react';
 import { KioskVoiceStatusStack } from './KioskVoiceStatusStack';
 import type { VoiceInterfaceRenderProps } from './VoiceInterface';
 
@@ -46,13 +46,20 @@ export function KioskBottomBar({
   setWelcomeMemberOcrOpen: (open: boolean) => void;
   setOcrMode: (mode: 'member_card' | 'handwriting') => void;
 }) {
-  const isVoiceCaptureActive = kioskPhase === 'voice' && kioskVoiceLocked;
+  const isVoiceCaptureActive =
+    kioskPhase === 'voice' &&
+    ((voice.sessionState === 'listening' &&
+      voice.loadingPhase !== 'llm' &&
+      voice.loadingPhase !== 'tts') ||
+      voice.loadingPhase === 'mic' ||
+      voice.loadingPhase === 'stt');
   const controlsLocked = voice.uiLockState === 'locked';
   const controlsInterruptible = voice.uiLockState === 'interruptible';
-  const welcomeDisabled = controlsLocked || controlsInterruptible || welcomeCooldown;
+  const welcomeDisabled = controlsLocked || welcomeCooldown;
   const nonWelcomeDisabled = controlsLocked;
   const isPushToTalk = micInputMode === 'push_to_talk';
   const pushToTalkPointerActiveRef = useRef(false);
+  const voiceRestartSuppressedUntilRef = useRef(0);
   const voiceButtonLabel = isPushToTalk
     ? isVoiceCaptureActive
       ? labels.kioskVoicePushActive
@@ -63,6 +70,12 @@ export function KioskBottomBar({
 
   const handleKioskVoiceStart = async () => {
     if (controlsLocked) {
+      return;
+    }
+    if (voice.uiLockState === 'normal') {
+      voiceRestartSuppressedUntilRef.current = 0;
+    }
+    if (Date.now() < voiceRestartSuppressedUntilRef.current) {
       return;
     }
     if (voice.unlockAudioPlayback()) {
@@ -84,6 +97,7 @@ export function KioskBottomBar({
   };
 
   const handleKioskVoiceStop = () => {
+    voiceRestartSuppressedUntilRef.current = Date.now() + 450;
     setKioskVoiceLocked(false);
     if (isPushToTalk) {
       voice.stopListening();
@@ -102,6 +116,20 @@ export function KioskBottomBar({
       voice.cancelSession();
     }
   };
+
+  useEffect(() => {
+    if (voice.uiLockState === 'normal') {
+      voiceRestartSuppressedUntilRef.current = 0;
+    }
+  }, [voice.uiLockState]);
+
+  useEffect(() => {
+    if (!kioskVoiceLocked || !voice.error || voice.uiLockState !== 'normal') {
+      return;
+    }
+
+    setKioskVoiceLocked(false);
+  }, [kioskVoiceLocked, setKioskVoiceLocked, voice.error, voice.uiLockState]);
 
   const statusEnabled =
     kioskPhase === 'voice' || kioskPhase === 'idle' || kioskPhase === 'notice';
@@ -126,6 +154,7 @@ export function KioskBottomBar({
             <button
               type="button"
               onClick={() => {
+                interruptActiveVoiceTurn();
                 unlockAudioForUserGesture();
                 void onPlayWelcome();
               }}

--- a/frontend/src/app/components/KioskVoiceStatusStack.tsx
+++ b/frontend/src/app/components/KioskVoiceStatusStack.tsx
@@ -141,10 +141,15 @@ export function KioskVoiceStatusStack({
   }
 
   const isSttLoading = isLoading && loadingPhase === 'stt';
-  const isListeningVisible = phase === 'voice' && sessionState === 'listening';
   const isAnswerLoading = isLoading && loadingPhase === 'llm';
   const isTtsSynthesizing =
     isLoading && response.length > 0 && sessionState !== 'speaking';
+  const isListeningVisible =
+    phase === 'voice' &&
+    sessionState === 'listening' &&
+    !isSttLoading &&
+    !isAnswerLoading &&
+    !isTtsSynthesizing;
   const isErrorVisible = Boolean(error) && errorVisibleUntil > now;
   const isOcrStatusVisible = Boolean(ocrStatus && ocrStatus.visibleUntil > now);
   const responseDisplay = getKioskResponseDisplayState({

--- a/frontend/src/app/components/ReceptionPdfGuide.tsx
+++ b/frontend/src/app/components/ReceptionPdfGuide.tsx
@@ -12,7 +12,12 @@ import {
   unlockAudioForUserGesture,
 } from '@/lib/audio/audio-interaction-manager';
 import { MobileAudioService } from '@/lib/audio/mobile-audio-service';
-import type { AudioDataInput, AudioOperationResult } from '@/lib/audio/audio-interfaces';
+import {
+  AudioError,
+  AudioErrorType,
+  type AudioDataInput,
+  type AudioOperationResult,
+} from '@/lib/audio/audio-interfaces';
 import {
   RECEPTION_GUIDE_AUDIO_EXT,
   receptionGuideAudioPrefix,
@@ -24,6 +29,7 @@ import {
   shouldFallbackToGeneratedNarration,
   type StaticNarrationAudioState,
 } from '@/lib/reception/reception-audio-readiness';
+import { getReceptionNarrationAdvanceDelay } from '@/lib/reception/reception-narration-timing';
 import { parseReceptionNarrationMarkdown } from '@/lib/reception/parse-reception-narration-md';
 import { preprocessTTS } from '@/utils/tts-preprocess';
 import { cn } from '@/lib/cn';
@@ -35,11 +41,15 @@ import type { PresentationCompleteReason } from './presentation-types';
 
 const SLIDE_DELAY_MS = 500;
 const NARRATION_GAP_MS = 300;
+const NARRATION_ASSET_RETRY_MS = 250;
+const MIN_STATIC_NARRATION_PLAYBACK_MS = 1200;
 
 type NarrationRun = {
   id: number;
   playbackSessionId: number;
   page: number;
+  slideShownAtMs: number;
+  playbackStartedAtMs: number | null;
   controller: AbortController;
   audioService: MobileAudioService | null;
 };
@@ -180,6 +190,7 @@ export default function ReceptionPdfGuide({
   const [isNarrationInProgress, setIsNarrationInProgress] = useState(false);
   const [containerBounds, setContainerBounds] = useState({ width: 800, height: 600 });
   const [narrationTexts, setNarrationTexts] = useState<string[]>([]);
+  const [isNarrationTextReady, setIsNarrationTextReady] = useState(false);
   const [audioPermissionRequired, setAudioPermissionRequired] = useState(false);
 
   const canvasRef = useRef<HTMLCanvasElement>(null);
@@ -219,6 +230,7 @@ export default function ReceptionPdfGuide({
 
   useEffect(() => {
     let cancelled = false;
+    setIsNarrationTextReady(false);
     (async () => {
       const mdUrl =
         language === 'ja'
@@ -230,10 +242,12 @@ export default function ReceptionPdfGuide({
         const slides = parseReceptionNarrationMarkdown(md, language);
         if (!cancelled) {
           setNarrationTexts(slides);
+          setIsNarrationTextReady(true);
         }
       } catch {
         if (!cancelled) {
           setNarrationTexts([]);
+          setIsNarrationTextReady(true);
         }
       }
     })();
@@ -589,6 +603,8 @@ export default function ReceptionPdfGuide({
         id: narrationRunSeqRef.current + 1,
         playbackSessionId,
         page,
+        slideShownAtMs: Date.now(),
+        playbackStartedAtMs: null,
         controller: new AbortController(),
         audioService: null,
       };
@@ -632,6 +648,7 @@ export default function ReceptionPdfGuide({
 
       return new Promise<AudioOperationResult>((resolve) => {
         let settled = false;
+        let didStartPlayback = false;
         let service: MobileAudioService | null = null;
 
         const settle = (result: AudioOperationResult) => {
@@ -648,7 +665,6 @@ export default function ReceptionPdfGuide({
         };
 
         const stopAsCancelled = () => {
-          service?.stop();
           settle({ success: false, method: 'cancelled' });
         };
 
@@ -661,10 +677,28 @@ export default function ReceptionPdfGuide({
           onPlay: () => {
             if (!isActiveNarrationRun(run)) {
               stopAsCancelled();
+              return;
             }
+            didStartPlayback = true;
+            run.playbackStartedAtMs = Date.now();
           },
           onEnded: () => {
             onVisemeControl?.('Closed', 0);
+            if (!isActiveNarrationRun(run)) {
+              stopAsCancelled();
+              return;
+            }
+            if (!didStartPlayback) {
+              settle({
+                success: false,
+                method: service?.getCurrentMethod() ?? undefined,
+                error: new AudioError(
+                  AudioErrorType.PLAYBACK_FAILED,
+                  'Audio ended before playback start was observed',
+                ),
+              });
+              return;
+            }
             settle({ success: true, method: service?.getCurrentMethod() ?? undefined });
           },
           onError: (error) => {
@@ -770,6 +804,42 @@ export default function ReceptionPdfGuide({
     [onPresentationComplete, setPageState]
   );
 
+  const advanceAfterSafeDwell = useCallback(
+    (run: NarrationRun, requestedDelayMs = SLIDE_DELAY_MS) => {
+      if (!isActiveNarrationRun(run)) {
+        return;
+      }
+      advancePresentation(
+        getReceptionNarrationAdvanceDelay({
+          slideShownAtMs: run.slideShownAtMs,
+          nowMs: Date.now(),
+          requestedDelayMs,
+        }),
+      );
+    },
+    [advancePresentation, isActiveNarrationRun],
+  );
+
+  const scheduleNarrationRetry = useCallback(
+    (playbackSessionId: number, page: number) => {
+      if (narrationScheduleRef.current) {
+        clearTimeout(narrationScheduleRef.current);
+      }
+      narrationScheduleRef.current = setTimeout(() => {
+        narrationScheduleRef.current = null;
+        if (
+          isActiveSession(playbackSessionId) &&
+          currentPageRef.current === page &&
+          !isNarratingRef.current &&
+          !isNarrationInProgressRef.current
+        ) {
+          void narrateWithRetryRef.current();
+        }
+      }, NARRATION_ASSET_RETRY_MS);
+    },
+    [],
+  );
+
   const narrateCurrentSlide = useCallback(async () => {
     if (
       !isPlayingRef.current ||
@@ -794,19 +864,25 @@ export default function ReceptionPdfGuide({
 
         let playedStaticAudio = false;
         try {
+          const playbackStartedAt = Date.now();
           const result = await playNarrationAudio(audioUrl, run);
+          const playbackElapsedMs = Date.now() - playbackStartedAt;
           if (!isActiveNarrationRun(run)) {
             return;
           }
           if (!result.success) {
             throw result.error ?? new Error('Audio playback failed');
           }
-          playedStaticAudio = true;
+          if (playbackElapsedMs < MIN_STATIC_NARRATION_PLAYBACK_MS) {
+            preloadedAudioStateRef.current.set(audioUrl, 'failed');
+          } else {
+            playedStaticAudio = true;
+          }
           if (!isActiveNarrationRun(run)) {
             return;
           }
-          if (settings.autoAdvance) {
-            advancePresentation(SLIDE_DELAY_MS);
+          if (playedStaticAudio && settings.autoAdvance) {
+            advanceAfterSafeDwell(run, SLIDE_DELAY_MS);
           }
         } catch (err: unknown) {
           if (!isActiveNarrationRun(run)) {
@@ -828,8 +904,14 @@ export default function ReceptionPdfGuide({
       const text =
         narrationTexts[pageAtStart - 1]?.trim() ?? '';
       if (!text) {
+        if (!isNarrationTextReady) {
+          if (isActiveNarrationRun(run)) {
+            scheduleNarrationRetry(sid, pageAtStart);
+          }
+          return;
+        }
         if (isActiveNarrationRun(run)) {
-          advancePresentation(400);
+          advanceAfterSafeDwell(run, SLIDE_DELAY_MS);
         }
         return;
       }
@@ -883,27 +965,31 @@ export default function ReceptionPdfGuide({
         return;
       }
       if (settings.autoAdvance) {
-        advancePresentation(SLIDE_DELAY_MS);
+        advanceAfterSafeDwell(run, SLIDE_DELAY_MS);
       }
     } catch (e) {
       if (e instanceof Error && e.name === 'AbortError') {
         return;
       }
       if (isActiveNarrationRun(run)) {
-        advancePresentation(400);
+        invalidatePlaybackSession();
+        setIsPlaying(false);
+        onPresentationComplete?.('stopped');
       }
     } finally {
       finishNarrationRun(run);
     }
   }, [
-    advancePresentation,
+    advanceAfterSafeDwell,
     beginNarrationRun,
     finishNarrationRun,
     isActiveNarrationRun,
+    isNarrationTextReady,
     language,
     narrationTexts,
     onPresentationComplete,
     playNarrationAudio,
+    scheduleNarrationRetry,
     sessionId,
     settings.autoAdvance,
   ]);
@@ -921,14 +1007,16 @@ export default function ReceptionPdfGuide({
           return;
         } catch {
           if (i === retries - 1 && isActiveSession(sid)) {
-            advancePresentation(600);
+            invalidatePlaybackSession();
+            setIsPlaying(false);
+            onPresentationComplete?.('stopped');
           } else {
             await new Promise((r) => setTimeout(r, 300 * (i + 1)));
           }
         }
       }
     },
-    [advancePresentation, narrateCurrentSlide]
+    [narrateCurrentSlide, onPresentationComplete]
   );
   narrateWithRetryRef.current = narrateWithRetry;
 

--- a/frontend/src/app/components/VoiceInterface.tsx
+++ b/frontend/src/app/components/VoiceInterface.tsx
@@ -314,6 +314,9 @@ export default function VoiceInterface({
   const isRecordingRef = useRef(false);
   const isStartingRecorderRef = useRef(false);
   const shouldListenRef = useRef(false);
+  const isStoppingRecorderRef = useRef(false);
+  const voiceTurnInProgressRef = useRef(false);
+  const forceSkipAutoResumeRef = useRef(false);
   const fastFillerTimerRef = useRef<number | null>(null);
   const fastFillerUtteranceRef = useRef<SpeechSynthesisUtterance | null>(null);
   const pendingIOSPlaybackRef = useRef<{
@@ -461,7 +464,22 @@ export default function VoiceInterface({
 
   const sessionState = normalizeSessionState(voiceController.mode);
 
+  const completeAssistantTurn = useCallback(
+    (forceSkipAutoResume = false) => {
+      const skipAutoResume =
+        forceSkipAutoResume ||
+        skipAssistantTurnAutoResume ||
+        forceSkipAutoResumeRef.current;
+      forceSkipAutoResumeRef.current = false;
+      voiceController.notifySpeakingComplete(skipAutoResume);
+    },
+    [skipAssistantTurnAutoResume, voiceController],
+  );
+
   useEffect(() => {
+    if (isStoppingRecorderRef.current && voiceController.shouldListen) {
+      return;
+    }
     shouldListenRef.current = voiceController.shouldListen;
   }, [voiceController.shouldListen]);
 
@@ -517,9 +535,9 @@ export default function VoiceInterface({
     setLoadingMessage('');
     setLoadingPhase(null);
     setExclusiveUiLock(false);
-    voiceController.notifySpeakingComplete(true);
+    completeAssistantTurn(true);
     return true;
-  }, [cleanupAudioPlayback, currentLanguage, voiceController]);
+  }, [cleanupAudioPlayback, completeAssistantTurn, currentLanguage]);
 
   const resetConversation = useCallback(() => {
     setTranscript('');
@@ -586,15 +604,14 @@ export default function VoiceInterface({
       cleanupAudioPlayback();
 
       if (completeTurn) {
-        voiceController.notifySpeakingComplete(skipAssistantTurnAutoResume);
+        completeAssistantTurn();
       }
     },
     [
       cancelFastFiller,
       cleanupAudioPlayback,
+      completeAssistantTurn,
       onVisemeControl,
-      skipAssistantTurnAutoResume,
-      voiceController,
     ],
   );
 
@@ -605,7 +622,7 @@ export default function VoiceInterface({
         voiceController.notifySpeaking();
         onAssistantPlaybackStart?.({ metadata: metadataForPlayback ?? null });
         window.setTimeout(() => {
-          voiceController.notifySpeakingComplete(skipAssistantTurnAutoResume);
+          completeAssistantTurn();
         }, 240);
         return;
       }
@@ -622,7 +639,7 @@ export default function VoiceInterface({
         audioBytes = Uint8Array.from(atob(audioBase64), (char) => char.charCodeAt(0));
       } catch (decodeError) {
         console.error('Audio decode failed:', decodeError);
-        voiceController.notifySpeakingComplete(true);
+        completeAssistantTurn(true);
         return;
       }
       const detectedFormat = AudioDataProcessor.detectAudioFormat(audioBytes.buffer as ArrayBuffer);
@@ -660,19 +677,19 @@ export default function VoiceInterface({
         },
         onEnded: () => {
           cleanupAudioPlayback();
-          voiceController.notifySpeakingComplete(skipAssistantTurnAutoResume);
+          completeAssistantTurn();
         },
         onError: (playbackError) => {
           cleanupAudioPlayback();
           setError(formatError(playbackError, currentLanguage));
-          voiceController.notifySpeakingComplete(true);
+          completeAssistantTurn(true);
         },
       });
 
       const result = await audioService.playAudio(audioBlob);
       if (!result.success) {
         cleanupAudioPlayback();
-        voiceController.notifySpeakingComplete(true);
+        completeAssistantTurn(true);
         throw result.error ?? new Error('音声再生に失敗しました');
       }
     },
@@ -680,6 +697,7 @@ export default function VoiceInterface({
       cleanupAudioPlayback,
       cancelFastFiller,
       clearLipSyncTimers,
+      completeAssistantTurn,
       currentLanguage,
       ensureAudioService,
       isMuted,
@@ -687,7 +705,6 @@ export default function VoiceInterface({
       onVisemeControl,
       revokeAudioUrl,
       scheduleLipSyncFrames,
-      skipAssistantTurnAutoResume,
       deferForIOSAudioUnlock,
       voiceController,
     ],
@@ -865,7 +882,7 @@ export default function VoiceInterface({
           void fillerTask.catch(() => {});
           cancelFastFiller();
           onSlideAgentResponse({ answer: cleanAnswer, metadata: qaMeta });
-          voiceController.notifySpeakingComplete(true);
+          completeAssistantTurn(true);
           return;
         }
 
@@ -918,7 +935,7 @@ export default function VoiceInterface({
           voiceController.notifySpeaking();
           onAssistantPlaybackStart?.({ metadata: playbackMetadata ?? null });
           window.setTimeout(() => {
-            voiceController.notifySpeakingComplete(skipAssistantTurnAutoResume);
+            completeAssistantTurn();
           }, 240);
           return;
         }
@@ -932,7 +949,7 @@ export default function VoiceInterface({
             audioBytes = Uint8Array.from(atob(ttsResult.audioResponse), (char) => char.charCodeAt(0));
           } catch (decodeError) {
             console.error('Audio decode failed:', decodeError);
-            voiceController.notifySpeakingComplete(true);
+            completeAssistantTurn(true);
             return;
           }
           const detectedFormat = AudioDataProcessor.detectAudioFormat(audioBytes.buffer as ArrayBuffer);
@@ -980,14 +997,14 @@ export default function VoiceInterface({
             },
             onPlaybackEnd: () => {
               cleanupAudioPlayback();
-              voiceController.notifySpeakingComplete(skipAssistantTurnAutoResume);
+              completeAssistantTurn();
             },
           });
         } else {
           cancelFastFiller();
           voiceController.notifySpeaking();
           window.setTimeout(() => {
-            voiceController.notifySpeakingComplete(skipAssistantTurnAutoResume);
+            completeAssistantTurn();
           }, 240);
         }
       } catch (voiceError) {
@@ -997,13 +1014,14 @@ export default function VoiceInterface({
         }
         cancelFastFiller();
         setError(formatError(voiceError, currentLanguage));
-        voiceController.notifySpeakingComplete(true);
+        completeAssistantTurn(true);
       }
     },
     [
       cancelFastFiller,
       cleanupAudioPlayback,
       clearLipSyncTimers,
+      completeAssistantTurn,
       currentLanguage,
       ensureVisitorId,
       isMuted,
@@ -1015,7 +1033,6 @@ export default function VoiceInterface({
       playAssistantAudio,
       resolveAutoVrmControlForPlayback,
       scheduleLipSyncFrames,
-      skipAssistantTurnAutoResume,
       deferForIOSAudioUnlock,
       fetchAutoVrmControl,
       stopPlayback,
@@ -1084,7 +1101,7 @@ export default function VoiceInterface({
         if (onSlideAgentResponse && isSlideAgentMetadata(qaMeta)) {
           cancelFastFiller();
           onSlideAgentResponse({ answer: cleanAnswer, metadata: qaMeta });
-          voiceController.notifySpeakingComplete(true);
+          completeAssistantTurn(true);
           return;
         }
 
@@ -1134,7 +1151,7 @@ export default function VoiceInterface({
           cancelFastFiller();
           voiceController.notifySpeaking();
           window.setTimeout(() => {
-            voiceController.notifySpeakingComplete(skipAssistantTurnAutoResume);
+            completeAssistantTurn();
           }, 240);
         }
       } catch (sendError) {
@@ -1144,7 +1161,7 @@ export default function VoiceInterface({
 
         cancelFastFiller();
         setError(formatError(sendError, currentLanguage));
-        voiceController.notifySpeakingComplete(true);
+        completeAssistantTurn(true);
       } finally {
         if (requestAbortRef.current === abortController) {
           requestAbortRef.current = null;
@@ -1158,6 +1175,7 @@ export default function VoiceInterface({
     [
       cancelPendingRequest,
       cancelFastFiller,
+      completeAssistantTurn,
       currentLanguage,
       ensureVisitorId,
       fetchAutoVrmControl,
@@ -1165,7 +1183,6 @@ export default function VoiceInterface({
       playAssistantAudio,
       resolveAutoVrmControlForPlayback,
       scheduleFastFiller,
-      skipAssistantTurnAutoResume,
       stopPlayback,
       voiceController,
     ],
@@ -1243,7 +1260,7 @@ export default function VoiceInterface({
         } else {
           voiceController.notifySpeaking();
           window.setTimeout(() => {
-            voiceController.notifySpeakingComplete(skipAssistantTurnAutoResume);
+            completeAssistantTurn();
           }, 240);
         }
       } catch (speakError) {
@@ -1252,7 +1269,7 @@ export default function VoiceInterface({
         }
 
         setError(formatError(speakError, currentLanguage));
-        voiceController.notifySpeakingComplete(true);
+        completeAssistantTurn(true);
       } finally {
         if (requestAbortRef.current === abortController) {
           requestAbortRef.current = null;
@@ -1265,11 +1282,11 @@ export default function VoiceInterface({
     },
     [
       cancelPendingRequest,
+      completeAssistantTurn,
       currentLanguage,
       fetchAutoVrmControl,
       playAssistantAudio,
       resolveAutoVrmControlForPlayback,
-      skipAssistantTurnAutoResume,
       stopPlayback,
       voiceController,
     ],
@@ -1281,12 +1298,17 @@ export default function VoiceInterface({
         shouldDiscardNextAudioRef.current = false;
         return;
       }
+      if (voiceTurnInProgressRef.current) {
+        return;
+      }
 
+      voiceTurnInProgressRef.current = true;
       cancelPendingRequest();
       setError(null);
       setIsLoading(true);
       setLoadingMessage(LOADING_LABELS[currentLanguage].recognize);
       setLoadingPhase('stt');
+      voiceController.notifyProcessing();
       scheduleFastFiller();
 
       const abortController = new AbortController();
@@ -1324,7 +1346,7 @@ export default function VoiceInterface({
 
         cancelFastFiller();
         setError(formatError(recordingError, currentLanguage));
-        voiceController.notifySpeakingComplete(true);
+        completeAssistantTurn(true);
       } finally {
         if (requestAbortRef.current === abortController) {
           requestAbortRef.current = null;
@@ -1332,11 +1354,14 @@ export default function VoiceInterface({
         setIsLoading(false);
         setLoadingMessage('');
         setLoadingPhase(null);
+        isStoppingRecorderRef.current = false;
+        voiceTurnInProgressRef.current = false;
       }
     },
     [
       cancelPendingRequest,
       cancelFastFiller,
+      completeAssistantTurn,
       currentLanguage,
       processVoiceTurnWithParallelFiller,
       scheduleFastFiller,
@@ -1459,6 +1484,9 @@ export default function VoiceInterface({
 
   useEffect(() => {
     if (voiceController.shouldListen) {
+      if (!shouldListenRef.current) {
+        return;
+      }
       void startRecorderCapture();
       return;
     }
@@ -1474,6 +1502,8 @@ export default function VoiceInterface({
     }
 
     shouldListenRef.current = true;
+    isStoppingRecorderRef.current = false;
+    forceSkipAutoResumeRef.current = false;
     cancelPendingRequest();
     stopPlayback(false);
     setError(null);
@@ -1496,8 +1526,11 @@ export default function VoiceInterface({
 
   const stopListening = useCallback(() => {
     shouldListenRef.current = false;
+    isStoppingRecorderRef.current = true;
+    forceSkipAutoResumeRef.current = true;
+    stopRecorderCapture(false);
     voiceController.notifyProcessing();
-  }, [voiceController]);
+  }, [stopRecorderCapture, voiceController]);
 
   const cancelSession = useCallback(() => {
     pendingIOSPlaybackRef.current = null;
@@ -1508,6 +1541,9 @@ export default function VoiceInterface({
     cancelPendingRequest();
     stopPlayback(false);
     shouldDiscardNextAudioRef.current = true;
+    isStoppingRecorderRef.current = false;
+    voiceTurnInProgressRef.current = false;
+    forceSkipAutoResumeRef.current = false;
     stopRecorderCapture(true);
     setIsLoading(false);
     setLoadingMessage('');
@@ -1572,7 +1608,7 @@ export default function VoiceInterface({
     if (exclusiveUiLock) {
       return 'locked';
     }
-    if (sessionState === 'listening' || loadingPhase === 'mic' || loadingPhase === 'stt') {
+    if (loadingPhase === 'mic' || loadingPhase === 'stt') {
       return 'locked';
     }
     if (
@@ -1582,6 +1618,9 @@ export default function VoiceInterface({
       loadingPhase === 'tts'
     ) {
       return 'interruptible';
+    }
+    if (sessionState === 'listening') {
+      return 'locked';
     }
     return 'normal';
   }, [exclusiveUiLock, loadingPhase, sessionState]);

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -337,9 +337,7 @@ export default function Home() {
         language={currentLanguage}
         onLanguageChange={setCurrentLanguage}
         wakeWordEnabled={false}
-        autoResumeListeningAfterAssistant={
-          micInputMode === 'push_to_talk' ? false : kioskVoiceLocked
-        }
+        autoResumeListeningAfterAssistant={false}
         onVisemeControl={setVisemeFunction}
         showDefaultUI={false}
         onMetadataChange={(metadata) => {

--- a/frontend/src/lib/reception/reception-narration-timing.ts
+++ b/frontend/src/lib/reception/reception-narration-timing.ts
@@ -1,0 +1,25 @@
+export const RECEPTION_NARRATION_MIN_SLIDE_DWELL_MS = 4_000;
+
+type AdvanceDelayInput = {
+  slideShownAtMs: number;
+  nowMs: number;
+  requestedDelayMs: number;
+  minimumDwellMs?: number;
+};
+
+function safeNonNegativeMs(value: number, fallback = 0): number {
+  return Number.isFinite(value) && value > 0 ? value : fallback;
+}
+
+export function getReceptionNarrationAdvanceDelay({
+  slideShownAtMs,
+  nowMs,
+  requestedDelayMs,
+  minimumDwellMs = RECEPTION_NARRATION_MIN_SLIDE_DWELL_MS,
+}: AdvanceDelayInput): number {
+  const requested = safeNonNegativeMs(requestedDelayMs);
+  const minimum = safeNonNegativeMs(minimumDwellMs);
+  const elapsed = safeNonNegativeMs(nowMs - slideShownAtMs);
+
+  return Math.max(requested, minimum - elapsed, 0);
+}

--- a/frontend/src/lib/voice-recorder.ts
+++ b/frontend/src/lib/voice-recorder.ts
@@ -1,6 +1,7 @@
 declare global {
   interface Window {
     __PLAYWRIGHT_VOICE_AUDIO_BASE64__?: string;
+    __PLAYWRIGHT_VOICE_RECORDER_ERROR_NAME__?: string;
   }
 }
 
@@ -80,6 +81,18 @@ export class VoiceRecorder {
     try {
       const playwrightAudioBase64 =
         typeof window !== 'undefined' ? window.__PLAYWRIGHT_VOICE_AUDIO_BASE64__ : undefined;
+      const playwrightRecorderErrorName =
+        typeof window !== 'undefined' ? window.__PLAYWRIGHT_VOICE_RECORDER_ERROR_NAME__ : undefined;
+
+      if (typeof playwrightRecorderErrorName === 'string' && playwrightRecorderErrorName.length > 0) {
+        delete window.__PLAYWRIGHT_VOICE_RECORDER_ERROR_NAME__;
+        this.onError(
+          this.createRecorderError('Playwright injected recorder failure', {
+            name: playwrightRecorderErrorName,
+          }),
+        );
+        return;
+      }
 
       if (typeof playwrightAudioBase64 === 'string' && playwrightAudioBase64.length > 0) {
         this.stream = new MediaStream();


### PR DESCRIPTION
## Summary
- stop slide narration fast-forward/overlap paths by gating narration readiness, enforcing safe dwell time, and stopping stale narration on close/rapid navigation
- harden voice UX around STT gating, Safari mic recovery, response-prep interrupt handling, and mobile audio turn state
- speed up and harden backend STT/TTS/filler/Cerebras fallback paths, including provider soft timeouts, fallback caching, and empty-audio rejection
- normalize LangGraph routing by agent/category/request_type so business hours/pricing/contact and facility cases reach the intended nodes

Fixes #777
Fixes #773
Part of #781

## Verification
- python -m ruff check backend/config/routing_constants.py backend/agents/orchestrator_agent.py backend/workflows/main_workflow.py backend/agents/voice_agent.py backend/main.py backend/llm/model_resolve.py backend/llm/openrouter.py backend/tests/config/test_routing_constants.py backend/tests/agents/test_orchestrator_fast_routing.py backend/tests/workflows/test_main_workflow.py backend/tests/agents/test_voice_agent.py backend/tests/api/test_voice_filler_api.py backend/tests/llm/test_openrouter.py
- python -m black --check backend/config/routing_constants.py backend/agents/orchestrator_agent.py backend/workflows/main_workflow.py backend/agents/voice_agent.py backend/main.py backend/llm/model_resolve.py backend/llm/openrouter.py backend/tests/config/test_routing_constants.py backend/tests/agents/test_orchestrator_fast_routing.py backend/tests/workflows/test_main_workflow.py backend/tests/agents/test_voice_agent.py backend/tests/api/test_voice_filler_api.py backend/tests/llm/test_openrouter.py
- python -m pytest backend/tests/config/test_routing_constants.py backend/tests/agents/test_orchestrator_fast_routing.py backend/tests/workflows/test_main_workflow.py backend/tests/workflows/test_reception_invoke.py backend/tests/workflows/test_reception_workflow.py::TestRouteToAgentNode backend/tests/agents/test_voice_agent.py backend/tests/api/test_voice_filler_api.py backend/tests/llm/test_openrouter.py backend/tests/llm/test_model_resolve.py backend/tests/agents/test_stt_agent.py -q
- pnpm lint
- pnpm exec tsc --noEmit --pretty false --incremental false
- pnpm exec tsx --test --import ./src/__tests__/node-test-setup.ts src/__tests__/reception-narration-timing.test.ts src/__tests__/error-messages.test.ts
- PLAYWRIGHT_VIDEO=off pnpm exec playwright test --config=playwright.config.ts e2e/slide-pdf-narration.spec.ts --project=chromium --workers=1
- PLAYWRIGHT_VIDEO=off pnpm exec playwright test --config=playwright.config.ts --project=webkit-permissions e2e/voice-permission-denial.spec.ts --workers=1
- PLAYWRIGHT_VIDEO=off pnpm exec playwright test --config=playwright.config.ts --project=webkit-mobile-audio e2e/mobile-audio-proof.spec.ts --workers=1
- PLAYWRIGHT_VIDEO=off pnpm exec playwright test --config=playwright.config.ts --project=chromium e2e/voice-network-recovery.spec.ts --workers=1
- pnpm build
- git diff --check