### PR TITLE
Fix kiosk viewport lock on orientation changes

### DIFF
--- a/frontend/e2e/kiosk-viewport-lock.spec.ts
+++ b/frontend/e2e/kiosk-viewport-lock.spec.ts
@@ -1,0 +1,142 @@
+import { expect, test } from '@playwright/test';
+
+async function dismissInitialModal(page: import('@playwright/test').Page) {
+  const closeButton = page.getByTestId('initial-settings-close');
+  if (await closeButton.isVisible({ timeout: 3_000 }).catch(() => false)) {
+    await closeButton.click();
+  }
+  await expect(page.getByRole('button', { name: 'Welcome' })).toBeVisible({ timeout: 5_000 });
+}
+
+async function collectViewportMetrics(page: import('@playwright/test').Page) {
+  return page.evaluate(() => {
+    const root = document.querySelector<HTMLElement>('[data-testid="kiosk-viewport-root"]');
+    const rect = root?.getBoundingClientRect();
+    const avatar = document.querySelector<HTMLElement>('[data-testid="character-avatar-root"]');
+    const avatarRect = avatar?.getBoundingClientRect();
+    const avatarCanvasRect = avatar?.querySelector('canvas')?.getBoundingClientRect();
+    const htmlStyle = getComputedStyle(document.documentElement);
+    const bodyStyle = getComputedStyle(document.body);
+    return {
+      avatar: avatarRect
+        ? {
+            height: avatarRect.height,
+            width: avatarRect.width,
+          }
+        : null,
+      avatarCanvas: avatarCanvasRect
+        ? {
+            height: avatarCanvasRect.height,
+            width: avatarCanvasRect.width,
+          }
+        : null,
+      bodyOverflowY: bodyStyle.overflowY,
+      bodyPosition: bodyStyle.position,
+      docScrollHeight: document.documentElement.scrollHeight,
+      htmlHasLock: document.documentElement.classList.contains('kiosk-viewport-lock'),
+      htmlOverflowY: htmlStyle.overflowY,
+      innerHeight: window.innerHeight,
+      innerWidth: window.innerWidth,
+      root: rect
+        ? {
+            bottom: rect.bottom,
+            height: rect.height,
+            left: rect.left,
+            right: rect.right,
+            top: rect.top,
+            width: rect.width,
+          }
+        : null,
+      scrollX: window.scrollX,
+      scrollY: window.scrollY,
+    };
+  });
+}
+
+test.describe('Kiosk viewport lock', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/');
+    await dismissInitialModal(page);
+  });
+
+  test('keeps the kiosk root fixed to the viewport through orientation-sized resizes', async ({
+    page,
+  }) => {
+    await expect(page.locator('meta[name="viewport"]')).toHaveAttribute(
+      'content',
+      /user-scalable=no/,
+    );
+    await expect(page.locator('meta[name="viewport"]')).toHaveAttribute(
+      'content',
+      /viewport-fit=cover/,
+    );
+
+    for (const size of [
+      { width: 390, height: 844 },
+      { width: 844, height: 390 },
+      { width: 390, height: 844 },
+    ]) {
+      await page.setViewportSize(size);
+      await page.waitForTimeout(900);
+      await page.evaluate(() => window.scrollTo(0, 240));
+      await page.waitForTimeout(100);
+
+      const metrics = await collectViewportMetrics(page);
+      expect(metrics.htmlHasLock).toBe(true);
+      expect(metrics.htmlOverflowY).toBe('hidden');
+      expect(metrics.bodyOverflowY).toBe('hidden');
+      expect(metrics.bodyPosition).toBe('fixed');
+      expect(metrics.scrollX).toBe(0);
+      expect(metrics.scrollY).toBe(0);
+      expect(metrics.root).not.toBeNull();
+      expect(metrics.root?.top).toBeGreaterThanOrEqual(-1);
+      expect(metrics.root?.left).toBeGreaterThanOrEqual(-1);
+      expect(Math.abs((metrics.root?.width ?? 0) - metrics.innerWidth)).toBeLessThanOrEqual(1);
+      expect(Math.abs((metrics.root?.height ?? 0) - metrics.innerHeight)).toBeLessThanOrEqual(1);
+      expect(Math.abs((metrics.avatar?.height ?? 0) - metrics.innerHeight)).toBeLessThanOrEqual(1);
+      if (metrics.avatarCanvas) {
+        expect(Math.abs(metrics.avatarCanvas.height - metrics.innerHeight)).toBeLessThanOrEqual(1);
+      }
+      expect(metrics.docScrollHeight).toBeLessThanOrEqual(metrics.innerHeight + 1);
+    }
+  });
+
+  test('prevents native vertical panning on the slide surface after rotating', async ({ page }) => {
+    await page.route('**/api/reception/start', async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({
+          reception_session_id: 'mock-viewport-lock',
+          greeting: 'テストです。',
+          stage: 'greeting',
+        }),
+      });
+    });
+    await page.route('**/api/qa', async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({ answer: 'ok', emotion: 'neutral', metadata: {} }),
+      });
+    });
+    await page.route('**/api/voice', async (route) => {
+      await route.fulfill({ status: 200, contentType: 'application/json', body: '{}' });
+    });
+
+    await page.setViewportSize({ width: 390, height: 844 });
+    await page.getByTestId('kiosk-slides-button').click();
+    await page.getByTestId('slide-language-ja').click();
+    await expect(page.getByTestId('reception-pdf-rotate-hint')).toBeVisible({ timeout: 8_000 });
+
+    await page.setViewportSize({ width: 844, height: 390 });
+    await expect(page.getByTestId('reception-pdf-landscape-panel')).toBeVisible({
+      timeout: 15_000,
+    });
+
+    const touchAction = await page
+      .getByTestId('reception-pdf-landscape-panel')
+      .evaluate((node) => getComputedStyle(node).touchAction);
+    expect(touchAction).toBe('none');
+  });
+});

