### PR TITLE
[codex] Add onsite ops monitoring gates

### DIFF
--- a/docs/observability-runbook.md
+++ b/docs/observability-runbook.md
@@ -3,6 +3,54 @@
 Issue #513 Phase 1b monitors Cloud Run logs through Terraform-managed log metrics,
 dashboard panels, and alert policies. Terraform changes are applied manually after merge.
 
+## On-site Ops Gate
+
+Use `scripts/onsite-voice-live-proof.sh` for #774/#483/#489/#140 operational proof. It runs the
+real live path:
+
+```text
+/api/voice speech_to_text -> /api/chat -> /api/voice text_to_speech
+```
+
+Default pass/fail windows are based on the 2026-05-09 post-alpha baseline: STT was still the
+primary bottleneck (`p50=6877ms`, `p95/max=10006ms`), quick chat p50 was about `2486ms`, and
+PiperPlus TTS was usable but still required provider-fault proof.
+
+| Segment | PASS | WARN | FAIL |
+| --- | ---: | ---: | ---: |
+| STT | `<=5000ms` | `<=10000ms` | `>10000ms` |
+| Chat | `<=5000ms` | `<=10000ms` | `>10000ms` |
+| TTS | `<=5000ms` | `<=10000ms` | `>10000ms` |
+| Full turn (`STT+chat+TTS`) | `<=12000ms` | `<=15000ms` | `>15000ms` |
+
+Run from the repo root with a manifest built from actual kiosk/M5Stack microphone WAV files:
+
+```bash
+scripts/onsite-voice-live-proof.sh \
+  --manifest backend/evaluation/datasets/onsite_voice_live_manifest.example.json \
+  --timestamp onsite-YYYYMMDD-HHMM
+```
+
+Outputs:
+
+- `backend/tests/reports/onsite-voice-live-proof-<timestamp>.md`
+- `backend/tests/reports/onsite-voice-live-proof-<timestamp>.csv`
+- `backend/tests/reports/onsite-voice-ops-gate-<timestamp>.md`
+
+The shell gate fails on any runner failure, hop latency failure, missing STT/chat/TTS step, or
+full-turn latency failure. Thresholds are intentionally overridable for controlled experiments:
+`--stt-pass-ms`, `--stt-fail-ms`, `--chat-pass-ms`, `--chat-fail-ms`, `--tts-pass-ms`,
+`--tts-fail-ms`, `--full-turn-pass-ms`, and `--full-turn-fail-ms`.
+
+On-site checklist:
+
+1. Record WAV files on the target kiosk/M5Stack microphone path; do not use laptop fixtures.
+2. Note device, network, room/noise state, Cloud Run revision, and backend SHA beside the report.
+3. Run the matching Cloud Logging queries for the proof window.
+4. Treat TTS fallback, empty audio, `/api/chat` 5xx, memory helper errors, UUID hygiene hits, and
+   reception persistence errors as blockers until triaged.
+5. Do not apply Terraform from the on-site proof. Terraform remains review/plan/apply only.
+
 ## Alpha Live Verification Permission Note
 
 2026-04-25 の Alpha Live Verification run では、GitHub Actions の GCP service account
@@ -82,6 +130,58 @@ Triage:
 2. Check `sources` and `rag_fallback` for RAG degradation.
 3. Check Cloud Run request latency and 5xx logs for platform-level issues.
 4. Compare the current revision against the previous healthy revision.
+
+## TTS Response
+
+Primary signal: `jsonPayload.event="tts_complete"` with `tts_overall_duration_ms`, `provider`,
+`language`, `success`, `tts_cache_hit`, `fallback_used`, and `fallback_provider`.
+
+Useful Cloud Logging query:
+
+```text
+resource.type="cloud_run_revision"
+resource.labels.service_name="engineer-cafe-backend"
+jsonPayload.event="tts_complete"
+```
+
+High-latency query:
+
+```text
+resource.type="cloud_run_revision"
+resource.labels.service_name="engineer-cafe-backend"
+jsonPayload.event="tts_complete"
+jsonPayload.tts_overall_duration_ms>=5000
+```
+
+Failure or fallback query:
+
+```text
+resource.type="cloud_run_revision"
+resource.labels.service_name="engineer-cafe-backend"
+jsonPayload.event="tts_complete"
+(jsonPayload.success=false OR jsonPayload.fallback_used=true)
+```
+
+Triage:
+
+1. Split by `provider`, `language`, `tts_cache_hit`, and `fallback_used`.
+2. Check whether failures are empty audio, upstream provider failure, timeout, or fallback failure.
+3. Confirm whether on-site cases used long answers that should be shortened before TTS.
+4. Compare the TTS provider config against the last known healthy revision.
+
+## Full-Turn Latency
+
+There is no single production log event today that represents full user turn latency across
+STT, chat, and TTS. The operational gate derives full-turn latency from
+`onsite-voice-live-proof` CSV rows by summing:
+
+```text
+onsite_qwen_stt + live_langgraph_answer + live_answer_tts
+```
+
+Use the full-turn result in `onsite-voice-ops-gate-<timestamp>.md` as the on-site pass/fail signal.
+If it fails, inspect the hop table first; do not tune Cloud Monitoring thresholds until the slow hop
+is identified.
 
 ## Alpha Log Hygiene
 

