### PR TITLE
Fix production viewport lock E2E audio mock

### DIFF
--- a/frontend/e2e/kiosk-viewport-lock.spec.ts
+++ b/frontend/e2e/kiosk-viewport-lock.spec.ts
@@ -1,4 +1,5 @@
 import { expect, test } from '@playwright/test';
+import { MOCK_VOICE_RESPONSE, setupWebAudioMock } from './helpers/mocks';
 
 async function dismissInitialModal(page: import('@playwright/test').Page) {
   const closeButton = page.getByTestId('initial-settings-close');
@@ -55,6 +56,7 @@ async function collectViewportMetrics(page: import('@playwright/test').Page) {
 
 test.describe('Kiosk viewport lock', () => {
   test.beforeEach(async ({ page }) => {
+    await setupWebAudioMock(page);
     await page.goto('/');
     await dismissInitialModal(page);
   });
@@ -121,7 +123,11 @@ test.describe('Kiosk viewport lock', () => {
       });
     });
     await page.route('**/api/voice', async (route) => {
-      await route.fulfill({ status: 200, contentType: 'application/json', body: '{}' });
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify(MOCK_VOICE_RESPONSE),
+      });
     });
 
     await page.setViewportSize({ width: 390, height: 844 });


### PR DESCRIPTION
## Summary
- Makes the kiosk viewport-lock E2E production-safe by installing the existing Web Audio mock before page load.
- Returns the shared Piper-compatible mock voice response instead of an empty `/api/voice` body, so production URL verification does not create a false slide narration failure.

## Verification
- `corepack pnpm --dir frontend typecheck`
- `corepack pnpm --dir frontend lint`
- `PLAYWRIGHT_BASE_URL=https://frontend-delta-six-20.vercel.app corepack pnpm --dir frontend exec playwright test --config=playwright.config.ts e2e/kiosk-viewport-lock.spec.ts --workers=1`

Follow-up to #807 / #806.
