### PR TITLE
[codex] Instrument STT latency breakdown

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,9 @@
 
 設計議論: [docs/architecture/HIERARCHICAL-RAG-ARCHITECTURE.md](docs/architecture/HIERARCHICAL-RAG-ARCHITECTURE.md)
 
+音声・スライド音源の現行判断:
+[docs/architecture/stt-tts-stack-and-slide-audio-2026-05-09.md](docs/architecture/stt-tts-stack-and-slide-audio-2026-05-09.md)
+
 ---
 
 ## アーキテクチャ（概要）
@@ -83,13 +86,13 @@ make dev
 | 1 | [docs/STATUS.md](docs/STATUS.md) |
 | 2 | [docs/README.md](docs/README.md) |
 | 3 | [docs/architecture/SYSTEM-ARCHITECTURE.md](docs/architecture/SYSTEM-ARCHITECTURE.md) |
-| 4 | [docs/DEVELOPER-GUIDE.md](docs/DEVELOPER-GUIDE.md) |
-| 5 | [CLAUDE.md](CLAUDE.md) |
-| 6 | [frontend/README.md](frontend/README.md) / [backend/README.md](backend/README.md) |
+| 4 | [docs/architecture/stt-tts-stack-and-slide-audio-2026-05-09.md](docs/architecture/stt-tts-stack-and-slide-audio-2026-05-09.md) |
+| 5 | [docs/DEVELOPER-GUIDE.md](docs/DEVELOPER-GUIDE.md) |
+| 6 | [CLAUDE.md](CLAUDE.md) |
+| 7 | [frontend/README.md](frontend/README.md) / [backend/README.md](backend/README.md) |
 
 計画のみ: [docs/plans/comprehensive-refactoring-plan-2026-05-05.md](docs/plans/comprehensive-refactoring-plan-2026-05-05.md)
 
 ---
 
 古い Mastra 前提の長文は [docs/archive/](docs/archive/) にあります。現行は **STATUS.md** とコードを優先してください。
-

--- a/THIRD_PARTY_LICENSES.md
+++ b/THIRD_PARTY_LICENSES.md
@@ -5,7 +5,7 @@
 
 プロジェクト自体のライセンスは [LICENSE](./LICENSE) を参照してください（OSS リリース時）。
 
-最終更新: 2026-04-24
+最終更新: 2026-05-09
 
 ---
 
@@ -180,7 +180,7 @@
 
 | Engine / Voice | License | Source | Notes |
 |---|---|---|---|
-| Piper-plus TTS | MIT | https://github.com/OHF-voice/piper1-gpl | `docker/piper-plus/README.md` 参照、ja+en bilingual |
+| Piper-plus TTS | MIT | https://github.com/OHF-voice/piper1-gpl | `docker/piper-plus/README.md` 参照、ja+en bilingual。現行 production TTS primary |
 | VoiceVox Engine | LGPL-3.0 | https://github.com/VOICEVOX/voicevox_engine | `docker-compose.yml: image: voicevox/voicevox_engine:latest` |
 | Tsukuyomi-chan (VoiceVox 話者) | 独自 (VoiceVox 利用規約) | https://tyc.rei-yumesaki.net/ | つくよみちゃん利用規約準拠、クレジット表記必要 |
 | Google Cloud Text-to-Speech | Google Cloud 利用規約 | https://cloud.google.com/text-to-speech | ランタイム依存、ローカル再配布なし |
@@ -211,15 +211,21 @@
 
 ## 5. 独立系の Static Assets / 音声アセット
 
-本 repo に含まれる音声ファイル (`frontend/public/audio/` など) は以下のソースに由来します:
+本 repo に含まれる音声ファイル (`frontend/public/reception/audio/`、`backend/static/fillers/` など)
+は以下のソースに由来します:
 
-- ナレーション音源: プロジェクト内生成 (Piper-plus / VoiceVox / Google TTS のいずれか)
-- 効果音・BGM: 該当なし (2026-04-24 時点)
+- 受付 PDF ナレーション音源: プロジェクト内生成 (現行方針は Piper-plus)
+- filler 音源: プロジェクト内生成 (Piper-plus、fallback WAV を含む)
+- 効果音・BGM: 該当なし (2026-05-09 時点)
 
 > プロジェクト内で生成された TTS 出力については、元エンジン (VoiceVox/Piper-plus/GCP TTS) の
 > ライセンス・利用規約が派生物にも適用されます。特に **つくよみちゃん** を使った TTS 出力は
 > つくよみちゃん利用規約 (https://tyc.rei-yumesaki.net/about/terms/) の記載に従い、
 > 商用利用・公開時にクレジット表記が必要です。
+
+現行の音声・スライドアセット判断は
+[`docs/architecture/stt-tts-stack-and-slide-audio-2026-05-09.md`](docs/architecture/stt-tts-stack-and-slide-audio-2026-05-09.md)
+を参照してください。
 
 ---
 

--- a/backend/agents/stt_agent.py
+++ b/backend/agents/stt_agent.py
@@ -242,10 +242,40 @@ AUDIO_CONVERSION_ERROR_PREFIX = "Failed to convert WebM audio to WAV for STT tra
 PYDUB_IMPORT_ERROR = (
     "WebM audio conversion requires pydub. Install backend dependencies with pydub included."
 )
+_MEDIA_CONTAINER_SIGNATURES = (
+    b"\x1a\x45\xdf\xa3",  # WebM / Matroska EBML
+    b"OggS",
+    b"fLaC",
+    b"ID3",
+)
 
 
 def _duration_ms(started_at: float) -> int:
     return int((time.perf_counter() - started_at) * 1000)
+
+
+def _looks_like_non_wav_media(audio_data: bytes) -> bool:
+    return any(audio_data.startswith(signature) for signature in _MEDIA_CONTAINER_SIGNATURES)
+
+
+def _wav_metadata(audio_data: bytes) -> dict[str, Any]:
+    if not audio_data.startswith(WAV_RIFF_HEADER) or len(audio_data) < MIN_WAV_HEADER_BYTES:
+        return {}
+
+    try:
+        with wave.open(io.BytesIO(audio_data), "rb") as wav_file:
+            frame_count = wav_file.getnframes()
+            sample_rate = wav_file.getframerate()
+            duration_ms = int((frame_count / sample_rate) * 1000) if sample_rate else None
+            return {
+                "audio_sample_rate_hz": sample_rate,
+                "audio_channels": wav_file.getnchannels(),
+                "audio_sample_width_bytes": wav_file.getsampwidth(),
+                "audio_frame_count": frame_count,
+                "audio_duration_ms": duration_ms,
+            }
+    except Exception as exc:
+        return {"audio_probe_error_type": type(exc).__name__}
 
 
 def _parse_qwen_stt_timeout(raw_value: Optional[str], default: float = 24.0) -> float:
@@ -998,14 +1028,14 @@ class LocalSTTClient:
         logger.info("Converted non-WAV audio payload to 16kHz/16-bit/mono WAV for Vosk")
         return wav_bytes
 
-    def _load_model(self, lang: str):
+    def _load_model(self, lang: str, *, stt_trace_id: Optional[str] = None):
         if lang not in self.model_paths:
             raise ValueError(
                 f"Unsupported language: {lang}. Supported: {list(self.model_paths.keys())}"
             )
 
         if lang in self._models:
-            return self._models[lang]
+            return self._models[lang], 0
 
         try:
             from vosk import Model
@@ -1021,9 +1051,19 @@ class LocalSTTClient:
                 f"Download from https://alphacephei.com/vosk/models"
             )
 
+        load_started_at = time.perf_counter()
         self._models[lang] = Model(model_path)
+        load_duration_ms = _duration_ms(load_started_at)
         logger.info("Loaded Vosk %s model from %s", lang, model_path)
-        return self._models[lang]
+        log_stt_event(
+            event="stt_model_load_complete",
+            stt_trace_id=stt_trace_id,
+            provider="vosk",
+            language=lang,
+            model_path=model_path,
+            stt_model_load_duration_ms=load_duration_ms,
+        )
+        return self._models[lang], load_duration_ms
 
     @staticmethod
     def _resample_to_16khz(frames: bytes, orig_rate: int) -> tuple[bytes, int]:
@@ -1064,107 +1104,192 @@ class LocalSTTClient:
         audio_data: bytes,
         language: str = "ja",
         grammar: Optional[List[str]] = None,
+        *,
+        stt_trace_id: Optional[str] = None,
     ) -> TranscriptionResult:
         """Synchronous Vosk transcription (called via thread pool).
 
         注意: 入力は WAV (PCM) で、可能であれば 16kHz, 16bit, mono を推奨します。
         非16kHz音声は自動的に16kHzにリサンプルされます。
         """