--- a/infra/terraform/alerts.tf
+++ b/infra/terraform/alerts.tf
@@ -216,6 +216,79 @@ resource "google_monitoring_alert_policy" "stt_latency_p95" {
   }
 }
 
+resource "google_monitoring_alert_policy" "tts_latency_p95" {
+  display_name = "Engineer Cafe TTS p95 latency"
+  combiner     = "OR"
+  enabled      = var.alert_enabled
+
+  notification_channels = var.notification_channel_ids
+
+  documentation {
+    content   = "TTS p95 latency exceeded the onsite pass window of 5s for 15 minutes. See docs/observability-runbook.md."
+    mime_type = "text/markdown"
+  }
+
+  conditions {
+    display_name = "tts_complete p95 > 5000 ms"
+
+    condition_threshold {
+      filter                  = "metric.type=\"${local.metric_type.tts_overall_duration_ms}\" ${local.cloud_run_metric_scope}"
+      comparison              = "COMPARISON_GT"
+      threshold_value         = local.slo.tts_latency_p95_ms
+      duration                = "900s"
+      evaluation_missing_data = "EVALUATION_MISSING_DATA_INACTIVE"
+
+      aggregations {
+        alignment_period     = "300s"
+        per_series_aligner   = "ALIGN_PERCENTILE_95"
+        cross_series_reducer = "REDUCE_MAX"
+        group_by_fields = [
+          "resource.label.service_name",
+        ]
+      }
+
+      trigger {
+        count = 1
+      }
+    }
+  }
+}
+
+resource "google_monitoring_alert_policy" "tts_failures" {
+  display_name = "Engineer Cafe TTS failures"
+  combiner     = "OR"
+  enabled      = var.alert_enabled
+
+  notification_channels = var.notification_channel_ids
+
+  documentation {
+    content   = "TTS emitted one or more success=false completion events in 15 minutes. See docs/observability-runbook.md."
+    mime_type = "text/markdown"
+  }
+
+  conditions {
+    display_name = "tts_complete success=false count > 0"
+
+    condition_threshold {
+      filter                  = "metric.type=\"${local.metric_type.tts_failure_count}\" ${local.cloud_run_metric_scope}"
+      comparison              = "COMPARISON_GT"
+      threshold_value         = local.slo.tts_failure_count_15
+      duration                = "0s"
+      evaluation_missing_data = "EVALUATION_MISSING_DATA_INACTIVE"
+
+      aggregations {
+        alignment_period     = "900s"
+        per_series_aligner   = "ALIGN_DELTA"
+        cross_series_reducer = "REDUCE_SUM"
+      }
+
+      trigger {
+        count = 1
+      }
+    }
+  }
+}
+
 resource "google_monitoring_alert_policy" "memory_helper_errors" {
   display_name = "Engineer Cafe memory helper errors"
   combiner     = "OR"

--- a/infra/terraform/dashboard.tf
+++ b/infra/terraform/dashboard.tf
@@ -139,6 +139,70 @@ resource "google_monitoring_dashboard" "observability_phase1b" {
               }
             }
           }