--- a/frontend/e2e/reception-pdf-guide.spec.ts
+++ b/frontend/e2e/reception-pdf-guide.spec.ts
@@ -1,4 +1,5 @@
 import { expect, test } from '@playwright/test';
+import { MOCK_VOICE_RESPONSE, setupWebAudioMock } from './helpers/mocks';
 
 /**
  * Reception PDF slide guide (ReceptionPdfGuide + autoStartPresentation).
@@ -15,6 +16,7 @@ async function dismissInitialModal(page: import('@playwright/test').Page) {
 }
 
 async function mockReceptionApis(page: import('@playwright/test').Page) {
+  await setupWebAudioMock(page);
   await page.route('**/api/reception/start', async (route) => {
     await route.fulfill({
       status: 200,
@@ -34,7 +36,11 @@ async function mockReceptionApis(page: import('@playwright/test').Page) {
     });
   });
   await page.route('**/api/voice', async (route) => {
-    await route.fulfill({ status: 200, contentType: 'application/json', body: '{}' });
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify(MOCK_VOICE_RESPONSE),
+    });
   });
 }
 

--- a/frontend/src/app/components/CharacterAvatar.tsx
+++ b/frontend/src/app/components/CharacterAvatar.tsx
@@ -645,6 +645,13 @@ export default function CharacterAvatar({
     };
 
     window.addEventListener('resize', handleResize);
+    window.addEventListener('orientationchange', handleResize);
+    window.visualViewport?.addEventListener('resize', handleResize);
+    const resizeObserver =
+      typeof ResizeObserver !== 'undefined' && containerRef.current
+        ? new ResizeObserver(handleResize)
+        : null;
+    resizeObserver?.observe(containerRef.current);
 
     animate();
 
@@ -652,6 +659,9 @@ export default function CharacterAvatar({
       ok: true,
       disposeResize: () => {
         window.removeEventListener('resize', handleResize);
+        window.removeEventListener('orientationchange', handleResize);
+        window.visualViewport?.removeEventListener('resize', handleResize);
+        resizeObserver?.disconnect();
       },
     };
   };

--- a/frontend/src/app/components/ReceptionPdfGuide.tsx
+++ b/frontend/src/app/components/ReceptionPdfGuide.tsx
@@ -67,20 +67,49 @@ function useLandscapeReady(): boolean {
   const [landscape, setLandscape] = useState(false);
 
   useEffect(() => {
-    const update = () => {
+    let frameId = 0;
+    let settleTimers: number[] = [];
+
+    const getLandscape = () => {
       const mq = window.matchMedia('(orientation: landscape)');
-      const bySize = window.innerWidth > window.innerHeight;
-      setLandscape(mq.matches || bySize);
+      const viewport = window.visualViewport;
+      const width = viewport?.width || window.innerWidth;
+      const height = viewport?.height || window.innerHeight;
+      return mq.matches || width > height;
     };
-    update();
+
+    const clearSettledTimers = () => {
+      for (const timer of settleTimers) {
+        window.clearTimeout(timer);
+      }
+      settleTimers = [];
+    };
+
+    const update = () => {
+      window.cancelAnimationFrame(frameId);
+      frameId = window.requestAnimationFrame(() => {
+        setLandscape(getLandscape());
+      });
+    };
+
+    const updateAfterViewportSettles = () => {
+      clearSettledTimers();
+      update();
+      settleTimers = [80, 180, 360].map((delay) => window.setTimeout(update, delay));
+    };
+    updateAfterViewportSettles();
     const mq = window.matchMedia('(orientation: landscape)');
-    mq.addEventListener('change', update);
-    window.addEventListener('resize', update);
-    window.addEventListener('orientationchange', update);
+    mq.addEventListener('change', updateAfterViewportSettles);
+    window.addEventListener('resize', updateAfterViewportSettles);
+    window.addEventListener('orientationchange', updateAfterViewportSettles);
+    window.visualViewport?.addEventListener('resize', updateAfterViewportSettles);
     return () => {
-      mq.removeEventListener('change', update);
-      window.removeEventListener('resize', update);
-      window.removeEventListener('orientationchange', update);
+      clearSettledTimers();
+      window.cancelAnimationFrame(frameId);
+      mq.removeEventListener('change', updateAfterViewportSettles);
+      window.removeEventListener('resize', updateAfterViewportSettles);
+      window.removeEventListener('orientationchange', updateAfterViewportSettles);
+      window.visualViewport?.removeEventListener('resize', updateAfterViewportSettles);
     };
   }, []);
 
@@ -1160,7 +1189,7 @@ export default function ReceptionPdfGuide({
       <div
         data-testid="reception-pdf-guide"
         className={cn(
-          'fixed inset-0 z-[100] flex min-h-[100dvh] flex-col items-center justify-center gap-6 bg-slate-950 p-8 text-center text-white',
+          'flex h-full min-h-0 flex-col items-center justify-center gap-6 bg-slate-950 p-8 text-center text-white',
           className,
         )}
       >
@@ -1186,7 +1215,7 @@ export default function ReceptionPdfGuide({
         onPointerDown={onSlidePointerDown}
         onPointerUp={onSlidePointerUp}
         onPointerCancel={onSlidePointerCancel}
-        className="relative flex min-h-0 flex-1 touch-pan-y items-center justify-center overflow-hidden bg-slate-100 p-0.5 sm:p-1"
+        className="kiosk-slide-surface relative flex min-h-0 flex-1 items-center justify-center overflow-hidden bg-slate-100 p-0.5 sm:p-1"
       >
         <canvas ref={canvasRef} className="max-h-full max-w-full shadow-lg" data-testid="reception-pdf-canvas" />
       </div>

--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -11,6 +11,31 @@
   body {
     @apply text-gray-900 bg-white;
   }
+
+  html.kiosk-viewport-lock {
+    width: 100%;
+    height: var(--kiosk-viewport-height, 100dvh);
+    min-height: var(--kiosk-viewport-height, 100dvh);
+    overflow: hidden;
+    overscroll-behavior: none;
+    scroll-behavior: auto;
+    background: #020617;
+    -webkit-text-size-adjust: 100%;
+    text-size-adjust: 100%;
+  }
+
+  html.kiosk-viewport-lock body {
+    position: fixed;
+    inset: 0;
+    width: var(--kiosk-viewport-width, 100dvw);
+    height: var(--kiosk-viewport-height, 100dvh);
+    min-height: var(--kiosk-viewport-height, 100dvh);
+    margin: 0;
+    overflow: hidden;
+    overscroll-behavior: none;
+    touch-action: manipulation;
+    background: #020617;
+  }
 }
 
 @layer components {
@@ -59,6 +84,34 @@
 }
 
 @layer utilities {
+  .kiosk-viewport-root {
+    position: fixed;
+    inset: 0;
+    width: var(--kiosk-viewport-width, 100dvw);
+    height: var(--kiosk-viewport-height, 100dvh);
+    min-width: var(--kiosk-viewport-width, 100dvw);
+    min-height: var(--kiosk-viewport-height, 100dvh);
+    max-width: var(--kiosk-viewport-width, 100dvw);
+    max-height: var(--kiosk-viewport-height, 100dvh);
+    overflow: hidden;
+    overscroll-behavior: none;
+    background: #020617;
+    contain: layout size style;
+  }
+
+  .kiosk-slide-surface {
+    touch-action: none;
+    overscroll-behavior: none;
+    -webkit-user-select: none;
+    user-select: none;
+  }
+
+  html.kiosk-viewport-lock .overflow-y-auto,
+  html.kiosk-viewport-lock .overflow-auto {
+    overscroll-behavior: contain;
+    -webkit-overflow-scrolling: touch;
+  }
+
   /* Custom scrollbar */
   .scrollbar-thin::-webkit-scrollbar {
     width: 6px;

--- a/frontend/src/app/hooks/useKioskViewportLock.ts
+++ b/frontend/src/app/hooks/useKioskViewportLock.ts
@@ -1,0 +1,74 @@
+'use client';
+
+import { useEffect } from 'react';
+
+const VIEWPORT_LOCK_CLASS = 'kiosk-viewport-lock';
+const KIOSK_VIEWPORT_HEIGHT_VAR = '--kiosk-viewport-height';
+const KIOSK_VIEWPORT_WIDTH_VAR = '--kiosk-viewport-width';
+const SETTLE_DELAYS_MS = [80, 180, 360, 720] as const;
+
+function getVisualViewportSize() {
+  const viewport = window.visualViewport;
+  return {
+    height: Math.round(viewport?.height || window.innerHeight),
+    width: Math.round(viewport?.width || window.innerWidth),
+  };
+}
+
+export function useKioskViewportLock() {
+  useEffect(() => {
+    const html = document.documentElement;
+    const body = document.body;
+    let frameId = 0;
+    let settleTimers: number[] = [];
+
+    const clearSettledTimers = () => {
+      for (const timer of settleTimers) {
+        window.clearTimeout(timer);
+      }
+      settleTimers = [];
+    };
+
+    const syncViewport = () => {
+      window.cancelAnimationFrame(frameId);
+      frameId = window.requestAnimationFrame(() => {
+        const { height, width } = getVisualViewportSize();
+        html.style.setProperty(KIOSK_VIEWPORT_HEIGHT_VAR, `${height}px`);
+        html.style.setProperty(KIOSK_VIEWPORT_WIDTH_VAR, `${width}px`);
+        window.scrollTo(0, 0);
+      });
+    };
+
+    const syncAfterViewportSettles = () => {
+      clearSettledTimers();
+      syncViewport();
+      settleTimers = SETTLE_DELAYS_MS.map((delay) => window.setTimeout(syncViewport, delay));
+    };
+
+    html.classList.add(VIEWPORT_LOCK_CLASS);
+    body.classList.add(VIEWPORT_LOCK_CLASS);
+    syncAfterViewportSettles();
+
+    window.addEventListener('resize', syncAfterViewportSettles, { passive: true });
+    window.addEventListener('orientationchange', syncAfterViewportSettles, { passive: true });
+    window.visualViewport?.addEventListener('resize', syncAfterViewportSettles, {
+      passive: true,
+    });
+    window.visualViewport?.addEventListener('scroll', syncAfterViewportSettles, {
+      passive: true,
+    });
+
+    return () => {
+      clearSettledTimers();
+      window.cancelAnimationFrame(frameId);
+      window.removeEventListener('resize', syncAfterViewportSettles);
+      window.removeEventListener('orientationchange', syncAfterViewportSettles);
+      window.visualViewport?.removeEventListener('resize', syncAfterViewportSettles);
+      window.visualViewport?.removeEventListener('scroll', syncAfterViewportSettles);
+      html.classList.remove(VIEWPORT_LOCK_CLASS);
+      body.classList.remove(VIEWPORT_LOCK_CLASS);
+      html.style.removeProperty(KIOSK_VIEWPORT_HEIGHT_VAR);
+      html.style.removeProperty(KIOSK_VIEWPORT_WIDTH_VAR);
+    };
+  }, []);
+}

--- a/frontend/src/app/layout.tsx
+++ b/frontend/src/app/layout.tsx
@@ -23,6 +23,10 @@ export const metadata: Metadata = {
 export const viewport: Viewport = {
   width: 'device-width',
   initialScale: 1,
+  maximumScale: 1,
+  userScalable: false,
+  viewportFit: 'cover',
+  interactiveWidget: 'overlays-content',
   themeColor: '#3B82F6',
 }
 

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -24,6 +24,7 @@ import { Languages, Settings, X } from 'lucide-react';
 import { useCallback, useEffect, useRef, useState, type CSSProperties } from 'react';
 import type { CharacterAnimationData } from './utils/character-animation-utils';
 import type { BackgroundOption } from './components/BackgroundSelector';
+import { useKioskViewportLock } from './hooks/useKioskViewportLock';
 import CharacterAvatar from './components/CharacterAvatar';
 import {
   ConversationHistoryEffects,
@@ -76,6 +77,8 @@ function kioskVoiceModeBadgeLabel(
 
 
 export default function Home() {
+  useKioskViewportLock();
+
   const [kioskPhase, setKioskPhase] = useState<KioskPhase>('notice');
   const kioskPhaseRef = useRef<KioskPhase>('notice');
   const [kioskVoiceLocked, setKioskVoiceLocked] = useState(false);
@@ -493,7 +496,7 @@ export default function Home() {
                 lastResponseRef={lastResponseRef}
                 setConversationHistory={setConversationHistory}
               />
-              <main className="relative h-[100svh] w-screen overflow-hidden">
+              <main data-testid="kiosk-viewport-root" className="kiosk-viewport-root">
                 {(kioskPhase === 'voice' || kioskPhase === 'idle') && (
                   <div
                     className="pointer-events-none absolute left-1/2 top-[max(0.5rem,env(safe-area-inset-top))] z-[38] max-w-[92vw] -translate-x-1/2 truncate rounded-full border border-white/25 bg-black/55 px-4 py-1.5 text-center text-[11px] font-semibold text-white shadow-md backdrop-blur-md sm:text-xs"


### PR DESCRIPTION
## Summary
- Fixes kiosk viewport locking for tablet/mobile orientation changes by syncing the visual viewport into CSS variables and locking only the kiosk route.
- Prevents slide-panel vertical native panning/overscroll while preserving horizontal swipe navigation.
- Makes the VRM canvas follow container resizes via `ResizeObserver`, so returning from landscape to portrait does not leave a stale-height canvas and white margin.
- Updates reception PDF E2E mocks to return a Piper-compatible audio response after the Piper-only voice path change.

## Verification
- `corepack pnpm --dir frontend typecheck`
- `corepack pnpm --dir frontend lint`
- `corepack pnpm --dir frontend build`
- `corepack pnpm --dir frontend exec playwright test --config=playwright.config.ts e2e/kiosk-viewport-lock.spec.ts`
- `corepack pnpm --dir frontend exec playwright test --config=playwright.config.ts e2e/kiosk-viewport-lock.spec.ts e2e/reception-pdf-guide.spec.ts --workers=1`
- Browser checked `844x390 -> 390x844`; VRM/background filled the viewport after rotation without the stale white lower margin.

Closes #806
