### PR TITLE
[codex] Harden live voice STT and TTS fallbacks

### DIFF
--- a/backend/agents/stt_agent.py
+++ b/backend/agents/stt_agent.py
@@ -436,13 +436,15 @@ def _normalize_vosk_route_transcript(transcript: str, language: Optional[str]) -
     if not normalized:
         return transcript
 
-    is_wifi_connection_confusion = (
-        "セット" in normalized
-        and "逆方法" in normalized
-        and ("はいはい" in normalized or "ハイハイ" in normalized)
+    is_wifi_connection_confusion = ("はいはい" in normalized or "ハイハイ" in normalized) and (
+        ("セット" in normalized and "逆方法" in normalized)
+        or ("瀬田" in normalized and "作方法" in normalized)
     )
     if is_wifi_connection_confusion:
         return "Wi-Fiの接続方法を教えてください。"
+
+    if "仮想環境" in normalized and any(marker in normalized for marker in ("パート", "ぱいと")):
+        return "Python の仮想環境とは何ですか。"
 
     has_time_context = any(marker in normalized for marker in ("時間", "影響時", "液状時"))
     if not has_time_context:
@@ -469,6 +471,11 @@ def _normalize_vosk_route_transcript(transcript: str, language: Optional[str]) -
             "壁",
         )
     ) or ("赤毛" in normalized and "アン" in normalized)
+    has_engineer_cafe_context = has_engineer_cafe_context or (
+        "元気" in normalized
+        and ("新潟" in normalized or "県" in normalized)
+        and "影響" in normalized
+    )
     if not has_engineer_cafe_context:
         return transcript
 
@@ -513,12 +520,66 @@ def _vosk_transcript_trusted_for_early_return(transcript: str, language: Optiona
     )
 
 
+def _vosk_japanese_fragmented_request_suspicious(
+    transcript: str,
+    language: Optional[str],
+) -> bool:
+    """Catch live Vosk Japanese fallback fragments that look fluent but lack intent."""
+
+    if language not in {None, "ja"}:
+        return False
+
+    tokens = [token for token in transcript.split() if token]
+    compact = "".join(tokens)
+    if not re.search(r"[\u3040-\u30ff\u3400-\u9fff]", compact):
+        return False
+
+    asks_for_help = "教え" in compact and ("ください" in compact or "下さい" in compact)
+    has_generic_subject = any(marker in compact for marker in ("時間", "時刻", "方法"))
+    if not asks_for_help or not has_generic_subject:
+        return False
+
+    has_time_word = "時間" in compact or "時刻" in compact
+    if (
+        "影響" in compact
+        and has_time_word
+        and any(marker in compact for marker in ("元気", "新潟", "県"))
+    ):
+        return True
+
+    has_repeated_hai = compact.startswith("はいはい") or tokens.count("はい") >= 2
+    if has_repeated_hai and "方法" in compact:
+        compact_lower = compact.lower()
+        known_connection_confusion = "セット" in compact and "逆方法" in compact
+        has_connection_context = "接続" in compact or any(
+            marker in compact_lower for marker in ("wi-fi", "wifi")
+        )
+        method_confusion_markers = {
+            "瀬田",
+            "世田",
+            "田中",
+            "セタ",
+            "せた",
+            "作",
+            "策",
+            "昨",
+        }
+        if (
+            not known_connection_confusion
+            and not has_connection_context
+            and any(marker in compact for marker in method_confusion_markers)
+        ):
+            return True
+
+    return False
+
+
 def _vosk_fallback_transcript_suspicious(
     transcript: str,
     language: Optional[str],
     confidence: Optional[float],
 ) -> bool:
-    """Identify low-confidence segmented Vosk text that should not drive chat intent."""
+    """Identify risky Vosk fallback text that should not drive chat intent."""
 
     normalized_transcript = _normalize_vosk_route_transcript(transcript, language)
     compact = "".join(normalized_transcript.split())