-        import wave
-
-        if audio_data[:4] == WAV_RIFF_HEADER:
-            if len(audio_data) < MIN_WAV_HEADER_BYTES:
-                raise ValueError(TRUNCATED_WAV_AUDIO_ERROR)
-        else:
-            audio_data = self._convert_audio_to_wav(audio_data)
-
-        from vosk import KaldiRecognizer
-
-        bio = io.BytesIO(audio_data)
-        with wave.open(bio, "rb") as wf:
-            sample_rate = wf.getframerate()
-            nchannels = wf.getnchannels()
-            sampwidth = wf.getsampwidth()
-            frames = wf.readframes(wf.getnframes())
-
-        if sampwidth != 2:
-            raise ValueError(
-                f"Unsupported sample width: {sampwidth} bytes (only 16-bit PCM supported)"
-            )
-
-        if nchannels > 1:
-            audio_np = np.frombuffer(frames, dtype=np.int16).reshape(-1, nchannels)
-            frames = audio_np.mean(axis=1).astype(np.int16).tobytes()
-            logger.info("Downmixed %d-channel audio to mono", nchannels)
-
-        if sample_rate != 16000:
-            logger.info(
-                "Received sample rate %dHz — resampling to 16000Hz for Vosk.",
-                sample_rate,
-            )
-            frames, sample_rate = self._resample_to_16khz(frames, sample_rate)
-
-        model = self._load_model(language)
-
-        if grammar:
-            grammar_json = json.dumps(grammar)
-            rec = KaldiRecognizer(model, sample_rate, grammar_json)
-        else:
-            rec = KaldiRecognizer(model, sample_rate)
-
-        rec.SetWords(True)
-        rec.AcceptWaveform(frames)
-        result_json = rec.FinalResult()
+        runtime_started_at = time.perf_counter()
+        audio_conversion_duration_ms = 0
+        wav_decode_duration_ms = 0
+        downmix_duration_ms = 0
+        resample_duration_ms = 0
+        model_load_duration_ms = 0
+        recognition_duration_ms = 0
+        audio_metadata: dict[str, Any] = {}
+        conversion_required = not audio_data.startswith(WAV_RIFF_HEADER)
 
         try:
-            result = json.loads(result_json)
-        except Exception:
-            logger.error("Failed to parse Vosk result: %s", result_json)
-            raise RuntimeError("Failed to parse Vosk recognition result")
+            if audio_data[:4] == WAV_RIFF_HEADER:
+                if len(audio_data) < MIN_WAV_HEADER_BYTES:
+                    raise ValueError(TRUNCATED_WAV_AUDIO_ERROR)
+            else:
+                conversion_started_at = time.perf_counter()
+                audio_data = self._convert_audio_to_wav(audio_data)
+                audio_conversion_duration_ms = _duration_ms(conversion_started_at)
 
-        text = result.get("text", "")
+            from vosk import KaldiRecognizer
 
-        # Extract word-level confidences
-        word_results = result.get("result", [])
-        word_confidences = [
-            {"word": w.get("word", ""), "conf": w.get("conf", 0.0)} for w in word_results
-        ]
+            wav_decode_started_at = time.perf_counter()
+            bio = io.BytesIO(audio_data)
+            with wave.open(bio, "rb") as wf:
+                sample_rate = wf.getframerate()
+                nchannels = wf.getnchannels()
+                sampwidth = wf.getsampwidth()
+                frame_count = wf.getnframes()
+                frames = wf.readframes(frame_count)
+            wav_decode_duration_ms = _duration_ms(wav_decode_started_at)
+            audio_metadata = {
+                "audio_sample_rate_hz": sample_rate,
+                "audio_channels": nchannels,
+                "audio_sample_width_bytes": sampwidth,
+                "audio_frame_count": frame_count,
+                "audio_duration_ms": (
+                    int((frame_count / sample_rate) * 1000) if sample_rate else None
+                ),
+            }
 
-        # Compute average confidence
-        if word_confidences:
-            avg_confidence = sum(w["conf"] for w in word_confidences) / len(word_confidences)
-        else:
-            avg_confidence = None
+            if sampwidth != 2:
+                raise ValueError(
+                    f"Unsupported sample width: {sampwidth} bytes (only 16-bit PCM supported)"
+                )
 
-        # Fallback: assemble text from word results
-        if not text and word_results:
-            text = " ".join(w.get("word", "") for w in word_results).strip()
+            if nchannels > 1:
+                downmix_started_at = time.perf_counter()
+                audio_np = np.frombuffer(frames, dtype=np.int16).reshape(-1, nchannels)
+                frames = audio_np.mean(axis=1).astype(np.int16).tobytes()
+                downmix_duration_ms = _duration_ms(downmix_started_at)
+                logger.info("Downmixed %d-channel audio to mono", nchannels)
 
-        text = (text or "").strip()
-        if not text:
-            logger.warning("Vosk returned empty transcript")
-            raise RuntimeError("Vosk returned empty recognition result")
+            if sample_rate != 16000:
+                logger.info(
+                    "Received sample rate %dHz — resampling to 16000Hz for Vosk.",
+                    sample_rate,
+                )
+                resample_started_at = time.perf_counter()
+                frames, sample_rate = self._resample_to_16khz(frames, sample_rate)
+                resample_duration_ms = _duration_ms(resample_started_at)
 
-        logger.info("Vosk transcription success: %s", text[:100])
-        return TranscriptionResult(
-            text=text,
-            confidence=avg_confidence,
-            language=language,
-            word_confidences=word_confidences,
-        )
+            load_result = self._load_model(
+                language,
+                stt_trace_id=stt_trace_id,
+            )
+            if isinstance(load_result, tuple) and len(load_result) == 2:
+                model, model_load_duration_ms = load_result
+            else:
+                model = load_result
+                model_load_duration_ms = 0
+
+            if grammar:
+                grammar_json = json.dumps(grammar)
+                rec = KaldiRecognizer(model, sample_rate, grammar_json)
+            else:
+                rec = KaldiRecognizer(model, sample_rate)
+
+            recognition_started_at = time.perf_counter()
+            rec.SetWords(True)
+            rec.AcceptWaveform(frames)
+            result_json = rec.FinalResult()
+            recognition_duration_ms = _duration_ms(recognition_started_at)
+
+            try:
+                result = json.loads(result_json)
+            except Exception:
+                logger.error("Failed to parse Vosk result: %s", result_json)
+                raise RuntimeError("Failed to parse Vosk recognition result")
+
+            text = result.get("text", "")
+
+            # Extract word-level confidences
+            word_results = result.get("result", [])
+            word_confidences = [
+                {"word": w.get("word", ""), "conf": w.get("conf", 0.0)} for w in word_results
+            ]
+
+            # Compute average confidence
+            if word_confidences:
+                avg_confidence = sum(w["conf"] for w in word_confidences) / len(word_confidences)
+            else:
+                avg_confidence = None
+
+            # Fallback: assemble text from word results
+            if not text and word_results:
+                text = " ".join(w.get("word", "") for w in word_results).strip()
+
+            text = (text or "").strip()
+            if not text:
+                logger.warning("Vosk returned empty transcript")
+                raise RuntimeError("Vosk returned empty recognition result")
+
+            logger.info("Vosk transcription success: %s", text[:100])
+            log_stt_event(
+                event="stt_vosk_runtime_complete",
+                stt_trace_id=stt_trace_id,
+                provider="vosk-fallback",
+                language=language,
+                success=True,
+                conversion_required=conversion_required,
+                stt_vosk_runtime_duration_ms=_duration_ms(runtime_started_at),
+                stt_vosk_audio_conversion_duration_ms=audio_conversion_duration_ms,
+                stt_vosk_wav_decode_duration_ms=wav_decode_duration_ms,
+                stt_vosk_downmix_duration_ms=downmix_duration_ms,
+                stt_vosk_resample_duration_ms=resample_duration_ms,
+                stt_vosk_model_load_duration_ms=model_load_duration_ms,
+                stt_vosk_recognition_duration_ms=recognition_duration_ms,
+                transcript_chars=len(text),
+                confidence=avg_confidence,
+                grammar_enabled=bool(grammar),
+                **audio_metadata,
+            )
+            return TranscriptionResult(
+                text=text,
+                confidence=avg_confidence,
+                language=language,
+                word_confidences=word_confidences,
+            )
+        except Exception as exc:
+            log_stt_event(
+                event="stt_vosk_runtime_complete",
+                stt_trace_id=stt_trace_id,
+                provider="vosk-fallback",
+                language=language,
+                success=False,
+                error_type=type(exc).__name__,
+                conversion_required=conversion_required,
+                stt_vosk_runtime_duration_ms=_duration_ms(runtime_started_at),
+                stt_vosk_audio_conversion_duration_ms=audio_conversion_duration_ms,
+                stt_vosk_wav_decode_duration_ms=wav_decode_duration_ms,
+                stt_vosk_downmix_duration_ms=downmix_duration_ms,
+                stt_vosk_resample_duration_ms=resample_duration_ms,
+                stt_vosk_model_load_duration_ms=model_load_duration_ms,
+                stt_vosk_recognition_duration_ms=recognition_duration_ms,
+                grammar_enabled=bool(grammar),
+                **audio_metadata,
+            )
+            raise
 
     async def transcribe(
         self,
         audio_data: bytes,
         language: str = "ja",
         grammar: Optional[List[str]] = None,
+        *,
+        stt_trace_id: Optional[str] = None,
     ) -> TranscriptionResult:
         """WAVバイト列を受け取り、TranscriptionResult を返します (thread pool経由)。"""
         try:
             loop = asyncio.get_running_loop()
             return await loop.run_in_executor(
                 _get_vosk_stt_executor(),
-                lambda: self._sync_transcribe(audio_data, language, grammar),
+                lambda: self._sync_transcribe(
+                    audio_data,
+                    language,
+                    grammar,
+                    stt_trace_id=stt_trace_id,
+                ),
             )
         except ValueError as e:
             message = f"Invalid audio data for STT transcription: {e}"
@@ -1178,6 +1303,8 @@ class LocalSTTClient:
         self,
         audio_data: bytes,
         grammar: Optional[Dict[str, List[str]]] = None,
