### PR TITLE
Fix membership RAG and Cloud Run deploy routing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -505,14 +505,63 @@ jobs:
             --max-instances 15 \
             --cpu-boost \
             --no-cpu-throttling \
-            --update-env-vars "ENVIRONMENT=production,TTS_PROVIDER=piper,PIPER_PLUS_API_URL=https://piper-plus-639959525777.asia-northeast1.run.app,VOICEVOX_API_URL=https://voicevox-proto-639959525777.asia-northeast2.run.app,STT_PROVIDER=qwen-primary,STT_LLM_POSTPROCESS=false,QWEN_STT_TIMEOUT=45,QWEN_STT_HEDGE_DELAY_SECONDS=2,QWEN_STT_HEDGE_GRACE_SECONDS=6,STT_PRELOAD_QWEN_PRIMARY=true,HF_HOME=/app/.hf_cache,FRONTEND_PRODUCTION_ORIGIN=${FRONTEND_PRODUCTION_ORIGIN},ALLOWED_ORIGINS=${FRONTEND_PRODUCTION_ORIGIN},FAST_LLM_ENABLED=true,FAST_LLM_PRIMARY_PROVIDER=cerebras,FAST_LLM_PRIMARY_MODEL=google/gemini-3.1-flash-lite-preview,FAST_LLM_FALLBACK_PROVIDER=gemini,FAST_LLM_FALLBACK_MODEL=google/gemini-2.5-flash-lite,FAST_LLM_TERTIARY_PROVIDER=cerebras,CEREBRAS_ENABLED=true,CEREBRAS_FAST_MODEL=gpt-oss-120b,CEREBRAS_REASONING_EFFORT=low,DEEP_REASONING_MODEL=google/gemini-3.1-pro-preview,DEEP_REASONING_FALLBACK_MODEL=google/gemini-2.5-pro" \
+            --update-env-vars "ENVIRONMENT=production,TTS_PROVIDER=piper,PIPER_PLUS_API_URL=https://piper-plus-639959525777.asia-northeast1.run.app,VOICEVOX_API_URL=https://voicevox-proto-639959525777.asia-northeast2.run.app,STT_PROVIDER=qwen-primary,STT_QWEN_RUNTIME=torch,STT_LLM_POSTPROCESS=false,QWEN_STT_TIMEOUT=45,QWEN_STT_HEDGE_DELAY_SECONDS=2,QWEN_STT_HEDGE_GRACE_SECONDS=6,STT_PRELOAD_QWEN_PRIMARY=true,HF_HOME=/app/.hf_cache,FRONTEND_PRODUCTION_ORIGIN=${FRONTEND_PRODUCTION_ORIGIN},ALLOWED_ORIGINS=${FRONTEND_PRODUCTION_ORIGIN},FAST_LLM_ENABLED=true,FAST_LLM_PRIMARY_PROVIDER=cerebras,FAST_LLM_PRIMARY_MODEL=google/gemini-3.1-flash-lite-preview,FAST_LLM_FALLBACK_PROVIDER=gemini,FAST_LLM_FALLBACK_MODEL=google/gemini-2.5-flash-lite,FAST_LLM_TERTIARY_PROVIDER=cerebras,CEREBRAS_ENABLED=true,CEREBRAS_FAST_MODEL=gpt-oss-120b,CEREBRAS_REASONING_EFFORT=low,DEEP_REASONING_MODEL=google/gemini-3.1-pro-preview,DEEP_REASONING_FALLBACK_MODEL=google/gemini-2.5-pro" \
             --update-secrets "OPENROUTER_API_KEY=OPENROUTER_API_KEY:latest,CEREBRAS_API_KEY=CEREBRAS_API_KEY:latest,SUPABASE_URL=SUPABASE_URL:latest,SUPABASE_KEY=SUPABASE_KEY:latest,SUPABASE_DB_URI=SUPABASE_DB_URI:latest,API_SECRET_KEY=API_SECRET_KEY:latest,TAVILY_API_KEY=TAVILY_API_KEY:latest"