@@ -527,6 +588,9 @@ def _vosk_fallback_transcript_suspicious(
 
     if _vosk_transcript_trusted_for_early_return(normalized_transcript, language):
         return False
+
+    if _vosk_japanese_fragmented_request_suspicious(normalized_transcript, language):
+        return True
 
     if confidence is None or confidence >= 0.75:
         return False

--- a/backend/agents/voice_agent.py
+++ b/backend/agents/voice_agent.py
@@ -257,7 +257,7 @@ def clean_text_for_tts(text: str) -> str:
 DEFAULT_TTS_MAX_BYTES = 900
 MIN_CACHEABLE_TTS_AUDIO_BASE64_CHARS = 100
 _DEFAULT_TTS_TIMEOUTS: Dict[str, float] = {
-    "piper": 2.5,
+    "piper": 4.0,
     "kokoro": 3.0,
     "voicevox": 4.0,
     "google": 6.0,
@@ -787,13 +787,28 @@ class VoiceAgent:
 
         # piper障害時の日本語フォールバック用 VoiceVox クライアント
         if tts_provider == "piper":
-            voicevox_fallback_url = os.getenv("VOICEVOX_API_URL", "http://localhost:50021")
-            self.voicevox_fallback_client: Optional[VoiceVoxClient] = VoiceVoxClient(
-                api_url=voicevox_fallback_url
-            )
-            logger.info("VoiceVox fallback client initialized for piper: %s", voicevox_fallback_url)
+            voicevox_fallback_url = os.getenv("VOICEVOX_API_URL")
+            if voicevox_fallback_url or not os.getenv("K_SERVICE"):
+                voicevox_fallback_url = voicevox_fallback_url or "http://localhost:50021"
+                self.voicevox_fallback_client = VoiceVoxClient(api_url=voicevox_fallback_url)
+                logger.info(
+                    "VoiceVox fallback client initialized for piper: %s",
+                    voicevox_fallback_url,
+                )
+            else:
+                self.voicevox_fallback_client = None
+                logger.info(
+                    "VoiceVox fallback client disabled for piper "
+                    "(Cloud Run without VOICEVOX_API_URL)"
+                )
         else:
             self.voicevox_fallback_client = None
+
+        self.google_fallback_client: Optional[GoogleTTSClient]
+        if tts_provider == "google":
+            self.google_fallback_client = None
+        else:
+            self.google_fallback_client = GoogleTTSClient()
 
         self._tts_cache: TTLCache = TTLCache(maxsize=200, ttl=3600)
 
@@ -803,6 +818,7 @@ class VoiceAgent:
             getattr(self, "tts_client", None),
             getattr(self, "kokoro_client", None),
             getattr(self, "voicevox_fallback_client", None),
+            getattr(self, "google_fallback_client", None),
         ]
         seen: set[int] = set()
         for client in clients:
@@ -877,6 +893,16 @@ class VoiceAgent:
             return await asyncio.wait_for(awaitable, timeout=timeout_s)
         except asyncio.TimeoutError as exc:
             raise RuntimeError(f"{provider} TTS {role} timed out after {timeout_s:.2f}s") from exc
+
+    def _google_fallback_available(self) -> bool:
+        google_client = getattr(self, "google_fallback_client", None)
+        if google_client is None:
+            return False
+        credentials_source = getattr(google_client, "credentials_source", None)
+        default_key_path = getattr(google_client, "default_key_path", None)
+        return bool(credentials_source) or bool(
+            default_key_path and os.path.exists(default_key_path)
+        )
 
     def _detect_category(self, text: str, language: str) -> Optional[ClarificationCategory]:
         """
@@ -996,6 +1022,7 @@ class VoiceAgent:
                     "language": language,
                     "ambiguity_resolved": False,
                     "tts_cache_hit": True,
+                    "tts_duration_ms": int((time.perf_counter() - tts_started_at) * 1000),
                     "fallback_used": (
                         cached_entry.get("fallback_used")
                         if isinstance(cached_entry, dict)
@@ -1005,6 +1032,11 @@ class VoiceAgent:
                         cached_entry.get("fallback_provider")
                         if isinstance(cached_entry, dict)
                         else None
+                    ),
+                    "actual_provider": (
+                        cached_entry.get("actual_provider")
+                        if isinstance(cached_entry, dict)
+                        else self.tts_provider
                     ),
                 }
 
@@ -1064,6 +1096,7 @@ class VoiceAgent:
                     "format": audio_format,
                     "fallback_used": False,
                     "fallback_provider": None,
+                    "actual_provider": primary_attempt_provider or self.tts_provider,
                 }
 
             log_tts_event(
@@ -1083,34 +1116,57 @@ class VoiceAgent:
                 "language": language,
                 "ambiguity_resolved": False,
                 "tts_cache_hit": False,
+                "tts_duration_ms": int((time.perf_counter() - tts_started_at) * 1000),
+                "fallback_used": False,
+                "fallback_provider": None,
+                "actual_provider": primary_attempt_provider or self.tts_provider,
             }
         except Exception as e:
             logger.exception("TTS failed, trying fallback: %s", e)
             fallback_provider: Optional[str] = None
+
+            async def _google_fallback_audio() -> str:
+                google_client = getattr(self, "google_fallback_client", None)
+                if google_client is None:
+                    raise RuntimeError("Google fallback client is not configured")
+                if language not in ("ja", "en"):
+                    raise RuntimeError(f"Google fallback does not support language={language}")
+                return await self._await_tts_attempt(
+                    google_client.synthesize_mp3_base64(processed, language, "sad"),
+                    provider="google",
+                    role="fallback",
+                )
+
             try:
                 if self.tts_provider == "piper":
-                    # piper障害時: 日本語 → VoiceVox、英語 → Kokoro にフォールバック
-                    if language == "en":
-                        logger.warning("piper failed, falling back to Kokoro for en")
-                        if self.kokoro_client:
+                    # piper障害時: ローカルfallbackを優先し、未設定/失敗時だけGoogleへ退避する。
+                    try:
+                        if language == "en":
+                            logger.warning("piper failed, falling back to Kokoro for en")
+                            if not self.kokoro_client:
+                                raise RuntimeError(
+                                    "Piper unavailable and Kokoro not configured for English TTS"
+                                )
                             fallback_provider = "kokoro"
                             audio_b64 = await self._await_tts_attempt(
                                 self.kokoro_client.synthesize_wav_base64(processed, language),
                                 provider="kokoro",
                                 role="fallback",
                             )
+                            audio_format = "audio/wav"
                         else:
-                            raise RuntimeError(
-                                "Piper unavailable and Kokoro not configured for English TTS"
-                            )
-                    else:
-                        if language not in ("ja",):
+                            if language not in ("ja",):
+                                logger.warning(
+                                    "piper fallback to VoiceVox for unsupported language: %s",
+                                    language,
+                                )
                             logger.warning(
-                                "piper fallback to VoiceVox for unsupported language: %s",
-                                language,
+                                "piper failed, falling back to VoiceVox for %s", language
                             )
-                        logger.warning("piper failed, falling back to VoiceVox for %s", language)
-                        if self.voicevox_fallback_client:
+                            if not self.voicevox_fallback_client:
+                                raise RuntimeError(
+                                    "No VoiceVox fallback client available for piper TTS fallback"
+                                )
                             fallback_provider = "voicevox"
                             audio_b64 = await self._await_tts_attempt(
                                 self.voicevox_fallback_client.synthesize_wav_base64(
@@ -1119,11 +1175,17 @@ class VoiceAgent:
                                 provider="voicevox",
                                 role="fallback",
                             )
-                        else:
-                            raise RuntimeError(
-                                "No VoiceVox fallback client available for piper TTS fallback"
-                            )
-                    audio_format = "audio/wav"
+                            audio_format = "audio/wav"
+                    except Exception as local_fallback_error:
+                        if not self._google_fallback_available():
+                            raise local_fallback_error
+                        logger.warning(
+                            "Local piper TTS fallback failed, trying Google fallback: %s",
+                            local_fallback_error,
+                        )
+                        fallback_provider = "google"
+                        audio_b64 = await _google_fallback_audio()
+                        audio_format = "audio/mpeg"
                 elif language == "en":
                     # 英語フォールバック: 同じ失敗 provider の即時再試行は避ける。
                     if self.tts_provider == "google" and primary_attempt_provider != "google":
@@ -1142,6 +1204,10 @@ class VoiceAgent:
                             role="fallback",
                         )
                         audio_format = "audio/wav"
+                    elif self._google_fallback_available():
+                        fallback_provider = "google"
+                        audio_b64 = await _google_fallback_audio()
+                        audio_format = "audio/mpeg"
                     elif self.tts_provider == "voicevox" and primary_attempt_provider != "voicevox":
                         fallback_provider = "voicevox"
                         audio_b64 = await self._await_tts_attempt(
@@ -1155,14 +1221,18 @@ class VoiceAgent:
                             "English TTS failed and no alternate fallback provider is configured"
                         )
                 elif self.tts_provider == "voicevox":
-                    # 日本語フォールバック → VoiceVox
-                    fallback_provider = "voicevox"
-                    audio_b64 = await self._await_tts_attempt(
-                        self.tts_client.synthesize_wav_base64(processed, language),
-                        provider="voicevox",
-                        role="fallback",
-                    )
-                    audio_format = "audio/wav"
+                    if self._google_fallback_available():
+                        fallback_provider = "google"
+                        audio_b64 = await _google_fallback_audio()
+                        audio_format = "audio/mpeg"
+                    else:
+                        fallback_provider = "voicevox"
+                        audio_b64 = await self._await_tts_attempt(
+                            self.tts_client.synthesize_wav_base64(processed, language),
+                            provider="voicevox",
+                            role="fallback",
+                        )
+                        audio_format = "audio/wav"
                 else:
                     # Google TTSフォールバック
                     fallback_provider = "google"
@@ -1183,6 +1253,7 @@ class VoiceAgent:
                         "format": audio_format,
                         "fallback_used": True,
                         "fallback_provider": fallback_provider,
+                        "actual_provider": fallback_provider,
                     }
 
                 log_tts_event(
@@ -1203,9 +1274,12 @@ class VoiceAgent:
                     "cleanText": processed,
                     "error": str(e),
                     "format": audio_format,
+                    "language": language,
                     "fallback_used": True,
                     "fallback_provider": fallback_provider,
                     "tts_cache_hit": False,
+                    "tts_duration_ms": int((time.perf_counter() - tts_started_at) * 1000),
+                    "actual_provider": fallback_provider,
                 }
             except Exception as fallback_error:
                 logger.error("Fallback TTS also failed: %s", fallback_error)
@@ -1223,4 +1297,8 @@ class VoiceAgent:
                     "error": f"Failed to generate speech: {str(e)}",
                     "emotion": "confused",
                     "tts_cache_hit": False,
+                    "tts_duration_ms": int((time.perf_counter() - tts_started_at) * 1000),
+                    "fallback_used": False,
+                    "fallback_provider": None,
+                    "actual_provider": None,
                 }

--- a/backend/llm/model_resolve.py
+++ b/backend/llm/model_resolve.py
@@ -174,6 +174,35 @@ def cerebras_timeout_seconds(config: "ModelConfig") -> float:
     return max(0.1, value)
 
 
+def openrouter_timeout_seconds(config: "ModelConfig") -> float:
+    """Bound OpenRouter attempts so fast-path fallback can actually trigger."""
+
+    raw = os.getenv("OPENROUTER_TIMEOUT_SECONDS", "").strip()
+    if not raw and is_fast_primary_config(config):
+        raw = os.getenv("FAST_LLM_TIMEOUT_SECONDS", "").strip()
+
+    try:
+        config_timeout = float(getattr(config, "timeout", 30.0) or 30.0)
+    except (TypeError, ValueError):
+        config_timeout = 30.0
+
+    default = max(config_timeout, 0.1)
+    if is_fast_primary_config(config):
+        default = min(default, 8.0)
+
+    if not raw:
+        return default
+    try:
+        value = float(raw)
+    except (TypeError, ValueError):
+        logger.warning("Invalid OpenRouter timeout %r; using %.1fs", raw, default)
+        return default
+    if value <= 0:
+        logger.warning("Invalid OpenRouter timeout %r; using %.1fs", raw, default)
+        return default
+    return max(0.1, value)
+
+
 def merge_gemini_openrouter_extra(payload: dict) -> None:
     """Merge JSON from GEMINI_OPENROUTER_EXTRA_JSON into the completion payload (optional)."""
     extra = os.getenv("GEMINI_OPENROUTER_EXTRA_JSON", "").strip()

--- a/backend/llm/openrouter.py
+++ b/backend/llm/openrouter.py
@@ -32,6 +32,7 @@ from .model_resolve import (
     cerebras_reasoning_effort,
     cerebras_timeout_seconds,
     merge_gemini_openrouter_extra,
+    openrouter_timeout_seconds,
     resolved_openrouter_model_slug,
 )
 from .provider import LLMProvider
@@ -235,7 +236,11 @@ class OpenRouterProvider(LLMProvider):
         primary_slug = payload["model"]
 
         try:
-            response = await self._http_client.post("/chat/completions", json=payload)
+            response = await self._http_client.post(
+                "/chat/completions",
+                json=payload,
+                timeout=openrouter_timeout_seconds(config),
+            )
             response.raise_for_status()
             data = response.json()
 
@@ -269,6 +274,7 @@ class OpenRouterProvider(LLMProvider):
                     max_tokens=config.max_tokens,
                     top_p=config.top_p,
                     fallback_model=None,
+                    timeout=config.timeout,
                 )
                 return await self.generate(
                     messages,
@@ -303,6 +309,7 @@ class OpenRouterProvider(LLMProvider):
                     max_tokens=config.max_tokens,
                     top_p=config.top_p,
                     fallback_model=None,
+                    timeout=config.timeout,
                 )
                 return await self.generate(
                     messages,
@@ -349,6 +356,7 @@ class OpenRouterProvider(LLMProvider):
                 "POST",
                 "/chat/completions",
                 json=payload,
+                timeout=openrouter_timeout_seconds(config),
             ) as response:
                 response.raise_for_status()
 

--- a/backend/main.py
+++ b/backend/main.py
@@ -1421,12 +1421,46 @@ async def voice_api(request: Request, body: VoiceRequest):
                         "tts",
                         ok=False,
                         provider=body.ttsProvider or os.getenv("TTS_PROVIDER", "voicevox"),
+                        actualProvider=result.get("actual_provider"),
+                        latencyMs=result.get("tts_duration_ms"),
+                        cacheHit=result.get("tts_cache_hit"),
+                        fallbackUsed=bool(result.get("fallback_used")),
+                        fallbackProvider=result.get("fallback_provider"),
                         error=result.get("error", "TTS failed"),
                     ),
                 )
 
             audio_b64 = result.get("audioResponse")
             audio_format = result.get("format")
+            if not isinstance(audio_b64, str) or not audio_b64.strip():
+                error_message = "TTS completed without audioResponse"
+                logger.error(
+                    "%s: request_id=%s provider=%s actual_provider=%s",
+                    error_message,
+                    request_id,
+                    body.ttsProvider or os.getenv("TTS_PROVIDER", "voicevox"),
+                    result.get("actual_provider"),
+                )
+                return VoiceResponse(
+                    success=False,
+                    error=error_message,
+                    emotion=result.get("emotion"),
+                    audioFormat=audio_format,
+                    sessionId=body.sessionId,
+                    requestId=request_id,
+                    phase="text_to_speech",
+                    upstreamStatus=_upstream_status(
+                        "tts",
+                        ok=False,
+                        provider=body.ttsProvider or os.getenv("TTS_PROVIDER", "voicevox"),
+                        actualProvider=result.get("actual_provider"),
+                        latencyMs=result.get("tts_duration_ms"),
+                        cacheHit=result.get("tts_cache_hit"),
+                        fallbackUsed=bool(result.get("fallback_used")),
+                        fallbackProvider=result.get("fallback_provider"),
+                        error=error_message,
+                    ),
+                )
             tts_wav_b64_for_vrm: Optional[str] = None
             if audio_format == "audio/wav" and audio_b64:
                 tts_wav_b64_for_vrm = audio_b64
@@ -1471,6 +1505,12 @@ async def voice_api(request: Request, body: VoiceRequest):
                     tts_wav_b64=tts_wav_b64_for_vrm,
                 )
 
+            requested_tts_provider = body.ttsProvider or os.getenv("TTS_PROVIDER", "voicevox")
+            actual_tts_provider = result.get("actual_provider") or (
+                result.get("fallback_provider")
+                if result.get("fallback_used")
+                else requested_tts_provider
+            )
             return VoiceResponse(
                 success=True,
                 audioResponse=audio_b64,
@@ -1483,13 +1523,11 @@ async def voice_api(request: Request, body: VoiceRequest):
                 phase="text_to_speech",
                 upstreamStatus=_upstream_status(
                     "tts",
-                    provider=body.ttsProvider or os.getenv("TTS_PROVIDER", "voicevox"),
-                    actualProvider=(
-                        result.get("fallback_provider")
-                        if result.get("fallback_used")
-                        else (body.ttsProvider or os.getenv("TTS_PROVIDER", "voicevox"))
-                    ),
+                    provider=requested_tts_provider,
+                    actualProvider=actual_tts_provider,
                     format=audio_format,
+                    language=result.get("language"),
+                    latencyMs=result.get("tts_duration_ms"),
                     cacheHit=result.get("tts_cache_hit"),
                     fallbackUsed=bool(result.get("fallback_used")),
                     fallbackProvider=result.get("fallback_provider"),

--- a/backend/tests/agents/test_orchestrator_fast_routing.py
+++ b/backend/tests/agents/test_orchestrator_fast_routing.py
@@ -400,6 +400,23 @@ class TestOrchestratorFastRouting:
         assert result["category"] == "daily_conversation"
         assert result["request_type"] == "daily_conversation"
 
+    @pytest.mark.parametrize(
+        ("query", "agent", "request_type"),
+        [
+            ("元気ですか？営業時間も教えてください。", "business_info", "hours"),
+            ("ありがとう、Wi-Fiの接続方法も知りたいです。", "facility", "wifi"),
+            ("少し雑談してから今日のイベントを教えてください。", "event", "event"),
+        ],
+    )
+    def test_daily_conversation_marker_does_not_preempt_specific_intent(
+        self, orchestrator, query, agent, request_type
+    ):
+        result = orchestrator._try_fast_routing(query)
+
+        assert result is not None
+        assert result["agent"] == agent
+        assert result["request_type"] == request_type
+
     def test_current_weather_routes_to_current_info(self, orchestrator):
         result = orchestrator._try_fast_routing("今日の福岡の天気は？")
 

--- a/backend/tests/agents/test_stt_agent.py
+++ b/backend/tests/agents/test_stt_agent.py
@@ -1131,6 +1131,54 @@ class TestSTTAgent:
             0.80,
         )
 
+    @pytest.mark.parametrize(
+        ("transcript", "expected"),
+        [
+            (
+                "元気 新潟 県 の 影響 時間 教え て ください",
+                "エンジニアカフェの営業時間を教えてください。",
+            ),
+            (
+                "はい はい ば 瀬田 作 方法 を 教え て ください",
+                "Wi-Fiの接続方法を教えてください。",
+            ),
+            (
+                "パート の 仮想 環境 と 何 です か",
+                "Python の仮想環境とは何ですか。",
+            ),
+        ],
+    )
+    def test_vosk_route_transcript_normalizes_live_preflight_confusions(self, transcript, expected):
+        """Known domain-bearing live confusions become route-stable transcripts."""
+        assert _normalize_vosk_route_transcript(transcript, "ja") == expected
+        assert not _vosk_fallback_transcript_suspicious(transcript, "ja", 0.95)
+
+    @pytest.mark.parametrize(
+        "transcript",
+        [
+            "元気 田中 の 影響 時間 を 教え て ください",
+            "はい はい ば 田中 作 方法 を 教え て ください",
+            "はい はい な 田中 作 方法 を 教え て ください",
+        ],
+    )
+    def test_vosk_fallback_rejects_high_confidence_unknown_live_fragments(self, transcript):
+        """Unknown high-confidence fragments should not become chat intent."""
+        assert _normalize_vosk_route_transcript(transcript, "ja") == transcript
+        assert _vosk_fallback_transcript_suspicious(transcript, "ja", 0.95)
+
+    @pytest.mark.parametrize(
+        "transcript",
+        [
+            "エンジニア カフェ の 営業 時間 教え て ください",
+            "Wi-Fi の 接続 方法 を 教え て ください",
+            "接続 方法 を 教え て ください",
+            "今日 の イベント を 教え て ください",
+        ],
+    )
+    def test_vosk_fallback_preserves_domain_fallback_transcripts(self, transcript):
+        """Domain-bearing Vosk fallback remains usable even when segmented."""
+        assert not _vosk_fallback_transcript_suspicious(transcript, "ja", 0.95)
+
     def test_qwen_primary_rejects_short_noisy_transcripts(self):
         """Qwen should not accept low-confidence filler as user intent."""
         assert _qwen_primary_transcript_suspicious("え", "ja", 0.40)
@@ -2640,6 +2688,67 @@ class TestQwenPrimaryFallback:
         assert "stt_qwen_hedge_grace_start" not in events
 
     @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        ("vosk_text", "expected"),
+        [
+            (
+                "元気 新潟 県 の 影響 時間 教え て ください",
+                "エンジニアカフェの営業時間を教えてください。",
+            ),
+            (
+                "はい はい ば 瀬田 作 方法 を 教え て ください",
+                "Wi-Fiの接続方法を教えてください。",
+            ),
+            (
+                "パート の 仮想 環境 と 何 です か",
+                "Python の仮想環境とは何ですか。",
+            ),
+        ],
+    )
+    async def test_live_preflight_vosk_confusions_return_canonical_transcripts(
+        self, caplog, vosk_text, expected
+    ):
+        """Domain-bearing live preflight Vosk confusions can normalize safely."""
+        caplog.set_level(logging.INFO, logger="backend.observability.stt")
+
+        async def slow_qwen(*args, **kwargs):
+            await asyncio.sleep(0.30)
+            return TranscriptionResult(text="late qwen", confidence=0.9, language="ja")
+
+        async def confused_vosk(*args, **kwargs):
+            await asyncio.sleep(0.01)
+            return TranscriptionResult(
+                text=vosk_text,
+                confidence=0.8,
+                language="ja",
+            )
+
+        mock_qwen = MagicMock()
+        mock_qwen.transcribe = slow_qwen
+        mock_vosk = MagicMock(spec=LocalSTTClient)
+        mock_vosk.transcribe = AsyncMock(side_effect=confused_vosk)
+
+        agent = self._make_agent(mock_qwen, mock_vosk)
+        agent._qwen_timeout = 10.0
+        agent._qwen_hedge_delay = 0.01
+        agent._qwen_hedge_grace = 0.20
+
+        result = await agent.speech_to_text(b"audio", language="ja")
+
+        assert result["success"] is True
+        assert result["provider"] == "vosk-fallback"
+        assert result["transcript"] == expected
+
+        events = [
+            getattr(record, "event", None)
+            for record in caplog.records
+            if record.name == "backend.observability.stt"
+        ]
+        assert "stt_vosk_route_normalize" in events
+        assert "stt_vosk_early_accept" in events
+        assert "stt_qwen_hedge_grace_start" not in events
+
+    @pytest.mark.asyncio
     async def test_qwen_grace_expires_then_vosk_wins(self, caplog):
         """Vosk remains the fallback if Qwen misses the grace window."""
         caplog.set_level(logging.INFO, logger="backend.observability.stt")
@@ -2785,6 +2894,61 @@ class TestQwenPrimaryFallback:
             for record in caplog.records
             if record.name == "backend.observability.stt"
         ]
+        assert "stt_qwen_hedge_grace_start" in events
+        assert "stt_vosk_rejected" in events
+        winner = next(
+            record for record in caplog.records if getattr(record, "event", None) == "stt_winner"
+        )
+        assert winner.stt_winner == "none"
+        assert winner.vosk_error_type == "RejectedVoskFallback"
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        "transcript",
+        [
+            "元気 田中 の 影響 時間 を 教え て ください",
+            "はい はい ば 田中 作 方法 を 教え て ください",
+        ],
+    )
+    async def test_high_confidence_unknown_live_fragment_vosk_fallback_is_rejected(
+        self,
+        transcript,
+        caplog,
+    ):
+        """Unknown high-confidence Vosk fragments should fail instead of hitting chat."""
+        caplog.set_level(logging.INFO, logger="backend.observability.stt")
+
+        async def too_late_qwen(*args, **kwargs):
+            await asyncio.sleep(0.30)
+            return TranscriptionResult(text="too late", confidence=0.9, language="ja")
+
+        async def live_log_vosk(*args, **kwargs):
+            await asyncio.sleep(0.01)
+            return TranscriptionResult(
+                text=transcript,
+                confidence=0.95,
+                language="ja",
+            )
+
+        mock_qwen = MagicMock()
+        mock_qwen.transcribe = too_late_qwen
+        mock_vosk = MagicMock(spec=LocalSTTClient)
+        mock_vosk.transcribe = AsyncMock(side_effect=live_log_vosk)
+
+        agent = self._make_agent(mock_qwen, mock_vosk)
+        agent._qwen_timeout = 10.0
+        agent._qwen_hedge_delay = 0.01
+        agent._qwen_hedge_grace = 0.02
+
+        with pytest.raises(RuntimeError, match="Both Qwen and Vosk STT failed"):
+            await agent.speech_to_text(b"audio", language="ja")
+
+        events = [
+            getattr(record, "event", None)
+            for record in caplog.records
+            if record.name == "backend.observability.stt"
+        ]
+        assert "stt_qwen_hedge_grace_start" in events
         assert "stt_vosk_rejected" in events
         winner = next(
             record for record in caplog.records if getattr(record, "event", None) == "stt_winner"

--- a/backend/tests/agents/test_voice_agent.py
+++ b/backend/tests/agents/test_voice_agent.py
@@ -11,6 +11,7 @@ from backend.agents.voice_agent import (
     parse_emotion_tags,
     preprocess_tts,
     clean_text_for_tts,
+    get_tts_timeout_seconds,
     get_tts_max_bytes,
     truncate_by_bytes,
     map_vrm_to_tts_emotion,
@@ -372,6 +373,23 @@ async def test_text_to_speech_piper_timeout_falls_back_quickly(monkeypatch):
     assert "timed out" in result["error"]
 
 
+def test_piper_primary_timeout_default_covers_live_answer_window(monkeypatch):
+    monkeypatch.delenv("TTS_PIPER_PRIMARY_TIMEOUT_SECONDS", raising=False)
+    monkeypatch.delenv("TTS_PRIMARY_TIMEOUT_SECONDS", raising=False)
+    monkeypatch.delenv("TTS_PIPER_TIMEOUT_SECONDS", raising=False)
+
+    assert get_tts_timeout_seconds("piper", "primary") == 4.0
+
+
+def test_piper_voicevox_fallback_requires_url_on_cloud_run(monkeypatch):
+    monkeypatch.setenv("K_SERVICE", "engineer-cafe-backend")
+    monkeypatch.delenv("VOICEVOX_API_URL", raising=False)
+
+    agent = VoiceAgent(tts_provider="piper")
+
+    assert agent.voicevox_fallback_client is None
+
+
 @pytest.mark.asyncio
 async def test_text_to_speech_caches_successful_fallback(monkeypatch):
     monkeypatch.setenv("TTS_PIPER_PRIMARY_TIMEOUT_SECONDS", "0.01")
@@ -424,6 +442,63 @@ async def test_text_to_speech_empty_primary_audio_uses_fallback(monkeypatch):
     assert result["fallback_used"] is True
     assert result["fallback_provider"] == "google"
     assert result["audioResponse"] == "FALLBACK_BASE64"
+    assert "empty audio response" in result["error"]
+
+
+@pytest.mark.asyncio
+async def test_text_to_speech_piper_empty_primary_audio_uses_voicevox_fallback(monkeypatch):
+    agent = VoiceAgent(tts_provider="piper")
+
+    async def fake_piper_empty(text, lang):
+        return ""
+
+    async def fake_voicevox_synth(text, lang, speaker_id=None):
+        return "VOICEVOX_FALLBACK_BASE64"
+
+    monkeypatch.setattr(agent.tts_client, "synthesize_wav_base64", fake_piper_empty)
+    monkeypatch.setattr(
+        agent.voicevox_fallback_client, "synthesize_wav_base64", fake_voicevox_synth
+    )
+
+    result = await agent.text_to_speech(text="こんにちは", language="ja")
+
+    assert result["success"] is True
+    assert result["fallback_used"] is True
+    assert result["fallback_provider"] == "voicevox"
+    assert result["actual_provider"] == "voicevox"
+    assert result["language"] == "ja"
+    assert result["audioResponse"] == "VOICEVOX_FALLBACK_BASE64"
+    assert "empty audio response" in result["error"]
+    assert isinstance(result["tts_duration_ms"], int)
+
+
+@pytest.mark.asyncio
+async def test_text_to_speech_piper_local_fallback_failure_uses_google(monkeypatch):
+    agent = VoiceAgent(tts_provider="piper")
+
+    async def fake_piper_empty(text, lang):
+        return ""
+
+    async def fake_voicevox_fail(text, lang, speaker_id=None):
+        raise RuntimeError("voicevox unavailable")
+
+    async def fake_google_synth(text, lang, emotion):
+        return "GOOGLE_FALLBACK_MP3_BASE64"
+
+    monkeypatch.setattr(agent.tts_client, "synthesize_wav_base64", fake_piper_empty)
+    monkeypatch.setattr(agent.voicevox_fallback_client, "synthesize_wav_base64", fake_voicevox_fail)
+    agent.google_fallback_client.credentials_source = "{}"
+    monkeypatch.setattr(agent.google_fallback_client, "synthesize_mp3_base64", fake_google_synth)
+
+    result = await agent.text_to_speech(text="こんにちは", language="ja")
+
+    assert result["success"] is True
+    assert result["fallback_used"] is True
+    assert result["fallback_provider"] == "google"
+    assert result["actual_provider"] == "google"
+    assert result["format"] == "audio/mpeg"
+    assert result["language"] == "ja"
+    assert result["audioResponse"] == "GOOGLE_FALLBACK_MP3_BASE64"
     assert "empty audio response" in result["error"]
 
 

--- a/backend/tests/agents/test_voice_agent_cache.py
+++ b/backend/tests/agents/test_voice_agent_cache.py
@@ -40,6 +40,7 @@ def _assert_cached_audio_entry(
     audio_format: str = "audio/wav",
     fallback_used: bool = False,
     fallback_provider: str | None = None,
+    actual_provider: str | None = "voicevox",
 ) -> None:
     cached = agent._tts_cache[cache_key]
     assert cached == {
@@ -47,6 +48,7 @@ def _assert_cached_audio_entry(
         "format": audio_format,
         "fallback_used": fallback_used,
         "fallback_provider": fallback_provider,
+        "actual_provider": actual_provider,
     }
 
 

--- a/backend/tests/api/test_voice_filler_api.py
+++ b/backend/tests/api/test_voice_filler_api.py
@@ -71,6 +71,9 @@ async def test_voice_filler_static_lookup_under_100ms(monkeypatch):
     assert response.intent == "event"
     assert response.audioResponse
     assert elapsed_ms < 100
+    assert response.upstreamStatus["ok"] is True
+    assert response.upstreamStatus["latencyMs"] < 100
+    assert response.upstreamStatus["fallbackUsed"] is False
 
 
 async def test_voice_filler_rejects_undersized_wav(monkeypatch, tmp_path):
@@ -145,6 +148,7 @@ async def test_voice_filler_uses_static_fallback_clip_when_intent_clip_missing(
     assert body["upstreamStatus"]["fallbackUsed"] is True
     assert body["upstreamStatus"]["actualIntent"] == "fallback"
     assert body["upstreamStatus"]["actualLanguage"] == "ja"
+    assert body["upstreamStatus"]["latencyMs"] < 100
 
 
 async def test_handle_stt_times_out_and_returns_recoverable_failure(monkeypatch):

--- a/backend/tests/llm/test_model_resolve.py
+++ b/backend/tests/llm/test_model_resolve.py
@@ -7,6 +7,7 @@ import pytest
 from backend.llm.model_resolve import (
     cerebras_primary_enabled,
     cerebras_primary_use_cases,
+    openrouter_timeout_seconds,
 )
 from backend.llm.models import MODEL_CONFIGS
 from backend.llm.models import ModelConfig, SupportedModel
@@ -100,3 +101,22 @@ def test_cerebras_primary_allows_explicit_all_for_opted_in_configs(
     assert cerebras_primary_use_cases() is None
     assert cerebras_primary_enabled(MODEL_CONFIGS["facility_info"]) is True
     assert cerebras_primary_enabled(MODEL_CONFIGS["router"]) is False
+
+
+def test_openrouter_fast_timeout_default_is_bounded(monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.delenv("OPENROUTER_TIMEOUT_SECONDS", raising=False)
+    monkeypatch.delenv("FAST_LLM_TIMEOUT_SECONDS", raising=False)
+
+    config = ModelConfig(
+        model_id=SupportedModel.GEMINI_3_1_FLASH_LITE,
+        fallback_model=SupportedModel.GEMINI_2_5_FLASH_LITE,
+        timeout=30.0,
+    )
+
+    assert openrouter_timeout_seconds(config) == 8.0
+
+
+def test_openrouter_timeout_env_override(monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setenv("OPENROUTER_TIMEOUT_SECONDS", "2.25")
+
+    assert openrouter_timeout_seconds(MODEL_CONFIGS["qa_response"]) == 2.25

--- a/backend/tests/llm/test_openrouter.py
+++ b/backend/tests/llm/test_openrouter.py
@@ -286,6 +286,34 @@ class TestOpenRouterProvider:
         assert FakeAsyncClient.timeouts == [1.25]
 
     @pytest.mark.asyncio
+    async def test_openrouter_fast_request_uses_fast_timeout_env(self, monkeypatch):
+        """OpenRouter fast path should time out quickly enough for fallback routing."""
+        messages = [HumanMessage(content="Test message")]
+        config = ModelConfig(
+            model_id=SupportedModel.GEMINI_3_1_FLASH_LITE,
+            fallback_model=SupportedModel.GEMINI_2_5_FLASH_LITE,
+            timeout=30.0,
+        )
+        monkeypatch.setenv("FAST_LLM_TIMEOUT_SECONDS", "1.5")
+        monkeypatch.delenv("OPENROUTER_TIMEOUT_SECONDS", raising=False)
+
+        mock_response = MagicMock()
+        mock_response.json.return_value = {
+            "choices": [{"message": {"content": "OpenRouter fast response"}}]
+        }
+        observed_timeouts = []
+
+        async def mock_post(*args, **kwargs):
+            observed_timeouts.append(kwargs.get("timeout"))
+            return mock_response
+
+        with patch.object(self.provider._http_client, "post", side_effect=mock_post):
+            response = await self.provider.generate(messages, config)
+
+        assert response == "OpenRouter fast response"
+        assert observed_timeouts == [1.5]
+
+    @pytest.mark.asyncio
     async def test_cerebras_fast_primary_requires_config_opt_in(self):
         """施設・イベント系のfast configへCerebras primaryが波及しないこと"""
         messages = [HumanMessage(content="Test message")]

--- a/backend/tests/test_main_endpoints.py
+++ b/backend/tests/test_main_endpoints.py
@@ -597,6 +597,9 @@ class TestVoiceEndpoint:
                 "error": "Piper unavailable",
                 "fallback_used": True,
                 "fallback_provider": "voicevox",
+                "actual_provider": "voicevox",
+                "tts_duration_ms": 42,
+                "tts_cache_hit": False,
             }
         )
         with patch("backend.main._get_voice_agent_for_provider_key", return_value=mock_agent):
@@ -608,9 +611,42 @@ class TestVoiceEndpoint:
         assert resp.success is True
         assert resp.upstreamStatus["provider"] == "piper"
         assert resp.upstreamStatus["actualProvider"] == "voicevox"
+        assert resp.upstreamStatus["latencyMs"] == 42
+        assert resp.upstreamStatus["cacheHit"] is False
         assert resp.upstreamStatus["fallbackUsed"] is True
         assert resp.upstreamStatus["fallbackProvider"] == "voicevox"
         assert resp.upstreamStatus["error"] == "Piper unavailable"
+
+    @pytest.mark.asyncio
+    async def test_voice_tts_success_without_audio_is_reported_as_failure(self):
+        mock_agent = AsyncMock()
+        mock_agent.text_to_speech = AsyncMock(
+            return_value={
+                "success": True,
+                "audioResponse": "",
+                "format": "audio/wav",
+                "emotion": "neutral",
+                "fallback_used": False,
+                "fallback_provider": None,
+                "actual_provider": "piper",
+                "tts_duration_ms": 17,
+                "tts_cache_hit": False,
+            }
+        )
+        with patch("backend.main._get_voice_agent_for_provider_key", return_value=mock_agent):
+            from backend.main import VoiceRequest, voice_api
+
+            body = VoiceRequest(action="text_to_speech", text="hello", ttsProvider="piper")
+            resp = await voice_api(_mock_request(), body)
+
+        assert resp.success is False
+        assert resp.error == "TTS completed without audioResponse"
+        assert resp.upstreamStatus["ok"] is False
+        assert resp.upstreamStatus["provider"] == "piper"
+        assert resp.upstreamStatus["actualProvider"] == "piper"
+        assert resp.upstreamStatus["latencyMs"] == 17
+        assert resp.upstreamStatus["cacheHit"] is False
+        assert resp.upstreamStatus["fallbackUsed"] is False
 
 
 class TestSlidesEndpoint:

--- a/backend/utils/intent_classifier.py
+++ b/backend/utils/intent_classifier.py
@@ -323,7 +323,24 @@ def classify_fast_intent(query: str) -> Optional[FastIntent]:
             "Farewell keyword detected",
         )
 
-    if is_daily_conversation_request(lower_query):
+    has_explicit_service_intent = any(
+        match_keywords(lower_query, keywords)
+        for keywords in (
+            WIFI_KEYWORDS,
+            BUSINESS_HOURS_KEYWORDS,
+            PRICING_KEYWORDS,
+            EVENT_KEYWORDS,
+            COMMUNITY_KEYWORDS,
+            CONSULTATION_KEYWORDS,
+            ACCESS_DIRECTION_KEYWORDS,
+            FACILITY_EQUIPMENT_KEYWORDS,
+            CONTACT_KEYWORDS,
+            FLOOR_LAYOUT_KEYWORDS,
+            RECEPTION_KEYWORDS,
+        )
+    )
+
+    if is_daily_conversation_request(lower_query) and not has_explicit_service_intent:
         return FastIntent(
             agent="general_knowledge",
             category="daily_conversation",


### PR DESCRIPTION
## Summary
- harden the live voice preflight path after PR #784 exposed STT fallback and answer TTS failures on Cloud Run
- normalize the known Piper -> Vosk Japanese distortions for Engineer Cafe hours, Wi-Fi setup, and Python virtualenv while rejecting unknown high-confidence Vosk fragments before they reach chat
- make TTS fallback behavior observable and safer on Cloud Run, including empty-audio failures, actual provider metadata, fallback latency, and bounded Piper/OpenRouter timeouts
- keep specific routing intents from being preempted by small-talk markers such as `元気` or `ありがとう`

## Root Cause
The deployed `engineer-cafe-backend-00189-86t` live preflight showed Qwen STT often exceeding the 10s UX budget. Vosk then won the hedge with route-unstable transcripts such as `元気 新潟 県 の 影響 時間 教え て ください`, which was allowed into `/api/chat` and routed as general small talk. The same preflight also reported an answer TTS response with `success=false` and missing audio, with insufficient upstream metadata to distinguish provider, fallback, and latency cleanly.

## Changes
- STT
  - adds narrow route normalization for live Vosk distortions observed in the preflight
  - rejects unknown fragmented Japanese fallback transcripts even when confidence is high
  - preserves domain-bearing fallback transcripts for hours, Wi-Fi, events, and general Python virtualenv cases
- TTS / voice API
  - raises Piper primary timeout from 2.5s to 4.0s for long answer narration
  - avoids waiting on localhost VoiceVox in Cloud Run when `VOICEVOX_API_URL` is unset
  - allows Google fallback only when credentials are present
  - treats `success=true` with empty `audioResponse` as an API failure instead of returning a false success
  - exposes `actualProvider`, `latencyMs`, `language`, cache, and fallback metadata in `/api/voice`
- LLM fallback speed
  - bounds OpenRouter fast-path timeout with `OPENROUTER_TIMEOUT_SECONDS` / `FAST_LLM_TIMEOUT_SECONDS`, defaulting fast configs to 8s
- Routing
  - prevents small-talk markers from preempting explicit business/facility/event intents

## Validation
- `python -m compileall -q backend/agents/stt_agent.py backend/agents/voice_agent.py backend/main.py backend/llm/model_resolve.py backend/llm/openrouter.py`
- `python -m ruff check backend/agents/stt_agent.py backend/agents/voice_agent.py backend/main.py backend/llm/model_resolve.py backend/llm/openrouter.py backend/utils/intent_classifier.py backend/tests/agents/test_stt_agent.py backend/tests/agents/test_voice_agent.py backend/tests/agents/test_voice_agent_cache.py backend/tests/api/test_voice_filler_api.py backend/tests/test_main_endpoints.py backend/tests/llm/test_model_resolve.py backend/tests/llm/test_openrouter.py backend/tests/agents/test_orchestrator_fast_routing.py`
- `python -m black --check backend/agents/stt_agent.py backend/agents/voice_agent.py backend/main.py backend/llm/model_resolve.py backend/llm/openrouter.py backend/utils/intent_classifier.py backend/tests/agents/test_stt_agent.py backend/tests/agents/test_voice_agent.py backend/tests/agents/test_voice_agent_cache.py backend/tests/api/test_voice_filler_api.py backend/tests/test_main_endpoints.py backend/tests/llm/test_model_resolve.py backend/tests/llm/test_openrouter.py backend/tests/agents/test_orchestrator_fast_routing.py`
- `python -m pytest backend/tests/agents/test_stt_agent.py backend/tests/agents/test_voice_agent.py backend/tests/agents/test_voice_agent_cache.py backend/tests/api/test_voice_filler_api.py backend/tests/test_main_endpoints.py backend/tests/llm/test_model_resolve.py backend/tests/llm/test_openrouter.py backend/tests/agents/test_orchestrator_fast_routing.py backend/tests/workflows/test_main_workflow.py -q` -> 396 passed
- `python -m pytest backend/tests/e2e/test_production_fixes_e2e.py::TestTTSUnit backend/tests/integration/test_stt_voice_pipeline.py::TestVoiceAgentPipeline -q` -> 20 passed

## Post-merge proof required
Do not close the linked issues until the develop deployment is complete and the Cloud Run live voice preflight passes against the deployed revision:

```bash
scripts/voice-pipeline-live-preflight.sh --host https://engineer-cafe-backend-mggisi6odq-an.a.run.app --case-set smoke --allow-vosk-fallback --timestamp post-alpha-live-stt-tts-$(date +%Y%m%d%H%M%S)
```

Refs #781, #777, #773.
