### PR TITLE
docs(adr): record post-alpha RAG production evidence

### DIFF
--- a/docs/adr/020-knowledge-ingestion-mutation-contract.md
+++ b/docs/adr/020-knowledge-ingestion-mutation-contract.md
@@ -66,6 +66,49 @@ Required production gates after merge:
 - Updated uploaded knowledge is observable through the live RAG/chat path or a
   direct live RAG verification script.
 
+### 2026-05-09 Production Evidence
+
+The contract was deployed by PR #790 after PR #787, #788, and #789 were merged.
+The production backend served 100% traffic from Cloud Run revision
+`engineer-cafe-backend-00192-bzt` with image
+`engineer-cafe-backend:a9e85d3d7896aded7be0021649538b303a2cd34e`.
+
+Observed results:
+
+- GitHub Actions develop run `25588854013` passed, including
+  `backend-test`, `backend-test-ragas`, and `backend-deploy-staging`.
+- The deploy job used `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24=true`, Node.js 24
+  action versions, `google-github-actions/setup-gcloud@v3.0.1`, and produced no
+  Node.js 20 action deprecation warnings.
+- `/health` returned `status=ok` with `supabase=ok`.
+- Live Markdown preview, upload, get, update, delete, and cleanup passed against
+  `/api/knowledge/*`.
+- Live `/api/chat` retrieved the uploaded token before update and retrieved the
+  updated token after update, proving retrieval-visible mutation behavior.
+- Live filler API returned audio for 12 samples; backend upstream latency max
+  was 7 ms.
+- Voice pipeline retry report
+  `backend/tests/reports/voice-pipeline-live-post-alpha-rag-node24-deploy-retry-20260509024048.md`
+  recorded `14 PASS / 4 WARN / 0 FAIL`.
+- Frontend production voice-live Playwright retry passed: `1 passed`.
+- Cloud Logging error gate report
+  `backend/tests/reports/cloud-logging-check-post-alpha-rag-node24-logs-20260509024521.md`
+  passed with zero `/api/chat` 5xx, memory helper errors, UUID hygiene errors,
+  or reception persistence errors. A direct Cloud Run log query also found zero
+  `ERROR`, `Traceback`, `Timeout`, or `routing error` rows for the verification
+  window.
+
+Residual risk:
+
+- STT latency remains outside the target for #529. In the same verification
+  window, STT logs on revision `engineer-cafe-backend-00192-bzt` showed 9
+  `stt_winner` rows, winners `qwen=4` and `vosk=5`, p50 `6877 ms`, p90
+  `9000 ms`, max `10006 ms`, and `stt_qwen_rejected=0`. The STT live latency
+  gate report
+  `backend/tests/reports/stt-live-preflight-post-alpha-rag-node24-stt-20260509024521.md`
+  failed on p95/over-10s ratio, so STT latency remains tracked by #529 and does
+  not close under this ADR.
+
 ## Related
 
 - #540: Knowledge ingestion pipeline hardening for RAG quality


### PR DESCRIPTION
## Summary
- add 2026-05-09 production verification evidence to ADR 020
- record Cloud Run revision/image, live RAG CRUD/chat proof, filler/voice/log results, and STT residual risk under #529

## Validation
- git diff --check