+
+          LATEST_READY_REVISION=$(gcloud run services describe engineer-cafe-backend \
+            --region asia-northeast1 \
+            --format="value(status.latestReadyRevisionName)")
+          if [[ -z "$LATEST_READY_REVISION" ]]; then
+            echo "error: unable to determine latest ready Cloud Run revision" >&2
+            exit 1
+          fi
+          echo "Routing 100% traffic to latest ready revision: $LATEST_READY_REVISION"
+          gcloud run services update-traffic engineer-cafe-backend \
+            --region asia-northeast1 \
+            --to-latest
         env:
           FRONTEND_PRODUCTION_ORIGIN: ${{ vars.FRONTEND_PRODUCTION_ORIGIN }}
 
       - name: Smoke test deployed service
         run: |
-          SERVICE_URL=$(gcloud run services describe engineer-cafe-backend --region asia-northeast1 --format="value(status.url)")
+          SERVICE_JSON=$(mktemp)
+          gcloud run services describe engineer-cafe-backend --region asia-northeast1 --format=json > "$SERVICE_JSON"
+          python3 - "$SERVICE_JSON" <<'PY'
+          import json
+          import sys
+
+          with open(sys.argv[1], encoding="utf-8") as f:
+              service = json.load(f)
+
+          status = service.get("status", {})
+          latest_ready = status.get("latestReadyRevisionName")
+          traffic = status.get("traffic", [])
+
+          if not latest_ready:
+              raise SystemExit("error: unable to determine latest ready Cloud Run revision")
+
+          latest_percent = 0
+          stale_targets = []
+          for target in traffic:
+              percent = int(target.get("percent") or 0)
+              revision = target.get("revisionName")
+              is_latest = revision == latest_ready or target.get("latestRevision") is True
+              if is_latest:
+                  latest_percent += percent
+              elif percent:
+                  stale_targets.append(f"{revision or '<unknown>'}={percent}%")
+
+          if latest_percent != 100 or stale_targets:
+              details = ", ".join(stale_targets) if stale_targets else "no stale nonzero targets"
+              raise SystemExit(
+                  f"error: expected 100% traffic on latest ready revision {latest_ready}; "
+                  f"found latest={latest_percent}%, stale={details}"
+              )
+
+          print(f"Traffic check passed: 100% on latest ready revision {latest_ready}")
+          PY
+
+          SERVICE_URL=$(python3 -c 'import json,sys; print(json.load(open(sys.argv[1]))["status"]["url"])' "$SERVICE_JSON")
           echo "Testing $SERVICE_URL/health ..."
           for i in 1 2 3; do
             HEALTH=$(curl -sf --max-time 30 "$SERVICE_URL/health") && break

--- a/backend/agents/business_info_agent.py
+++ b/backend/agents/business_info_agent.py
@@ -709,6 +709,38 @@ Information: {context}
             }
             return self._canonical_result(answers.get(language, answers["ja"]), request_type)
 
+        if self._asks_membership_overview(normalized, request_type):
+            answers = {
+                "ja": (
+                    "[relaxed]エンジニアカフェの会員登録・利用登録は無料です。"
+                    "初めて利用する場合は1階受付でWebフォームに入力し、約5〜10分で"
+                    "登録できます。登録後に会員番号が発行され、2回目以降は会員番号を"
+                    "伝えてチェックインしてください。オンライン事前登録はできません。"
+                ),
+                "en": (
+                    "[relaxed]Engineer Cafe membership registration is free. "
+                    "First-time visitors register at the 1F reception by filling out a "
+                    "web form; it usually takes about 5 to 10 minutes and no ID is required. "
+                    "After registration, you receive a member number. On later visits, "
+                    "give your member number at reception to check in. Online pre-registration "
+                    "is not available."
+                ),
+                "zh": (
+                    "[relaxed]工程师咖啡的会员登记和设施使用是免费的。首次来访时，"
+                    "请在一楼前台填写网页表单，通常约5到10分钟完成，不需要身份证件。"
+                    "登记后会取得会员编号，之后来访时在前台告知会员编号即可。"
+                    "不支持线上预先登记。"
+                ),
+                "ko": (
+                    "[relaxed]엔지니어 카페의 회원 등록과 시설 이용은 무료입니다. "
+                    "처음 방문하실 때는 1층 접수에서 웹 양식을 작성하며 보통 5-10분 정도 "
+                    "걸리고 신분증은 필요하지 않습니다. 등록 후 회원 번호를 받으며, "
+                    "다음 방문부터는 접수에서 회원 번호를 말씀해 주세요. 온라인 사전 등록은 "
+                    "지원하지 않습니다."
+                ),
+            }
+            return self._canonical_result(answers.get(language, answers["ja"]), request_type)
+
         if self._asks_first_visit_registration(normalized, request_type):
             if (
                 language == "ja"
@@ -1127,6 +1159,43 @@ Information: {context}
             "등록",
         )
         return any(keyword in query for keyword in keywords)
