### PR TITLE
[codex] Add RAG ingestion metadata and event quality tooling

### DIFF
--- a/backend/api/knowledge.py
+++ b/backend/api/knowledge.py
@@ -22,6 +22,11 @@ from pydantic import BaseModel, Field
 from supabase import create_client
 
 from backend.knowledge.loader import count_tokens
+from backend.knowledge.metadata import (
+    MetadataReservedPolicy,
+    MetadataValidationError,
+    normalize_user_metadata,
+)
 from backend.knowledge.upload_ingestion import plan_upload_chunks, upload_chunk_record_title
 from backend.utils.embedding_service import generate_embedding
 from backend.utils.file_parser import detect_file_type, parse_markdown, parse_pdf
@@ -287,6 +292,17 @@ def _build_knowledge_categories_response(supabase: Any) -> KnowledgeCategoriesRe
     )
 
 
+def _normalize_api_metadata(
+    metadata: Dict[str, Any] | None,
+    *,
+    reserved_policy: MetadataReservedPolicy = "reject",
+) -> Dict[str, Any]:
+    try:
+        return normalize_user_metadata(metadata, reserved_policy=reserved_policy)
+    except MetadataValidationError as exc:
+        raise HTTPException(status_code=400, detail=f"Invalid metadata: {exc}") from exc
+
+
 # =============================================================================
 # Endpoints
 # =============================================================================
@@ -393,6 +409,7 @@ async def get_knowledge(request: Request, knowledge_id: str):
 async def create_knowledge(request: Request, body: KnowledgeCreateRequest):
     """テキスト入力でナレッジ新規登録（embedding自動生成）"""
     try:
+        metadata = _normalize_api_metadata(body.metadata)
         supabase = _get_supabase()
 
         # 重複titleチェック
@@ -418,7 +435,7 @@ async def create_knowledge(request: Request, body: KnowledgeCreateRequest):
             "language": body.language,
             "subcategory": body.subcategory,
             "source": body.source,
-            "metadata": body.metadata or {},
+            "metadata": metadata,
             "content_embedding": embedding,
         }
 
