### PR TITLE
[codex] Upgrade Google GitHub Actions to Node 24

### DIFF
--- a/.github/workflows/alpha-live-verification.yml
+++ b/.github/workflows/alpha-live-verification.yml
@@ -56,12 +56,12 @@ jobs:
           python-version: ${{ env.PYTHON_VERSION }}
 
       - name: Authenticate to Google Cloud
-        uses: google-github-actions/auth@v2
+        uses: google-github-actions/auth@v3
         with:
           credentials_json: ${{ secrets.GCP_SA_KEY }}
 
       - name: Set up Cloud SDK
-        uses: google-github-actions/setup-gcloud@v2
+        uses: google-github-actions/setup-gcloud@v3.0.1
 
       - name: Install backend evaluation dependencies
         working-directory: backend

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -467,12 +467,12 @@ jobs:
       - uses: actions/checkout@v6.0.2
 
       - name: Authenticate to Google Cloud
-        uses: google-github-actions/auth@v2
+        uses: google-github-actions/auth@v3
         with:
           credentials_json: ${{ secrets.GCP_SA_KEY }}
 
       - name: Set up Cloud SDK
-        uses: google-github-actions/setup-gcloud@v2
+        uses: google-github-actions/setup-gcloud@v3.0.1
 
       - name: Configure Docker for Artifact Registry
         run: gcloud auth configure-docker asia-northeast1-docker.pkg.dev

--- a/.github/workflows/terraform-plan.yml
+++ b/.github/workflows/terraform-plan.yml
@@ -93,7 +93,7 @@ jobs:
 
       - name: Authenticate to Google Cloud
         if: steps.terraform_directory.outputs.exists == 'true' && steps.gcp_credentials.outputs.can_plan == 'true'
-        uses: google-github-actions/auth@v2
+        uses: google-github-actions/auth@v3
         with:
           project_id: ${{ vars.GCP_PROJECT_ID || secrets.GCP_PROJECT_ID || 'aipartner-426616' }}
           workload_identity_provider: ${{ secrets.GCP_WORKLOAD_IDENTITY_PROVIDER }}


### PR DESCRIPTION
## Summary
- upgrade google-github-actions/auth to v3
- upgrade google-github-actions/setup-gcloud to v3.0.1
- remove remaining Node.js 20-targeted Google Action warnings from deploy and live verification workflows

## Validation
- git diff --check

Related #668