+        },
+        {
+          xPos   = 0
+          yPos   = 8
+          width  = 6
+          height = 4
+          widget = {
+            title = "TTS latency"
+            xyChart = {
+              dataSets = [
+                {
+                  plotType   = "LINE"
+                  targetAxis = "Y1"
+                  timeSeriesQuery = {
+                    timeSeriesFilter = {
+                      filter = "metric.type=\"${local.metric_type.tts_overall_duration_ms}\" ${local.cloud_run_metric_scope}"
+                      aggregation = {
+                        alignmentPeriod    = "300s"
+                        perSeriesAligner   = "ALIGN_PERCENTILE_95"
+                        crossSeriesReducer = "REDUCE_MAX"
+                        groupByFields      = ["metric.label.provider"]
+                      }
+                    }
+                  }
+                }
+              ]
+              yAxis = {
+                label = "p95 ms"
+                scale = "LINEAR"
+              }
+            }
+          }
+        },
+        {
+          xPos   = 6
+          yPos   = 8
+          width  = 6
+          height = 4
+          widget = {
+            title = "TTS failures"
+            xyChart = {
+              dataSets = [
+                {
+                  plotType   = "STACKED_BAR"
+                  targetAxis = "Y1"
+                  timeSeriesQuery = {
+                    timeSeriesFilter = {
+                      filter = "metric.type=\"${local.metric_type.tts_failure_count}\" ${local.cloud_run_metric_scope}"
+                      aggregation = {
+                        alignmentPeriod    = "900s"
+                        perSeriesAligner   = "ALIGN_DELTA"
+                        crossSeriesReducer = "REDUCE_SUM"
+                        groupByFields      = ["metric.label.provider", "metric.label.error_type"]
+                      }
+                    }
+                  }
+                }
+              ]
+              yAxis = {
+                label = "failures / 15m"
+                scale = "LINEAR"
+              }
+            }
+          }
         }
       ]
     }

--- a/infra/terraform/locals.tf
+++ b/infra/terraform/locals.tf
@@ -9,6 +9,9 @@ locals {
     stt_winner_count          = "logging.googleapis.com/user/${google_logging_metric.stt_winner_count.name}"
     stt_none_count            = "logging.googleapis.com/user/${google_logging_metric.stt_none_count.name}"
     stt_overall_duration_ms   = "logging.googleapis.com/user/${google_logging_metric.stt_overall_duration_ms.name}"
+    tts_complete_count        = "logging.googleapis.com/user/${google_logging_metric.tts_complete_count.name}"
+    tts_failure_count         = "logging.googleapis.com/user/${google_logging_metric.tts_failure_count.name}"
+    tts_overall_duration_ms   = "logging.googleapis.com/user/${google_logging_metric.tts_overall_duration_ms.name}"
     memory_helper_error_count = "logging.googleapis.com/user/${google_logging_metric.memory_helper_error_count.name}"
   }
 
@@ -21,6 +24,8 @@ locals {
     slow_burn_threshold   = 0.12
     chat_latency_p95_ms   = 10000
     stt_latency_p95_ms    = 6000
+    tts_latency_p95_ms    = 5000
+    tts_failure_count_15  = 0
     memory_error_count_15 = 0
   }
 }

--- a/infra/terraform/log_metrics.tf
+++ b/infra/terraform/log_metrics.tf
@@ -184,6 +184,146 @@ resource "google_logging_metric" "stt_overall_duration_ms" {
   }
 }
 
