### PR TITLE
docs: define post-alpha voice rag frontend scope

### DIFF
--- a/docs/adr/016-qwen-stt-phase2-profiling.md
+++ b/docs/adr/016-qwen-stt-phase2-profiling.md
@@ -1,11 +1,11 @@
 # ADR 016: Qwen STT Phase 2 Profiling
 
 作成日: 2026-04-24
-更新日: 2026-04-25 (Phase B-1 production 実測結果追記)
+更新日: 2026-05-09 (Post-alpha STT latency rebaseline 方針追記)
 
 ## ステータス
 
-**完了**: Phase A profiling (PR #558) + Phase B-1 Qwen-only fast-path (PR #560) 両方実装・
+**Accepted / rebaseline required**: Phase A profiling (PR #558) + Phase B-1 Qwen-only fast-path (PR #560) 両方実装・
 deploy・live 実測済み。目標 p50 3.1s を上回る 2827ms (34% 短縮) を達成。
 Epic #474 Exit Criterion `/api/voice p95 < 10s` 達成 (p95 = 7035ms)。
 
@@ -15,6 +15,27 @@ Alpha Live Verification では NO-GO。PR #592 の live run
 `vosk-fallback` が多数発生した。Alpha GO には、STT 単体 p95 だけでなく
 Welcome 起点の live round-trip で `sttProvider=qwen-primary` を維持できることが必要。
 最新の blocker は `docs/testing/alpha-live-verification-status-2026-04-25.md` を参照。
+
+**2026-05-09 post-alpha 追記**: Phase B-1 の改善は履歴として有効だが、現在の
+production voice path では STT が再び user-facing latency の主因になっている。
+Cloud Run revision `engineer-cafe-backend-00192-bzt` の post-deploy window では
+`stt_winner` 9 rows、winner 分布 `qwen=4` / `vosk=5`、p50 `6877ms`、p90 `9000ms`、
+max `10006ms`、`stt-live-preflight` は p95/over-10s ratio で FAIL だった。
+
+このため #529 は「観測性」ではなく「精度を維持した STT first-hop latency」の
+P1-A として再優先化する。ユーザー指摘どおり、回答生成は概ね 3-5 秒で返るため、
+音声入力から transcript 確定までの 6-7 秒台が体感速度の主ボトルネックである。
+
+判断:
+
+- 速度だけを理由に Vosk winner を早期採用する方針へ戻さない。過去の live voice
+  pipeline では Vosk の低品質 transcript が route 誤判定と不適切な回答を引き起こした。
+- 現行の Qwen-first / Vosk fallback / hedge は精度保全のため維持する。ただし
+  hedge delay、grace、CPU contention、audio conversion、model runtime の内訳を再計測し、
+  Qwen の品質を保ったまま transcript latency を戻す。
+- `<1.5s` target は #529 の最終 acceptance として残す。次の実装セッションでは、
+  まず p50/p95 の分解計測と候補 runtime の spike を行い、CPU path だけで不足する場合は
+  GPU/remote STT/streaming partial transcript を明示的な比較対象にする。
 
 ## 背景
 

--- a/docs/adr/021-frontend-backend-separation-before-react-vite.md
+++ b/docs/adr/021-frontend-backend-separation-before-react-vite.md
@@ -1,0 +1,75 @@
+# ADR 021: Frontend/backend separation before React/Vite migration
+
+## Status
+
+Accepted, 2026-05-09.
+
+## Context
+
+The current frontend uses Next.js App Router for both the kiosk/admin UI and
+server-side route handlers under `frontend/src/app/api`.
+
+The route-handler layer is not just UI plumbing. It currently provides:
+
+- backend API key secrecy
+- Vercel-to-Cloud Run proxying
+- request/response shape adaptation for `/api/qa`, `/api/voice`,
+  `/api/reception/*`, and admin knowledge endpoints
+- operational middleware for admin, cron, and monitoring routes
+- CSP/security headers
+- PDF worker bundling through `next.config.js`
+
+The post-alpha refactoring discussion raised whether replacing Next.js with a
+plain React/Vite frontend would significantly reduce code and improve
+development velocity.
+
+The inventory found 29 route-handler files under `frontend/src/app/api`, with
+about 1797 lines of code. That is the main removable surface. A framework
+rewrite alone does not remove it unless the backend first owns authentication,
+CORS, rate limits, and public API contracts.
+
+## Decision
+
+Do not start with a Next.js to React/Vite rewrite.
+
+First, separate the browser UI from backend server responsibilities:
+
+1. Define backend auth for browser-origin requests. Candidate designs are
+   short-lived kiosk/admin tokens, public read-only endpoints with stricter
+   rate limits, or a limited backend-for-frontend boundary kept only where
+   secrets must remain server-side.
+2. Move `/api/qa` traffic to backend `/api/chat` directly as the first slice.
+3. Move `/api/voice` only after STT/TTS timeout and CORS behavior are measured
+   without the Vercel proxy.
+4. Move admin knowledge endpoints after upload/preview auth and file-size
+   limits are explicitly owned by the backend.
+5. After `frontend/src/app/api` is mostly gone, measure whether keeping Next as
+   a client shell is still useful. If not, migrate to Vite/React as a mechanical
+   frontend build-tool change.
+
+## Consequences
+
+- Code reduction is expected from deleting proxy routes, not from changing the
+  React renderer.
+- The first implementation issue remains #358, but its priority is raised from
+  generic P2 cleanup to post-alpha P1-C architecture work.
+- Vite remains a good target if the frontend becomes a static SPA, but it must
+  not become a replacement for the current server-side secret boundary by
+  accident.
+- Frontend migration work must not block the P1-A voice latency work.
+
+## Verification
+
+The first PR in this lane should prove:
+
+- `/api/qa` can be replaced by direct backend `/api/chat` calls in development
+  and production-like environments.
+- Browser CORS, rate limit, auth, and error responses remain explicit.
+- Existing voice and admin knowledge flows are unchanged.
+- Playwright voice-live and admin knowledge tests still pass.
+
+## Related
+
+- #358: Frontend `/api/qa` proxy retirement / backend `/api/chat` direct call
+- ADR 005: Backend-first logic
+- ADR 020: Knowledge ingestion mutation contract

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -13,6 +13,7 @@
 | [008 — Operational verification & deployment guardrails](008-operational-verification-and-deployment-guardrails.md) | 監査・デプロイ・検証のガードレール                             |
 | [019 — Alpha live RAGAS case accounting](019-alpha-live-ragas-case-accounting.md)                                   | C-127 ケース数・収集の会計                              |
 | [020 — Knowledge ingestion mutation contract](020-knowledge-ingestion-mutation-contract.md)                         | RAG 投入・変更・preview の契約                           |
+| [021 — Frontend/backend separation before React/Vite migration](021-frontend-backend-separation-before-react-vite.md) | Next API proxy 廃止を React/Vite 移行より先に行う判断           |
 
 
 ## ワークフロー・音声・観測
@@ -47,5 +48,5 @@
 
 ## メモ
 
-- ADR 番号は 005 以降を運用しており、**015 は欠番**です（採番のみ存在し、文書化に至らなかったため）。新しい ADR を起票する際は 021 から付番してください。
+- ADR 番号は 005 以降を運用しており、**015 は欠番**です（採番のみ存在し、文書化に至らなかったため）。新しい ADR を起票する際は 022 から付番してください。
 - 001–004 についても、本リポジトリでは初期から ADR 005 以降のみを保守しています。

--- a/docs/plans/post-alpha-voice-rag-frontend-scope-2026-05-09.md
+++ b/docs/plans/post-alpha-voice-rag-frontend-scope-2026-05-09.md
@@ -1,0 +1,186 @@
+# Post-alpha Voice / RAG / Frontend Scope Cleanup
+
+作成日: 2026-05-09
+
+## 目的
+
+PR #787-#791 で本番反映された Node.js 24 / RAG mutation / voice guard の
+証跡を踏まえ、次の実装スコープを voice latency、RAG/LangGraph quality、
+frontend/backend 分離、運用検証の 4 本に再整理する。
+
+## 開発環境の現在地
+
+- `develop` は `origin/develop` と一致し、作業ツリーは clean。
+- 不要 worktree は削除済み。
+- 事前に残っていた tracked dirty file は復元済み。
+- `.claude/worktrees/` は削除済み。
+- `develop` に merge 済みの stale local branch は削除済み。
+- 未マージ local branch は保全する。
+
+## 本番実測値
+
+対象 Cloud Run revision は `engineer-cafe-backend-00192-bzt`。
+100% traffic で、`/health` は `api/supabase/llm_provider` すべて OK。
+
+### Voice / STT / TTS
+
+- voice pipeline retry: `14 PASS / 4 WARN / 0 FAIL`
+- STT live latency gate: FAIL
+  - samples: 9
+  - p50: `6877ms`
+  - p95/max: `10006ms`
+  - winners: `qwen=4`, `vosk=5`
+  - provider: `qwen-primary=4`, `vosk-fallback=5`
+  - samples over 10s: `1/9`, `11.1%`
+- filler live probe:
+  - prior proof: p50 `164.3ms`, max `274.9ms`
+  - 2026-05-09 quick probe: p50 `267.5ms`, 3/3 static audio returned
+- quick chat route probe:
+  - hours: `5856ms`, `BusinessInfoAgent`
+  - Wi-Fi: `1070ms`, `facility-info`
+  - event: `1643ms`, `EventAgent`
+  - Python: `3328ms`, `general_knowledge`
+  - p50: `2485.7ms`
+
+結論: TTS/filler と route は実用域に入ったが、STT は #529 の `<1.5s`
+目標に未達。体感速度の主ボトルネックはまだ初回 STT hop。
+
+### STT latency debate
+
+現状の体感値は、音声入力から文字起こし結果が出るまで 6-7 秒程度、その後の
+回答生成と音声出力が概ね 3-5 秒程度である。後段はすでに比較的速く、
+これ以上の UX 改善は first-hop STT を戻すほうが効果が大きい。
+
+ただし、速度だけで Vosk fallback を優先するのは採用しない。直近の live voice
+pipeline では Vosk の低品質 transcript が `Wi-Fi` や `Python 仮想環境` の route
+を崩し、後続回答の品質を落とした。つまり今回の改善条件は「速い transcript」
+ではなく「現在の route/TTS 成功率を維持した速い transcript」である。
+
+実装候補の評価:
+
+| Candidate | Speed | Accuracy risk | Scope judgment |
+| --- | --- | --- | --- |
+| Vosk early winner へ戻す | 速い場合がある | 高い。route 誤判定の再発リスク | 不採用 |
+| Qwen hedge/grace 再調整 | 中 | 低〜中。既存構造を活かせる | 最初に実施 |
+| audio conversion / model runtime 分解計測 | 改善余地の特定 | 低 | 必須 |
+| Cloud Run CPU/memory/concurrency tuning | 中 | 低 | 計測後に実施 |
+| GPU/remote STT spike | 高い可能性 | 中。運用・コスト・外部依存 | CPU path 不足時に比較 |
+| streaming partial transcript | 体感改善大 | 中。確定 transcript との差分制御が必要 | UX spike として後段 |
+
+次セッションでは、#529 を P1-A として、`stt_overall` を
+audio conversion、Qwen inference、hedge wait、Vosk fallback、HTTP request total に
+再分解する。最終 target `<1.5s` は維持するが、まず post-alpha の現実的な中間ゲートとして
+`p50 < 3s`、`p95 < 5s`、route/TTS regression 0 を置く。
+
+## RAG / LangGraph / Knowledge Ingestion
+
+ADR 020 の mutation contract は本番で確認済み。
+
+- Markdown/PDF preview: dry-run
+- upload: YAML と同じ category-aware chunk planning
+- create/update: embedding 欠落時は保存前に reject
+- uploaded document: `entry_id` / `document_id` / chunk metadata 付与
+- update/delete: RAG retrieval visible state まで検証済み
+- live upload/update/delete/chat retrieval: PASS
+
+残る未完了:
+
+- bilingual ingestion
+- metadata schema validation
+- event KB live bridge / ICS -> KB cron sync
+- abstract EN membership query の enhanced_rag hit
+- rerank / cross-encoder / D-RAG の quality-vs-latency 評価
+- RAGAS groundedness / hallucination / toxicity の実効ゲート化
+
+RAGAS の直近有効レポートは 2026-04-27 で全言語 target PASS だが、
+`ragas_context_source=golden_dataset` であり、context_precision /
+faithfulness は `0.0000` 表示。live source metadata gate はあるが、live
+retrieved chunks に対する groundedness gate ではない。
+
+## Issue 再整理
+
+### P1-A: Voice first-hop latency and resilience
+
+- #529: STT latency `<1.5s` 未達。最優先。
+- #611: static filler は速いが、first-audible UX 定義と browser timing proof が未完。
+- #584: network/mic/autoplay/silence/noise/long utterance edge-case proof が未完。
+- #774: onsite hardening。M5Stack、DB/cron load、TTS provider fault を実機で確認。
+- #763/#762/#770/#399: frontend voice UI の follow-up。
+
+### P1-B: RAG / LangGraph answer quality
+
+- #540: ingestion hardening は Phase 0/1 一部完了。bilingual/schema/RAGAS gate が残る。
+- #567: abstract EN membership query の retrieval miss。
+- #398: multilingual answer stability。
+- #514: rerank / cross-encoder。
+- #518: hallucination / groundedness / toxicity metrics。
+- #517: event KB live bridge。
+- #655: LangGraph memory recall WARN。
+- #511: 127-case RAGAS / CI gate 実効化。
+- #380: D-RAG spike。
+
+### P1-C: Frontend/backend separation
+
+- #358: `/api/qa` proxy 廃止検討が既存の入口。
+- 現状 Next.js route handlers は `frontend/src/app/api` に 29 files / 1797 LOC。
+- まず API proxy 削減と認証/CORS設計を決める。
+- Next -> Vite/React 移行は、proxy 廃止後に判断する。
+
+### Closed / Done
+
+- #668: Node.js 20 GitHub Actions deprecation は PR #787-#790 と develop CI
+  run `25588854013` で完了済み。再オープン不要。
+
+## Frontend: Next.js から React/Vite へ置き換えるべきか
+
+認識は半分正しい。フロントとサーバーを完全分離する方向は妥当だが、
+削減効果の本体は「Next をやめること」ではなく、`src/app/api` の BFF/proxy
+を backend へ寄せて消すこと。
+
+現在 Next は UI shell だけでなく、次を担っている。
+
+- backend API key の秘匿
+- Vercel -> Cloud Run proxy
+- voice / qa / reception / admin knowledge API の変換
+- admin/cron/monitoring middleware
+- CSP/security headers
+- PDF worker copy webpack hook
+
+Next static export は動的 route handlers、Request/Cookies、server actions、
+headers/rewrites 等に制約がある。Vite は SPA と dev proxy には向くが、本番
+proxy/secret boundary は持たない。したがって移行順は:
+
+1. backend に公開 API / short-lived token / CORS / rate-limit を設計する。
+2. frontend call sites を backend 直呼び client に寄せる。
+3. `src/app/api` を段階削除する。
+4. Next を client-only shell として残すか、Vite/React へ移すかを測定で決める。
+
+## 次の実装スコープ
+
+1. STT latency root-cause branch
+   - qwen/vosk winner trace の最新再計測
+   - CPU inference / conversion / hedge / request budget の分解
+   - 精度を落とす Vosk early-winner は避け、Qwen 品質を維持したまま speed を戻す
+   - #529 の final acceptance は `<1.5s` を維持し、中間ゲートを `p50 < 3s`, `p95 < 5s` に置く
+   - CPU path だけで不足する場合は GPU/remote STT/streaming partial transcript を比較
+
+2. Voice UX proof branch
+   - first audible timing を browser-level で測る
+   - late filler / stale playback / close 後再生なしを regression 化
+   - #611/#584/#774 の proof checklist を issue comment に集約
+
+3. RAG quality gate branch
+   - live retrieved contexts を使う RAGAS/LLM judge gate を追加
+   - #567 の raw similarity / source selection trace を追加
+   - #540 の bilingual/schema 残件を独立 issue に分割
+
+4. Frontend separation ADR
+   - #358 を ADR 化
+   - backend auth/CORS 方針を決定
+   - `/api/qa` -> `/api/chat` 直接化から始め、`/api/voice` と admin knowledge は後段に分ける
+   - ADR 021 に従い、Next -> Vite/React 移行は `src/app/api` 削除後の build-tool 判断にする
+
+5. Documentation hygiene
+   - `docs/STATUS.md` を正本に維持
+   - alpha 系の過去 plan は archive 候補
+   - runbook は「どの live script をいつ使うか」に集約


### PR DESCRIPTION
## Summary
- Rebaseline ADR 016 for post-alpha STT latency: preserve Qwen accuracy while reducing first-hop transcript delay
- Add ADR 021 for frontend/backend separation before any React/Vite migration
- Add a post-alpha scope document covering voice, RAG/LangGraph, issue triage, and frontend separation

## Verification
- git diff --check