+
+    @staticmethod
+    def _asks_membership_overview(query: str, request_type: Optional[str]) -> bool:
+        if request_type == "community" and BusinessInfoAgent._asks_engineer_cafe_lab(query):
+            return False
+
+        membership_terms = (
+            "membership",
+            "member",
+            "become a member",
+            "member benefits",
+            "会員制度",
+            "会員登録",
+            "会員にな",
+            "会员制度",
+            "加入会员",
+            "會員制度",
+            "加入會員",
+            "멤버십",
+            "회원 등록",
+            "회원가입",
+        )
+        if any(term in query for term in membership_terms):
+            return True
+
+        return request_type == "reception" and any(
+            term in query
+            for term in (
+                "sign up",
+                "registration",
+                "利用登録",
+                "登録",
+                "登记",
+                "登記",
+                "등록",
+            )
+        )
 
     @staticmethod
     def _asks_opening_hours(query: str, request_type: Optional[str]) -> bool:

--- a/backend/config/routing_constants.py
+++ b/backend/config/routing_constants.py
@@ -267,6 +267,12 @@ COMMUNITY_KEYWORDS = [
 ]
 
 RECEPTION_KEYWORDS = [
+    "membership",
+    "member",
+    "member benefits",
+    "become a member",
+    "register",
+    "sign up",
     "registration",
     "reception",
     "初回利用",

--- a/backend/services/memory_promoter.py
+++ b/backend/services/memory_promoter.py
@@ -13,7 +13,7 @@ import uuid
 from dataclasses import dataclass
 from typing import Any, Dict, Iterable
 
-from backend.utils.cafe_entity import canonicalize_facility_aliases
+from backend.utils.cafe_entity import canonicalize_facility_memory_key_text
 
 
 @dataclass
@@ -226,7 +226,7 @@ class MemoryPromoter:
 
     @staticmethod
     def _aggregate_key(memory_type: str, content: str) -> str:
-        normalized = canonicalize_facility_aliases(content)
+        normalized = canonicalize_facility_memory_key_text(content)
         normalized = unicodedata.normalize("NFKC", normalized)
         normalized = " ".join(normalized.strip().lower().split())
         return f"{memory_type}:{normalized}"

--- a/backend/tests/agents/test_business_info_agent.py
+++ b/backend/tests/agents/test_business_info_agent.py
@@ -97,6 +97,25 @@ class TestBusinessInfoAgent:
         assert "staff" in response["answer"].lower()
         assert "5 to 10 minutes" in response["answer"]
 
+    @pytest.mark.parametrize(
+        "query",
+        [
+            "How do I become a member?",
+            "Tell me about membership",
+            "What is the membership like?",
+        ],
+    )
+    def test_abstract_english_membership_canonical_response(self, query):
+        """#567: abstract English membership queries must not fall back."""
+        response = self.agent._get_canonical_response(query, "reception", "en")
+
+        assert response is not None
+        assert response["metadata"]["sources"] == ["enhanced_rag"]
+        answer = response["answer"].lower()
+        assert "membership registration is free" in answer
+        assert "member number" in answer
+        assert "online pre-registration is not available" in answer
+
     def test_returning_visitor_canonical_response_japanese(self):
         """gt-082/gt-085: 再来館発話は退館・会話履歴ではなく歓迎にする"""
         response = self.agent._get_canonical_response("前にも来たことがあります", "reception", "ja")

--- a/backend/tests/agents/test_orchestrator_fast_routing.py
+++ b/backend/tests/agents/test_orchestrator_fast_routing.py
@@ -178,6 +178,25 @@ class TestOrchestratorFastRouting:
         assert filler_intent_for_query("WiFiのパスワードは？") == "wifi"
         assert filler_intent_for_query("明日のイベントは？") == "event"
         assert filler_intent_for_query("スライドを見せて") == "slide"
+        assert filler_intent_for_query("Tell me about membership") == "business_info"
+
+    @pytest.mark.parametrize(
+        "query",
+        [
+            "How do I become a member?",
+            "Tell me about membership",
+            "What is the membership like?",
+            "Do I need to register to use Engineer Cafe?",
+        ],
+    )
+    def test_abstract_english_membership_routes_to_business_info(self, orchestrator, query):
+        """#567: abstract EN membership queries should not fall through to general fallback."""
+        result = orchestrator._try_fast_routing(query)
+
+        assert result is not None
+        assert result["agent"] == "business_info"
+        assert result["category"] == "reception"
+        assert result["request_type"] == "reception"
 
     # --- Phase 1A: 新規キーワードパターンテスト ---
 

--- a/backend/tests/services/test_memory_promoter.py
+++ b/backend/tests/services/test_memory_promoter.py
@@ -162,6 +162,39 @@ class TestNFKCNormalization:
         key2 = MemoryPromoter._aggregate_key("facility_interest", "エンジニアカフェの営業時間")
         assert key1 == key2
 
+    def test_multilingual_facility_aliases_in_aggregate_key(self):
+        """#516: Engineer Cafe と エンジニアカフェを同じ施設記憶として集約する"""
+        key1 = MemoryPromoter._aggregate_key("facility_interest", "Engineer Cafeの営業時間")
+        key2 = MemoryPromoter._aggregate_key("facility_interest", "エンジニアカフェの営業時間")
+        assert key1 == key2
+
+    def test_aggregate_candidates_merges_multilingual_facility_aliases(self):
+        """#516: 多言語facility aliasの候補を1件に集約する"""
+        items = [
+            _item(
+                "k1",
+                {
+                    "candidate_type": "facility_interest",
+                    "content": "Engineer Cafeの営業時間",
+                    "confidence": 0.9,
+                },
+            ),
+            _item(
+                "k2",
+                {
+                    "candidate_type": "facility_interest",
+                    "content": "エンジニアカフェの営業時間",
+                    "confidence": 0.8,
+                },
+            ),
+        ]
+
+        grouped = MemoryPromoter.aggregate_candidates(items)
+
+        assert len(grouped) == 1
+        aggregate = next(iter(grouped.values()))
+        assert aggregate["candidate_count"] == 2
+
 
 class TestNewTypePromotionRules:
     """新メモリタイプ昇格ルールのテスト"""

--- a/backend/tests/test_trag_multilingual.py
+++ b/backend/tests/test_trag_multilingual.py
@@ -38,7 +38,10 @@ class TestMultilingualReceptionKeywords:
 
     def test_reception_keywords_include_english(self):
         assert "registration" in RECEPTION_KEYWORDS
+        assert "register" in RECEPTION_KEYWORDS
         assert "check-in" in RECEPTION_KEYWORDS
+        assert "membership" in RECEPTION_KEYWORDS
+        assert "become a member" in RECEPTION_KEYWORDS
 
     def test_reception_keywords_exclude_generic_english(self):
         """Generic English terms that cause mis-routing should be excluded."""

--- a/backend/tests/tools/test_enhanced_rag.py
+++ b/backend/tests/tools/test_enhanced_rag.py
@@ -778,6 +778,7 @@ class TestTextFallbackSearch:
     @pytest.mark.parametrize(
         "query",
         [
+            "How do I become a member?",
             "Tell me about membership",
             "What is the membership like?",
         ],
@@ -800,6 +801,54 @@ class TestTextFallbackSearch:
         assert result["data"]["results"][0]["id"] == "general-membership-overview"
         assert "membership" in result["data"]["context"].lower()
         assert result["data"]["topEntity"] == "engineer-cafe"
+
+    @pytest.mark.asyncio
+    async def test_search_replaces_irrelevant_vector_results_for_english_membership(
+        self, rag_search, mock_supabase
+    ):
+        """membership内容を含まないvector候補は公式会員KBへ置き換える"""
+        rag_search._generate_embedding = AsyncMock(return_value=[0.1] * 1536)
+        mock_execute = MagicMock()
+        mock_execute.execute.return_value = MagicMock(
+            data=[
+                {
+                    "id": "unrelated-history",
+                    "title": "Building History",
+                    "content": "The red brick building was completed in 1909.",
+                    "category": "general",
+                    "language": "en",
+                    "source": "official",
+                    "metadata": {"entity": "engineer-cafe"},
+                    "similarity": 0.95,
+                },
+                {
+                    "id": "unrelated-access",
+                    "title": "Access",
+                    "content": "Engineer Cafe is located in Tenjin near the station.",
+                    "category": "location",
+                    "language": "en",
+                    "source": "official",
+                    "metadata": {"entity": "engineer-cafe"},
+                    "similarity": 0.93,
+                },
+            ]
+        )
+        mock_supabase.rpc.return_value = mock_execute
+        rag_search._text_fallback_search = AsyncMock(return_value=[])
+
+        result = await rag_search.search(
+            query="How do I become a member?",
+            category="general",
+            language="en",
+            include_advice=False,
+        )
+
+        result_ids = {row["id"] for row in result["data"]["results"]}
+        assert result["success"] is True
+        assert result["data"]["results"][0]["id"] == "general-membership-overview"
+        assert "membership" in result["data"]["context"].lower()
+        assert "unrelated-history" not in result_ids
+        assert "unrelated-access" not in result_ids
 
     @pytest.mark.parametrize(
         ("query", "language"),

--- a/backend/tests/utils/test_memory_helper.py
+++ b/backend/tests/utils/test_memory_helper.py
@@ -341,6 +341,54 @@ class TestSimplifiedMemoryHelper:
 
         call_args = mock_table.insert.call_args[0][0]
         assert call_args["value"]["content"] == "エンジニアカフェの営業時間は？"
+        assert call_args["value"]["canonicalContentKey"] == "engineer_cafeの営業時間は？"
+
+    @pytest.mark.asyncio
+    @patch("backend.utils.memory_helper.create_client")
+    async def test_store_message_adds_multilingual_canonical_content_key(self, mock_create_client):
+        """#516: Engineer Cafe と エンジニアカフェの保存キーを同じ施設名へ寄せる"""
+        mock_client = Mock()
+        mock_table = Mock()
+        mock_insert = Mock()
+        mock_insert.execute = Mock(return_value=Mock(data=[{"id": 1}]))
+        mock_table.insert = Mock(return_value=mock_insert)
+        mock_client.table = Mock(return_value=mock_table)
+        mock_create_client.return_value = mock_client
+
+        helper = SimplifiedMemoryHelper()
+
+        await helper.store_message(
+            role="user",
+            content="Engineer Cafeの営業時間は？",
+            session_id="test-session",
+        )
+
+        call_args = mock_table.insert.call_args[0][0]
+        assert call_args["value"]["content"] == "Engineer Cafeの営業時間は？"
+        assert call_args["value"]["canonicalContentKey"] == "engineer_cafeの営業時間は？"
+
+    @patch("backend.utils.memory_helper.create_client")
+    def test_rank_messages_dedupes_multilingual_facility_aliases(self, mock_create_client):
+        """#516: 同一施設aliasの履歴はcontext投入前に重複排除する"""
+        mock_create_client.return_value = Mock()
+        helper = SimplifiedMemoryHelper()
+        messages = [
+            {
+                "role": "user",
+                "content": "Engineer Cafeの営業時間は？",
+                "metadata": {"timestamp": 1000},
+            },
+            {
+                "role": "user",
+                "content": "エンジニアカフェの営業時間は？",
+                "metadata": {"timestamp": 2000},
+            },
+        ]
+
+        ranked = helper._rank_messages(messages, "エンジニアカフェの営業時間")
+
+        assert len(ranked) == 1
+        assert ranked[0]["content"] == "エンジニアカフェの営業時間は？"
 
     @pytest.mark.asyncio
     async def test_is_session_active_no_supabase(self):

--- a/backend/tools/enhanced_rag.py
+++ b/backend/tools/enhanced_rag.py
@@ -427,7 +427,8 @@ class EnhancedRAGSearch:
                 and not self._query_mentions_engineer_cafe(query)
                 and not any(r.get("entity") == "saino" for r in scored_results)
             )
-            if not scored_results or needs_entity_fallback:
+            needs_membership_fallback = self._needs_membership_fallback(query, scored_results)
+            if not scored_results or needs_entity_fallback or needs_membership_fallback:
                 local_results = self._local_knowledge_fallback_search(
                     query, category, language, max_results
                 )
@@ -785,7 +786,8 @@ class EnhancedRAGSearch:
             and not self._query_mentions_engineer_cafe(query)
             and not any(r.get("entity") == "saino" for r in scored_results)
         )
-        if not scored_results or needs_entity_fallback:
+        needs_membership_fallback = self._needs_membership_fallback(query, scored_results)
+        if not scored_results or needs_entity_fallback or needs_membership_fallback:
             local_results = self._local_knowledge_fallback_search(
                 query, category, language, max_results
             )
@@ -1095,6 +1097,65 @@ class EnhancedRAGSearch:
     def _is_membership_query(query: str) -> bool:
         query_lower = query.lower()
         return any(term.lower() in query_lower for term in MEMBERSHIP_QUERY_TERMS)
+
+    def _needs_membership_fallback(self, query: str, scored_results: List[Dict]) -> bool:
+        """Force official local knowledge for membership queries with no membership hit."""
+        return (
+            self._is_strong_membership_query(query)
+            and not self._query_mentions_saino(query)
+            and not any(self._result_has_membership_content(result) for result in scored_results)
+        )
+
+    @staticmethod
+    def _is_strong_membership_query(query: str) -> bool:
+        query_lower = query.lower()
+        if re.search(r"\bmembership\b|\bmembers?\b", query_lower):
+            return True
+        return any(
+            term in query_lower
+            for term in (
+                "会員",
+                "会員制度",
+                "会員登録",
+                "利用登録",
+                "會員",
+                "会员",
+                "회원",
+                "멤버십",
+            )
+        )
+
+    @staticmethod
+    def _result_has_membership_content(result: Dict) -> bool:
+        metadata = result.get("metadata", {})
+        tags = metadata.get("tags", []) if isinstance(metadata, dict) else []
+        combined = " ".join(
+            str(part)
+            for part in (
+                result.get("id", ""),
+                result.get("title", ""),
+                result.get("content", ""),
+                " ".join(str(tag) for tag in tags if tag is not None),
+            )
+            if part is not None
+        ).lower()
+
+        if re.search(r"\bmembership\b|\bmembers?\b|\bmember\s+number\b", combined):
+            return True
+
+        return any(
+            term in combined
+            for term in (
+                "会員",
+                "会員制度",
+                "会員番号",
+                "利用登録",
+                "會員",
+                "会员",
+                "회원",
+                "멤버십",
+            )
+        )
 
     @staticmethod
     def _infer_entity_from_yaml_entry(entry: Dict) -> str:

--- a/backend/utils/cafe_entity.py
+++ b/backend/utils/cafe_entity.py
@@ -291,3 +291,25 @@ def canonicalize_facility_aliases(text: str) -> str:
     canonical = canonical.replace("才能", "saino")
     canonical = canonical.replace("閉接のカフェ", "併設のカフェ")
     return canonical
+
+
+def canonicalize_facility_memory_key_text(text: str) -> str:
+    """Return display-safe text with multilingual facility names collapsed for dedup keys."""
+
+    canonical = canonicalize_facility_aliases(text)
+    if not canonical:
+        return canonical
+
+    canonical = re.sub(
+        r"engineer\s*cafe|engineercafe|エンジニアカフェ|工程师咖啡|工程師咖啡|엔지니어\s*카페",
+        "engineer_cafe",
+        canonical,
+        flags=re.IGNORECASE,
+    )
+    canonical = re.sub(
+        r"cafe\s*&\s*bar\s*saino|saino\s*cafe|saino|サイノカフェ|사이노\s*카페",
+        "saino_cafe",
+        canonical,
+        flags=re.IGNORECASE,
+    )
+    return canonical

--- a/backend/utils/memory_helper.py
+++ b/backend/utils/memory_helper.py
@@ -17,7 +17,10 @@ import logging
 from supabase import create_client, Client
 
 from backend.config.routing_constants import extract_request_type
-from backend.utils.cafe_entity import canonicalize_facility_aliases
+from backend.utils.cafe_entity import (
+    canonicalize_facility_aliases,
+    canonicalize_facility_memory_key_text,
+)
 from backend.utils.postgres_sanitizer import sanitize_for_postgres
 
 logger = logging.getLogger(__name__)
@@ -279,15 +282,18 @@ class SimplifiedMemoryHelper:
             for item in response.data:
                 value = item.get("value", {})
                 if value.get("sessionId") == session_id:
+                    content = value.get("content")
                     messages.append(
                         {
                             "role": value.get("role"),
-                            "content": value.get("content"),
+                            "content": content,
                             "metadata": {
                                 "emotion": value.get("emotion"),
                                 "confidence": value.get("confidence"),
                                 "timestamp": value.get("timestamp"),
                                 "request_type": value.get("request_type"),
+                                "canonical_content_key": value.get("canonicalContentKey")
+                                or canonicalize_facility_memory_key_text(str(content or "")),
                             },
                         }
                     )
@@ -338,7 +344,25 @@ class SimplifiedMemoryHelper:
             scored.append({**msg, "_rank_score": composite})
 
         scored.sort(key=lambda x: x["_rank_score"], reverse=True)
-        return scored
+        return self._dedupe_ranked_messages(scored)
+
+    @staticmethod
+    def _dedupe_ranked_messages(messages: List[Dict]) -> List[Dict]:
+        """Keep the highest-ranked message for the same canonical facility content."""
+        deduped: List[Dict] = []
+        seen: set[str] = set()
+        for msg in messages:
+            metadata = msg.get("metadata", {})
+            key = metadata.get("canonical_content_key") if isinstance(metadata, dict) else None
+            if not key:
+                key = canonicalize_facility_memory_key_text(str(msg.get("content") or ""))
+            normalized_key = " ".join(str(key).strip().lower().split())
+            if normalized_key and normalized_key in seen:
+                continue
+            if normalized_key:
+                seen.add(normalized_key)
+            deduped.append(msg)
+        return deduped
 
     def _topic_overlap(self, msg_a: Dict, msg_b: Dict) -> float:
         """2メッセージのトピック類似度（bigramマッチ率）
@@ -480,6 +504,9 @@ class SimplifiedMemoryHelper:
         metadata = sanitize_for_postgres(metadata or {})
         role = sanitize_for_postgres(role)
         content = sanitize_for_postgres(canonicalize_facility_aliases(content))
+        canonical_content_key = sanitize_for_postgres(
+            canonicalize_facility_memory_key_text(content)
+        )
         session_id = sanitize_for_postgres(session_id)
 
         # リクエストタイプの自動抽出（user messageの場合）
@@ -503,6 +530,7 @@ class SimplifiedMemoryHelper:
                 "emotion": metadata.get("emotion"),
                 "confidence": metadata.get("confidence"),
                 "request_type": metadata.get("request_type"),
+                "canonicalContentKey": canonical_content_key,
             }
 
             # ユニークなキーを生成（タイムスタンプ + UUID）


### PR DESCRIPTION
## Summary
- route abstract English membership queries to BusinessInfoAgent reception answers and add deterministic membership overview responses
- harden Enhanced RAG so strong membership queries replace irrelevant vector hits with the official `general-membership-overview` YAML fallback
- collapse multilingual Engineer Cafe facility aliases into canonical memory keys for #516 while preserving display text
- make Cloud Run develop deploy reset `STT_QWEN_RUNTIME=torch`, route 100% traffic to latest, and fail smoke if traffic stays pinned to an old revision

Closes #516
Closes #567
Relates #398

## Tests
- `python -m ruff check backend/config/routing_constants.py backend/agents/business_info_agent.py backend/tools/enhanced_rag.py backend/utils/cafe_entity.py backend/utils/memory_helper.py backend/services/memory_promoter.py backend/tests/agents/test_business_info_agent.py backend/tests/agents/test_orchestrator_fast_routing.py backend/tests/test_trag_multilingual.py backend/tests/tools/test_enhanced_rag.py backend/tests/services/test_memory_promoter.py backend/tests/utils/test_memory_helper.py`
- `python -m pytest backend/tests/agents/test_business_info_agent.py backend/tests/agents/test_orchestrator_fast_routing.py backend/tests/test_trag_multilingual.py backend/tests/tools/test_enhanced_rag.py backend/tests/services/test_memory_promoter.py backend/tests/utils/test_memory_helper.py -q`
- `python -m pytest backend/tests/evaluation/test_fast_path_accuracy.py backend/tests/evaluation/test_ground_truth_dataset.py backend/tests/config/test_routing_constants.py -q`
- `python -m pytest backend/tests/utils/test_memory_helper_unit.py -q`
- `git diff --check`
- workflow YAML parse + bash parse for deploy/smoke snippets

## Deploy note
This PR intentionally keeps production STT on Qwen torch runtime. ONNX remains a separate candidate path until the model artifact is baked into the image or mounted explicitly.