+resource "google_logging_metric" "tts_complete_count" {
+  name        = "engineer_cafe_tts_complete_count"
+  description = "Count of TTS completion events by provider, language, success, cache, and fallback state."
+  filter      = "${local.cloud_run_filter} jsonPayload.event=\"tts_complete\""
+
+  label_extractors = {
+    provider        = "EXTRACT(jsonPayload.provider)"
+    language        = "EXTRACT(jsonPayload.language)"
+    success         = "EXTRACT(jsonPayload.success)"
+    tts_cache_hit   = "EXTRACT(jsonPayload.tts_cache_hit)"
+    fallback_used   = "EXTRACT(jsonPayload.fallback_used)"
+    fallback_source = "EXTRACT(jsonPayload.fallback_provider)"
+  }
+
+  metric_descriptor {
+    metric_kind = "DELTA"
+    value_type  = "INT64"
+    unit        = "1"
+
+    labels {
+      key         = "provider"
+      value_type  = "STRING"
+      description = "Requested TTS provider."
+    }
+    labels {
+      key         = "language"
+      value_type  = "STRING"
+      description = "TTS language."
+    }
+    labels {
+      key         = "success"
+      value_type  = "STRING"
+      description = "Whether the TTS request completed successfully."
+    }
+    labels {
+      key         = "tts_cache_hit"
+      value_type  = "STRING"
+      description = "Whether TTS returned from cache."
+    }
+    labels {
+      key         = "fallback_used"
+      value_type  = "STRING"
+      description = "Whether TTS used a fallback provider."
+    }
+    labels {
+      key         = "fallback_source"
+      value_type  = "STRING"
+      description = "Fallback provider when one was used."
+    }
+  }
+}
+
+resource "google_logging_metric" "tts_failure_count" {
+  name        = "engineer_cafe_tts_failure_count"
+  description = "Count of TTS completion events where success=false."
+  filter      = "${local.cloud_run_filter} jsonPayload.event=\"tts_complete\" jsonPayload.success=false"
+
+  label_extractors = {
+    provider      = "EXTRACT(jsonPayload.provider)"
+    language      = "EXTRACT(jsonPayload.language)"
+    fallback_used = "EXTRACT(jsonPayload.fallback_used)"
+    error_type    = "EXTRACT(jsonPayload.error_type)"
+  }
+
+  metric_descriptor {
+    metric_kind = "DELTA"
+    value_type  = "INT64"
+    unit        = "1"
+
+    labels {
+      key         = "provider"
+      value_type  = "STRING"
+      description = "Requested TTS provider."
+    }
+    labels {
+      key         = "language"
+      value_type  = "STRING"
+      description = "TTS language."
+    }
+    labels {
+      key         = "fallback_used"
+      value_type  = "STRING"
+      description = "Whether TTS attempted fallback before failure."
+    }
+    labels {
+      key         = "error_type"
+      value_type  = "STRING"
+      description = "TTS exception class when available."
+    }
+  }
+}
+
+resource "google_logging_metric" "tts_overall_duration_ms" {
+  name        = "engineer_cafe_tts_overall_duration_ms"
+  description = "Distribution of TTS synthesis latency in milliseconds."
+  filter      = "${local.cloud_run_filter} jsonPayload.event=\"tts_complete\" jsonPayload.tts_overall_duration_ms:*"
+
+  value_extractor = "EXTRACT(jsonPayload.tts_overall_duration_ms)"
+
+  label_extractors = {
+    provider      = "EXTRACT(jsonPayload.provider)"
+    language      = "EXTRACT(jsonPayload.language)"
+    success       = "EXTRACT(jsonPayload.success)"
+    fallback_used = "EXTRACT(jsonPayload.fallback_used)"
+  }
+
+  bucket_options {
+    explicit_buckets {
+      bounds = [250, 500, 1000, 2000, 3000, 5000, 8000, 10000, 15000, 30000]
+    }
+  }
+
+  metric_descriptor {
+    metric_kind = "DELTA"
+    value_type  = "DISTRIBUTION"
+    unit        = "ms"
+
+    labels {
+      key         = "provider"
+      value_type  = "STRING"
+      description = "Requested TTS provider."
+    }
+    labels {
+      key         = "language"
+      value_type  = "STRING"
+      description = "TTS language."
+    }
+    labels {
+      key         = "success"
+      value_type  = "STRING"
+      description = "Whether the TTS request completed successfully."
+    }
+    labels {
+      key         = "fallback_used"
+      value_type  = "STRING"
+      description = "Whether TTS used a fallback provider."
+    }
+  }
+}
+
 resource "google_logging_metric" "memory_helper_error_count" {
   name        = "engineer_cafe_memory_helper_error_count"
   description = "Count of existing structured root logs from backend.utils.memory_helper at ERROR level."

--- a/infra/terraform/outputs.tf
+++ b/infra/terraform/outputs.tf
@@ -10,7 +10,8 @@ output "alert_policy_ids" {
     stt_failure_burn_rate   = google_monitoring_alert_policy.stt_failure_burn_rate.id
     chat_latency_p95        = google_monitoring_alert_policy.chat_latency_p95.id
     stt_latency_p95         = google_monitoring_alert_policy.stt_latency_p95.id
+    tts_latency_p95         = google_monitoring_alert_policy.tts_latency_p95.id
+    tts_failures            = google_monitoring_alert_policy.tts_failures.id
     memory_helper_errors    = google_monitoring_alert_policy.memory_helper_errors.id
   }
 }
-

--- a/scripts/onsite-voice-live-proof.sh
+++ b/scripts/onsite-voice-live-proof.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-# On-site voice live proof for #571.
+# On-site voice live proof for #774/#483/#489/#140.
 #
 # This script is for real kiosk/device audio, not CI fixtures. Record WAV files
 # from the target microphone, describe them in a manifest, then run the same
@@ -25,6 +25,22 @@ OUTPUT_DIR="$ROOT_DIR/backend/tests/reports"
 TIMESTAMP="$(date +%Y%m%d_%H%M%S)"
 MANIFEST=""
 DRY_RUN=0