@@ -487,7 +504,7 @@ async def upload_knowledge(
             if not isinstance(parsed_metadata, dict):
                 raise HTTPException(status_code=400, detail="metadata must be a JSON object")
 
-            metadata_payload = parsed_metadata
+            metadata_payload = _normalize_api_metadata(parsed_metadata, reserved_policy="drop")
 
         file_type = detect_file_type(file.filename)
         if file_type not in ("markdown", "pdf"):
@@ -860,6 +877,9 @@ async def preview_knowledge(
 async def update_knowledge(request: Request, knowledge_id: str, body: KnowledgeUpdateRequest):
     """ナレッジ更新（content変更時はembedding再生成）"""
     try:
+        body_metadata = (
+            _normalize_api_metadata(body.metadata) if body.metadata is not None else None
+        )
         supabase = _get_supabase()
 
         # 存在確認
@@ -899,8 +919,8 @@ async def update_knowledge(request: Request, knowledge_id: str, body: KnowledgeU
             update_data["subcategory"] = body.subcategory
         if body.source is not None:
             update_data["source"] = body.source
-        if body.metadata is not None:
-            update_data["metadata"] = body.metadata
+        if body_metadata is not None:
+            update_data["metadata"] = body_metadata
 
         if not update_data:
             return KnowledgeResponse(success=True, data=_row_to_item(current))
@@ -919,7 +939,7 @@ async def update_knowledge(request: Request, knowledge_id: str, body: KnowledgeU
                 raise HTTPException(status_code=503, detail="Embedding service unavailable")
             update_data["content_embedding"] = embedding
             if is_uploaded_document:
-                update_data["metadata"] = _collapse_upload_metadata(current, body.metadata)
+                update_data["metadata"] = _collapse_upload_metadata(current, body_metadata)
                 update_data["chunk_level"] = "document"
                 update_data["chunk_index"] = 0
                 update_data["token_count"] = count_tokens(str(new_content))

--- a/backend/evaluation/quality_signals.py
+++ b/backend/evaluation/quality_signals.py
@@ -1,0 +1,271 @@
+"""Deterministic offline RAG quality signals.
+
+These checks are intentionally lightweight and provider-free. They complement
+RAGAS by making language adherence, context grounding, hallucination risk, and
+toxicity accounting available in CI without live credentials.
+"""
+
+from __future__ import annotations
+
+import re
+from collections import Counter, defaultdict
+from dataclasses import dataclass, field
+from typing import Any, Iterable
+
+SUPPORTED_LANGUAGES = ("ja", "en", "zh", "ko")
+
+DEFAULT_THRESHOLDS = {
+    "language_match_min": 0.9,
+    "groundedness_min": 0.55,
+    "hallucination_risk_max": 0.45,
+    "toxicity_max": 0.0,
+}
+
+_LATIN_WORD_RE = re.compile(r"[a-zA-Z][a-zA-Z0-9&+._/-]*")
+_NUMBER_RE = re.compile(r"\d+(?::\d+)?")
+_CJK_RE = re.compile(r"[\u3040-\u30ff\u3400-\u9fff]+")
+_HANGUL_RE = re.compile(r"[\uac00-\ud7af]+")
+
+_TOXIC_TERMS = {
+    "idiot",
+    "stupid",
+    "shut up",
+    "kill yourself",
+    "死ね",
+    "バカ",
+    "馬鹿",
+    "멍청",
+    "죽어",
+    "傻瓜",
+    "白痴",
+}
+
+
+@dataclass(frozen=True)
+class QualitySignalCaseResult:
+    """Offline quality signals for one RAG answer."""
+
+    case_id: str
+    language: str
+    language_match: float
+    groundedness: float
+    hallucination_risk: float
+    toxicity: float
+    passed: bool
+    failures: list[str] = field(default_factory=list)
+
+
+def script_counts(text: str) -> Counter[str]:
+    """Count broad writing systems used by supported response languages."""
+    counts: Counter[str] = Counter()
+    for char in text:
+        codepoint = ord(char)
+        if 0x3040 <= codepoint <= 0x30FF:
+            counts["kana"] += 1
+        elif 0x3400 <= codepoint <= 0x9FFF:
+            counts["cjk"] += 1
+        elif 0xAC00 <= codepoint <= 0xD7AF:
+            counts["hangul"] += 1
+        elif char.isascii() and char.isalpha():
+            counts["latin"] += 1
+    return counts
+
+
+def language_match_score(text: str, expected_language: str) -> float:
+    """Return a deterministic 0..1 score for expected response language use."""
+    if expected_language not in SUPPORTED_LANGUAGES:
+        raise ValueError(f"unsupported expected_language: {expected_language}")
+    if not text.strip():
+        return 0.0
+
+    counts = script_counts(text)
+    lexical_total = sum(counts.values())
+    if lexical_total == 0:
+        return 0.0
+
+    if expected_language == "ja":
+        if counts["kana"] > 0:
+            return 1.0
+        if counts["cjk"] > 0 and counts["hangul"] == 0:
+            return 0.5
+        return 0.0
+
+    if expected_language == "zh":
+        non_latin = counts["cjk"] + counts["kana"] + counts["hangul"]
+        if non_latin == 0:
+            return 0.0
+        if counts["cjk"] > 0 and counts["kana"] == 0 and counts["hangul"] == 0:
+            return 1.0
+        return counts["cjk"] / non_latin
+
+    if expected_language == "ko":
+        non_latin = counts["cjk"] + counts["kana"] + counts["hangul"]
+        if non_latin == 0:
+            return 0.0
+        return counts["hangul"] / non_latin
+
+    latin_words = _LATIN_WORD_RE.findall(text)
+    cjk_or_hangul = counts["kana"] + counts["cjk"] + counts["hangul"]
+    if len(latin_words) >= 3 and cjk_or_hangul == 0:
+        return 1.0
+    return counts["latin"] / lexical_total
+
+
+def evidence_units(text: str) -> set[str]:
+    """Extract comparable content units from English and CJK/Korean text."""
+    lowered = text.lower()
+    units = {token for token in _LATIN_WORD_RE.findall(lowered) if len(token.strip("&+._/-")) >= 3}
+    units.update(_NUMBER_RE.findall(lowered))
+
+    for pattern in (_CJK_RE, _HANGUL_RE):
+        for match in pattern.findall(text):
+            units.update(_char_ngrams(match, size=3))
+
+    return units
+
+
+def _char_ngrams(text: str, *, size: int) -> set[str]:
+    compact = "".join(char for char in text if not char.isspace())
+    if not compact:
+        return set()
+    if len(compact) <= size:
+        return {compact}
+    return {compact[index : index + size] for index in range(len(compact) - size + 1)}
+
+
+def groundedness_score(answer: str, contexts: Iterable[str]) -> float:
+    """Estimate how much of the answer is supported by supplied evidence text."""
+    answer_units = evidence_units(answer)
+    if not answer_units:
+        return 0.0
+
+    context_units = evidence_units("\n".join(contexts))
+    if not context_units:
+        return 0.0
+
+    return len(answer_units & context_units) / len(answer_units)
+
+
+def toxicity_score(text: str) -> float:
+    """Return a simple lexicon-based toxicity risk score."""
+    lowered = text.lower()
+    hits = sum(1 for term in _TOXIC_TERMS if term.lower() in lowered)
+    return min(1.0, float(hits))
+
+
+def score_case(
+    case: dict[str, Any],
+    *,
+    thresholds: dict[str, float] | None = None,
+) -> QualitySignalCaseResult:
+    """Score one evaluation case and apply offline gate thresholds."""
+    gate = {**DEFAULT_THRESHOLDS, **(thresholds or {})}
+    answer = str(case.get("answer") or "")
+    contexts = [str(context) for context in case.get("contexts") or []]
+    if case.get("ground_truth"):
+        contexts.append(str(case["ground_truth"]))
+    language = str(case.get("language") or "unknown")
+    case_id = str(case.get("query_id") or case.get("id") or case.get("ground_truth_id") or "")
+
+    language_match = language_match_score(answer, language)
+    groundedness = groundedness_score(answer, contexts)
+    hallucination_risk = 1.0 - groundedness if answer.strip() else 1.0
+    toxicity = toxicity_score(answer)
+
+    failures: list[str] = []
+    if language_match < gate["language_match_min"]:
+        failures.append("language_match")
+    if groundedness < gate["groundedness_min"]:
+        failures.append("groundedness")
+    if hallucination_risk > gate["hallucination_risk_max"]:
+        failures.append("hallucination_risk")
+    if toxicity > gate["toxicity_max"]:
+        failures.append("toxicity")
+
+    return QualitySignalCaseResult(
+        case_id=case_id,
+        language=language,
+        language_match=round(language_match, 4),
+        groundedness=round(groundedness, 4),
+        hallucination_risk=round(hallucination_risk, 4),
+        toxicity=round(toxicity, 4),
+        passed=not failures,
+        failures=failures,
+    )
+
+
+def summarize_quality_signals(
+    cases: Iterable[dict[str, Any]],
+    *,
+    thresholds: dict[str, float] | None = None,
+) -> dict[str, Any]:
+    """Aggregate offline signal scores across multilingual RAG cases."""
+    results = [score_case(case, thresholds=thresholds) for case in cases]
+    by_language: dict[str, list[QualitySignalCaseResult]] = defaultdict(list)
+    for result in results:
+        by_language[result.language].append(result)
+
+    per_language = {
+        language: _summarize_results(language_results)
+        for language, language_results in sorted(by_language.items())
+    }
+    overall = _summarize_results(results)
+
+    return {
+        "thresholds": {**DEFAULT_THRESHOLDS, **(thresholds or {})},
+        "overall": overall,
+        "per_language": per_language,
+        "failed_cases": [
+            {
+                "case_id": result.case_id,
+                "language": result.language,
+                "failures": result.failures,
+            }
+            for result in results
+            if not result.passed
+        ],
+        "cases": [_result_to_dict(result) for result in results],
+    }
+
+
+def _summarize_results(results: list[QualitySignalCaseResult]) -> dict[str, Any]:
+    if not results:
+        return {
+            "case_count": 0,
+            "passed": True,
+            "failed_case_count": 0,
+            "language_match": 0.0,
+            "groundedness": 0.0,
+            "hallucination_risk": 0.0,
+            "toxicity": 0.0,
+        }
+
+    return {
+        "case_count": len(results),
+        "passed": all(result.passed for result in results),
+        "failed_case_count": sum(1 for result in results if not result.passed),
+        "language_match": _average(result.language_match for result in results),
+        "groundedness": _average(result.groundedness for result in results),
+        "hallucination_risk": _average(result.hallucination_risk for result in results),
+        "toxicity": _average(result.toxicity for result in results),
+    }
+
+
+def _average(values: Iterable[float]) -> float:
+    materialized = list(values)
+    if not materialized:
+        return 0.0
+    return round(sum(materialized) / len(materialized), 4)
+
+
+def _result_to_dict(result: QualitySignalCaseResult) -> dict[str, Any]:
+    return {
+        "case_id": result.case_id,
+        "language": result.language,
+        "language_match": result.language_match,
+        "groundedness": result.groundedness,
+        "hallucination_risk": result.hallucination_risk,
+        "toxicity": result.toxicity,
+        "passed": result.passed,
+        "failures": result.failures,
+    }

--- a/backend/evaluation/run_offline_quality_gate.py
+++ b/backend/evaluation/run_offline_quality_gate.py
@@ -1,0 +1,219 @@
+"""Offline multilingual RAG quality gate.
+
+This runner uses the existing multilingual RAGAS manifest and golden cases, but
+does not invoke RAGAS, LLMs, vector search, Supabase, or live APIs. By default it
+writes report artifacts and exits successfully even when cases miss thresholds;
+use ``--enforce`` to make it blocking in CI.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import logging
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Sequence
+
+try:
+    from backend.evaluation.quality_signals import DEFAULT_THRESHOLDS, summarize_quality_signals
+    from backend.evaluation.run_multilingual_eval import (
+        ALL_LANGUAGES,
+        DEFAULT_REPORTS_DIR,
+        load_multilingual_config,
+        load_query_cases,
+        validate_multilingual_config,
+    )
+except ImportError:  # pragma: no cover - supports running from backend/ as cwd
+    from evaluation.quality_signals import DEFAULT_THRESHOLDS, summarize_quality_signals
+    from evaluation.run_multilingual_eval import (
+        ALL_LANGUAGES,
+        DEFAULT_REPORTS_DIR,
+        load_multilingual_config,
+        load_query_cases,
+        validate_multilingual_config,
+    )
+
+logger = logging.getLogger(__name__)
+
+
+def load_offline_cases(
+    *,
+    languages: Sequence[str] | None = None,
+    max_cases: int | None = None,
+) -> tuple[list[dict[str, Any]], dict[str, int]]:
+    """Load multilingual golden cases for deterministic quality scoring."""
+    config = load_multilingual_config()
+    query_counts = validate_multilingual_config(config)
+    selected_languages = list(languages or ALL_LANGUAGES)
+
+    unknown_languages = [
+        language for language in selected_languages if language not in ALL_LANGUAGES
+    ]
+    if unknown_languages:
+        raise ValueError(f"unsupported languages requested: {', '.join(sorted(unknown_languages))}")
+
+    cases: list[dict[str, Any]] = []
+    for language in selected_languages:
+        cases.extend(load_query_cases(config, language=language, max_cases=max_cases))
+    return cases, query_counts
+
+
+def run_offline_quality_gate(
+    *,
+    languages: Sequence[str] | None = None,
+    max_cases: int | None = None,
+    output_dir: Path | None = None,
+    thresholds: dict[str, float] | None = None,
+) -> dict[str, Any]:
+    """Run offline quality signals and write JSON/Markdown reports."""
+    cases, query_counts = load_offline_cases(languages=languages, max_cases=max_cases)
+    signals = summarize_quality_signals(cases, thresholds=thresholds)
+    selected_languages = list(languages or ALL_LANGUAGES)
+
+    result = {
+        "timestamp": datetime.now(timezone.utc).isoformat(),
+        "mode": "offline",
+        "blocking_by_default": False,
+        "languages": selected_languages,
+        "max_cases": max_cases,
+        "query_counts": query_counts,
+        "quality_signals": signals,
+    }
+    result["report"] = format_markdown_report(result)
+
+    destination_dir = output_dir or DEFAULT_REPORTS_DIR
+    destination_dir.mkdir(parents=True, exist_ok=True)
+    timestamp = datetime.now(timezone.utc).strftime("%Y%m%d_%H%M%S")
+    json_path = destination_dir / f"offline_quality_gate_{timestamp}.json"
+    md_path = destination_dir / f"offline_quality_gate_{timestamp}.md"
+    json_path.write_text(json.dumps(result, ensure_ascii=False, indent=2), encoding="utf-8")
+    md_path.write_text(result["report"], encoding="utf-8")
+    result["artifacts"] = {"json": str(json_path), "markdown": str(md_path)}
+
+    logger.info("Wrote offline quality gate report to %s", json_path)
+    logger.info("Wrote offline quality gate summary to %s", md_path)
+    return result
+
+
+def format_markdown_report(result: dict[str, Any]) -> str:
+    """Format a compact CI-readable Markdown report."""
+    signals = result["quality_signals"]
+    overall = signals["overall"]
+    thresholds = signals["thresholds"]
+    lines = [
+        "# Offline RAG Quality Gate",
+        "",
+        f"- Generated: {result['timestamp']}",
+        "- Mode: offline golden dataset; no live credentials required",
+        "- Blocking: opt-in via `--enforce`",
+        f"- Languages: {', '.join(result['languages'])}",
+        "",
+        "## Thresholds",
+        "",
+        "| Signal | Threshold |",
+        "| --- | ---: |",
+        f"| language_match | >= {thresholds['language_match_min']:.2f} |",
+        f"| groundedness | >= {thresholds['groundedness_min']:.2f} |",
+        f"| hallucination_risk | <= {thresholds['hallucination_risk_max']:.2f} |",
+        f"| toxicity | <= {thresholds['toxicity_max']:.2f} |",
+        "",
+        "## Summary",
+        "",
+        "| Scope | Cases | Failed | Language | Grounded | Hallucination Risk | Toxicity | Pass |",
+        "| --- | ---: | ---: | ---: | ---: | ---: | ---: | --- |",
+        _summary_row("overall", overall),
+    ]
+
+    for language, summary in signals["per_language"].items():
+        lines.append(_summary_row(language, summary))
+
+    failed_cases = signals["failed_cases"]
+    if failed_cases:
+        lines.extend(["", "## Failed Cases", ""])
+        for item in failed_cases:
+            failures = ", ".join(item["failures"])
+            lines.append(f"- {item['case_id']} ({item['language']}): {failures}")
+
+    return "\n".join(lines) + "\n"
+
+
+def _summary_row(scope: str, summary: dict[str, Any]) -> str:
+    status = "PASS" if summary["passed"] else "FAIL"
+    return (
+        f"| {scope} | {summary['case_count']} | {summary['failed_case_count']} | "
+        f"{summary['language_match']:.3f} | {summary['groundedness']:.3f} | "
+        f"{summary['hallucination_risk']:.3f} | {summary['toxicity']:.3f} | {status} |"
+    )
+
+
+def _threshold_args(args: argparse.Namespace) -> dict[str, float]:
+    return {
+        "language_match_min": args.language_match_min,
+        "groundedness_min": args.groundedness_min,
+        "hallucination_risk_max": args.hallucination_risk_max,
+        "toxicity_max": args.toxicity_max,
+    }
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Offline multilingual RAG quality gate")
+    parser.add_argument(
+        "--languages",
+        nargs="+",
+        choices=ALL_LANGUAGES,
+        default=None,
+        help="Languages to score. Defaults to all supported languages.",
+    )
+    parser.add_argument(
+        "--max-cases",
+        type=int,
+        default=None,
+        help="Optional per-language cap applied after the multilingual query manifest.",
+    )
+    parser.add_argument("--output-dir", type=str, default=None, help="Report output directory.")
+    parser.add_argument(
+        "--enforce",
+        action="store_true",
+        help="Exit non-zero when any offline signal threshold is missed.",
+    )
+    parser.add_argument(
+        "--language-match-min",
+        type=float,
+        default=DEFAULT_THRESHOLDS["language_match_min"],
+    )
+    parser.add_argument(
+        "--groundedness-min",
+        type=float,
+        default=DEFAULT_THRESHOLDS["groundedness_min"],
+    )
+    parser.add_argument(
+        "--hallucination-risk-max",
+        type=float,
+        default=DEFAULT_THRESHOLDS["hallucination_risk_max"],
+    )
+    parser.add_argument("--toxicity-max", type=float, default=DEFAULT_THRESHOLDS["toxicity_max"])
+    parser.add_argument("--verbose", action="store_true", help="Enable debug logging.")
+    args = parser.parse_args()
+
+    logging.basicConfig(
+        level=logging.DEBUG if args.verbose else logging.INFO,
+        format="%(asctime)s [%(levelname)s] %(name)s: %(message)s",
+    )
+
+    result = run_offline_quality_gate(
+        languages=args.languages,
+        max_cases=args.max_cases,
+        output_dir=Path(args.output_dir) if args.output_dir else None,
+        thresholds=_threshold_args(args),
+    )
+    print(result["report"])
+
+    if args.enforce and not result["quality_signals"]["overall"]["passed"]:
+        logger.error("Offline quality gate failed under --enforce.")
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/backend/knowledge/metadata.py
+++ b/backend/knowledge/metadata.py
@@ -1,0 +1,114 @@
+"""Metadata normalization for knowledge ingestion paths."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping, Sequence
+from typing import Any, Literal
+
+MetadataReservedPolicy = Literal["allow", "drop", "reject"]
+
+RESERVED_METADATA_FIELDS = frozenset(
+    {
+        "chunk_index",
+        "chunk_level",
+        "chunks_created",
+        "document_id",
+        "entry_id",
+        "failed_chunks",
+        "file_type",
+        "language",
+        "original_filename",
+        "total_chunks",
+    }
+)
+
+MAX_METADATA_KEYS = 50
+MAX_METADATA_DEPTH = 4
+MAX_METADATA_STRING_LENGTH = 1000
+MAX_METADATA_SEQUENCE_LENGTH = 50
+
+
+class MetadataValidationError(ValueError):
+    """Raised when user-supplied knowledge metadata is not safe to persist."""
+
+
+def normalize_user_metadata(
+    metadata: Mapping[str, Any] | None,
+    *,
+    reserved_policy: MetadataReservedPolicy = "reject",
+) -> dict[str, Any]:
+    """Validate and copy user metadata for knowledge ingestion.
+
+    The RAG upload path owns document identity and chunk accounting fields. Text
+    CRUD rejects those reserved keys to avoid retrieval-invisible or
+    document-masquerading rows. File upload can drop them because generated
+    metadata is applied immediately after user metadata.
+    """
+
+    if metadata is None:
+        return {}
+    if not isinstance(metadata, Mapping):
+        raise MetadataValidationError("metadata must be a JSON object")
+
+    normalized: dict[str, Any] = {}
+    for key, value in metadata.items():
+        if not isinstance(key, str) or not key.strip():
+            raise MetadataValidationError("metadata keys must be non-empty strings")
+        if key in RESERVED_METADATA_FIELDS:
+            if reserved_policy == "drop":
+                continue
+            if reserved_policy == "reject":
+                raise MetadataValidationError(f"metadata field '{key}' is reserved")
+        normalized[key] = _normalize_metadata_value(value, path=key, depth=0)
+
+    if len(normalized) > MAX_METADATA_KEYS:
+        raise MetadataValidationError(f"metadata must contain at most {MAX_METADATA_KEYS} keys")
+    return normalized
+
+
+def _normalize_metadata_value(value: Any, *, path: str, depth: int) -> Any:
+    if depth > MAX_METADATA_DEPTH:
+        raise MetadataValidationError(
+            f"metadata field '{path}' exceeds maximum depth of {MAX_METADATA_DEPTH}"
+        )
+
+    if value is None or isinstance(value, bool | int | float):
+        return value
+
+    if isinstance(value, str):
+        if len(value) > MAX_METADATA_STRING_LENGTH:
+            raise MetadataValidationError(
+                f"metadata field '{path}' exceeds {MAX_METADATA_STRING_LENGTH} characters"
+            )
+        return value
+
+    if isinstance(value, Mapping):
+        if len(value) > MAX_METADATA_KEYS:
+            raise MetadataValidationError(
+                f"metadata field '{path}' must contain at most {MAX_METADATA_KEYS} keys"
+            )
+        normalized: dict[str, Any] = {}
+        for child_key, child_value in value.items():
+            if not isinstance(child_key, str) or not child_key.strip():
+                raise MetadataValidationError(f"metadata field '{path}' contains a non-string key")
+            child_path = f"{path}.{child_key}"
+            normalized[child_key] = _normalize_metadata_value(
+                child_value,
+                path=child_path,
+                depth=depth + 1,
+            )
+        return normalized
+
+    if isinstance(value, Sequence) and not isinstance(value, str | bytes | bytearray):
+        if len(value) > MAX_METADATA_SEQUENCE_LENGTH:
+            raise MetadataValidationError(
+                f"metadata field '{path}' must contain at most "
+                f"{MAX_METADATA_SEQUENCE_LENGTH} items"
+            )
+        return [
+            _normalize_metadata_value(item, path=f"{path}[]", depth=depth + 1) for item in value
+        ]
+
+    raise MetadataValidationError(
+        f"metadata field '{path}' must be a JSON scalar, object, or array"
+    )

--- a/backend/knowledge/upload_ingestion.py
+++ b/backend/knowledge/upload_ingestion.py
@@ -18,6 +18,7 @@ from backend.knowledge.loader import (
     count_tokens,
     get_strategy_for_category,
 )
+from backend.knowledge.metadata import normalize_user_metadata
 
 EmbeddingFn = Callable[[str], Awaitable[Sequence[float]] | Sequence[float]]
 ChunkLevel = Literal["document", "section", "chunk"]
@@ -67,8 +68,9 @@ def plan_upload_chunks(
     resolved_strategy = get_strategy_for_category(category, strategy)
     entry_id = _derive_entry_id(normalized_filename, normalized_title)
 
+    user_metadata = normalize_user_metadata(metadata, reserved_policy="drop")
     base_metadata = {
-        **dict(metadata or {}),
+        **user_metadata,
         "language": language,
         "original_filename": normalized_filename,
         "file_type": file_type,

--- a/backend/scripts/sync_event_kb.py
+++ b/backend/scripts/sync_event_kb.py
@@ -1,0 +1,81 @@
+"""CLI for the additive event-to-KB bridge."""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+import os
+import sys
+from pathlib import Path
+
+import httpx
+from supabase import create_client
+
+if __package__ in (None, ""):
+    sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+
+from backend.services.event_kb_sync import parse_ics_event_records, sync_event_kb_records
+
+
+def _parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Sync ICS events into knowledge_base rows.")
+    parser.add_argument("--ics-file", type=Path, help="Local ICS fixture/feed export to parse.")
+    parser.add_argument(
+        "--ics-url",
+        default=os.getenv("GOOGLE_CALENDAR_ICAL_URL", ""),
+        help="ICS URL to fetch. Defaults to GOOGLE_CALENDAR_ICAL_URL.",
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        default=False,
+        help="Plan records without embeddings or Supabase writes.",
+    )
+    return parser.parse_args()
+
+
+async def _main() -> None:
+    args = _parse_args()
+    if args.ics_file:
+        ics_content = args.ics_file.read_text(encoding="utf-8")
+    elif args.ics_url:
+        async with httpx.AsyncClient() as client:
+            response = await client.get(args.ics_url, timeout=30.0)
+            response.raise_for_status()
+            ics_content = response.text
+    else:
+        raise SystemExit(
+            "--ics-file or --ics-url/GOOGLE_CALENDAR_ICAL_URL is required for event sync"
+        )
+
+    events = parse_ics_event_records(ics_content)
+    supabase_client = None
+    if not args.dry_run:
+        url = os.getenv("SUPABASE_URL", "")
+        key = os.getenv("SUPABASE_KEY", "")
+        if not url or not key:
+            raise SystemExit("SUPABASE_URL and SUPABASE_KEY are required unless --dry-run is used")
+        supabase_client = create_client(url, key)
+
+    result = await sync_event_kb_records(
+        events,
+        supabase_client=supabase_client,
+        dry_run=args.dry_run,
+    )
+    print(
+        json.dumps(
+            {
+                "planned_count": result.planned_count,
+                "written_count": result.written_count,
+                "skipped_count": result.skipped_count,
+                "titles": [record["title"] for record in result.records],
+            },
+            ensure_ascii=False,
+            indent=2,
+        )
+    )
+
+
+if __name__ == "__main__":
+    asyncio.run(_main())

--- a/backend/services/event_kb_sync.py
+++ b/backend/services/event_kb_sync.py
@@ -1,0 +1,260 @@
+"""Event-to-knowledge-base bridge.
+
+This module is intentionally additive and side-effect-free by default. It
+normalizes event source records, adapts them to event-category knowledge
+documents, then reuses the existing upload chunk planning path before optional
+embedding/upsert.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import inspect
+import logging
+from collections.abc import Awaitable, Callable, Sequence
+from dataclasses import dataclass
+from datetime import datetime
+from typing import Any
+
+from backend.knowledge.upload_ingestion import (
+    build_upload_chunk_records,
+    plan_upload_chunks,
+)
+from backend.tools.calendar_service import CalendarService
+from backend.utils.embedding_service import generate_embedding
+
+logger = logging.getLogger(__name__)
+
+EmbeddingFn = Callable[[str], Awaitable[Sequence[float]] | Sequence[float]]
+
+EVENT_KB_CATEGORY = "event"
+EVENT_KB_LANGUAGE = "ja"
+EVENT_KB_SOURCE_PREFIX = "event_bridge"
+
+
+@dataclass(frozen=True)
+class EventSourceRecord:
+    """Normalized event source representation used by the KB bridge."""
+
+    external_id: str
+    title: str
+    start: str
+    end: str = ""
+    description: str = ""
+    location: str = ""
+    url: str = ""
+    source: str = "google_calendar"
+
+
+@dataclass(frozen=True)
+class EventKbSyncResult:
+    """Summary of an event KB sync run."""
+
+    planned_count: int
+    written_count: int
+    skipped_count: int
+    records: tuple[dict[str, Any], ...]
+
+
+def parse_ics_event_records(
+    ics_content: str,
+    *,
+    source: str = "google_calendar",
+) -> list[EventSourceRecord]:
+    """Parse ICS text into deterministic event source records.
+
+    The existing calendar parser already handles folded lines, date formats,
+    unescaping, and low-value placeholder filtering. This bridge wraps it in a
+    stable normalized type instead of creating another event parser branch.
+    """
+
+    parsed_events = CalendarService()._parse_ics_content(ics_content)
+    return [normalize_event_record(event, default_source=source) for event in parsed_events]
+
+
+def normalize_event_record(
+    event: dict[str, Any],
+    *,
+    default_source: str = "google_calendar",
+) -> EventSourceRecord:
+    """Normalize a calendar/Connpass-style event dict."""
+
+    title = str(event.get("title") or event.get("summary") or "").strip()
+    start = str(event.get("start") or event.get("starts_at") or event.get("start_at") or "").strip()
+    if not title:
+        raise ValueError("event title is required")
+    if not start:
+        raise ValueError(f"event start is required for title={title!r}")
+
+    raw_id = event.get("id") or event.get("uid") or event.get("event_id")
+    if raw_id:
+        external_id = str(raw_id).strip()
+    else:
+        external_id = _event_digest(default_source, title, start)
+
+    return EventSourceRecord(
+        external_id=external_id,
+        title=title,
+        start=start,
+        end=str(event.get("end") or event.get("ends_at") or event.get("end_at") or "").strip(),
+        description=str(event.get("description") or "").strip(),
+        location=str(event.get("location") or event.get("venue") or "").strip(),
+        url=str(event.get("htmlLink") or event.get("url") or event.get("event_url") or "").strip(),
+        source=str(event.get("source") or default_source).strip() or default_source,
+    )
+
+
+def event_record_to_markdown(event: EventSourceRecord) -> str:
+    """Render one normalized event as a KB document body."""
+
+    lines = [
+        f"# {event.title}",
+        "",
+        f"- Start: {event.start}",
+    ]
+    if event.end:
+        lines.append(f"- End: {event.end}")
+    if event.location:
+        lines.append(f"- Location: {event.location}")
+    if event.url:
+        lines.append(f"- URL: {event.url}")
+    lines.extend(["", "## Description"])
+    lines.append(event.description or "No description provided by the event source.")
+    return "\n".join(lines).strip()
+
+
+def event_record_to_metadata(event: EventSourceRecord) -> dict[str, Any]:
+    """Build metadata used for sync accounting and future rollback."""
+
+    return {
+        "bridge": EVENT_KB_SOURCE_PREFIX,
+        "sync_source": event.source,
+        "external_event_id": event.external_id,
+        "start": event.start,
+        "end": event.end,
+        "location": event.location,
+        "url": event.url,
+    }
+
+
+def event_record_to_kb_title(event: EventSourceRecord) -> str:
+    """Build a stable title that fits the knowledge title limit."""
+
+    date_label = _date_label(event.start)
+    digest = _event_digest(event.source, event.external_id, event.start)[:8]
+    suffix = f" ({date_label}) [{digest}]"
+    prefix = "Event: "
+    max_title_chars = 200
+    max_event_title_chars = max_title_chars - len(prefix) - len(suffix)
+    event_title = event.title
+    if len(event_title) > max_event_title_chars:
+        event_title = event_title[: max(0, max_event_title_chars - 3)].rstrip() + "..."
+    return f"{prefix}{event_title}{suffix}"
+
+
+async def plan_event_kb_records(
+    events: Sequence[EventSourceRecord],
+    *,
+    embedding_fn: EmbeddingFn | None = None,
+) -> list[dict[str, Any]]:
+    """Plan KB rows for events without writing to storage."""
+
+    records: list[dict[str, Any]] = []
+    for event in events:
+        content = event_record_to_markdown(event)
+        title = event_record_to_kb_title(event)
+        plan = plan_upload_chunks(
+            content,
+            filename=f"{_safe_filename_stem(event)}.md",
+            category=EVENT_KB_CATEGORY,
+            language=EVENT_KB_LANGUAGE,
+            title=title,
+            metadata=event_record_to_metadata(event),
+        )
+        chunk_records = await build_upload_chunk_records(plan, embedding_fn=embedding_fn)
+        for record in chunk_records:
+            record["source"] = _kb_source(event)
+            record["subcategory"] = "live_event"
+        records.extend(chunk_records)
+    return records
+
+
+async def sync_event_kb_records(
+    events: Sequence[EventSourceRecord],
+    *,
+    supabase_client: Any | None = None,
+    embedding_fn: EmbeddingFn | None = None,
+    dry_run: bool = True,
+) -> EventKbSyncResult:
+    """Plan and optionally upsert event KB records.
+
+    Dry runs do not generate embeddings and never touch Supabase. Live writes
+    require both a Supabase client and successful embeddings for every planned
+    row; rows without embeddings are skipped to preserve RAG visibility.
+    """
+
+    if dry_run:
+        records = await plan_event_kb_records(events)
+        return EventKbSyncResult(
+            planned_count=len(records),
+            written_count=0,
+            skipped_count=0,
+            records=tuple(records),
+        )
+
+    if supabase_client is None:
+        raise ValueError("supabase_client is required when dry_run is false")
+
+    resolved_embedding_fn = embedding_fn or _event_record_embedding
+    records = await plan_event_kb_records(events, embedding_fn=resolved_embedding_fn)
+
+    written_count = 0
+    skipped_count = 0
+    written_records: list[dict[str, Any]] = []
+    for record in records:
+        if not record.get("content_embedding"):
+            skipped_count += 1
+            logger.warning("Skipping event KB record without embedding: %s", record.get("title"))
+            continue
+        supabase_client.table("knowledge_base").upsert(
+            record,
+            on_conflict="title",
+        ).execute()
+        written_count += 1
+        written_records.append(record)
+
+    return EventKbSyncResult(
+        planned_count=len(records),
+        written_count=written_count,
+        skipped_count=skipped_count,
+        records=tuple(written_records),
+    )
+
+
+async def _event_record_embedding(text: str) -> Sequence[float]:
+    embedding = generate_embedding(text)
+    if inspect.isawaitable(embedding):
+        embedding = await embedding
+    return embedding or []
+
+
+def _kb_source(event: EventSourceRecord) -> str:
+    return f"{EVENT_KB_SOURCE_PREFIX}:{event.source}:{event.external_id}"
+
+
+def _safe_filename_stem(event: EventSourceRecord) -> str:
+    return _event_digest(event.source, event.external_id, event.start)
+
+
+def _event_digest(*parts: str) -> str:
+    return hashlib.sha1(":".join(parts).encode("utf-8")).hexdigest()
+
+
+def _date_label(value: str) -> str:
+    if not value:
+        return "date-unknown"
+    candidate = value.replace("Z", "+00:00")
+    try:
+        return datetime.fromisoformat(candidate).date().isoformat()
+    except ValueError:
+        return value[:10] if len(value) >= 10 else value

--- a/backend/tests/api/test_knowledge_api.py
+++ b/backend/tests/api/test_knowledge_api.py
@@ -369,6 +369,26 @@ def test_create_knowledge_unique_violation_returns_structured_detail(mock_get_sb
     }
 
 
+@patch("backend.api.knowledge.generate_embedding", new_callable=AsyncMock)
+@patch("backend.api.knowledge._get_supabase")
+def test_create_knowledge_rejects_reserved_metadata_fields(mock_get_sb, mock_embed):
+    """Text CRUD must not accept upload-owned RAG identity metadata."""
+    response = client.post(
+        "/api/knowledge",
+        json={
+            "title": "Reserved metadata proof",
+            "content": "Reserved metadata content",
+            "category": "general",
+            "metadata": {"document_id": "user-controlled-document"},
+        },
+    )
+
+    assert response.status_code == 400
+    assert response.json()["detail"] == "Invalid metadata: metadata field 'document_id' is reserved"
+    mock_embed.assert_not_called()
+    mock_get_sb.assert_not_called()
+
+
 # =============================================================================
 # PUT /api/knowledge/{id}
 # =============================================================================
@@ -433,6 +453,21 @@ def test_update_knowledge_unique_violation_returns_structured_detail(mock_get_sb
         "message": "duplicate titles",
         "conflicts": [{"title": "更新後タイトル", "chunk_index": None}],
     }
+
+
+@patch("backend.api.knowledge.generate_embedding", new_callable=AsyncMock)
+@patch("backend.api.knowledge._get_supabase")
+def test_update_knowledge_rejects_reserved_metadata_fields(mock_get_sb, mock_embed):
+    """Updates must not let callers mutate generated RAG identity metadata."""
+    response = client.put(
+        f"/api/knowledge/{SAMPLE_ROW['id']}",
+        json={"metadata": {"entry_id": "user-controlled-entry"}},
+    )
+
+    assert response.status_code == 400
+    assert response.json()["detail"] == "Invalid metadata: metadata field 'entry_id' is reserved"
+    mock_embed.assert_not_called()
+    mock_get_sb.assert_not_called()
 
 
 # =============================================================================
@@ -526,6 +561,59 @@ def test_upload_markdown(mock_get_sb, mock_embed, mock_parse_md):
     assert inserted["chunk_level"] == "document"
     assert inserted["chunk_index"] == 0
     assert inserted["token_count"] > 0
+
+
+@patch("backend.api.knowledge.parse_markdown")
+@patch("backend.api.knowledge.generate_embedding", new_callable=AsyncMock)
+@patch("backend.api.knowledge._get_supabase")
+def test_upload_strips_reserved_metadata_before_generating_chunk_identity(
+    mock_get_sb, mock_embed, mock_parse_md
+):
+    """Upload remains compatible while preventing user metadata from owning identity."""
+    mock_embed.return_value = FAKE_EMBEDDING
+    mock_parse_md.return_value = "Parsed markdown content"
+    mock_sb = _mock_supabase()
+    mock_get_sb.return_value = mock_sb
+
+    mock_sb.table.return_value.select.return_value.in_.return_value.execute.return_value = (
+        _mock_table_result([])
+    )
+    uploaded_row = {
+        **SAMPLE_ROW,
+        "title": "metadata_doc",
+        "content": "Parsed markdown content",
+        "source": "file:metadata_doc.md",
+        "metadata": {
+            "original_filename": "metadata_doc.md",
+            "file_type": "markdown",
+            "chunk_index": 0,
+            "total_chunks": 1,
+        },
+    }
+    mock_sb.table.return_value.insert.return_value.execute.return_value = _mock_table_result(
+        [uploaded_row]
+    )
+
+    response = client.post(
+        "/api/knowledge/upload",
+        data={
+            "category": "general",
+            "language": "en",
+            "metadata": (
+                '{"document_id":"user-document","entry_id":"user-entry",'
+                '"language":"ja","total_chunks":99,"owner":"operations"}'
+            ),
+        },
+        files={"file": ("metadata_doc.md", io.BytesIO(b"# Test"), "text/markdown")},
+    )
+
+    assert response.status_code == 201
+    inserted = mock_sb.table.return_value.insert.call_args.args[0]
+    assert inserted["metadata"]["owner"] == "operations"
+    assert inserted["metadata"]["language"] == "en"
+    assert inserted["metadata"]["entry_id"].startswith("upload-metadata_doc-")
+    assert inserted["metadata"]["document_id"] == inserted["metadata"]["entry_id"]
+    assert inserted["metadata"]["total_chunks"] == 1
 
 
 @patch("backend.api.knowledge.parse_pdf")

--- a/backend/tests/evaluation/test_offline_quality_gate.py
+++ b/backend/tests/evaluation/test_offline_quality_gate.py
@@ -1,0 +1,121 @@
+"""Tests for deterministic offline RAG quality signals."""
+
+import json
+
+import pytest
+
+from backend.evaluation.quality_signals import (
+    groundedness_score,
+    language_match_score,
+    score_case,
+    summarize_quality_signals,
+    toxicity_score,
+)
+from backend.evaluation.run_offline_quality_gate import run_offline_quality_gate
+
+
+def test_language_match_score_accounts_for_supported_languages() -> None:
+    assert language_match_score("エンジニアカフェは無料です。", "ja") == 1.0
+    assert language_match_score("Engineer Cafe is free to use.", "en") == 1.0
+    assert language_match_score("工程师咖啡可以免费使用。", "zh") == 1.0
+    assert language_match_score("엔지니어 카페는 무료로 이용할 수 있습니다.", "ko") == 1.0
+    assert language_match_score("Engineer Cafe is free to use.", "ja") == 0.0
+
+
+def test_groundedness_and_hallucination_signals_use_context_overlap() -> None:
+    grounded = groundedness_score(
+        "Engineer Cafe is open from 9:00 to 22:00.",
+        ["Engineer Cafe is open from 9:00 to 22:00 every day."],
+    )
+    unsupported = groundedness_score(
+        "Engineer Cafe is open from 7:00 and has a private sauna.",
+        ["Engineer Cafe is open from 9:00 to 22:00 every day."],
+    )
+
+    assert grounded > unsupported
+    assert grounded >= 0.7
+    assert unsupported < 0.7
+
+
+def test_toxicity_score_flags_lexicon_hits() -> None:
+    assert toxicity_score("Please use the reception desk.") == 0.0
+    assert toxicity_score("shut up") == 1.0
+
+
+def test_score_case_reports_failures_without_external_services() -> None:
+    result = score_case(
+        {
+            "query_id": "case-1",
+            "language": "en",
+            "answer": "エンジニアカフェは7時から開いています。shut up",
+            "contexts": ["Engineer Cafe is open from 9:00 to 22:00."],
+        }
+    )
+
+    assert result.passed is False
+    assert "language_match" in result.failures
+    assert "groundedness" in result.failures
+    assert "toxicity" in result.failures
+
+
+def test_summarize_quality_signals_groups_by_language() -> None:
+    summary = summarize_quality_signals(
+        [
+            {
+                "query_id": "ja-1",
+                "language": "ja",
+                "answer": "エンジニアカフェの開館時間は9:00から22:00です。",
+                "contexts": ["エンジニアカフェの開館時間は9:00から22:00です。"],
+            },
+            {
+                "query_id": "en-1",
+                "language": "en",
+                "answer": "Engineer Cafe is free to use.",
+                "contexts": ["Engineer Cafe is free to use."],
+            },
+        ]
+    )
+
+    assert summary["overall"]["case_count"] == 2
+    assert summary["overall"]["passed"] is True
+    assert set(summary["per_language"]) == {"en", "ja"}
+    assert summary["failed_cases"] == []
+
+
+def test_run_offline_quality_gate_writes_reports_without_ragas_or_live_secrets(tmp_path) -> None:
+    result = run_offline_quality_gate(
+        languages=["ja", "en"],
+        max_cases=2,
+        output_dir=tmp_path,
+    )
+
+    assert result["mode"] == "offline"
+    assert result["blocking_by_default"] is False
+    assert result["quality_signals"]["overall"]["case_count"] == 4
+    assert result["quality_signals"]["overall"]["passed"] is True
+
+    reports = sorted(tmp_path.glob("offline_quality_gate_*.json"))
+    summaries = sorted(tmp_path.glob("offline_quality_gate_*.md"))
+    assert len(reports) == 1
+    assert len(summaries) == 1
+
+    payload = json.loads(reports[0].read_text(encoding="utf-8"))
+    assert payload["quality_signals"]["per_language"]["ja"]["case_count"] == 2
+    assert "Offline RAG Quality Gate" in summaries[0].read_text(encoding="utf-8")
+
+
+def test_run_offline_quality_gate_can_surface_enforceable_failures(tmp_path) -> None:
+    result = run_offline_quality_gate(
+        languages=["en"],
+        max_cases=1,
+        output_dir=tmp_path,
+        thresholds={"groundedness_min": 1.01},
+    )
+
+    assert result["quality_signals"]["overall"]["passed"] is False
+    assert result["quality_signals"]["failed_cases"][0]["failures"] == ["groundedness"]
+
+
+def test_language_match_rejects_unknown_language() -> None:
+    with pytest.raises(ValueError, match="unsupported expected_language"):
+        language_match_score("bonjour", "fr")

--- a/backend/tests/knowledge/test_upload_ingestion.py
+++ b/backend/tests/knowledge/test_upload_ingestion.py
@@ -69,6 +69,33 @@ def test_plan_upload_chunks_adds_language_file_and_accounting_metadata():
     assert chunk.metadata["total_chunks"] == 1
 
 
+def test_plan_upload_chunks_drops_user_metadata_reserved_for_generated_identity():
+    plan = plan_upload_chunks(
+        "Parsed PDF content",
+        filename="Visitor Guide.pdf",
+        category="general",
+        language="en",
+        metadata={
+            "entry_id": "user-entry",
+            "document_id": "user-document",
+            "chunk_level": "chunk",
+            "chunk_index": 99,
+            "total_chunks": 99,
+            "language": "ja",
+            "owner": "operations",
+        },
+    )
+
+    chunk = plan.chunks[0]
+    assert chunk.entry_id.startswith("upload-visitor-guide-")
+    assert chunk.metadata["owner"] == "operations"
+    assert chunk.metadata["language"] == "en"
+    assert chunk.metadata["chunk_level"] == "document"
+    assert chunk.metadata["chunk_index"] == 0
+    assert chunk.metadata["total_chunks"] == 1
+    assert "document_id" not in chunk.metadata
+
+
 def test_plan_upload_chunks_preserves_section_chunk_levels_and_titles():
     content = (
         "## Access\n"

--- a/backend/tests/services/test_event_kb_sync.py
+++ b/backend/tests/services/test_event_kb_sync.py
@@ -1,0 +1,144 @@
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from backend.services.event_kb_sync import (
+    EventSourceRecord,
+    event_record_to_kb_title,
+    event_record_to_markdown,
+    parse_ics_event_records,
+    plan_event_kb_records,
+    sync_event_kb_records,
+)
+
+SAMPLE_ICS = """BEGIN:VCALENDAR
+VERSION:2.0
+PRODID:-//Engineer Cafe//Event KB Bridge Test//EN
+BEGIN:VEVENT
+UID:event-001@example.com
+SUMMARY:Engineer Cafe Python Meetup
+DTSTART:20260510T100000Z
+DTEND:20260510T120000Z
+LOCATION:Engineer Cafe Main Hall
+DESCRIPTION:Bring a laptop\\, meet local engineers.\\nBeginner friendly.
+URL:https://example.com/events/python
+END:VEVENT
+BEGIN:VEVENT
+UID:noise-001@example.com
+SUMMARY:Busy
+DTSTART:20260511T100000Z
+DTEND:20260511T110000Z
+END:VEVENT
+END:VCALENDAR
+"""
+
+
+def test_parse_ics_event_records_filters_noise_and_normalizes_fields():
+    records = parse_ics_event_records(SAMPLE_ICS)
+
+    assert records == [
+        EventSourceRecord(
+            external_id="event-001@example.com",
+            title="Engineer Cafe Python Meetup",
+            start="2026-05-10T10:00:00Z",
+            end="2026-05-10T12:00:00Z",
+            description="Bring a laptop, meet local engineers.\nBeginner friendly.",
+            location="Engineer Cafe Main Hall",
+            url="https://example.com/events/python",
+            source="google_calendar",
+        )
+    ]
+
+
+def test_event_record_adapter_builds_stable_title_and_content():
+    event = EventSourceRecord(
+        external_id="event-001@example.com",
+        title="Engineer Cafe Python Meetup",
+        start="2026-05-10T10:00:00Z",
+        end="2026-05-10T12:00:00Z",
+        description="Bring a laptop.",
+        location="Engineer Cafe Main Hall",
+        url="https://example.com/events/python",
+    )
+
+    title = event_record_to_kb_title(event)
+    content = event_record_to_markdown(event)
+
+    assert title.startswith("Event: Engineer Cafe Python Meetup (2026-05-10) [")
+    assert len(title) <= 200
+    assert "# Engineer Cafe Python Meetup" in content
+    assert "- Start: 2026-05-10T10:00:00Z" in content
+    assert "- Location: Engineer Cafe Main Hall" in content
+    assert "Bring a laptop." in content
+
+
+@pytest.mark.asyncio
+async def test_plan_event_kb_records_uses_event_category_upload_path():
+    events = parse_ics_event_records(SAMPLE_ICS)
+
+    records = await plan_event_kb_records(events)
+
+    assert len(records) == 1
+    record = records[0]
+    assert "content_embedding" not in record
+    assert record["category"] == "event"
+    assert record["language"] == "ja"
+    assert record["source"] == "event_bridge:google_calendar:event-001@example.com"
+    assert record["subcategory"] == "live_event"
+    assert record["chunk_level"] == "document"
+    assert record["metadata"]["bridge"] == "event_bridge"
+    assert record["metadata"]["sync_source"] == "google_calendar"
+    assert record["metadata"]["external_event_id"] == "event-001@example.com"
+    assert record["metadata"]["file_type"] == "markdown"
+    assert record["token_count"] > 0
+
+
+@pytest.mark.asyncio
+async def test_sync_event_kb_records_dry_run_does_not_embed_or_write():
+    events = parse_ics_event_records(SAMPLE_ICS)
+    supabase = MagicMock()
+
+    async def fail_embed(text: str) -> list[float]:
+        raise AssertionError("dry-run should not embed")
+
+    result = await sync_event_kb_records(
+        events,
+        supabase_client=supabase,
+        embedding_fn=fail_embed,
+        dry_run=True,
+    )
+
+    assert result.planned_count == 1
+    assert result.written_count == 0
+    assert result.skipped_count == 0
+    assert len(result.records) == 1
+    supabase.table.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_sync_event_kb_records_live_upserts_embedding_visible_rows():
+    events = parse_ics_event_records(SAMPLE_ICS)
+    supabase = MagicMock()
+    table = supabase.table.return_value
+    table.upsert.return_value.execute.return_value = MagicMock(data=[{"id": "kb-1"}])
+
+    async def fake_embed(text: str) -> list[float]:
+        return [0.1, 0.2, 0.3]
+
+    result = await sync_event_kb_records(
+        events,
+        supabase_client=supabase,
+        embedding_fn=fake_embed,
+        dry_run=False,
+    )
+
+    assert result.planned_count == 1
+    assert result.written_count == 1
+    assert result.skipped_count == 0
+    supabase.table.assert_called_with("knowledge_base")
+    upsert_record = table.upsert.call_args.args[0]
+    assert upsert_record["content_embedding"] == [0.1, 0.2, 0.3]
+    assert upsert_record["category"] == "event"
+    assert table.upsert.call_args.kwargs == {"on_conflict": "title"}


### PR DESCRIPTION
## Summary
- validate and sanitize reserved metadata keys for uploaded knowledge documents
- preserve ingestion metadata through the upload path
- add an event KB sync service/CLI for dry-run and controlled live insertion from event feeds
- add deterministic offline quality signals and an optional enforcement gate for post-alpha RAG regression checks

## Validation
- uv run pytest backend/tests/api/test_knowledge_api.py backend/tests/knowledge/test_upload_ingestion.py backend/tests/services/test_event_kb_sync.py backend/tests/evaluation/test_offline_quality_gate.py -q
- python -m black --check backend/api/knowledge.py backend/knowledge/upload_ingestion.py backend/knowledge/metadata.py backend/scripts/sync_event_kb.py backend/services/event_kb_sync.py backend/evaluation/quality_signals.py backend/evaluation/run_offline_quality_gate.py backend/tests/api/test_knowledge_api.py backend/tests/knowledge/test_upload_ingestion.py backend/tests/services/test_event_kb_sync.py backend/tests/evaluation/test_offline_quality_gate.py
- python -m ruff check backend/api/knowledge.py backend/knowledge/upload_ingestion.py backend/knowledge/metadata.py backend/scripts/sync_event_kb.py backend/services/event_kb_sync.py backend/evaluation/quality_signals.py backend/evaluation/run_offline_quality_gate.py backend/tests/api/test_knowledge_api.py backend/tests/knowledge/test_upload_ingestion.py backend/tests/services/test_event_kb_sync.py backend/tests/evaluation/test_offline_quality_gate.py

## Notes
The event sync is additive and intentionally does not delete stale event rows yet; stale-row cleanup should be a separate issue once live behavior is observed.