+        *,
+        stt_trace_id: Optional[str] = None,
     ) -> TranscriptionResult:
         """日英両モデルで並列認識し、confidence が高い方の結果を返す。
 
@@ -1192,7 +1319,12 @@ class LocalSTTClient:
         async def _run_model(lang: str) -> Optional[TranscriptionResult]:
             lang_grammar = (grammar or {}).get(lang)
             try:
-                return await self.transcribe(audio_data, lang, grammar=lang_grammar)
+                return await self.transcribe(
+                    audio_data,
+                    lang,
+                    grammar=lang_grammar,
+                    stt_trace_id=stt_trace_id,
+                )
             except (RuntimeError, ValueError) as e:
                 logger.debug("Auto-detect: %s model returned error: %s", lang, e)
                 return None
@@ -1347,9 +1479,9 @@ class QwenSTTClient:
             default_language,
         )
 
-    def _load_model(self) -> None:
+    def _load_model(self, *, stt_trace_id: Optional[str] = None) -> int:
         if self._model is not None:
-            return
+            return 0
 
         try:
             import torch
@@ -1376,54 +1508,167 @@ class QwenSTTClient:
             low_cpu_mem_usage=True,
             max_new_tokens=256,
         )
+        load_duration_ms = _duration_ms(load_started_at)
         log_stt_event(
             event="stt_model_load_complete",
-            stt_model_load_duration_ms=_duration_ms(load_started_at),
+            stt_trace_id=stt_trace_id,
+            stt_model_load_duration_ms=load_duration_ms,
             provider="qwen",
             model_name=self.model_name,
             model_variant=self.model_variant,
             device=self.device,
         )
+        return load_duration_ms
 
     def _sync_transcribe(
         self,
         audio_data: bytes,
         language: Optional[str] = None,
+        *,
+        stt_trace_id: Optional[str] = None,
     ) -> TranscriptionResult:
-        self._load_model()
-
-        if audio_data[:4] == WAV_RIFF_HEADER:
-            if len(audio_data) < MIN_WAV_HEADER_BYTES:
-                raise ValueError(TRUNCATED_WAV_AUDIO_ERROR)
-        else:
-            audio_data = convert_audio_to_wav_bytes(audio_data)
-
-        lang_code = language  # preserve None for auto-detect
-        qwen_language = self.LANGUAGE_NAMES.get(lang_code, lang_code) if lang_code else None
+        runtime_started_at = time.perf_counter()
+        model_load_duration_ms = 0
+        audio_conversion_duration_ms = 0
+        wav_decode_duration_ms = 0
+        pcm_prepare_duration_ms = 0
+        inference_duration_ms = 0
+        audio_metadata: dict[str, Any] = {}
+        conversion_required = not audio_data.startswith(WAV_RIFF_HEADER)
 
         try:
+            load_duration = self._load_model(stt_trace_id=stt_trace_id)
+            model_load_duration_ms = load_duration if isinstance(load_duration, int) else 0
+
+            if audio_data[:4] == WAV_RIFF_HEADER:
+                if len(audio_data) < MIN_WAV_HEADER_BYTES:
+                    raise ValueError(TRUNCATED_WAV_AUDIO_ERROR)
+            else:
+                conversion_started_at = time.perf_counter()
+                audio_data = convert_audio_to_wav_bytes(audio_data)
+                audio_conversion_duration_ms = _duration_ms(conversion_started_at)
+
+            lang_code = language  # preserve None for auto-detect
+            qwen_language = self.LANGUAGE_NAMES.get(lang_code, lang_code) if lang_code else None
+
+            wav_decode_started_at = time.perf_counter()
             with wave.open(io.BytesIO(audio_data), "rb") as wav_file:
                 sample_rate = wav_file.getframerate()
-                frames = wav_file.readframes(wav_file.getnframes())
+                frame_count = wav_file.getnframes()
+                channels = wav_file.getnchannels()
+                sample_width = wav_file.getsampwidth()
+                frames = wav_file.readframes(frame_count)
+            wav_decode_duration_ms = _duration_ms(wav_decode_started_at)
+            audio_metadata = {
+                "audio_sample_rate_hz": sample_rate,
+                "audio_channels": channels,
+                "audio_sample_width_bytes": sample_width,
+                "audio_frame_count": frame_count,
+                "audio_duration_ms": (
+                    int((frame_count / sample_rate) * 1000) if sample_rate else None
+                ),
+            }
 
+            pcm_prepare_started_at = time.perf_counter()
             pcm = np.frombuffer(frames, dtype=np.int16).astype(np.float32) / 32768.0
+            pcm_prepare_duration_ms = _duration_ms(pcm_prepare_started_at)
 
             kwargs: Dict[str, Any] = {"audio": (pcm, sample_rate)}
             if qwen_language:
                 kwargs["language"] = qwen_language
 
+            inference_started_at = time.perf_counter()
             results = self._model.transcribe(**kwargs)
+            inference_duration_ms = _duration_ms(inference_started_at)
             result = results[0] if results else None
             text = (getattr(result, "text", "") or "").strip() if result else ""
             detected_language = getattr(result, "language", None) if result else None
         except wave.Error as exc:
+            log_stt_event(
+                event="stt_qwen_runtime_complete",
+                stt_trace_id=stt_trace_id,
+                provider="qwen-primary",
+                model_name=self.model_name,
+                model_variant=self.model_variant,
+                device=self.device,
+                language=language,
+                success=False,
+                error_type="WaveError",
+                conversion_required=conversion_required,
+                stt_qwen_runtime_duration_ms=_duration_ms(runtime_started_at),
+                stt_qwen_model_load_duration_ms=model_load_duration_ms,
+                stt_qwen_audio_conversion_duration_ms=audio_conversion_duration_ms,
+                stt_qwen_wav_decode_duration_ms=wav_decode_duration_ms,
+                stt_qwen_pcm_prepare_duration_ms=pcm_prepare_duration_ms,
+                stt_qwen_model_inference_duration_ms=inference_duration_ms,
+                **audio_metadata,
+            )
             raise ValueError(f"Invalid WAV audio for Qwen STT transcription: {exc}") from exc
+        except Exception as exc:
+            log_stt_event(
+                event="stt_qwen_runtime_complete",
+                stt_trace_id=stt_trace_id,
+                provider="qwen-primary",
+                model_name=self.model_name,
+                model_variant=self.model_variant,
+                device=self.device,
+                language=language,
+                success=False,
+                error_type=type(exc).__name__,
+                conversion_required=conversion_required,
+                stt_qwen_runtime_duration_ms=_duration_ms(runtime_started_at),
+                stt_qwen_model_load_duration_ms=model_load_duration_ms,
+                stt_qwen_audio_conversion_duration_ms=audio_conversion_duration_ms,
+                stt_qwen_wav_decode_duration_ms=wav_decode_duration_ms,
+                stt_qwen_pcm_prepare_duration_ms=pcm_prepare_duration_ms,
+                stt_qwen_model_inference_duration_ms=inference_duration_ms,
+                **audio_metadata,
+            )
+            raise
 
         if not text:
+            log_stt_event(
+                event="stt_qwen_runtime_complete",
+                stt_trace_id=stt_trace_id,
+                provider="qwen-primary",
+                model_name=self.model_name,
+                model_variant=self.model_variant,
+                device=self.device,
+                language=language,
+                success=False,
+                error_type="EmptyRecognitionResult",
+                conversion_required=conversion_required,
+                stt_qwen_runtime_duration_ms=_duration_ms(runtime_started_at),
+                stt_qwen_model_load_duration_ms=model_load_duration_ms,
+                stt_qwen_audio_conversion_duration_ms=audio_conversion_duration_ms,
+                stt_qwen_wav_decode_duration_ms=wav_decode_duration_ms,
+                stt_qwen_pcm_prepare_duration_ms=pcm_prepare_duration_ms,
+                stt_qwen_model_inference_duration_ms=inference_duration_ms,
+                **audio_metadata,
+            )
             raise RuntimeError("Qwen3-ASR returned empty recognition result")
 
         normalized_lang = self._normalize_language_code(detected_language)
         logger.info("Qwen transcription success (%s): %s", self.model_variant, text[:100])
+        log_stt_event(
+            event="stt_qwen_runtime_complete",
+            stt_trace_id=stt_trace_id,
+            provider="qwen-primary",
+            model_name=self.model_name,
+            model_variant=self.model_variant,
+            device=self.device,
+            language=normalized_lang or lang_code or self.default_language,
+            success=True,
+            transcript_chars=len(text),
+            conversion_required=conversion_required,
+            stt_qwen_runtime_duration_ms=_duration_ms(runtime_started_at),
+            stt_qwen_model_load_duration_ms=model_load_duration_ms,
+            stt_qwen_audio_conversion_duration_ms=audio_conversion_duration_ms,
+            stt_qwen_wav_decode_duration_ms=wav_decode_duration_ms,
+            stt_qwen_pcm_prepare_duration_ms=pcm_prepare_duration_ms,
+            stt_qwen_model_inference_duration_ms=inference_duration_ms,
+            **audio_metadata,
+        )
         return TranscriptionResult(
             text=text,
             confidence=None,
@@ -1435,11 +1680,13 @@ class QwenSTTClient:
         self,
         audio_data: bytes,
         language: Optional[str] = None,
+        *,
+        stt_trace_id: Optional[str] = None,
     ) -> TranscriptionResult:
         loop = asyncio.get_running_loop()
         result = await loop.run_in_executor(
             _get_qwen_stt_executor(),
-            lambda: self._sync_transcribe(audio_data, language),
+            lambda: self._sync_transcribe(audio_data, language, stt_trace_id=stt_trace_id),
         )
 
         # Apply LLM post-processing for Japanese transcripts to correct
@@ -1447,8 +1694,21 @@ class QwenSTTClient:
         # Env-toggled (STT_QWEN_POSTPROCESS_ENABLED), falls back to raw on
         # any failure, guarded by edit-distance threshold.
         if result.language == "ja" and result.text.strip():
+            postprocess_started_at = time.perf_counter()
             try:
                 corrected_text = await _qwen_llm_post_process(result.text, result.language)
+                log_stt_event(
+                    event="stt_qwen_postprocess_complete",
+                    stt_trace_id=stt_trace_id,
+                    provider="qwen-primary",
+                    language=result.language,
+                    success=True,
+                    changed=corrected_text != result.text,
+                    enabled=_qwen_postprocess_enabled(),
+                    transcript_chars=len(result.text),
+                    corrected_chars=len(corrected_text),
+                    stt_qwen_postprocess_duration_ms=_duration_ms(postprocess_started_at),
+                )
                 if corrected_text != result.text:
                     result = TranscriptionResult(
                         text=corrected_text,
@@ -1458,6 +1718,17 @@ class QwenSTTClient:
                     )
             except Exception as exc:
                 logger.warning("Qwen post-process wrapper failed: %s", exc)
+                log_stt_event(
+                    event="stt_qwen_postprocess_complete",
+                    stt_trace_id=stt_trace_id,
+                    provider="qwen-primary",
+                    language=result.language,
+                    success=False,
+                    error_type=type(exc).__name__,
+                    enabled=_qwen_postprocess_enabled(),
+                    transcript_chars=len(result.text),
+                    stt_qwen_postprocess_duration_ms=_duration_ms(postprocess_started_at),
+                )
 
         return result
 
@@ -1788,6 +2059,55 @@ class STTAgent:
 
         return transcript
 
+    async def _prepare_qwen_primary_audio(
+        self,
+        audio_data: bytes,
+        *,
+        stt_trace_id: str,
+        language: Optional[str],
+    ) -> bytes:
+        """Prepare shared audio once before the Qwen/Vosk hedge race."""
+
+        prepare_started_at = time.perf_counter()
+        conversion_duration_ms = 0
+        conversion_attempted = False
+        conversion_required = not audio_data.startswith(WAV_RIFF_HEADER)
+        output_audio = audio_data
+        success = True
+        error_type: str | None = None
+
+        try:
+            if audio_data.startswith(WAV_RIFF_HEADER):
+                if len(audio_data) < MIN_WAV_HEADER_BYTES:
+                    raise ValueError(TRUNCATED_WAV_AUDIO_ERROR)
+            elif _looks_like_non_wav_media(audio_data):
+                conversion_attempted = True
+                conversion_started_at = time.perf_counter()
+                output_audio = await asyncio.to_thread(convert_audio_to_wav_bytes, audio_data)
+                conversion_duration_ms = _duration_ms(conversion_started_at)
+        except Exception as exc:
+            success = False
+            error_type = type(exc).__name__
+            output_audio = audio_data
+            logger.warning("qwen-primary shared audio preparation failed: %s", exc)
+
+        log_stt_event(
+            event="stt_audio_prepare_complete",
+            stt_trace_id=stt_trace_id,
+            provider="qwen-primary",
+            language=language,
+            success=success,
+            error_type=error_type,
+            conversion_required=conversion_required,
+            conversion_attempted=conversion_attempted,
+            input_audio_bytes=len(audio_data),
+            prepared_audio_bytes=len(output_audio),
+            stt_audio_prepare_duration_ms=_duration_ms(prepare_started_at),
+            stt_audio_conversion_duration_ms=conversion_duration_ms,
+            **_wav_metadata(output_audio),
+        )
+        return output_audio
+
     async def _transcribe_qwen_primary(
         self,
         audio_data: bytes,
@@ -1803,6 +2123,12 @@ class STTAgent:
         stt_trace_id = f"stt-{uuid.uuid4().hex[:12]}"
         overall_started_at = time.perf_counter()
         qwen_postprocess_enabled = _qwen_postprocess_enabled()
+
+        audio_data = await self._prepare_qwen_primary_audio(
+            audio_data,
+            stt_trace_id=stt_trace_id,
+            language=language,
+        )
 
         async def _run_qwen():
             qwen_started_at = time.perf_counter()
@@ -1820,7 +2146,11 @@ class STTAgent:
             )
             try:
                 result = await asyncio.wait_for(
-                    self.stt_client.transcribe(audio_data, language=language),
+                    self.stt_client.transcribe(
+                        audio_data,
+                        language=language,
+                        stt_trace_id=stt_trace_id,
+                    ),
                     timeout=self._qwen_timeout,
                 )
             except asyncio.CancelledError:
@@ -1873,9 +2203,16 @@ class STTAgent:
             )
             try:
                 if language is None:
-                    result = await self._vosk_fallback_client.transcribe_auto_detect(audio_data)
+                    result = await self._vosk_fallback_client.transcribe_auto_detect(
+                        audio_data,
+                        stt_trace_id=stt_trace_id,
+                    )
                 else:
-                    result = await self._vosk_fallback_client.transcribe(audio_data, language)
+                    result = await self._vosk_fallback_client.transcribe(
+                        audio_data,
+                        language,
+                        stt_trace_id=stt_trace_id,
+                    )
             except asyncio.CancelledError:
                 log_stt_event(
                     event="stt_vosk_complete",
@@ -2009,6 +2346,9 @@ class STTAgent:
             qwen_result: TranscriptionResult | Exception | None = None
             vosk_result: TranscriptionResult | Exception | None = None
             qwen_error_for_log: Exception | None = None
+            hedge_started = False
+            hedge_wait_duration_ms: int | None = None
+            grace_wait_duration_ms: int | None = None
 
             if self._qwen_hedge_delay is None:
                 try:
@@ -2023,6 +2363,8 @@ class STTAgent:
                         timeout=self._qwen_hedge_delay,
                     )
                 except asyncio.TimeoutError:
+                    hedge_started = True
+                    hedge_wait_duration_ms = _duration_ms(overall_started_at)
                     qwen_error_for_log = HedgedFallback(
                         f"Qwen exceeded hedge delay {self._qwen_hedge_delay:.2f}s"
                     )
@@ -2033,6 +2375,7 @@ class STTAgent:
                         language=language,
                         success=False,
                         stt_qwen_duration_ms=_duration_ms(overall_started_at),
+                        stt_hedge_wait_duration_ms=hedge_wait_duration_ms,
                         hedge_delay_s=self._qwen_hedge_delay,
                         hedge_grace_s=self._qwen_hedge_grace,
                         latency_budget_s=self._qwen_latency_budget,
@@ -2094,6 +2437,7 @@ class STTAgent:
                                 )
                                 remaining_budget = 0.0
                             if remaining_budget > 0:
+                                grace_started_at = time.perf_counter()
                                 log_stt_event(
                                     event="stt_qwen_hedge_grace_start",
                                     stt_trace_id=stt_trace_id,
@@ -2110,7 +2454,9 @@ class STTAgent:
                                         asyncio.shield(qwen_task),
                                         timeout=remaining_budget,
                                     )
+                                    grace_wait_duration_ms = _duration_ms(grace_started_at)
                                 except asyncio.TimeoutError:
+                                    grace_wait_duration_ms = _duration_ms(grace_started_at)
                                     log_stt_event(
                                         event="stt_qwen_hedge_grace_complete",
                                         stt_trace_id=stt_trace_id,
@@ -2121,6 +2467,7 @@ class STTAgent:
                                         hedge_grace_s=self._qwen_hedge_grace,
                                         latency_budget_s=self._qwen_latency_budget,
                                         effective_hedge_grace_s=remaining_budget,
+                                        stt_qwen_grace_wait_duration_ms=grace_wait_duration_ms,
                                         stt_qwen_duration_ms=_duration_ms(overall_started_at),
                                     )
                                 except Exception as exc:
@@ -2147,6 +2494,9 @@ class STTAgent:
                         language=qwen_result.language,
                         success=True,
                         stt_overall_duration_ms=_duration_ms(overall_started_at),
+                        stt_hedge_started=hedge_started,
+                        stt_hedge_wait_duration_ms=hedge_wait_duration_ms,
+                        stt_qwen_grace_wait_duration_ms=grace_wait_duration_ms,
                         hedge_grace_s=self._qwen_hedge_grace,
                         qwen_postprocess_enabled=qwen_postprocess_enabled,
                     )
@@ -2223,6 +2573,9 @@ class STTAgent:
                             language=qwen_result.language,
                             success=True,
                             stt_overall_duration_ms=_duration_ms(overall_started_at),
+                            stt_hedge_started=hedge_started,
+                            stt_hedge_wait_duration_ms=hedge_wait_duration_ms,
+                            stt_qwen_grace_wait_duration_ms=grace_wait_duration_ms,
                             hedge_grace_s=self._qwen_hedge_grace,
                             qwen_postprocess_enabled=qwen_postprocess_enabled,
                             vosk_error_type=type(vosk_result).__name__,
@@ -2251,6 +2604,9 @@ class STTAgent:
                     language=vosk_result.language,
                     success=True,
                     stt_overall_duration_ms=_duration_ms(overall_started_at),
+                    stt_hedge_started=hedge_started,
+                    stt_hedge_wait_duration_ms=hedge_wait_duration_ms,
+                    stt_qwen_grace_wait_duration_ms=grace_wait_duration_ms,
                     hedge_grace_s=self._qwen_hedge_grace,
                     vosk_postprocessed=postprocessed,
                     qwen_error_type=type(qwen_error_for_log).__name__,
@@ -2271,6 +2627,9 @@ class STTAgent:
                 stt_winner="none",
                 success=False,
                 stt_overall_duration_ms=_duration_ms(overall_started_at),
+                stt_hedge_started=hedge_started,
+                stt_hedge_wait_duration_ms=hedge_wait_duration_ms,
+                stt_qwen_grace_wait_duration_ms=grace_wait_duration_ms,
                 qwen_error_type=type(qwen_error_for_log).__name__,
                 vosk_error_type=type(vosk_result).__name__,
             )

--- a/backend/main.py
+++ b/backend/main.py
@@ -28,7 +28,7 @@ from starlette.middleware.base import BaseHTTPMiddleware
 from starlette.requests import Request
 
 from backend.tools.calendar_service import CalendarService, TimeRange
-from backend.observability.structured_logger import log_chat_response
+from backend.observability.structured_logger import log_chat_response, log_stt_event
 from backend.services.stt_warmup_service import get_stt_warmup_service
 from backend.utils.structured_logging import (
     get_request_id,
@@ -1229,10 +1229,13 @@ async def _handle_stt(body: VoiceRequest, request_id: str) -> VoiceResponse:
     if not body.audioData:
         raise HTTPException(status_code=400, detail="Missing audioData")
 
+    stt_request_started_at = time.perf_counter()
+    decode_started_at = time.perf_counter()
     try:
         audio_bytes = base64.b64decode(body.audioData, validate=True)
     except (binascii.Error, ValueError):
         raise HTTPException(status_code=400, detail="Invalid audioData")
+    base64_decode_duration_ms = int((time.perf_counter() - decode_started_at) * 1000)
 
     if len(audio_bytes) < MIN_STT_AUDIO_BYTES:
         logger.info(
@@ -1240,6 +1243,17 @@ async def _handle_stt(body: VoiceRequest, request_id: str) -> VoiceResponse:
             request_id,
             len(audio_bytes),
             MIN_STT_AUDIO_BYTES,
+        )
+        log_stt_event(
+            event="stt_request_complete",
+            request_id=request_id,
+            provider=os.getenv("STT_PROVIDER"),
+            language=body.language,
+            success=False,
+            error_type="AudioTooShort",
+            audio_bytes=len(audio_bytes),
+            stt_request_duration_ms=int((time.perf_counter() - stt_request_started_at) * 1000),
+            stt_base64_decode_duration_ms=base64_decode_duration_ms,
         )
         return _stt_failure_response(
             body=body,
@@ -1265,6 +1279,18 @@ async def _handle_stt(body: VoiceRequest, request_id: str) -> VoiceResponse:
             request_id,
             _voice_stt_request_timeout_seconds(),
         )
+        log_stt_event(
+            event="stt_request_complete",
+            request_id=request_id,
+            provider=os.getenv("STT_PROVIDER"),
+            language=body.language,
+            success=False,
+            error_type="TimeoutError",
+            audio_bytes=len(audio_bytes),
+            timeout_s=_voice_stt_request_timeout_seconds(),
+            stt_request_duration_ms=int((time.perf_counter() - stt_request_started_at) * 1000),
+            stt_base64_decode_duration_ms=base64_decode_duration_ms,
+        )
         return _stt_failure_response(
             body=body,
             request_id=request_id,
@@ -1274,6 +1300,17 @@ async def _handle_stt(body: VoiceRequest, request_id: str) -> VoiceResponse:
         )
     except RuntimeError as exc:
         logger.warning("STT runtime failure: %s", exc)
+        log_stt_event(
+            event="stt_request_complete",
+            request_id=request_id,
+            provider=os.getenv("STT_PROVIDER"),
+            language=body.language,
+            success=False,
+            error_type=type(exc).__name__,
+            audio_bytes=len(audio_bytes),
+            stt_request_duration_ms=int((time.perf_counter() - stt_request_started_at) * 1000),
+            stt_base64_decode_duration_ms=base64_decode_duration_ms,
+        )
         return _stt_failure_response(
             body=body,
             request_id=request_id,
@@ -1282,6 +1319,17 @@ async def _handle_stt(body: VoiceRequest, request_id: str) -> VoiceResponse:
         )
 
     if not stt_result["success"]:
+        log_stt_event(
+            event="stt_request_complete",
+            request_id=request_id,
+            provider=stt_result.get("provider"),
+            language=body.language,
+            success=False,
+            error_type=stt_result.get("error"),
+            audio_bytes=len(audio_bytes),
+            stt_request_duration_ms=int((time.perf_counter() - stt_request_started_at) * 1000),
+            stt_base64_decode_duration_ms=base64_decode_duration_ms,
+        )
         return _stt_failure_response(
             body=body,
             request_id=request_id,
@@ -1289,6 +1337,17 @@ async def _handle_stt(body: VoiceRequest, request_id: str) -> VoiceResponse:
             provider=stt_result.get("provider"),
         )
 
+    log_stt_event(
+        event="stt_request_complete",
+        request_id=request_id,
+        provider=stt_result.get("provider"),
+        language=stt_result.get("language") or body.language,
+        success=True,
+        audio_bytes=len(audio_bytes),
+        transcript_chars=len(stt_result.get("transcript") or ""),
+        stt_request_duration_ms=int((time.perf_counter() - stt_request_started_at) * 1000),
+        stt_base64_decode_duration_ms=base64_decode_duration_ms,
+    )
     return VoiceResponse(
         success=True,
         transcript=stt_result["transcript"],

--- a/backend/tests/agents/test_stt_agent.py
+++ b/backend/tests/agents/test_stt_agent.py
@@ -10,7 +10,7 @@ import time
 import wave
 import numpy as np
 from types import SimpleNamespace
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import ANY, AsyncMock, MagicMock, patch
 
 from backend.agents.stt_agent import (
     MAX_AUDIO_UPLOAD_BYTES,
@@ -3079,8 +3079,12 @@ class TestQwenPrimaryFallback:
         assert result["success"] is True
         assert result["provider"] == "vosk-fallback"
         assert result["transcript"] == "fallback ok"
-        mock_qwen.transcribe.assert_called_once_with(b"audio", language="en")
-        mock_vosk.transcribe.assert_called_once_with(b"audio", "en")
+        mock_qwen.transcribe.assert_called_once_with(
+            b"audio",
+            language="en",
+            stt_trace_id=ANY,
+        )
+        mock_vosk.transcribe.assert_called_once_with(b"audio", "en", stt_trace_id=ANY)
 
         stt_records = [
             record for record in caplog.records if record.name == "backend.observability.stt"
@@ -3119,8 +3123,12 @@ class TestQwenPrimaryFallback:
         assert result["success"] is True
         assert result["provider"] == "vosk-fallback"
         assert result["transcript"] == "fallback ok"
-        mock_qwen.transcribe.assert_called_once_with(b"audio", language="en")
-        mock_vosk.transcribe.assert_called_once_with(b"audio", "en")
+        mock_qwen.transcribe.assert_called_once_with(
+            b"audio",
+            language="en",
+            stt_trace_id=ANY,
+        )
+        mock_vosk.transcribe.assert_called_once_with(b"audio", "en", stt_trace_id=ANY)
 
         stt_records = [
             record for record in caplog.records if record.name == "backend.observability.stt"
@@ -3195,7 +3203,11 @@ class TestQwenPrimaryFallback:
 
         assert result["provider"] == "qwen-primary"
         assert result["language"] == "en"
-        mock_qwen.transcribe.assert_called_once_with(b"audio", language=None)
+        mock_qwen.transcribe.assert_called_once_with(
+            b"audio",
+            language=None,
+            stt_trace_id=ANY,
+        )
         mock_vosk.transcribe_auto_detect.assert_not_called()
 
     @pytest.mark.asyncio

--- a/backend/tests/e2e/test_stt_japanese_accuracy.py
+++ b/backend/tests/e2e/test_stt_japanese_accuracy.py
@@ -30,6 +30,8 @@ Run locally with:
 
 The aggregate accuracy assertion (>= 0.8) runs as a separate test that
 summarises per-sample pass/fail.
+Per-sample and aggregate tests share a session cache so the suite sends
+each sample through /api/voice only once.
 
 Future work
 -----------
@@ -157,6 +159,39 @@ async def _round_trip(client: httpx.AsyncClient, config: dict, text: str) -> str
     return await _transcribe_japanese(client, config, audio_b64)
 
 
+@pytest.fixture(scope="session")
+def stt_accuracy_result_cache() -> dict[str, tuple[bool, str]]:
+    """Share live round-trip results across per-sample and aggregate tests.
+
+    The backend /api/voice endpoint is intentionally rate-limited at 20/min.
+    Reusing the first-pass result avoids a false 429 failure while preserving
+    individual pytest visibility for each sample.
+    """
+
+    return {}
+
+
+async def _round_trip_cached(
+    client: httpx.AsyncClient,
+    config: dict,
+    sample_id: str,
+    text: str,
+    cache: dict[str, tuple[bool, str]],
+) -> str:
+    cached = cache.get(sample_id)
+    if cached is None:
+        try:
+            cached = (True, await _round_trip(client, config, text))
+        except Exception as exc:  # noqa: BLE001 - cache once to avoid duplicate live calls
+            cached = (False, f"{type(exc).__name__}: {exc}")
+        cache[sample_id] = cached
+
+    success, value = cached
+    if not success:
+        raise RuntimeError(value)
+    return value
+
+
 @pytest.mark.parametrize(
     "sample_id, ground_truth, required_substrings",
     JAPANESE_STT_SAMPLES,
@@ -167,6 +202,7 @@ async def test_japanese_stt_per_sample(
     ground_truth: str,
     required_substrings: List[str],
     live_backend_config: dict,
+    stt_accuracy_result_cache: dict[str, tuple[bool, str]],
 ) -> None:
     """Each sample's transcript must contain required substrings.
 
