### PR TITLE
fix(frontend): guard audio queue settlement

### DIFF
--- a/frontend/e2e/mobile-audio-proof.spec.ts
+++ b/frontend/e2e/mobile-audio-proof.spec.ts
@@ -5,6 +5,9 @@ import { expect, test, type Page, type Request } from '@playwright/test';
 
 import { MOCK_VOICE_RESPONSE, setupWebAudioMock } from './helpers/mocks';
 
+const sampleVoiceFixturePath = path.resolve(__dirname, 'fixtures/voice/sample.wav');
+const hasSampleVoiceFixture = fs.existsSync(sampleVoiceFixturePath);
+
 interface ObservedCalls {
   stt: number;
   qa: number;
@@ -12,9 +15,7 @@ interface ObservedCalls {
 }
 
 async function installDeterministicVoiceRecorder(page: Page): Promise<void> {
-  const sampleAudioBase64 = fs
-    .readFileSync(path.resolve(__dirname, 'fixtures/voice/sample.wav'))
-    .toString('base64');
+  const sampleAudioBase64 = fs.readFileSync(sampleVoiceFixturePath).toString('base64');
 
   await page.addInitScript(({ audioBase64 }) => {
     (window as Window & { __PLAYWRIGHT_VOICE_AUDIO_BASE64__?: string }).__PLAYWRIGHT_VOICE_AUDIO_BASE64__ =
@@ -69,6 +70,11 @@ async function getInteractionRequiredCount(page: Page): Promise<number> {
 }
 
 test.describe('Mobile audio proof', () => {
+  test.skip(
+    !hasSampleVoiceFixture,
+    `Missing voice fixture: ${sampleVoiceFixturePath}. Run frontend/e2e/fixtures/voice/generate.sh before this proof test.`,
+  );
+
   test('iPhone WebKit completes 10 voice turns without silent audio interaction failures', async ({
     page,
   }) => {

--- a/frontend/src/__tests__/audio-queue.test.ts
+++ b/frontend/src/__tests__/audio-queue.test.ts
@@ -1,0 +1,109 @@
+import assert from "node:assert/strict";
+import { afterEach, test } from "node:test";
+
+import { AudioQueue } from "../lib/audio-queue";
+import { AudioError, AudioErrorType, type AudioOperationResult } from "../lib/audio/audio-interfaces";
+import { AudioInteractionManager } from "../lib/audio/audio-interaction-manager";
+import { resetAudioUserInteractionGate } from "../lib/audio/audio-user-interaction-gate";
+import {
+  GlobalAudioManager,
+} from "../lib/audio/web-audio-player";
+import {
+  MobileAudioService,
+  type MobileAudioOptions,
+} from "../lib/audio/mobile-audio-service";
+
+const originalConsoleError = console.error;
+const originalNavigator = globalThis.navigator;
+const originalWindow = (globalThis as typeof globalThis & { window?: unknown }).window;
+const originalDocument = (globalThis as typeof globalThis & { document?: unknown }).document;
+const originalPlayAudio = MobileAudioService.prototype.playAudio;
+
+const restoreAudioInteractionSingleton = (): void => {
+  (AudioInteractionManager as unknown as { instance?: AudioInteractionManager }).instance = undefined;
+};
+
+const installBrowserStubs = (): void => {
+  Object.defineProperty(globalThis, "navigator", {
+    configurable: true,
+    value: { userAgent: "node:test", vendor: "", platform: "", maxTouchPoints: 0 },
+  });
+  Object.defineProperty(globalThis, "window", {
+    configurable: true,
+    value: {
+      addEventListener() {},
+      removeEventListener() {},
+      dispatchEvent() {
+        return true;
+      },
+    },
+  });
+  Object.defineProperty(globalThis, "document", {
+    configurable: true,
+    value: {
+      addEventListener() {},
+      removeEventListener() {},
+    },
+  });
+};
+
+afterEach(() => {
+  MobileAudioService.prototype.playAudio = originalPlayAudio;
+  console.error = originalConsoleError;
+  resetAudioUserInteractionGate();
+  GlobalAudioManager.getInstance().dispose();
+  restoreAudioInteractionSingleton();
+  Object.defineProperty(globalThis, "navigator", {
+    configurable: true,
+    value: originalNavigator,
+  });
+  Object.defineProperty(globalThis, "window", {
+    configurable: true,
+    value: originalWindow,
+  });
+  Object.defineProperty(globalThis, "document", {
+    configurable: true,
+    value: originalDocument,
+  });
+});
+
+test("AudioQueue only fires onPlaybackEnd once when service emits onError before resolving failure", async () => {
+  installBrowserStubs();
+  console.error = () => undefined;
+
+  let playAudioCalls = 0;
+  MobileAudioService.prototype.playAudio = function (): Promise<AudioOperationResult> {
+    playAudioCalls += 1;
+    const error = new AudioError(AudioErrorType.PLAYBACK_FAILED, "decode failed before resolve");
+    (this as unknown as { options: MobileAudioOptions }).options.onError?.(error);
+    return Promise.resolve({
+      success: false,
+      method: "web-audio",
+      error,
+    });
+  };
+
+  const queue = new AudioQueue();
+  let playbackEndCalls = 0;
+  const finished = new Promise<void>((resolve) => {
+    queue.setOnFinished(resolve);
+  });
+
+  queue.add({
+    id: "service-error-before-resolve",
+    audioData: "UklGRiQAAABXQVZFZm10IBAAAAABAAEA",
+    onPlaybackEnd: () => {
+      playbackEndCalls += 1;
+    },
+  });
+
+  await Promise.race([
+    finished,
+    new Promise<never>((_, reject) => {
+      setTimeout(() => reject(new Error("AudioQueue did not finish")), 1000);
+    }),
+  ]);
+
+  assert.equal(playAudioCalls, 1);
+  assert.equal(playbackEndCalls, 1);
+});

--- a/frontend/src/lib/audio-queue.ts
+++ b/frontend/src/lib/audio-queue.ts
@@ -143,20 +143,31 @@ export class AudioQueue {
    */
   private async playAudio(item: AudioQueueItem): Promise<void> {
     return new Promise((resolve, reject) => {
-      const audioService = new MobileAudioService({
+      let settled = false;
+
+      let audioService: MobileAudioService | null = null;
+      const settle = (complete: () => void): void => {
+        if (settled) {
+          return;
+        }
+        settled = true;
+        if (audioService && this.currentAudioService === audioService) {
+          this.currentAudioService = null;
+        }
+        item.onPlaybackEnd?.();
+        complete();
+      };
+
+      audioService = new MobileAudioService({
         volume: this.volume,
         onPlay: () => {
           item.onPlaybackStart?.();
         },
         onEnded: () => {
-          this.currentAudioService = null;
-          item.onPlaybackEnd?.();
-          resolve();
+          settle(() => resolve());
         },
         onError: (error) => {
-          this.currentAudioService = null;
-          item.onPlaybackEnd?.();
-          reject(error);
+          settle(() => reject(error));
         },
       });
 
@@ -165,15 +176,13 @@ export class AudioQueue {
       audioService.playAudio(item.audioData)
         .then((result) => {
           if (!result.success) {
-            this.currentAudioService = null;
-            item.onPlaybackEnd?.();
-            reject(result.error || new AudioError(AudioErrorType.PLAYBACK_FAILED, 'Audio playback failed'));
+            settle(() => {
+              reject(result.error || new AudioError(AudioErrorType.PLAYBACK_FAILED, 'Audio playback failed'));
+            });
           }
         })
         .catch((error) => {
-          this.currentAudioService = null;
-          item.onPlaybackEnd?.();
-          reject(error);
+          settle(() => reject(error));
         });
     });
   }


### PR DESCRIPTION
## Summary

Partially addresses #770.

- prevent `AudioQueue` from firing `onPlaybackEnd` twice when `MobileAudioService` reports an error before resolving failure
- add focused node-test coverage for that service-error-before-resolve path
- make `mobile-audio-proof.spec.ts` skip clearly when the sample WAV fixture is missing

This PR intentionally does not change MarpViewer Resume handling; that remains a separate #770 item.

## Verification

- `git diff --check`
- `cd frontend && mise exec node@24 -- corepack pnpm typecheck`
- `cd frontend && mise exec node@24 -- corepack pnpm lint`
- `cd frontend && mise exec node@24 -- corepack pnpm exec tsx --test --import ./src/__tests__/node-test-setup.ts src/__tests__/audio-queue.test.ts`
- `cd frontend && mise exec node@24 -- corepack pnpm exec playwright test --config=playwright.config.ts e2e/mobile-audio-proof.spec.ts --project=webkit-mobile-audio`

Note: the first Playwright run hit a transient `processing` timeout; immediate rerun passed.