+SLEEP="${ONSITE_VOICE_LIVE_SLEEP:-2.2}"
+TIMEOUT="${ONSITE_VOICE_LIVE_TIMEOUT:-120}"
+RETRIES="${ONSITE_VOICE_LIVE_RETRIES:-3}"
+STT_PASS_MS="${ONSITE_STT_PASS_MS:-5000}"
+STT_FAIL_MS="${ONSITE_STT_FAIL_MS:-10000}"
+CHAT_PASS_MS="${ONSITE_CHAT_PASS_MS:-5000}"
+CHAT_FAIL_MS="${ONSITE_CHAT_FAIL_MS:-10000}"
+TTS_PASS_MS="${ONSITE_TTS_PASS_MS:-5000}"
+TTS_FAIL_MS="${ONSITE_TTS_FAIL_MS:-10000}"
+FULL_TURN_PASS_MS="${ONSITE_FULL_TURN_PASS_MS:-12000}"
+FULL_TURN_FAIL_MS="${ONSITE_FULL_TURN_FAIL_MS:-15000}"
+TRANSCRIPT_SIMILARITY="${ONSITE_TRANSCRIPT_SIMILARITY:-0.50}"
+FACT_SIMILARITY="${ONSITE_FACT_SIMILARITY:-0.60}"
+TTS_PROVIDER="${ONSITE_TTS_PROVIDER:-piper}"
+MIN_TTS_AUDIO_CHARS="${ONSITE_MIN_TTS_AUDIO_CHARS:-64}"
+ALLOW_VOSK_FALLBACK=0
 
 usage() {
   sed -n '3,14p' "$0"
@@ -38,6 +54,19 @@ Options:
   --secret-name NAME     Secret Manager secret name (default: API_SECRET_KEY)
   --output-dir DIR       Report directory (default: backend/tests/reports)
   --timestamp VALUE      Stable timestamp for report names
+  --sleep SEC            Seconds between live calls (default: 2.2)
+  --timeout SECONDS      Per-request timeout (default: 120)
+  --retries N            Retries for 429/transient live calls (default: 3)
+  --stt-pass-ms N        STT green window upper bound (default: 5000)
+  --stt-fail-ms N        STT failure window lower bound (default: 10000)
+  --chat-pass-ms N       Chat green window upper bound (default: 5000)
+  --chat-fail-ms N       Chat failure window lower bound (default: 10000)
+  --tts-pass-ms N        TTS green window upper bound (default: 5000)
+  --tts-fail-ms N        TTS failure window lower bound (default: 10000)
+  --full-turn-pass-ms N  STT+chat+TTS green window upper bound (default: 12000)
+  --full-turn-fail-ms N  STT+chat+TTS failure window lower bound (default: 15000)
+  --tts-provider NAME    TTS provider override for answer synthesis (default: piper)
+  --allow-vosk-fallback  Permit Vosk fallback in the underlying STT proof
   --dry-run              Validate manifest and print plan without network
   -h, --help             Show this usage
 
@@ -68,6 +97,19 @@ while [ "$#" -gt 0 ]; do
     --secret-name) SECRET_NAME="$2"; shift 2 ;;
     --output-dir) OUTPUT_DIR="$2"; shift 2 ;;
     --timestamp) TIMESTAMP="$2"; shift 2 ;;
+    --sleep) SLEEP="$2"; shift 2 ;;
+    --timeout) TIMEOUT="$2"; shift 2 ;;
+    --retries) RETRIES="$2"; shift 2 ;;
+    --stt-pass-ms) STT_PASS_MS="$2"; shift 2 ;;
+    --stt-fail-ms) STT_FAIL_MS="$2"; shift 2 ;;
+    --chat-pass-ms) CHAT_PASS_MS="$2"; shift 2 ;;
+    --chat-fail-ms) CHAT_FAIL_MS="$2"; shift 2 ;;
+    --tts-pass-ms) TTS_PASS_MS="$2"; shift 2 ;;
+    --tts-fail-ms) TTS_FAIL_MS="$2"; shift 2 ;;
+    --full-turn-pass-ms) FULL_TURN_PASS_MS="$2"; shift 2 ;;
+    --full-turn-fail-ms) FULL_TURN_FAIL_MS="$2"; shift 2 ;;
+    --tts-provider) TTS_PROVIDER="$2"; shift 2 ;;
+    --allow-vosk-fallback) ALLOW_VOSK_FALLBACK=1; shift ;;
     --dry-run) DRY_RUN=1; shift ;;
     -h|--help) usage 0 ;;
     *) echo "Unknown arg: $1" >&2; usage 1 ;;
@@ -86,6 +128,50 @@ fetch_api_key_from_gcloud() {
   fi
 }
 