@@ -177,7 +213,13 @@ async def test_japanese_stt_per_sample(
     Fails surface as individual pytest failures so CI reports per-sample.
     """
     async with httpx.AsyncClient() as client:
-        transcript = await _round_trip(client, live_backend_config, ground_truth)
+        transcript = await _round_trip_cached(
+            client,
+            live_backend_config,
+            sample_id,
+            ground_truth,
+            stt_accuracy_result_cache,
+        )
 
     assert transcript, f"[{sample_id}] transcript was empty"
 
@@ -200,6 +242,7 @@ async def test_japanese_stt_per_sample(
 
 async def test_japanese_stt_aggregate_accuracy(
     live_backend_config: dict,
+    stt_accuracy_result_cache: dict[str, tuple[bool, str]],
 ) -> None:
     """Aggregate pass rate across all 10 samples must meet floor.
 
@@ -213,7 +256,13 @@ async def test_japanese_stt_aggregate_accuracy(
     async with httpx.AsyncClient() as client:
         for sample_id, ground_truth, required in JAPANESE_STT_SAMPLES:
             try:
-                transcript = await _round_trip(client, live_backend_config, ground_truth)
+                transcript = await _round_trip_cached(
+                    client,
+                    live_backend_config,
+                    sample_id,
+                    ground_truth,
+                    stt_accuracy_result_cache,
+                )
             except Exception as exc:  # noqa: BLE001 - capture for aggregate report
                 failed.append((sample_id, ground_truth, f"<error: {exc}>", 0.0))
                 continue

--- a/docs/adr/010-qwen-onnx-quantization.md
+++ b/docs/adr/010-qwen-onnx-quantization.md
@@ -6,6 +6,22 @@
 
 提案: **現時点のスコープでは Phase 2 の ONNX/INT4 実装へ進まない（No-Go）**
 
+2026-05-09 追記: この No-Go は「Optimum 標準 export を自前で進めない」という判断として
+維持する。一方で、Qwen3-ASR 公開後にコミュニティの ONNX CPU artifact / export tool が出て
+きたため、#529 の P1-A では「既存 PyTorch path の分解計測で model inference が支配的と
+確認できた場合に限り、コミュニティ ONNX artifact を候補 runtime として spike する」に更新する。
+production 採用前には license、supply-chain、model-card 再現性、Engineer Cafe 日本語/英語
+fixture 精度、Cloud Run メモリ/起動時間を別途 gate する。
+
+確認済みの外部候補:
+
+- Qwen 公式: `Qwen3-ASR-1.7B` / `Qwen3-ASR-0.6B` は 52 言語・方言の ASR/言語識別を
+  サポートすると説明されている。
+- `Daumee/Qwen3-ASR-0.6B-ONNX-CPU`: PyTorch 不要の ONNX Runtime CPU pipeline を公開。
+  model card では Intel N100 上の RTF と VAD chunking が示されている。
+- `andrewleech/qwen3-asr-onnx`: 0.6B/1.7B の ONNX export tool と INT4 artifact を公開。
+  README では CPU RTF / WER の参考値が示されている。
+
 ## 背景
 
 Issue #491 では、現在 PyTorch CPU で動かしている `Qwen/Qwen3-ASR-0.6B` を ONNX Runtime + INT4 量子化に変換し、STT レイテンシを現状の p50 約 4.0 秒から p50 1.5 秒へ下げることを狙っていた。

--- a/docs/adr/016-qwen-stt-phase2-profiling.md
+++ b/docs/adr/016-qwen-stt-phase2-profiling.md
@@ -37,6 +37,30 @@ P1-A として再優先化する。ユーザー指摘どおり、回答生成は
   まず p50/p95 の分解計測と候補 runtime の spike を行い、CPU path だけで不足する場合は
   GPU/remote STT/streaming partial transcript を明示的な比較対象にする。
 
+2026-05-09 implementation note:
+
+- `stt_request_complete`, `stt_audio_prepare_complete`, `stt_qwen_runtime_complete`,
+  `stt_qwen_postprocess_complete`, `stt_vosk_runtime_complete` を追加し、HTTP request、
+  base64 decode、shared audio preparation/conversion、Qwen model runtime、Qwen model inference、
+  postprocess、Vosk resample/recognition、hedge/grace wait を同じ `stt_trace_id` で追えるようにする。
+- WebM/Opus など明確な media container payload は `qwen-primary` の hedge race 前に一度だけ
+  WAV へ変換し、Qwen と Vosk が同じ prepared audio を使う。これにより二重変換の可能性を減らし、
+  変換コストを独立 metric として見る。
+- `scripts/profile_stt.sh` と `scripts/stt-postdeploy-logging-check.sh` は上記の詳細 timing を
+  summary に出す。次の live proof は、`stt_overall` だけでなく `qwen_model_inference`、
+  `audio_conversion`、`hedge_wait`、`qwen_grace_wait` のどれが支配的かを issue #529 に残す。
+
+外部 STT runtime 提案の扱い:
+
+- Qwen3-ASR の公式 repo / technical report は 0.6B/1.7B、52 言語・方言対応、0.6B の
+  accuracy-efficiency trade-off を明記しており、Qwen-first を維持する根拠はある。
+- `Daumee/Qwen3-ASR-0.6B-ONNX-CPU` と `andrewleech/qwen3-asr-onnx` により、ADR 010 時点で
+  blocked だった ONNX CPU path は「自前 export」ではなく「既存 artifact spike」として再評価可能。
+- ただし model card の RTF は Cloud Run CPU / Engineer Cafe fixtures / short Japanese voice
+  round-trip の証明ではない。#529 ではまず現行 path の内訳を計測し、`qwen_model_inference`
+  または model load が支配的な場合にだけ ONNX artifact / Google Cloud Speech-to-Text / GPU
+  を比較する。Vosk early winner への単純復帰は引き続き採用しない。
+
 ## 背景
 
 ADR 010 では Qwen3-ASR の ONNX/INT4 化を No-Go とした。理由は、Qwen3-ASR が

--- a/docs/architecture/stt-tts-stack-and-slide-audio-2026-05-09.md
+++ b/docs/architecture/stt-tts-stack-and-slide-audio-2026-05-09.md
@@ -1,0 +1,91 @@
+# STT / TTS Stack and Slide Audio Decision
+
+作成日: 2026-05-09
+
+## Status
+
+Accepted for the post-alpha baseline.
+
+This document closes the old OSS-release and slide-audio planning loop for
+#484, #492, #493, #494, #495, and #496. Future changes should be opened as
+new, concrete runtime or asset-management issues rather than reopening the
+old exploratory tickets.
+
+## Current Runtime Stack
+
+```mermaid
+flowchart LR
+  Browser["Kiosk browser / Next.js UI"]
+  VoiceProxy["Next.js /api/voice proxy"]
+  Backend["FastAPI /api/voice"]
+  STT["Qwen3-ASR 0.6B primary\nVosk fallback hedge"]
+  TTS["PiperPlus primary TTS"]
+  Filler["Static filler WAV catalog"]
+  Slides["ReceptionPdfGuide\nPDF + static MP3"]
+
+  Browser --> VoiceProxy --> Backend
+  Backend --> STT
+  Backend --> TTS
+  Backend --> Filler
+  Browser --> Slides
+```
+
+Production deploy sets `STT_PROVIDER=qwen-primary` and `TTS_PROVIDER=piper`.
+The STT path keeps Qwen-first accuracy and uses Vosk only as a fallback /
+hedged path. The STT latency work continues in #529; this document does not
+claim the `<1.5s` target is met.
+
+## Slide Narration
+
+The alpha slide path no longer depends on Marp playback. The runtime path is:
+
+- PDF assets:
+  - `frontend/public/reception/engineer-cafe-ja.pdf`
+  - `frontend/public/reception/engineer-cafe-en.pdf`
+- Static narration audio:
+  - `frontend/public/reception/audio/ja/01.mp3` through `05.mp3`
+  - `frontend/public/reception/audio/en/01.mp3` through `05.mp3`
+- Runtime component:
+  - `frontend/src/app/components/ReceptionPdfGuide.tsx`
+- Contract tests:
+  - `frontend/src/__tests__/reception-narration-assets.test.ts`
+  - `frontend/e2e/reception-pdf-guide.spec.ts`
+  - `frontend/e2e/slide-pdf-narration.spec.ts`
+
+The old D-series plan described CI-generated WAV/MP3 plus CDN versioning. For
+alpha, the simpler accepted architecture is checked-in PDF/MP3 assets under
+`frontend/public/reception`, served by the frontend host as immutable build
+assets. If the slide deck changes, regenerate the MP3 set in the same PR as the
+PDF/Markdown narration update and keep the page count tests green.
+
+## TTS Decision
+
+PiperPlus is the current production TTS stack. It is used for normal answer
+speech and for generated static narration/filler assets.
+
+Kokoro-82M remains a valid future research candidate, but it is not part of the
+alpha production stack. The Kokoro A/B issue is therefore closed as
+de-scoped, not failed. Reopen a new issue only if the production goal changes
+from "PiperPlus unified voice" to "compare TTS providers again".
+
+## License Summary
+
+| Component | Current role | License / terms | Repository artifact |
+| --- | --- | --- | --- |
+| Qwen3-ASR 0.6B | STT primary | Apache-2.0 | model downloaded by backend build |
+| Vosk small JA/EN | STT fallback | Apache-2.0 | model downloaded by backend build |
+| PiperPlus | TTS primary and generated audio source | MIT for engine/fork; generated voice output follows source voice terms | `docker/piper-plus`, generated MP3/WAV assets |
+| pdf.js (`pdfjs-dist`) | Reception PDF rendering | Apache-2.0 | frontend dependency |
+| Marp packages | Legacy / tooling only | MIT | not the alpha runtime slide path |
+
+The authoritative dependency and model inventory is
+`THIRD_PARTY_LICENSES.md`. This document is the architecture decision layer,
+not a legal opinion.
+
+## Operational Follow-up
+
+- #529 remains open for STT first-hop latency and runtime spike decisions.
+- #774 remains open for onsite hardening, including real M5Stack proof, DB/cron
+  load, and TTS provider fault recovery.
+- Any future slide-audio issue should be tied to a concrete defect such as a
+  missing MP3, wrong language, page-count mismatch, or frontend playback bug.

--- a/scripts/profile_stt.sh
+++ b/scripts/profile_stt.sh
@@ -210,13 +210,34 @@ for entry in logs:
 fieldnames = [
     "timestamp",
     "stt_trace_id",
+    "request_id",
     "event",
     "provider",
     "stt_winner",
     "success",
+    "stt_request_duration_ms",
+    "stt_base64_decode_duration_ms",
+    "stt_audio_prepare_duration_ms",
+    "stt_audio_conversion_duration_ms",
     "stt_qwen_duration_ms",
+    "stt_qwen_runtime_duration_ms",
+    "stt_qwen_model_load_duration_ms",
+    "stt_qwen_audio_conversion_duration_ms",
+    "stt_qwen_wav_decode_duration_ms",
+    "stt_qwen_pcm_prepare_duration_ms",
+    "stt_qwen_model_inference_duration_ms",
+    "stt_qwen_postprocess_duration_ms",
     "stt_vosk_duration_ms",
+    "stt_vosk_runtime_duration_ms",
+    "stt_vosk_audio_conversion_duration_ms",
+    "stt_vosk_wav_decode_duration_ms",
+    "stt_vosk_downmix_duration_ms",
+    "stt_vosk_resample_duration_ms",
+    "stt_vosk_model_load_duration_ms",
+    "stt_vosk_recognition_duration_ms",
     "stt_overall_duration_ms",
+    "stt_hedge_wait_duration_ms",
+    "stt_qwen_grace_wait_duration_ms",
     "stt_model_load_duration_ms",
     "language",
     "error_type",
@@ -252,16 +273,50 @@ def stats(values):
     }
 
 winner_events = [event for event in events if event.get("event") == "stt_winner"]
+request_events = [event for event in events if event.get("event") == "stt_request_complete"]
+audio_prepare_events = [
+    event for event in events if event.get("event") == "stt_audio_prepare_complete"
+]
 qwen_events = [event for event in events if event.get("event") == "stt_qwen_complete"]
+qwen_runtime_events = [
+    event for event in events if event.get("event") == "stt_qwen_runtime_complete"
+]
+qwen_postprocess_events = [
+    event for event in events if event.get("event") == "stt_qwen_postprocess_complete"
+]
 vosk_events = [event for event in events if event.get("event") == "stt_vosk_complete"]
+vosk_runtime_events = [
+    event for event in events if event.get("event") == "stt_vosk_runtime_complete"
+]
 model_events = [event for event in events if event.get("event") == "stt_model_load_complete"]
+hedge_events = [event for event in events if event.get("event") == "stt_qwen_hedge_start"]
+grace_events = winner_events
 
 request_totals = [row["total_ms"] for row in requests]
 overall = stats(event.get("stt_overall_duration_ms") for event in winner_events)
+backend_request = stats(event.get("stt_request_duration_ms") for event in request_events)
+base64_decode = stats(event.get("stt_base64_decode_duration_ms") for event in request_events)
+audio_prepare = stats(event.get("stt_audio_prepare_duration_ms") for event in audio_prepare_events)
+audio_conversion = stats(
+    event.get("stt_audio_conversion_duration_ms") for event in audio_prepare_events
+)
 qwen = stats(event.get("stt_qwen_duration_ms") for event in qwen_events)
+qwen_runtime = stats(event.get("stt_qwen_runtime_duration_ms") for event in qwen_runtime_events)
+qwen_model_inference = stats(
+    event.get("stt_qwen_model_inference_duration_ms") for event in qwen_runtime_events
+)
+qwen_postprocess = stats(
+    event.get("stt_qwen_postprocess_duration_ms") for event in qwen_postprocess_events
+)
 vosk = stats(event.get("stt_vosk_duration_ms") for event in vosk_events)
+vosk_runtime = stats(event.get("stt_vosk_runtime_duration_ms") for event in vosk_runtime_events)
+vosk_recognition = stats(
+    event.get("stt_vosk_recognition_duration_ms") for event in vosk_runtime_events
+)
 network = stats(request_totals)
 model = stats(event.get("stt_model_load_duration_ms") for event in model_events)
+hedge_wait = stats(event.get("stt_hedge_wait_duration_ms") for event in hedge_events)
+grace_wait = stats(event.get("stt_qwen_grace_wait_duration_ms") for event in grace_events)
 
 winners = defaultdict(int)
 for event in winner_events:
@@ -286,9 +341,20 @@ lines = [
     "| Metric | count | p50 ms | p90 ms | p95 ms | max ms |",
     "| --- | ---: | ---: | ---: | ---: | ---: |",
     f"| request_total | {network['count']} | {fmt(network['p50'])} | {fmt(network['p90'])} | {fmt(network['p95'])} | {fmt(network['max'])} |",
+    f"| backend_stt_request | {backend_request['count']} | {fmt(backend_request['p50'])} | {fmt(backend_request['p90'])} | {fmt(backend_request['p95'])} | {fmt(backend_request['max'])} |",
+    f"| base64_decode | {base64_decode['count']} | {fmt(base64_decode['p50'])} | {fmt(base64_decode['p90'])} | {fmt(base64_decode['p95'])} | {fmt(base64_decode['max'])} |",
+    f"| audio_prepare | {audio_prepare['count']} | {fmt(audio_prepare['p50'])} | {fmt(audio_prepare['p90'])} | {fmt(audio_prepare['p95'])} | {fmt(audio_prepare['max'])} |",
+    f"| audio_conversion | {audio_conversion['count']} | {fmt(audio_conversion['p50'])} | {fmt(audio_conversion['p90'])} | {fmt(audio_conversion['p95'])} | {fmt(audio_conversion['max'])} |",
     f"| stt_overall | {overall['count']} | {fmt(overall['p50'])} | {fmt(overall['p90'])} | {fmt(overall['p95'])} | {fmt(overall['max'])} |",
     f"| qwen_inference | {qwen['count']} | {fmt(qwen['p50'])} | {fmt(qwen['p90'])} | {fmt(qwen['p95'])} | {fmt(qwen['max'])} |",
+    f"| qwen_runtime | {qwen_runtime['count']} | {fmt(qwen_runtime['p50'])} | {fmt(qwen_runtime['p90'])} | {fmt(qwen_runtime['p95'])} | {fmt(qwen_runtime['max'])} |",
+    f"| qwen_model_inference | {qwen_model_inference['count']} | {fmt(qwen_model_inference['p50'])} | {fmt(qwen_model_inference['p90'])} | {fmt(qwen_model_inference['p95'])} | {fmt(qwen_model_inference['max'])} |",
+    f"| qwen_postprocess | {qwen_postprocess['count']} | {fmt(qwen_postprocess['p50'])} | {fmt(qwen_postprocess['p90'])} | {fmt(qwen_postprocess['p95'])} | {fmt(qwen_postprocess['max'])} |",
     f"| vosk_inference | {vosk['count']} | {fmt(vosk['p50'])} | {fmt(vosk['p90'])} | {fmt(vosk['p95'])} | {fmt(vosk['max'])} |",
+    f"| vosk_runtime | {vosk_runtime['count']} | {fmt(vosk_runtime['p50'])} | {fmt(vosk_runtime['p90'])} | {fmt(vosk_runtime['p95'])} | {fmt(vosk_runtime['max'])} |",
+    f"| vosk_recognition | {vosk_recognition['count']} | {fmt(vosk_recognition['p50'])} | {fmt(vosk_recognition['p90'])} | {fmt(vosk_recognition['p95'])} | {fmt(vosk_recognition['max'])} |",
+    f"| hedge_wait | {hedge_wait['count']} | {fmt(hedge_wait['p50'])} | {fmt(hedge_wait['p90'])} | {fmt(hedge_wait['p95'])} | {fmt(hedge_wait['max'])} |",
+    f"| qwen_grace_wait | {grace_wait['count']} | {fmt(grace_wait['p50'])} | {fmt(grace_wait['p90'])} | {fmt(grace_wait['p95'])} | {fmt(grace_wait['max'])} |",
     f"| model_load | {model['count']} | {fmt(model['p50'])} | {fmt(model['p90'])} | {fmt(model['p95'])} | {fmt(model['max'])} |",
     "",
     "## Winners",

--- a/scripts/stt-postdeploy-logging-check.sh
+++ b/scripts/stt-postdeploy-logging-check.sh
@@ -34,6 +34,7 @@ Options:
 Reports:
   - stt_winner counts
   - stt_overall_duration_ms p50/p90/max
+  - qwen/vosk runtime breakdown where available
   - stt_qwen_rejected count
 EOF
   exit "${1:-0}"
@@ -122,7 +123,15 @@ FILTER="$FILTER AND timestamp >= \"$SINCE_UTC\""
 if [ -n "$UNTIL_UTC" ]; then
   FILTER="$FILTER AND timestamp <= \"$UNTIL_UTC\""
 fi
-FILTER="$FILTER AND (jsonPayload.event=\"stt_winner\" OR jsonPayload.event=\"stt_qwen_rejected\")"
+FILTER="$FILTER AND (jsonPayload.event=\"stt_winner\""
+FILTER="$FILTER OR jsonPayload.event=\"stt_request_complete\""
+FILTER="$FILTER OR jsonPayload.event=\"stt_audio_prepare_complete\""
+FILTER="$FILTER OR jsonPayload.event=\"stt_qwen_runtime_complete\""
+FILTER="$FILTER OR jsonPayload.event=\"stt_qwen_postprocess_complete\""
+FILTER="$FILTER OR jsonPayload.event=\"stt_vosk_runtime_complete\""
+FILTER="$FILTER OR jsonPayload.event=\"stt_qwen_hedge_start\""
+FILTER="$FILTER OR jsonPayload.event=\"stt_qwen_hedge_grace_complete\""
+FILTER="$FILTER OR jsonPayload.event=\"stt_qwen_rejected\")"
 
 if [ "$DRY_RUN" = "1" ]; then
   echo "Dry run: no gcloud logging read calls will be executed."
@@ -184,8 +193,24 @@ def fmt_ms(value: float | None) -> str:
 
 winner_counts: Counter[str] = Counter()
 latencies: list[float] = []
+request_latencies: list[float] = []
+audio_prepare_latencies: list[float] = []
+audio_conversion_latencies: list[float] = []
+qwen_runtime_latencies: list[float] = []
+qwen_model_inference_latencies: list[float] = []
+qwen_postprocess_latencies: list[float] = []
+vosk_runtime_latencies: list[float] = []
+vosk_recognition_latencies: list[float] = []
+hedge_wait_latencies: list[float] = []
+qwen_grace_wait_latencies: list[float] = []
 qwen_rejected_count = 0
 event_counts: Counter[str] = Counter()
+
+def append_float(values: list[float], value: Any) -> None:
+    try:
+        values.append(float(value))
+    except (TypeError, ValueError):
+        pass
 
 for entry in entries:
     payload = entry.get("jsonPayload")
@@ -198,16 +223,39 @@ for entry in entries:
     if event == "stt_qwen_rejected":
         qwen_rejected_count += 1
         continue
+    if event == "stt_request_complete":
+        append_float(request_latencies, payload.get("stt_request_duration_ms"))
+        continue
+    if event == "stt_audio_prepare_complete":
+        append_float(audio_prepare_latencies, payload.get("stt_audio_prepare_duration_ms"))
+        append_float(audio_conversion_latencies, payload.get("stt_audio_conversion_duration_ms"))
+        continue
+    if event == "stt_qwen_runtime_complete":
+        append_float(qwen_runtime_latencies, payload.get("stt_qwen_runtime_duration_ms"))
+        append_float(
+            qwen_model_inference_latencies,
+            payload.get("stt_qwen_model_inference_duration_ms"),
+        )
+        continue
+    if event == "stt_qwen_postprocess_complete":
+        append_float(qwen_postprocess_latencies, payload.get("stt_qwen_postprocess_duration_ms"))
+        continue
+    if event == "stt_vosk_runtime_complete":
+        append_float(vosk_runtime_latencies, payload.get("stt_vosk_runtime_duration_ms"))
+        append_float(vosk_recognition_latencies, payload.get("stt_vosk_recognition_duration_ms"))
+        continue
+    if event == "stt_qwen_hedge_start":
+        append_float(hedge_wait_latencies, payload.get("stt_hedge_wait_duration_ms"))
+        continue
+    if event == "stt_qwen_hedge_grace_complete":
+        continue
     if event != "stt_winner":
         continue
 
     winner = payload.get("stt_winner") or payload.get("provider") or "unknown"
     winner_counts[str(winner)] += 1
-    duration = payload.get("stt_overall_duration_ms")
-    try:
-        latencies.append(float(duration))
-    except (TypeError, ValueError):
-        pass
+    append_float(latencies, payload.get("stt_overall_duration_ms"))
+    append_float(qwen_grace_wait_latencies, payload.get("stt_qwen_grace_wait_duration_ms"))
 
 print("# STT Post-Deploy Logging Check")
 print()
@@ -223,7 +271,17 @@ print("## Events")
 print()
 print("| Event | Count |")
 print("| --- | ---: |")
-for event in ("stt_winner", "stt_qwen_rejected"):
+for event in (
+    "stt_winner",
+    "stt_request_complete",
+    "stt_audio_prepare_complete",
+    "stt_qwen_runtime_complete",
+    "stt_qwen_postprocess_complete",
+    "stt_vosk_runtime_complete",
+    "stt_qwen_hedge_start",
+    "stt_qwen_hedge_grace_complete",
+    "stt_qwen_rejected",
+):
     print(f"| {event} | {event_counts.get(event, 0)} |")
 print()
 print("## Winners")
@@ -240,9 +298,23 @@ print("## Latency")
 print()
 print("| Metric | Value ms |")
 print("| --- | ---: |")
-print(f"| p50 | {fmt_ms(percentile(latencies, 0.50))} |")
-print(f"| p90 | {fmt_ms(percentile(latencies, 0.90))} |")
-print(f"| max | {fmt_ms(max(latencies) if latencies else None)} |")
+latency_rows = {
+    "stt_overall p50": percentile(latencies, 0.50),
+    "stt_overall p90": percentile(latencies, 0.90),
+    "stt_overall max": max(latencies) if latencies else None,
+    "backend_stt_request p50": percentile(request_latencies, 0.50),
+    "audio_prepare p50": percentile(audio_prepare_latencies, 0.50),
+    "audio_conversion p50": percentile(audio_conversion_latencies, 0.50),
+    "qwen_runtime p50": percentile(qwen_runtime_latencies, 0.50),
+    "qwen_model_inference p50": percentile(qwen_model_inference_latencies, 0.50),
+    "qwen_postprocess p50": percentile(qwen_postprocess_latencies, 0.50),
+    "vosk_runtime p50": percentile(vosk_runtime_latencies, 0.50),
+    "vosk_recognition p50": percentile(vosk_recognition_latencies, 0.50),
+    "hedge_wait p50": percentile(hedge_wait_latencies, 0.50),
+    "qwen_grace_wait p50": percentile(qwen_grace_wait_latencies, 0.50),
+}
+for metric, value in latency_rows.items():
+    print(f"| {metric} | {fmt_ms(value)} |")
 print()
 print(f"stt_qwen_rejected count: `{qwen_rejected_count}`")
 PY


### PR DESCRIPTION
## Summary

- add detailed STT timing events for request total, base64 decode, shared audio preparation/conversion, Qwen runtime/inference/postprocess, Vosk runtime/recognition, and hedge/grace waits
- convert clear non-WAV media containers once before the Qwen/Vosk hedge race so both paths use the same prepared audio
- expand STT profile/post-deploy logging scripts to summarize the new breakdown fields
- document the current STT/TTS and static slide-audio architecture, with license notes for the post-alpha baseline
- fix the live Japanese STT accuracy test so per-sample and aggregate checks share one session cache and do not double-hit `/api/voice` rate limits

## Issue Cleanup

Already closed as completed/superseded after confirming current implementation: #494, #496, #495, #128, #165, #190, #399, #482, #485.

Kept open with measurable close criteria: #140.

Closes #484
Closes #492
Closes #493
Closes #502
Refs #529
Refs #774

## Validation

- `uv run ruff check backend/tests/e2e/test_stt_japanese_accuracy.py backend/agents/stt_agent.py backend/main.py backend/tests/agents/test_stt_agent.py`
- `uv run black --check backend/tests/e2e/test_stt_japanese_accuracy.py backend/agents/stt_agent.py backend/main.py backend/tests/agents/test_stt_agent.py`
- `python -m py_compile backend/agents/stt_agent.py backend/main.py backend/tests/e2e/test_stt_japanese_accuracy.py`
- `bash -n scripts/profile_stt.sh && bash -n scripts/stt-postdeploy-logging-check.sh`
- `scripts/stt-postdeploy-logging-check.sh --since 2026-05-09T00:00:00Z --dry-run`
- `uv run pytest backend/tests/e2e/test_stt_japanese_accuracy.py -q` (skips without live env)
- `uv run pytest backend/tests/agents/test_stt_agent.py backend/tests/test_main_endpoints.py backend/tests/api/test_voice_api.py backend/tests/performance/test_voice_performance_contracts.py backend/tests/scripts/test_cloud_logging_verify.py backend/tests/scripts/test_alpha_smoke_comprehensive_contract.py -q`
