### PR TITLE
test(frontend): consolidate voice e2e helpers

### DIFF
--- a/frontend/e2e/helpers/voice.ts
+++ b/frontend/e2e/helpers/voice.ts
@@ -1,0 +1,118 @@
+import fs from 'node:fs';
+import path from 'node:path';
+
+import { expect, type Page, type Request, type Route } from '@playwright/test';
+
+interface DismissInitialModalOptions {
+  closeButtonTimeoutMs?: number;
+  closeDelayMs?: number;
+  hiddenTimeoutMs?: number;
+  welcomeTimeoutMs?: number;
+}
+
+export async function dismissInitialModal(
+  page: Page,
+  {
+    closeButtonTimeoutMs = 3_000,
+    closeDelayMs = 1_500,
+    hiddenTimeoutMs = 10_000,
+    welcomeTimeoutMs = 5_000,
+  }: DismissInitialModalOptions = {},
+) {
+  const modal = page.getByRole('dialog');
+  const closeButton = page.getByTestId('initial-settings-close');
+  if (await closeButton.isVisible({ timeout: closeButtonTimeoutMs }).catch(() => false)) {
+    if (closeDelayMs > 0) {
+      await page.waitForTimeout(closeDelayMs);
+    }
+    const deadline = Date.now() + 30_000;
+    while (Date.now() < deadline && !(await modal.isHidden().catch(() => false))) {
+      await closeButton.click({ timeout: 1_000, force: true }).catch(() => {});
+      if (!(await modal.isHidden().catch(() => false))) {
+        await closeButton
+          .evaluate((button) => {
+            if (button instanceof HTMLButtonElement) {
+              button.click();
+            }
+          })
+          .catch(() => {});
+      }
+      await page.waitForTimeout(250);
+    }
+    await expect(modal).toBeHidden({ timeout: hiddenTimeoutMs });
+  }
+  await expect(page.getByRole('button', { name: 'Welcome' })).toBeVisible({
+    timeout: welcomeTimeoutMs,
+  });
+}
+
+export async function installDeterministicVoiceRecorder(page: Page): Promise<void> {
+  const sampleAudioBase64 = fs
+    .readFileSync(path.resolve(__dirname, '../fixtures/voice/sample.wav'))
+    .toString('base64');
+
+  await page.addInitScript(({ audioBase64 }) => {
+    (window as Window & { __PLAYWRIGHT_VOICE_AUDIO_BASE64__?: string }).__PLAYWRIGHT_VOICE_AUDIO_BASE64__ =
+      audioBase64;
+  }, { audioBase64: sampleAudioBase64 });
+}
+
+export async function installMicDenial(page: Page, errorName: string): Promise<void> {
+  await page.addInitScript((name: string) => {
+    (window as Window & { __PLAYWRIGHT_VOICE_RECORDER_ERROR_NAME__?: string }).__PLAYWRIGHT_VOICE_RECORDER_ERROR_NAME__ =
+      name;
+  }, errorName);
+}
+
+export async function installIOSUserAgent(page: Page): Promise<void> {
+  await page.addInitScript(() => {
+    Object.defineProperty(navigator, 'userAgent', {
+      configurable: true,
+      value:
+        'Mozilla/5.0 (iPhone; CPU iPhone OS 17_0 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.0 Mobile/15E148 Safari/604.1',
+    });
+    Object.defineProperty(navigator, 'maxTouchPoints', {
+      configurable: true,
+      value: 5,
+    });
+  });
+}
+
+export function parseVoiceAction(request: Request): string | undefined {
+  const raw = request.postData();
+  if (raw) {
+    try {
+      const parsed = JSON.parse(raw) as { action?: unknown };
+      if (typeof parsed.action === 'string') {
+        return parsed.action;
+      }
+    } catch {
+      return undefined;
+    }
+  }
+
+  try {
+    const action = new URL(request.url()).searchParams.get('action');
+    return action ?? undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+export async function failUnexpectedVoiceAction(
+  route: Route,
+  action: string | undefined,
+  allowedActions: readonly string[],
+): Promise<never> {
+  const printableAction = action ?? '<missing>';
+  const message =
+    `Unexpected /api/voice action in Playwright mock: ${printableAction}. ` +
+    `Allowed actions: ${allowedActions.join(', ')}`;
+
+  await route.fulfill({
+    status: 500,
+    contentType: 'application/json',
+    body: JSON.stringify({ success: false, error: message }),
+  });
+  throw new Error(message);
+}

--- a/frontend/e2e/voice-live.spec.ts
+++ b/frontend/e2e/voice-live.spec.ts
@@ -1,7 +1,10 @@
-import fs from 'node:fs';
-import path from 'node:path';
+import { expect, test, type Page } from '@playwright/test';
 
-import { expect, test, type Page, type Request } from '@playwright/test';
+import {
+  dismissInitialModal,
+  installDeterministicVoiceRecorder,
+  parseVoiceAction,
+} from './helpers/voice';
 
 const voiceLive = process.env.PLAYWRIGHT_VOICE_LIVE === '1';
 
@@ -24,27 +27,6 @@ function normalizeText(value: string | null | undefined): string {
     .replace(/^(応答|Response)\s*:\s*/i, '')
     .replace(/\s+/g, ' ')
     .trim();
-}
-
-async function installDeterministicVoiceRecorder(page: Page): Promise<void> {
-  const sampleAudioBase64 = fs
-    .readFileSync(path.resolve(__dirname, 'fixtures/voice/sample.wav'))
-    .toString('base64');
-
-  await page.addInitScript(({ audioBase64 }) => {
-    (window as Window & { __PLAYWRIGHT_VOICE_AUDIO_BASE64__?: string }).__PLAYWRIGHT_VOICE_AUDIO_BASE64__ =
-      audioBase64;
-  }, { audioBase64: sampleAudioBase64 });
-}
-
-async function selectEnglishAndClose(page: Page, timeout = 15_000): Promise<void> {
-  const dialog = page.getByRole('dialog', { name: /初期設定|Initial Settings/i });
-  await expect(dialog).toBeVisible({ timeout });
-  await page.waitForTimeout(500);
-  const closeButton = dialog.getByTestId('initial-settings-close');
-  await expect(closeButton).toBeVisible({ timeout });
-  await closeButton.click();
-  await expect(dialog).toBeHidden({ timeout });
 }
 
 function parsePositiveInteger(value: string | undefined, fallback: number): number {
@@ -102,17 +84,6 @@ async function warmupSttForLiveVoice(
   );
 }
 
-function parseAction(request: Request): string | undefined {
-  const raw = request.postData();
-  if (!raw) return undefined;
-  try {
-    const parsed = JSON.parse(raw) as { action?: unknown };
-    return typeof parsed.action === 'string' ? parsed.action : undefined;
-  } catch {
-    return undefined;
-  }
-}
-
 async function readResponseText(page: Page): Promise<string> {
   const responseText = page.getByTestId('response-text');
   if ((await responseText.count()) === 0) {
@@ -149,11 +120,16 @@ test.describe('Voice live (browser voice round-trip against live backend)', () =
       const method = request.method();
       if (method !== 'POST') return;
       if (!(url.includes('/api/voice') || url.includes('/api/qa'))) return;
-      apiCalls.push({ url, method, action: parseAction(request) });
+      apiCalls.push({ url, method, action: parseVoiceAction(request) });
     });
 
     await page.goto('/', { waitUntil: 'domcontentloaded' });
-    await selectEnglishAndClose(page);
+    await dismissInitialModal(page, {
+      closeButtonTimeoutMs: 15_000,
+      closeDelayMs: 500,
+      hiddenTimeoutMs: 15_000,
+      welcomeTimeoutMs: 15_000,
+    });
 
     const voiceButton = page.getByTestId('kiosk-voice-button');
     await expect(voiceButton).toBeVisible({ timeout: 15_000 });
@@ -169,7 +145,7 @@ test.describe('Voice live (browser voice round-trip against live backend)', () =
       (response) =>
         response.url().includes('/api/voice') &&
         response.request().method() === 'POST' &&
-        parseAction(response.request()) === 'speech_to_text',
+        parseVoiceAction(response.request()) === 'speech_to_text',
       { timeout: 120_000 },
     );
     const qaResponsePromise = page.waitForResponse(
@@ -181,7 +157,7 @@ test.describe('Voice live (browser voice round-trip against live backend)', () =
       (response) =>
         response.url().includes('/api/voice') &&
         response.request().method() === 'POST' &&
-        parseAction(response.request()) === 'text_to_speech',
+        parseVoiceAction(response.request()) === 'text_to_speech',
       { timeout: 120_000 },
     );
 

--- a/frontend/e2e/voice-network-recovery.spec.ts
+++ b/frontend/e2e/voice-network-recovery.spec.ts
@@ -1,53 +1,11 @@
-import fs from 'node:fs';
-import path from 'node:path';
+import { expect, test } from '@playwright/test';
 
-import { expect, test, type Page, type Route } from '@playwright/test';
-
-async function dismissInitialModal(page: Page) {
-  const modal = page.getByRole('dialog');
-  const closeButton = page.getByTestId('initial-settings-close');
-  if (await closeButton.isVisible({ timeout: 3_000 }).catch(() => false)) {
-    await page.waitForTimeout(1_500);
-    const deadline = Date.now() + 30_000;
-    while (Date.now() < deadline && !(await modal.isHidden().catch(() => false))) {
-      await closeButton.click({ timeout: 1_000, force: true }).catch(() => {});
-      if (!(await modal.isHidden().catch(() => false))) {
-        await closeButton
-          .evaluate((button) => {
-            if (button instanceof HTMLButtonElement) {
-              button.click();
-            }
-          })
-          .catch(() => {});
-      }
-      await page.waitForTimeout(250);
-    }
-    await expect(modal).toBeHidden({ timeout: 10_000 });
-  }
-  await expect(page.getByRole('button', { name: 'Welcome' })).toBeVisible({ timeout: 5_000 });
-}
-
-async function installDeterministicVoiceRecorder(page: Page) {
-  const sampleAudioBase64 = fs
-    .readFileSync(path.resolve(__dirname, 'fixtures/voice/sample.wav'))
-    .toString('base64');
-
-  await page.addInitScript(({ audioBase64 }) => {
-    (window as Window & { __PLAYWRIGHT_VOICE_AUDIO_BASE64__?: string }).__PLAYWRIGHT_VOICE_AUDIO_BASE64__ =
-      audioBase64;
-  }, { audioBase64: sampleAudioBase64 });
-}
-
-function requestAction(route: Route): string {
-  const raw = route.request().postData();
-  if (!raw) return '';
-  try {
-    const parsed = JSON.parse(raw) as { action?: unknown };
-    return typeof parsed.action === 'string' ? parsed.action : '';
-  } catch {
-    return '';
-  }
-}
+import {
+  dismissInitialModal,
+  failUnexpectedVoiceAction,
+  installDeterministicVoiceRecorder,
+  parseVoiceAction,
+} from './helpers/voice';
 
 test.describe('Voice network recovery (#584 F-1)', () => {
   test('STT network failure returns to idle and a second voice turn can succeed', async ({ page }) => {
@@ -68,7 +26,7 @@ test.describe('Voice network recovery (#584 F-1)', () => {
     });
 
     await page.route('**/api/voice', async (route) => {
-      const action = requestAction(route);
+      const action = parseVoiceAction(route.request());
       if (action === 'speech_to_text') {
         sttAttempts += 1;
         if (sttAttempts === 1) {
@@ -95,11 +53,21 @@ test.describe('Voice network recovery (#584 F-1)', () => {
         return;
       }
 
-      await route.fulfill({
-        status: 200,
-        contentType: 'application/json',
-        body: JSON.stringify({ success: true }),
-      });
+      if (action === 'text_to_speech' || action === 'interrupt') {
+        await route.fulfill({
+          status: 200,
+          contentType: 'application/json',
+          body: JSON.stringify({ success: true }),
+        });
+        return;
+      }
+
+      await failUnexpectedVoiceAction(route, action, [
+        'speech_to_text',
+        'warmup',
+        'text_to_speech',
+        'interrupt',
+      ]);
     });
 
     await page.route('**/api/voice/filler', async (route) => {

--- a/frontend/e2e/voice-permission-denial.spec.ts
+++ b/frontend/e2e/voice-permission-denial.spec.ts
@@ -1,53 +1,17 @@
-import fs from 'node:fs';
-import path from 'node:path';
+import { expect, test, type Page } from '@playwright/test';
 
-import { expect, test } from '@playwright/test';
+import {
+  dismissInitialModal,
+  failUnexpectedVoiceAction,
+  installDeterministicVoiceRecorder,
+  installIOSUserAgent,
+  installMicDenial,
+  parseVoiceAction,
+} from './helpers/voice';
 
 /**
  * Alpha #638 — getUserMedia rejection UX (WebKit project in playwright.config).
  */
-
-async function dismissInitialModal(page: import('@playwright/test').Page) {
-  const modal = page.getByRole('dialog');
-  const closeButton = page.getByTestId('initial-settings-close');
-  if (await closeButton.isVisible({ timeout: 3_000 }).catch(() => false)) {
-    await closeButton.click({ force: true }).catch(() => {});
-    await expect(modal).toBeHidden({ timeout: 10_000 });
-  }
-  await expect(page.getByRole('button', { name: 'Welcome' })).toBeVisible({ timeout: 5_000 });
-}
-
-async function installMicDenial(page: import('@playwright/test').Page, errorName: string) {
-  await page.addInitScript((name: string) => {
-    (window as Window & { __PLAYWRIGHT_VOICE_RECORDER_ERROR_NAME__?: string }).__PLAYWRIGHT_VOICE_RECORDER_ERROR_NAME__ =
-      name;
-  }, errorName);
-}
-
-async function installDeterministicVoiceRecorder(page: import('@playwright/test').Page) {
-  const sampleAudioBase64 = fs
-    .readFileSync(path.resolve(__dirname, 'fixtures/voice/sample.wav'))
-    .toString('base64');
-
-  await page.addInitScript(({ audioBase64 }) => {
-    (window as Window & { __PLAYWRIGHT_VOICE_AUDIO_BASE64__?: string }).__PLAYWRIGHT_VOICE_AUDIO_BASE64__ =
-      audioBase64;
-  }, { audioBase64: sampleAudioBase64 });
-}
-
-async function installIOSUserAgent(page: import('@playwright/test').Page) {
-  await page.addInitScript(() => {
-    Object.defineProperty(navigator, 'userAgent', {
-      configurable: true,
-      value:
-        'Mozilla/5.0 (iPhone; CPU iPhone OS 17_0 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.0 Mobile/15E148 Safari/604.1',
-    });
-    Object.defineProperty(navigator, 'maxTouchPoints', {
-      configurable: true,
-      value: 5,
-    });
-  });
-}
 
 test.describe('Microphone permission denial (#638)', () => {
   test.beforeEach(async ({ page }) => {
@@ -63,15 +27,32 @@ test.describe('Microphone permission denial (#638)', () => {
       });
     });
     await page.route('**/api/voice', async (route) => {
-      await route.fulfill({
-        status: 200,
-        contentType: 'application/json',
-        body: JSON.stringify({ success: true }),
-      });
+      const action = parseVoiceAction(route.request());
+
+      if (
+        action === 'warmup' ||
+        action === 'speech_to_text' ||
+        action === 'text_to_speech' ||
+        action === 'interrupt'
+      ) {
+        await route.fulfill({
+          status: 200,
+          contentType: 'application/json',
+          body: JSON.stringify({ success: true }),
+        });
+        return;
+      }
+
+      await failUnexpectedVoiceAction(route, action, [
+        'warmup',
+        'speech_to_text',
+        'text_to_speech',
+        'interrupt',
+      ]);
     });
   });
 
-  async function assertMicDeniedRecovery(page: import('@playwright/test').Page) {
+  async function assertMicDeniedRecovery(page: Page) {
     await page.goto('/', { waitUntil: 'domcontentloaded' });
     await dismissInitialModal(page);
 
@@ -105,8 +86,7 @@ test.describe('Microphone permission denial (#638)', () => {
     });
 
     await page.route('**/api/voice', async (route) => {
-      const raw = route.request().postData();
-      const action = raw ? (JSON.parse(raw) as { action?: string }).action : '';
+      const action = parseVoiceAction(route.request());
       if (action === 'speech_to_text') {
         await route.fulfill({
           status: 200,
@@ -118,11 +98,22 @@ test.describe('Microphone permission denial (#638)', () => {
         });
         return;
       }
-      await route.fulfill({
-        status: 200,
-        contentType: 'application/json',
-        body: JSON.stringify({ success: true, sttWarmupStatus: 'ready' }),
-      });
+
+      if (action === 'warmup' || action === 'text_to_speech' || action === 'interrupt') {
+        await route.fulfill({
+          status: 200,
+          contentType: 'application/json',
+          body: JSON.stringify({ success: true, sttWarmupStatus: 'ready' }),
+        });
+        return;
+      }
+
+      await failUnexpectedVoiceAction(route, action, [
+        'speech_to_text',
+        'warmup',
+        'text_to_speech',
+        'interrupt',
+      ]);
     });
 
     await page.route('**/api/qa', async (route) => {


### PR DESCRIPTION
## Summary

Closes #763.

- move duplicated Playwright voice helpers into `frontend/e2e/helpers/voice.ts`
- update network recovery, permission denial, and live voice specs to use the shared helpers
- make mocked `/api/voice` action handling explicit so unknown actions fail tests instead of returning false green success

## Verification

- `git diff --check`
- `cd frontend && mise exec node@24 -- corepack pnpm typecheck`
- `cd frontend && mise exec node@24 -- corepack pnpm lint`
- `cd frontend && mise exec node@24 -- corepack pnpm exec playwright test --config=playwright.config.ts e2e/voice-network-recovery.spec.ts --project=chromium`
- `cd frontend && mise exec node@24 -- corepack pnpm exec playwright test --config=playwright.config.ts e2e/voice-permission-denial.spec.ts --project=webkit-permissions`
- `cd frontend && mise exec node@24 -- corepack pnpm exec playwright test --config=playwright.config.ts e2e/voice-live.spec.ts --project=chromium-voice-live` skipped as expected without live backend env

Live voice round-trip was not executed because the required live backend env vars are not set.