+require_positive_number() {
+  local name="$1"
+  local value="$2"
+  if ! [[ "$value" =~ ^[0-9]+([.][0-9]+)?$ ]]; then
+    echo "Error: $name must be a positive number: $value" >&2
+    exit 2
+  fi
+}
+
+require_threshold_order() {
+  local pass_name="$1"
+  local pass_value="$2"
+  local fail_name="$3"
+  local fail_value="$4"
+  python3 - "$pass_name" "$pass_value" "$fail_name" "$fail_value" <<'PY'
+import sys
+pass_name, pass_value, fail_name, fail_value = sys.argv[1:5]
+if float(pass_value) > float(fail_value):
+    raise SystemExit(f"Error: {pass_name} must be <= {fail_name}: {pass_value} > {fail_value}")
+PY
+}
+
+for pair in \
+  "sleep:$SLEEP" \
+  "timeout:$TIMEOUT" \
+  "retries:$RETRIES" \
+  "stt-pass-ms:$STT_PASS_MS" \
+  "stt-fail-ms:$STT_FAIL_MS" \
+  "chat-pass-ms:$CHAT_PASS_MS" \
+  "chat-fail-ms:$CHAT_FAIL_MS" \
+  "tts-pass-ms:$TTS_PASS_MS" \
+  "tts-fail-ms:$TTS_FAIL_MS" \
+  "full-turn-pass-ms:$FULL_TURN_PASS_MS" \
+  "full-turn-fail-ms:$FULL_TURN_FAIL_MS" \
+  "transcript-similarity:$TRANSCRIPT_SIMILARITY" \
+  "fact-similarity:$FACT_SIMILARITY" \
+  "min-tts-audio-chars:$MIN_TTS_AUDIO_CHARS"; do
+  require_positive_number "${pair%%:*}" "${pair#*:}"
+done
+require_threshold_order "--stt-pass-ms" "$STT_PASS_MS" "--stt-fail-ms" "$STT_FAIL_MS"
+require_threshold_order "--chat-pass-ms" "$CHAT_PASS_MS" "--chat-fail-ms" "$CHAT_FAIL_MS"
+require_threshold_order "--tts-pass-ms" "$TTS_PASS_MS" "--tts-fail-ms" "$TTS_FAIL_MS"
+require_threshold_order "--full-turn-pass-ms" "$FULL_TURN_PASS_MS" "--full-turn-fail-ms" "$FULL_TURN_FAIL_MS"
+
 if [ -z "$API_KEY" ] && [ "$DRY_RUN" != "1" ]; then
   API_KEY="$(fetch_api_key_from_gcloud)"
 fi
@@ -101,12 +187,238 @@ cmd=(
   --host "$BASE_URL"
   --output-dir "$OUTPUT_DIR"
   --timestamp "$TIMESTAMP"
+  --sleep "$SLEEP"
+  --timeout "$TIMEOUT"
+  --retries "$RETRIES"
+  --stt-warn-ms "$STT_PASS_MS"
+  --stt-max-ms "$STT_FAIL_MS"
+  --chat-warn-ms "$CHAT_PASS_MS"
+  --tts-max-ms "$TTS_FAIL_MS"
+  --transcript-similarity "$TRANSCRIPT_SIMILARITY"
+  --fact-similarity "$FACT_SIMILARITY"
+  --tts-provider "$TTS_PROVIDER"
+  --min-tts-audio-chars "$MIN_TTS_AUDIO_CHARS"
 )
 
+if [ "$ALLOW_VOSK_FALLBACK" = "1" ]; then
+  cmd+=(--allow-vosk-fallback)
+fi
+
 if [ "$DRY_RUN" = "1" ]; then
+  echo "Operational gate windows:"
+  echo "  STT: pass<=${STT_PASS_MS}ms warn<=${STT_FAIL_MS}ms fail>${STT_FAIL_MS}ms"
+  echo "  Chat: pass<=${CHAT_PASS_MS}ms warn<=${CHAT_FAIL_MS}ms fail>${CHAT_FAIL_MS}ms"
+  echo "  TTS: pass<=${TTS_PASS_MS}ms warn<=${TTS_FAIL_MS}ms fail>${TTS_FAIL_MS}ms"
+  echo "  Full turn: pass<=${FULL_TURN_PASS_MS}ms warn<=${FULL_TURN_FAIL_MS}ms fail>${FULL_TURN_FAIL_MS}ms"
+  echo ""
   cmd+=(--dry-run)
 else
   cmd+=(--api-key "$API_KEY")
 fi
 
