### PR TITLE
[codex] Align Qwen ONNX artifact layout

### DIFF
--- a/backend/agents/stt_onnx.py
+++ b/backend/agents/stt_onnx.py
@@ -167,7 +167,9 @@ class QwenOnnxRuntime:
         required_files = (
             inference_path,
             onnx_dir / "encoder_conv.onnx",
+            onnx_dir / "encoder_conv.onnx.data",
             onnx_dir / "encoder_transformer.onnx",
+            onnx_dir / "encoder_transformer.onnx.data",
             onnx_dir / "decoder_init.int8.onnx",
             onnx_dir / "decoder_step.int8.onnx",
             onnx_dir / "embed_tokens.bin",

--- a/backend/scripts/download_qwen_onnx_model.sh
+++ b/backend/scripts/download_qwen_onnx_model.sh
@@ -12,7 +12,8 @@ BASE_URL="https://huggingface.co/${REPO}/resolve/${REVISION}"
 
 download_file() {
   local relative_path="$1"
-  local output_path="${TARGET_DIR}/${relative_path}"
+  local output_relative_path="${2:-$relative_path}"
+  local output_path="${TARGET_DIR}/${output_relative_path}"
   local output_dir
   output_dir="$(dirname "$output_path")"
   mkdir -p "$output_dir"
@@ -31,9 +32,11 @@ download_file() {
 mkdir -p "$TARGET_DIR"
 
 download_file "onnx_inference.py"
-download_file "onnx_models/tokenizer.json"
+download_file "tokenizer.json" "onnx_models/tokenizer.json"
 download_file "onnx_models/encoder_conv.onnx"
+download_file "onnx_models/encoder_conv.onnx.data"
 download_file "onnx_models/encoder_transformer.onnx"
+download_file "onnx_models/encoder_transformer.onnx.data"
 download_file "onnx_models/decoder_init.int8.onnx"
 download_file "onnx_models/decoder_step.int8.onnx"
 download_file "onnx_models/embed_tokens.bin"

--- a/backend/tests/agents/test_stt_agent.py
+++ b/backend/tests/agents/test_stt_agent.py
@@ -1104,7 +1104,9 @@ class OnnxAsrPipeline:
         )
         for relative_path in (
             "encoder_conv.onnx",
+            "encoder_conv.onnx.data",
             "encoder_transformer.onnx",
+            "encoder_transformer.onnx.data",
             "decoder_init.int8.onnx",
             "decoder_step.int8.onnx",
             "embed_tokens.bin",

--- a/scripts/download_qwen_onnx_model.sh
+++ b/scripts/download_qwen_onnx_model.sh
@@ -11,7 +11,8 @@ BASE_URL="https://huggingface.co/${REPO}/resolve/${REVISION}"
 
 download_file() {
   local relative_path="$1"
-  local output_path="${TARGET_DIR}/${relative_path}"
+  local output_relative_path="${2:-$relative_path}"
+  local output_path="${TARGET_DIR}/${output_relative_path}"
   local output_dir
   output_dir="$(dirname "$output_path")"
   mkdir -p "$output_dir"
@@ -30,9 +31,11 @@ download_file() {
 mkdir -p "$TARGET_DIR"
 
 download_file "onnx_inference.py"
-download_file "onnx_models/tokenizer.json"
+download_file "tokenizer.json" "onnx_models/tokenizer.json"
 download_file "onnx_models/encoder_conv.onnx"
+download_file "onnx_models/encoder_conv.onnx.data"
 download_file "onnx_models/encoder_transformer.onnx"
+download_file "onnx_models/encoder_transformer.onnx.data"
 download_file "onnx_models/decoder_init.int8.onnx"
 download_file "onnx_models/decoder_step.int8.onnx"
 download_file "onnx_models/embed_tokens.bin"


### PR DESCRIPTION
## Summary
- update Qwen ONNX download scripts for the actual Daumee artifact layout
- download root tokenizer.json into onnx_models/tokenizer.json for the bundled inference script
- include encoder external data files required by ONNX Runtime
- make runtime artifact validation catch the external .onnx.data files

## Validation
- bash -n scripts/download_qwen_onnx_model.sh backend/scripts/download_qwen_onnx_model.sh
- python -m black --check backend/agents/stt_onnx.py backend/tests/agents/test_stt_agent.py
- python -m ruff check backend/agents/stt_onnx.py backend/tests/agents/test_stt_agent.py
- uv run pytest backend/tests/agents/test_stt_agent.py::TestSTTAgent::test_qwen_onnx_runtime_can_use_daumee_model_dir backend/tests/agents/test_stt_agent.py::TestSTTAgent::test_qwen_onnx_runtime_model_dir_reports_missing_files -q

## Candidate build note
This fixes the second ONNX candidate build blocker: HF returned 404 for onnx_models/tokenizer.json because tokenizer.json lives at repository root.