### PR TITLE
fix(frontend): keep VRMA playback resilient

### DIFF
--- a/frontend/src/__tests__/vrm-utils.test.ts
+++ b/frontend/src/__tests__/vrm-utils.test.ts
@@ -1,0 +1,46 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import { VRMUtils } from '@/lib/vrm-utils';
+import type { VRM } from '@pixiv/three-vrm';
+import * as THREE from 'three';
+
+const createVrmWithHips = (hipsName = 'hips'): VRM => ({
+  humanoid: {
+    getNormalizedBoneNode: (name: string) => (name === 'hips' ? { name: hipsName } : null),
+  },
+}) as unknown as VRM;
+
+test('sampleHipsPositionXZAtTime returns null for degenerate hips values', () => {
+  const vrm = createVrmWithHips();
+  const clip = new THREE.AnimationClip('degenerate', 1, [
+    new THREE.VectorKeyframeTrack('hips.position', [0], [1, 2]),
+  ]);
+
+  assert.equal(VRMUtils.sampleHipsPositionXZAtTime(clip, vrm, 0), null);
+});
+
+test('sampleHipsPositionXZAtTime returns null for non-finite hips values', () => {
+  const vrm = createVrmWithHips();
+  const clip = new THREE.AnimationClip('nan', 1, [
+    new THREE.VectorKeyframeTrack('hips.position', [0], [1, 2, Number.NaN]),
+  ]);
+
+  assert.equal(VRMUtils.sampleHipsPositionXZAtTime(clip, vrm, 0), null);
+});
+
+test('rebaseHipsHorizontalInClip leaves degenerate hips tracks unchanged', () => {
+  const vrm = createVrmWithHips();
+  const track = new THREE.VectorKeyframeTrack('hips.position', [0], [1, 2]);
+  const clip = new THREE.AnimationClip('degenerate', 1, [track]);
+
+  const result = VRMUtils.rebaseHipsHorizontalInClip(
+    clip,
+    vrm,
+    { x: 10, z: 20 },
+    { x: 1, z: 2 },
+  );
+
+  assert.equal(result, clip);
+  assert.deepEqual(Array.from(track.values), [1, 2]);
+});

--- a/frontend/src/app/components/CharacterAvatar.tsx
+++ b/frontend/src/app/components/CharacterAvatar.tsx
@@ -231,6 +231,7 @@ export default function CharacterAvatar({
   const clockRef = useRef<THREE.Clock | null>(null);
   const mixerRef = useRef<THREE.AnimationMixer | null>(null);
   const currentActionRef = useRef<THREE.AnimationAction | null>(null);
+  const currentRebasedClipRef = useRef<THREE.AnimationClip | null>(null);
   const isPlayingSequence = useRef(false);
   const blendShapeControllerRef = useRef<VRMBlendShapeController | null>(null);
   const lipSyncAnalyzerRef = useRef<LipSyncAnalyzer | null>(null);
@@ -686,12 +687,16 @@ export default function CharacterAvatar({
       } else {
         let baseline = idleHipsBaselineRef.current;
         if (!baseline) {
-          const idlePack = await loadVRMAAnimationClipFromUrl(DEFAULT_IDLE_VRMA_URL, vrm);
-          if (idlePack.clip) {
-            baseline = VRMUtils.sampleHipsPositionXZAtTime(idlePack.clip, vrm, 0);
-            if (baseline) {
-              idleHipsBaselineRef.current = baseline;
+          try {
+            const idlePack = await loadVRMAAnimationClipFromUrl(DEFAULT_IDLE_VRMA_URL, vrm);
+            if (idlePack.clip) {
+              baseline = VRMUtils.sampleHipsPositionXZAtTime(idlePack.clip, vrm, 0);
+              if (baseline) {
+                idleHipsBaselineRef.current = baseline;
+              }
             }
+          } catch {
+            baseline = null;
           }
         }
         const other = VRMUtils.sampleHipsPositionXZAtTime(clip, vrm, 0);
@@ -707,6 +712,10 @@ export default function CharacterAvatar({
       if (currentActionRef.current) {
         currentActionRef.current.stop();
       }
+      if (currentRebasedClipRef.current && currentRebasedClipRef.current !== clip) {
+        mixerRef.current.uncacheClip(currentRebasedClipRef.current);
+        currentRebasedClipRef.current = null;
+      }
 
       const action = mixerRef.current.clipAction(clip);
       if (loop) {
@@ -717,6 +726,7 @@ export default function CharacterAvatar({
       }
       action.play();
       currentActionRef.current = action;
+      currentRebasedClipRef.current = clip !== initialClip ? clip : null;
 
       applyRootScenePosition(vrm);
 
@@ -1348,6 +1358,10 @@ export default function CharacterAvatar({
     
     if (mixerRef.current) {
       mixerRef.current.stopAllAction();
+      if (currentRebasedClipRef.current) {
+        mixerRef.current.uncacheClip(currentRebasedClipRef.current);
+        currentRebasedClipRef.current = null;
+      }
       mixerRef.current = null;
     }
 

--- a/frontend/src/lib/vrm-utils.ts
+++ b/frontend/src/lib/vrm-utils.ts
@@ -90,8 +90,14 @@ export class VRMUtils {
     if (!track) {
       return null;
     }
+    if (track.times.length === 0 || track.values.length < 3) {
+      return null;
+    }
     const interpolant = new THREE.LinearInterpolant(track.times, track.values, 3);
     const out = interpolant.evaluate(time) as Float32Array | number[];
+    if (out.length < 3 || !Number.isFinite(out[0]) || !Number.isFinite(out[2])) {
+      return null;
+    }
     return { x: out[0], z: out[2] };
   }
 
@@ -109,8 +115,14 @@ export class VRMUtils {
     if (!target) {
       return clip;
     }
+    if (target.values.length < 3) {
+      return clip;
+    }
     const dx = refIdleXZ.x - refOtherXZ.x;
     const dz = refIdleXZ.z - refOtherXZ.z;
+    if (!Number.isFinite(dx) || !Number.isFinite(dz)) {
+      return clip;
+    }
     if (Math.abs(dx) < 1e-9 && Math.abs(dz) < 1e-9) {
       return clip;
     }
@@ -121,7 +133,7 @@ export class VRMUtils {
       }
       const cloned = tr.clone();
       const { values } = cloned;
-      for (let i = 0; i < values.length; i += 3) {
+      for (let i = 0; i + 2 < values.length; i += 3) {
         values[i] += dx;
         values[i + 2] += dz;
       }


### PR DESCRIPTION
## Summary

Closes #762.

- continue non-idle VRMA playback when idle baseline fetch fails
- guard degenerate/non-finite hips tracks so NaN does not propagate into rebasing
- track and uncache rebased clips on animation swap and avatar cleanup
- add focused `VRMUtils` tests for degenerate hips data

## Verification

- `git diff --check`
- `cd frontend && mise exec node@24 -- corepack pnpm exec tsx --test --import ./src/__tests__/node-test-setup.ts src/__tests__/vrm-utils.test.ts`
- `cd frontend && mise exec node@24 -- corepack pnpm typecheck`
- `cd frontend && mise exec node@24 -- corepack pnpm lint`
- `cd frontend && mise exec node@24 -- corepack pnpm build`

Residual risk: no long-running iPad/kiosk memory soak was run.