-"${cmd[@]}"
+runner_rc=0
+"${cmd[@]}" || runner_rc=$?
+
+if [ "$DRY_RUN" = "1" ]; then
+  exit "$runner_rc"
+fi
+
+CSV="$OUTPUT_DIR/onsite-voice-live-proof-$TIMESTAMP.csv"
+OPS_REPORT="$OUTPUT_DIR/onsite-voice-ops-gate-$TIMESTAMP.md"
+if [ ! -f "$CSV" ]; then
+  echo "Error: expected runner CSV not found: $CSV" >&2
+  exit "${runner_rc:-1}"
+fi
+
+ops_rc=0
+python3 - "$CSV" "$OPS_REPORT" "$TIMESTAMP" "$BASE_URL" "$MANIFEST" \
+  "$STT_PASS_MS" "$STT_FAIL_MS" "$CHAT_PASS_MS" "$CHAT_FAIL_MS" \
+  "$TTS_PASS_MS" "$TTS_FAIL_MS" "$FULL_TURN_PASS_MS" "$FULL_TURN_FAIL_MS" \
+  "$runner_rc" <<'PY' || ops_rc=$?
+from __future__ import annotations
+
+import csv
+import pathlib
+import sys
+from collections import defaultdict
+from typing import Any
+
+(
+    csv_path,
+    report_path,
+    timestamp,
+    base_url,
+    manifest,
+    stt_pass,
+    stt_fail,
+    chat_pass,
+    chat_fail,
+    tts_pass,
+    tts_fail,
+    full_pass,
+    full_fail,
+    runner_rc,
+) = sys.argv[1:15]
+
+thresholds = {
+    "onsite_qwen_stt": ("STT", float(stt_pass), float(stt_fail)),
+    "live_langgraph_answer": ("Chat", float(chat_pass), float(chat_fail)),
+    "live_answer_tts": ("TTS", float(tts_pass), float(tts_fail)),
+}
+full_pass_f = float(full_pass)
+full_fail_f = float(full_fail)
+
+
+def md(value: Any) -> str:
+    return str(value if value is not None else "").replace("|", "\\|").replace("\n", " ")
+
+
+def classify(duration_ms: float, pass_ms: float, fail_ms: float) -> str:
+    if duration_ms > fail_ms:
+        return "FAIL"
+    if duration_ms > pass_ms:
+        return "WARN"
+    return "PASS"
+
+
+def worse(left: str, right: str) -> str:
+    order = {"PASS": 0, "WARN": 1, "FAIL": 2}
+    return left if order[left] >= order[right] else right
+
+
+rows: list[dict[str, str]] = []
+with pathlib.Path(csv_path).open("r", encoding="utf-8", newline="") as fh:
+    rows = list(csv.DictReader(fh))
+
+by_case: dict[str, dict[str, dict[str, str]]] = defaultdict(dict)
+latency_rows: list[tuple[str, str, str, int, str, str]] = []
+gate_status = "PASS"
+
+for row in rows:
+    case_id = row.get("case_id", "")
+    step = row.get("step", "")
+    by_case[case_id][step] = row
+    if row.get("status") == "FAIL":
+        gate_status = "FAIL"
+    if step not in thresholds:
+        continue
+    label, pass_ms, fail_ms = thresholds[step]
+    duration = int(float(row.get("duration_ms") or 0))
+    latency_status = classify(duration, pass_ms, fail_ms)
+    gate_status = worse(gate_status, latency_status)
+    latency_rows.append(
+        (
+            case_id,
+            label,
+            latency_status,
+            duration,
+            f"pass<={int(pass_ms)}ms warn<={int(fail_ms)}ms fail>{int(fail_ms)}ms",
+            row.get("status", ""),
+        )
+    )
+
+full_rows: list[tuple[str, str, int, str]] = []
+for case_id, steps in sorted(by_case.items()):
+    missing = [step for step in thresholds if step not in steps]
+    if missing:
+        full_rows.append((case_id, "FAIL", 0, f"missing steps: {', '.join(missing)}"))
+        gate_status = "FAIL"
+        continue
+    total = sum(int(float(steps[step].get("duration_ms") or 0)) for step in thresholds)
+    status = classify(total, full_pass_f, full_fail_f)
+    gate_status = worse(gate_status, status)
+    full_rows.append(
+        (
+            case_id,
+            status,
+            total,
+            f"pass<={int(full_pass_f)}ms warn<={int(full_fail_f)}ms fail>{int(full_fail_f)}ms",
+        )
+    )
+
+if int(runner_rc) != 0:
+    gate_status = "FAIL"
+
+lines = [
+    "# On-site Voice Ops Gate",
+    "",
+    f"- Timestamp: {timestamp}",
+    f"- Backend: {base_url}",
+    f"- Manifest: {manifest}",
+    f"- Source CSV: {pathlib.Path(csv_path).name}",
+    f"- Runner exit code: {runner_rc}",
+    f"- Overall gate: {gate_status}",
+    "",
+    "## Pass/Fail Windows",
+    "",
+    "| Hop | PASS | WARN | FAIL |",
+    "| --- | ---: | ---: | ---: |",
+    f"| STT | <= {int(float(stt_pass))}ms | <= {int(float(stt_fail))}ms | > {int(float(stt_fail))}ms |",
+    f"| Chat | <= {int(float(chat_pass))}ms | <= {int(float(chat_fail))}ms | > {int(float(chat_fail))}ms |",
+    f"| TTS | <= {int(float(tts_pass))}ms | <= {int(float(tts_fail))}ms | > {int(float(tts_fail))}ms |",
+    f"| Full turn | <= {int(full_pass_f)}ms | <= {int(full_fail_f)}ms | > {int(full_fail_f)}ms |",
+    "",
+    "## Hop Results",
+    "",
+    "| Case | Hop | Gate | Duration | Window | Runner status |",
+    "| --- | --- | --- | ---: | --- | --- |",
+]
+for case_id, label, status, duration, window, runner_status in latency_rows:
+    lines.append(
+        f"| {md(case_id)} | {label} | {status} | {duration}ms | {md(window)} | {md(runner_status)} |"
+    )
+
+lines.extend(
+    [
+        "",
+        "## Full-Turn Results",
+        "",
+        "| Case | Gate | STT+chat+TTS | Window |",
+        "| --- | --- | ---: | --- |",
+    ]
+)
+for case_id, status, total, window in full_rows:
+    lines.append(f"| {md(case_id)} | {status} | {total}ms | {md(window)} |")
+
+lines.extend(
+    [
+        "",
+        "## On-site Checklist",
+        "",
+        "- Capture WAV files on the target kiosk/M5Stack microphone path, not laptop fixtures.",
+        "- Keep Cloud Run revision, backend SHA, device, network, and room/noise notes with this report.",
+        "- Run Cloud Logging checks for the same timestamp window before marking onsite proof complete.",
+        "- Treat any TTS fallback, empty audio, chat 5xx, memory helper error, UUID hygiene hit, or reception persistence error as a blocker until triaged.",
+        "- Do not run Terraform apply from this proof script; monitoring changes remain plan/review/apply only.",
+        "",
+        "## Cloud Logging Queries",
+        "",
+        "```text",
+        'resource.type="cloud_run_revision"',
+        'resource.labels.service_name="engineer-cafe-backend"',
+        'jsonPayload.event="stt_winner"',
+        "```",
+        "",
+        "```text",
+        'resource.type="cloud_run_revision"',
+        'resource.labels.service_name="engineer-cafe-backend"',
+        'jsonPayload.event="chat_response"',
+        "```",
+        "",
+        "```text",
+        'resource.type="cloud_run_revision"',
+        'resource.labels.service_name="engineer-cafe-backend"',
+        'jsonPayload.event="tts_complete"',
+        "```",
+    ]
+)
+
+pathlib.Path(report_path).write_text("\n".join(lines) + "\n", encoding="utf-8")
+print(report_path)
+raise SystemExit(0 if gate_status != "FAIL" else 1)
+PY
+
+if [ "$runner_rc" -ne 0 ]; then
+  exit "$runner_rc"
+fi
+exit "$ops_rc"


### PR DESCRIPTION
## Summary
- add an observability runbook for post-alpha voice/RAG operations
- extend Cloud Monitoring log metrics, dashboard widgets, and alerting for STT/TTS/voice latency signals
- add operational gate windows to onsite voice live proof so pass/warn/fail thresholds are explicit

## Validation
- bash -n scripts/onsite-voice-live-proof.sh
- scripts/onsite-voice-live-proof.sh --manifest backend/evaluation/datasets/onsite_voice_live_manifest.example.json --dry-run --timestamp ops-split-dry-run
- terraform -chdir=infra/terraform fmt -check
- terraform -chdir=infra/terraform init -backend=false && terraform -chdir=infra/terraform validate

## Notes
Terraform init artifacts were removed after validation; this PR only contains source config and the runbook.