### PR TITLE
[codex] Fix OCR reception and voice start regressions

### DIFF
--- a/backend/api/ocr.py
+++ b/backend/api/ocr.py
@@ -96,6 +96,7 @@ class OcrResponse(BaseModel):
     expression: Optional[str] = None
     processing_time_ms: int = 0
     visitor_identity: Optional[dict] = None
+    identity_lookup: Optional[dict] = None
     error: Optional[str] = None
 
 
@@ -268,6 +269,7 @@ async def recognize_image(request: Request, body: OcrRequest) -> OcrResponse:
     # --- Mode-specific post-processing --------------------------------------
     member_number: Optional[int] = None
     visitor_identity: Optional[dict[str, Any]] = None
+    identity_lookup: Optional[dict[str, Any]] = None
     detected_language: Optional[str] = None
 
     if body.mode == "member_card":
@@ -279,13 +281,23 @@ async def recognize_image(request: Request, body: OcrRequest) -> OcrResponse:
                 member_number = int(match.group(1))
                 try:
                     svc = _get_visitor_id_service()
-                    visitor_identity = await svc.identify_by_member_number(member_number)
+                    lookup_result = await svc.identify_by_member_number_with_lookup(member_number)
+                    visitor_identity = lookup_result.get("identity")
+                    identity_lookup = lookup_result.get("lookup")
                 except Exception as exc:
                     logger.warning(
                         "Visitor identification failed for member %s: %s",
                         member_number,
                         exc,
                     )
+                    identity_lookup = {
+                        "attempted": True,
+                        "source": "public.users",
+                        "member_number": member_number,
+                        "status": "lookup_failed",
+                        "resolved": False,
+                        "reason": "service_exception",
+                    }
 
     elif body.mode == "handwriting":
         if recognized_text:
@@ -319,4 +331,5 @@ async def recognize_image(request: Request, body: OcrRequest) -> OcrResponse:
         expression=expression_str,
         processing_time_ms=elapsed_ms,
         visitor_identity=visitor_identity,
+        identity_lookup=identity_lookup,
     )

--- a/backend/api/reception.py
+++ b/backend/api/reception.py
@@ -459,7 +459,10 @@ async def start_reception(request: ReceptionStartRequest) -> ReceptionStartRespo
     )
 
     # If visitor_identity provided (from OCR), identify immediately
-    if request.visitor_identity and request.visitor_identity.user_id:
+    has_resolved_visitor_identity = bool(
+        request.visitor_identity and request.visitor_identity.user_id
+    )
+    if has_resolved_visitor_identity:
         from backend.utils.reception_templates import get_personalized_greeting
 
         identity = VisitorIdentity(
@@ -485,7 +488,7 @@ async def start_reception(request: ReceptionStartRequest) -> ReceptionStartRespo
         "Reception session started: id=%s session_id=%s visitor=%s",
         session.id,
         request.session_id,
-        "identified" if request.visitor_identity else "new",
+        "identified" if has_resolved_visitor_identity else "new",
     )
 
     return ReceptionStartResponse(

--- a/backend/services/visitor_identification_service.py
+++ b/backend/services/visitor_identification_service.py
@@ -9,6 +9,8 @@ from typing import Any, Dict, List, Optional
 
 logger = logging.getLogger(__name__)
 
+_USER_LOOKUP_SOURCE = "public.users"
+
 
 class VisitorIdentificationService:
     """Identifies visitors using multiple signals.
@@ -77,7 +79,17 @@ class VisitorIdentificationService:
         Returns:
             A dict with visitor identity fields, or None when not found.
         """
-        return await self._get_user_profile(member_number)
+        result = await self.identify_by_member_number_with_lookup(member_number)
+        return result["identity"]
+
+    async def identify_by_member_number_with_lookup(self, member_number: int) -> Dict[str, Any]:
+        """Look up a visitor by member number and include lookup metadata.
+
+        ``public.users`` is not created by the current backend migrations, so
+        callers that need to distinguish "not found" from "lookup unavailable"
+        should use this method instead of relying on logs.
+        """
+        return await self._get_user_profile_lookup(member_number)
 
     async def identify_by_visitor_id(self, visitor_id: str) -> Optional[Dict[str, Any]]:
         """Look up a visitor by frontend-generated persistent visitor_id.
@@ -158,32 +170,93 @@ class VisitorIdentificationService:
 
     async def _get_user_profile(self, user_id: int) -> Optional[Dict[str, Any]]:
         """Fetch an enriched user profile and visit count from the ``users`` table."""
+        result = await self._get_user_profile_lookup(user_id)
+        return result["identity"]
+
+    async def _get_user_profile_lookup(self, user_id: int) -> Dict[str, Any]:
+        """Fetch an enriched user profile and explicit lookup metadata."""
         client = await self._get_supabase()
         if not client:
-            return None
-        try:
-            result = (
-                client.table("users")
-                .select("id, name, email, phone, prefecture, job, belong")
-                .eq("id", user_id)
-                .execute()
+            return self._build_lookup_result(
+                user_id,
+                None,
+                status="skipped",
+                reason="supabase_unavailable",
             )
+        try:
+            result = client.table("users").select("*").eq("id", user_id).execute()
             if result.data:
                 user = result.data[0]
                 visit_count = await self._count_visits_by_user(user_id)
                 profile = {
                     "visitor_type": "returning",
-                    "user_id": user["id"],
+                    "user_id": user.get("id", user_id),
                     "name": user.get("name"),
                     "visit_count": visit_count,
                 }
                 for field in ("email", "prefecture", "job", "belong"):
                     if user.get(field) is not None:
                         profile[field] = user.get(field)
-                return profile
+                return self._build_lookup_result(user_id, profile, status="found")
         except Exception as e:
-            logger.warning("User profile lookup failed: %s", e)
-        return None
+            reason = self._classify_user_lookup_error(e)
+            if reason == "users_table_unavailable":
+                logger.info("User profile lookup unavailable: %s", e)
+            else:
+                logger.warning("User profile lookup failed: %s", e)
+            return self._build_lookup_result(
+                user_id,
+                None,
+                status="lookup_failed",
+                reason=reason,
+            )
+        return self._build_lookup_result(
+            user_id,
+            None,
+            status="not_found",
+            reason="member_number_not_found",
+        )
+
+    @staticmethod
+    def _build_lookup_result(
+        user_id: int,
+        identity: Optional[Dict[str, Any]],
+        *,
+        status: str,
+        reason: Optional[str] = None,
+    ) -> Dict[str, Any]:
+        lookup: Dict[str, Any] = {
+            "attempted": True,
+            "source": _USER_LOOKUP_SOURCE,
+            "member_number": user_id,
+            "status": status,
+            "resolved": identity is not None,
+        }
+        if reason:
+            lookup["reason"] = reason
+        return {"identity": identity, "lookup": lookup}
+
+    @staticmethod
+    def _classify_user_lookup_error(exc: Exception) -> str:
+        text_parts = [str(exc)]
+        for attr in ("code", "message", "details", "hint"):
+            value = getattr(exc, attr, None)
+            if value:
+                text_parts.append(str(value))
+        error_text = " ".join(text_parts).lower()
+
+        missing_table_markers = (
+            "pgrst205",
+            "42p01",
+            "could not find the table",
+            "schema cache",
+            'relation "public.users" does not exist',
+            'relation "users" does not exist',
+        )
+        if any(marker in error_text for marker in missing_table_markers):
+            return "users_table_unavailable"
+
+        return "query_failed"
 
     async def _count_visits(self, visitor_id: str) -> int:
         """Count total visits for a given ``visitor_id``."""

--- a/backend/tests/api/test_ocr_api.py
+++ b/backend/tests/api/test_ocr_api.py
@@ -231,6 +231,7 @@ class TestRecognizeImageEndpoint:
         assert data["expression"] == "happy"
         assert data["confidence"] == pytest.approx(0.8)
         assert data["member_number"] is None
+        assert data["identity_lookup"] is None
 
         run_payload = mock_agent.run.await_args.args[0]
         assert run_payload["image"] is decoded_image
@@ -262,8 +263,17 @@ class TestRecognizeImageEndpoint:
             }
         )
         mock_service = MagicMock()
-        mock_service.identify_by_member_number = AsyncMock(
-            return_value={"visitor_id": "visitor-123", "member_number": 123}
+        mock_service.identify_by_member_number_with_lookup = AsyncMock(
+            return_value={
+                "identity": {"visitor_id": "visitor-123", "member_number": 123},
+                "lookup": {
+                    "attempted": True,
+                    "source": "public.users",
+                    "member_number": 123,
+                    "status": "found",
+                    "resolved": True,
+                },
+            }
         )
 
         with (
@@ -276,9 +286,97 @@ class TestRecognizeImageEndpoint:
         assert data["success"] is True
         assert data["member_number"] == 123
         assert data["visitor_identity"] == {"visitor_id": "visitor-123", "member_number": 123}
+        assert data["identity_lookup"] == {
+            "attempted": True,
+            "source": "public.users",
+            "member_number": 123,
+            "status": "found",
+            "resolved": True,
+        }
         assert data["expression"] == "neutral"
         assert data["confidence"] == 1.0
-        mock_service.identify_by_member_number.assert_awaited_once_with(123)
+        mock_service.identify_by_member_number_with_lookup.assert_awaited_once_with(123)
+
+    def test_member_card_mode_keeps_ocr_success_when_identity_is_null(self):
+        """visitor lookup が未発見でも OCR 成功と会員番号は返す。"""
+        mock_agent = MagicMock()
+        mock_agent.run = AsyncMock(
+            return_value={
+                "text": {"success": True, "text": "会員番号9999"},
+                "face": {"detected": False, "expression": None},
+            }
+        )
+        mock_service = MagicMock()
+        mock_service.identify_by_member_number_with_lookup = AsyncMock(
+            return_value={
+                "identity": None,
+                "lookup": {
+                    "attempted": True,
+                    "source": "public.users",
+                    "member_number": 9999,
+                    "status": "not_found",
+                    "resolved": False,
+                    "reason": "member_number_not_found",
+                },
+            }
+        )
+
+        with (
+            patch.object(ocr_module, "_decode_image", return_value=np.zeros((2, 2, 3))),
+            patch.object(ocr_module, "_get_vision_agent", return_value=mock_agent),
+            patch.object(ocr_module, "_get_visitor_id_service", return_value=mock_service),
+        ):
+            data = self._post_ocr(mode="member_card")
+
+        assert data["success"] is True
+        assert data["member_number"] == 9999
+        assert data["visitor_identity"] is None
+        assert data["identity_lookup"]["status"] == "not_found"
+        assert data["identity_lookup"]["reason"] == "member_number_not_found"
+
+    def test_member_card_mode_reports_users_table_lookup_failure(self):
+        """public.users 不在時は lookup 失敗を metadata として返す。"""
+        mock_agent = MagicMock()
+        mock_agent.run = AsyncMock(
+            return_value={
+                "text": {"success": True, "text": "会員番号123"},
+                "face": {"detected": False, "expression": None},
+            }
+        )
+        mock_service = MagicMock()
+        mock_service.identify_by_member_number_with_lookup = AsyncMock(
+            return_value={
+                "identity": None,
+                "lookup": {
+                    "attempted": True,
+                    "source": "public.users",
+                    "member_number": 123,
+                    "status": "lookup_failed",
+                    "resolved": False,
+                    "reason": "users_table_unavailable",
+                },
+            }
+        )
+
+        with (
+            patch.object(ocr_module, "_decode_image", return_value=np.zeros((2, 2, 3))),
+            patch.object(ocr_module, "_get_vision_agent", return_value=mock_agent),
+            patch.object(ocr_module, "_get_visitor_id_service", return_value=mock_service),
+        ):
+            data = self._post_ocr(mode="member_card")
+
+        assert data["success"] is True
+        assert data["error"] is None
+        assert data["member_number"] == 123
+        assert data["visitor_identity"] is None
+        assert data["identity_lookup"] == {
+            "attempted": True,
+            "source": "public.users",
+            "member_number": 123,
+            "status": "lookup_failed",
+            "resolved": False,
+            "reason": "users_table_unavailable",
+        }
 
     def test_handwriting_mode_detects_language(self):
         """handwriting モードでは言語推定結果を返す。"""

--- a/backend/tests/services/test_visitor_identification_service.py
+++ b/backend/tests/services/test_visitor_identification_service.py
@@ -92,7 +92,7 @@ async def test_identify_by_nfc_found(service: VisitorIdentificationService, mock
 
     result = await service.identify_by_nfc("nfc-abc-123")
 
-    user_builder.select.assert_called_once_with("id, name, email, phone, prefecture, job, belong")
+    user_builder.select.assert_called_once_with("*")
     assert result is not None
     assert result["visitor_type"] == "returning"
     assert result["user_id"] == 42
@@ -252,7 +252,7 @@ async def test_identify_by_member_number_found(
 
     result = await service.identify_by_member_number(7)
 
-    user_builder.select.assert_called_once_with("id, name, email, phone, prefecture, job, belong")
+    user_builder.select.assert_called_once_with("*")
     assert result is not None
     assert result["visitor_type"] == "returning"
     assert result["user_id"] == 7
@@ -309,6 +309,66 @@ async def test_identify_by_member_number_not_found(
 
 
 @pytest.mark.asyncio
+async def test_identify_by_member_number_with_lookup_not_found(
+    service: VisitorIdentificationService, mock_client: MagicMock
+):
+    """Should expose metadata when lookup succeeds but identity is null."""
+    builder = MagicMock()
+    builder.select.return_value = builder
+    builder.eq.return_value = builder
+    builder.execute.return_value = _make_query_result(data=[])
+
+    mock_client.table = MagicMock(return_value=builder)
+
+    result = await service.identify_by_member_number_with_lookup(9999)
+
+    assert result["identity"] is None
+    assert result["lookup"] == {
+        "attempted": True,
+        "source": "public.users",
+        "member_number": 9999,
+        "status": "not_found",
+        "resolved": False,
+        "reason": "member_number_not_found",
+    }
+
+
+@pytest.mark.asyncio
+async def test_identify_by_member_number_with_lookup_found(
+    service: VisitorIdentificationService, mock_client: MagicMock
+):
+    """Should expose success metadata when member number resolves to a user."""
+    user_builder = MagicMock()
+    user_builder.select.return_value = user_builder
+    user_builder.eq.return_value = user_builder
+    user_builder.execute.return_value = _make_query_result(data=[{"id": 7, "name": "Hanako"}])
+
+    count_builder = MagicMock()
+    count_builder.select.return_value = count_builder
+    count_builder.eq.return_value = count_builder
+    count_builder.execute.return_value = _make_query_result(count=12)
+
+    tables = {"users": user_builder, "visits": count_builder}
+    mock_client.table = MagicMock(side_effect=lambda n: tables[n])
+
+    result = await service.identify_by_member_number_with_lookup(7)
+
+    assert result["identity"] == {
+        "visitor_type": "returning",
+        "user_id": 7,
+        "name": "Hanako",
+        "visit_count": 12,
+    }
+    assert result["lookup"] == {
+        "attempted": True,
+        "source": "public.users",
+        "member_number": 7,
+        "status": "found",
+        "resolved": True,
+    }
+
+
+@pytest.mark.asyncio
 async def test_identify_by_member_number_supabase_failure(
     service: VisitorIdentificationService, mock_client: MagicMock
 ):
@@ -317,6 +377,35 @@ async def test_identify_by_member_number_supabase_failure(
 
     result = await service.identify_by_member_number(1)
     assert result is None
+
+
+@pytest.mark.asyncio
+async def test_identify_by_member_number_with_lookup_users_table_failure(
+    service: VisitorIdentificationService, mock_client: MagicMock
+):
+    """Should classify a missing public.users table without raising."""
+
+    class MissingUsersTableError(Exception):
+        code = "PGRST205"
+        message = "Could not find the table 'public.users' in the schema cache"
+
+    builder = MagicMock()
+    builder.select.return_value = builder
+    builder.eq.return_value = builder
+    builder.execute.side_effect = MissingUsersTableError("public.users missing")
+    mock_client.table = MagicMock(return_value=builder)
+
+    result = await service.identify_by_member_number_with_lookup(123)
+
+    assert result["identity"] is None
+    assert result["lookup"] == {
+        "attempted": True,
+        "source": "public.users",
+        "member_number": 123,
+        "status": "lookup_failed",
+        "resolved": False,
+        "reason": "users_table_unavailable",
+    }
 
 
 # ---------------------------------------------------------------------------

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -56,15 +56,20 @@ Vercel project の Environment Variables に設定する。
 
 | Variable | Required | Description |
 | --- | --- | --- |
-| `NEXT_PUBLIC_BACKEND_API_URL` | Yes | browser から見える backend URL |
-| `BACKEND_API_URL` | Yes (server) | server-side proxy の転送先 |
-| `BACKEND_API_KEY` | Yes (server) | protected backend route へ送る `X-API-Key` |
-| `ADMIN_API_SECRET` | Yes | `/api/admin/*`, `/api/cron/*`, `/api/monitoring/*` を保護 |
+| `NEXT_PUBLIC_SUPABASE_URL` | Yes (production build/startup) | Supabase project URL. `frontend/src/lib/env.ts` と `pnpm env:check:production` の production required 対象 |
+| `NEXT_PUBLIC_SUPABASE_ANON_KEY` | Yes (production build/startup) | Supabase anon key. 値は公開前提だが smoke / logs には出力しない |
+| `BACKEND_API_URL` | Yes (production build/startup) | server-side proxy の転送先 |
+| `BACKEND_API_KEY` | Yes (production build/startup) | protected backend route へ送る `X-API-Key` |
+| `ADMIN_API_SECRET` | Yes (protected routes) | `/api/admin/*`, `/api/cron/*`, `/api/monitoring/*` を保護。middleware は production で未設定時 fail closed |
+| `NEXT_PUBLIC_BACKEND_API_URL` | If direct-call flags are used | browser から見える backend URL |
+| `SUPABASE_SERVICE_ROLE_KEY` | Functionally required for server-side Supabase admin features | server-only の service role。build/startup block 対象ではない |
 | `ALERT_WEBHOOK_SECRET` | If used | `/api/alerts/webhook` POST を保護 |
-| `NEXT_PUBLIC_SUPABASE_URL` | Yes | Supabase project URL |
-| `NEXT_PUBLIC_SUPABASE_ANON_KEY` | Yes | Supabase anon key |
-| `SUPABASE_SERVICE_ROLE_KEY` | Yes | server-only の service role |
 | Other AI / optional keys | As needed | frontend README と CI 設定に合わせる |
+
+production build/startup required の正本は `frontend/src/lib/env.ts` の
+`productionRequiredVercelEnvKeys`。Vercel production build では
+`frontend/package.json` の `build` が `pnpm env:check:production` を先に実行し、
+不足・空白・不正 URL を値なしで明示失敗させる。
 
 ### バックエンド（Cloud Run）
 
@@ -197,6 +202,12 @@ gcloud run services describe engineer-cafe-backend \
 - Vercel dashboard の Deployments / Domains を確認
 - CLI を使う場合は `vercel list --yes`
 - `FRONTEND_PRODUCTION_ORIGIN` が production domain と一致していることを確認
+- production env の明示チェック:
+
+```bash
+cd frontend
+VERCEL_ENV=production pnpm env:check:production
+```
 
 ### 最近のログ確認
 
@@ -215,6 +226,7 @@ curl -sf "$(gcloud run services describe engineer-cafe-backend --region asia-nor
 ### リリース前（毎回）
 
 - CI が green
+- Vercel target 環境に `NEXT_PUBLIC_SUPABASE_URL` と `NEXT_PUBLIC_SUPABASE_ANON_KEY` がある
 - Vercel target 環境に `BACKEND_API_KEY` がある
 - Cloud Run target 環境に `API_SECRET_KEY` がある
 - Vercel に `ADMIN_API_SECRET` がある

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -125,7 +125,10 @@ production deploy に関わる主要変数:
 | 変数名 | サービス | 起動ブロック | 目的 |
 |---|---|---|---|
 | `ADMIN_API_SECRET` | Frontend (Vercel) | Yes, middleware behavior | `/api/admin/*`, `/api/cron/*`, `/api/monitoring/*` を保護 |
-| `BACKEND_API_KEY` | Frontend (Vercel server runtime) | No | protected backend route に `X-API-Key` を付ける |
+| `NEXT_PUBLIC_SUPABASE_URL` | Frontend (Vercel build/runtime) | Yes, production build/startup check | browser/client Supabase project URL |
+| `NEXT_PUBLIC_SUPABASE_ANON_KEY` | Frontend (Vercel build/runtime) | Yes, production build/startup check | browser/client Supabase anon key |
+| `BACKEND_API_URL` | Frontend (Vercel server runtime) | Yes, production build/startup check | server-side proxy の転送先 |
+| `BACKEND_API_KEY` | Frontend (Vercel server runtime) | Yes, production build/startup check | protected backend route に `X-API-Key` を付ける |
 | `API_SECRET_KEY` | Backend (Cloud Run) | Yes (`sys.exit(1)`) | frontend -> backend request を検証 |
 | `ALERT_WEBHOOK_SECRET` | Frontend (Vercel) | No | `/api/alerts/webhook` POST を保護 |
 | `SUPABASE_SERVICE_ROLE_KEY` | Frontend + Backend | No, but functionally required | server-side Supabase access |
@@ -133,6 +136,8 @@ production deploy に関わる主要変数:
 
 運用ルール:
 
+- Frontend の production build/startup check 対象は `frontend/src/lib/env.ts` の `productionRequiredVercelEnvKeys` と一致させる
+- `pnpm env:check:production` は不足した env 名だけを表示し、secret 値は表示しない
 - `BACKEND_API_KEY` と `API_SECRET_KEY` は 1 つの coupled contract として扱う
 - 片方だけを更新して smoke check を省略するのは release risk
 

--- a/frontend/e2e/reception-flow.spec.ts
+++ b/frontend/e2e/reception-flow.spec.ts
@@ -88,6 +88,74 @@ async function keepOcrCameraPending(page: import('@playwright/test').Page) {
   });
 }
 
+async function provideReadableOcrCamera(page: import('@playwright/test').Page) {
+  await page.addInitScript(() => {
+    const existingMediaDevices = navigator.mediaDevices ?? {};
+    Object.defineProperty(navigator, 'mediaDevices', {
+      configurable: true,
+      value: {
+        ...existingMediaDevices,
+        getUserMedia: async () => new MediaStream(),
+      },
+    });
+
+    const originalPlay = HTMLMediaElement.prototype.play;
+    HTMLMediaElement.prototype.play = function (this: HTMLMediaElement) {
+      if (this instanceof HTMLVideoElement && this.srcObject instanceof MediaStream) {
+        return Promise.resolve();
+      }
+      return originalPlay.call(this);
+    };
+
+    Object.defineProperty(HTMLVideoElement.prototype, 'videoWidth', {
+      configurable: true,
+      get() {
+        return this.srcObject instanceof MediaStream ? 640 : 0;
+      },
+    });
+    Object.defineProperty(HTMLVideoElement.prototype, 'videoHeight', {
+      configurable: true,
+      get() {
+        return this.srcObject instanceof MediaStream ? 480 : 0;
+      },
+    });
+
+    const contextPrototype = CanvasRenderingContext2D.prototype as unknown as {
+      drawImage: (...args: unknown[]) => void;
+      getImageData: (sx: number, sy: number, sw: number, sh: number) => ImageData;
+    };
+    const originalDrawImage = contextPrototype.drawImage;
+    contextPrototype.drawImage = function (
+      this: CanvasRenderingContext2D,
+      ...args: unknown[]
+    ) {
+      if (args[0] instanceof HTMLVideoElement) {
+        return;
+      }
+      return originalDrawImage.apply(this, args);
+    };
+    contextPrototype.getImageData = (_sx, _sy, sw, sh) => {
+      const width = Math.max(1, Math.floor(sw));
+      const height = Math.max(1, Math.floor(sh));
+      const data = new Uint8ClampedArray(width * height * 4);
+      for (let y = 0; y < height; y += 1) {
+        for (let x = 0; x < width; x += 1) {
+          const index = (y * width + x) * 4;
+          const value = (x + y) % 2 === 0 ? 32 : 224;
+          data[index] = value;
+          data[index + 1] = value;
+          data[index + 2] = value;
+          data[index + 3] = 255;
+        }
+      }
+      return new ImageData(data, width, height);
+    };
+
+    HTMLCanvasElement.prototype.toDataURL = () =>
+      'data:image/jpeg;base64,bW9jay1vY3ItZnJhbWU=';
+  });
+}
+
 async function installDeterministicVoiceRecorder(page: import('@playwright/test').Page) {
   const sampleAudioBase64 = fs
     .readFileSync(path.resolve(__dirname, 'fixtures/voice/sample.wav'))
@@ -313,6 +381,149 @@ test.describe('Reception flow — member card OCR', () => {
     );
 
     expect(visitorIdAfterReturn).toBeNull();
+  });
+});
+
+test.describe('Reception flow — member card OCR success', () => {
+  test.beforeEach(async ({ page }) => {
+    await provideReadableOcrCamera(page);
+    await page.route('**/api/voice', async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({ success: true }),
+      });
+    });
+    await page.route(`**${QA_CHAT_URL}`, async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({ answer: 'テスト応答', emotion: 'neutral', metadata: {} }),
+      });
+    });
+  });
+
+  test('member_number success starts reception and displays the read number without visitor_identity', async ({
+    page,
+  }) => {
+    const receptionStartRequests: Array<Record<string, unknown>> = [];
+
+    await page.route('**/api/ocr', async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({
+          success: true,
+          mode: 'member_card',
+          member_number: 12345,
+          recognized_text: null,
+          confidence: 0.96,
+          language: null,
+          expression: null,
+          processing_time_ms: 120,
+          visitor_identity: null,
+          error: null,
+        }),
+      });
+    });
+
+    await page.route(`**${RECEPTION_START_URL}`, async (route) => {
+      receptionStartRequests.push(route.request().postDataJSON() as Record<string, unknown>);
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({
+          reception_session_id: 'mock-member-reception-001',
+          greeting: '会員証を確認しました。ご用件をお聞かせください。',
+          stage: 'greeting',
+        }),
+      });
+    });
+
+    await page.goto('/', { waitUntil: 'domcontentloaded' });
+    await dismissInitialModal(page);
+
+    await page.getByRole('button', { name: /会員証|Member card/ }).click();
+
+    await expect
+      .poll(() => receptionStartRequests.length, { timeout: 10_000 })
+      .toBe(1);
+    expect(receptionStartRequests[0]).not.toHaveProperty('visitor_identity');
+
+    await expect(page.getByTestId('kiosk-ocr-overlay')).toBeHidden({ timeout: 5_000 });
+    await expect(
+      page.getByText('会員番号 12345 を読み取りました。受付を開始します。'),
+    ).toBeVisible({ timeout: 5_000 });
+    await expect(page.getByTestId('response-text')).toContainText(
+      '会員証を確認しました',
+      { timeout: 8_000 },
+    );
+  });
+});
+
+test.describe('Reception flow — handwriting OCR success', () => {
+  test.beforeEach(async ({ page }) => {
+    await provideReadableOcrCamera(page);
+    await page.route('**/api/voice', async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({ success: true }),
+      });
+    });
+  });
+
+  test('handwriting OCR sends recognized text to the voice conversation', async ({ page }) => {
+    const qaRequests: Array<Record<string, unknown>> = [];
+    const recognizedText = 'イベントの場所を教えてください';
+
+    await page.route('**/api/ocr', async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({
+          success: true,
+          mode: 'handwriting',
+          member_number: null,
+          recognized_text: recognizedText,
+          confidence: 0.94,
+          language: 'ja',
+          expression: null,
+          processing_time_ms: 118,
+          visitor_identity: null,
+          error: null,
+        }),
+      });
+    });
+
+    await page.route(`**${QA_CHAT_URL}`, async (route) => {
+      qaRequests.push(route.request().postDataJSON() as Record<string, unknown>);
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({
+          success: true,
+          answer: 'イベントは1階のメインスペースで開催されます。',
+          emotion: 'neutral',
+          metadata: {},
+        }),
+      });
+    });
+
+    await page.goto('/', { waitUntil: 'domcontentloaded' });
+    await dismissInitialModal(page);
+
+    await page.getByRole('button', { name: /筆談|Handwriting/ }).click();
+
+    await expect.poll(() => qaRequests.length, { timeout: 10_000 }).toBe(1);
+    expect(qaRequests[0]).toMatchObject({
+      question: recognizedText,
+      text: recognizedText,
+    });
+    await expect(page.getByTestId('response-text')).toContainText(
+      'イベントは1階のメインスペースで開催されます。',
+      { timeout: 8_000 },
+    );
   });
 });
 

--- a/frontend/e2e/voice-permission-denial.spec.ts
+++ b/frontend/e2e/voice-permission-denial.spec.ts
@@ -33,7 +33,8 @@ test.describe('Microphone permission denial (#638)', () => {
         action === 'warmup' ||
         action === 'speech_to_text' ||
         action === 'text_to_speech' ||
-        action === 'interrupt'
+        action === 'interrupt' ||
+        action === 'client_telemetry'
       ) {
         await route.fulfill({
           status: 200,
@@ -48,6 +49,7 @@ test.describe('Microphone permission denial (#638)', () => {
         'speech_to_text',
         'text_to_speech',
         'interrupt',
+        'client_telemetry',
       ]);
     });
   });
@@ -99,7 +101,12 @@ test.describe('Microphone permission denial (#638)', () => {
         return;
       }
 
-      if (action === 'warmup' || action === 'text_to_speech' || action === 'interrupt') {
+      if (
+        action === 'warmup' ||
+        action === 'text_to_speech' ||
+        action === 'interrupt' ||
+        action === 'client_telemetry'
+      ) {
         await route.fulfill({
           status: 200,
           contentType: 'application/json',
@@ -113,6 +120,7 @@ test.describe('Microphone permission denial (#638)', () => {
         'warmup',
         'text_to_speech',
         'interrupt',
+        'client_telemetry',
       ]);
     });
 

--- a/frontend/e2e/welcome-voice-first.spec.ts
+++ b/frontend/e2e/welcome-voice-first.spec.ts
@@ -1,4 +1,12 @@
-import { expect, test } from '@playwright/test';
+import { expect, test, type Page } from '@playwright/test';
+
+import { MOCK_VOICE_RESPONSE } from './helpers/mocks';
+import {
+  failUnexpectedVoiceAction,
+  installDeterministicVoiceRecorder,
+  installIOSUserAgent,
+  parseVoiceAction,
+} from './helpers/voice';
 
 const RECEPTION_START_URL = '/api/reception/start';
 
@@ -64,6 +72,98 @@ async function installMediaRequestProbe(page: import('@playwright/test').Page) {
           return new MediaStream();
         },
       },
+    });
+  });
+}
+
+async function installSuspendedAudioContext(page: Page) {
+  await page.addInitScript(() => {
+    class MockAudioBuffer {
+      duration = 0.01;
+      length = 441;
+      numberOfChannels = 1;
+      sampleRate = 44100;
+
+      getChannelData() {
+        return new Float32Array(441);
+      }
+    }
+
+    class MockBufferSource {
+      buffer: unknown = null;
+      onended: (() => void) | null = null;
+
+      connect() {
+        return this;
+      }
+
+      start() {
+        setTimeout(() => {
+          this.onended?.();
+        }, 25);
+      }
+
+      stop() {}
+      disconnect() {}
+
+      addEventListener(event: string, cb: () => void) {
+        if (event === 'ended') {
+          this.onended = cb;
+        }
+      }
+
+      removeEventListener() {}
+    }
+
+    class MockGainNode {
+      gain = { value: 1, setValueAtTime() {}, linearRampToValueAtTime() {} };
+
+      connect() {
+        return this;
+      }
+
+      disconnect() {}
+    }
+
+    class MockAudioContext {
+      state: AudioContextState = 'suspended';
+      sampleRate = 44100;
+      currentTime = 0;
+      destination = { connect() {} };
+
+      createBuffer() {
+        return new MockAudioBuffer();
+      }
+
+      createBufferSource() {
+        return new MockBufferSource();
+      }
+
+      createGain() {
+        return new MockGainNode();
+      }
+
+      decodeAudioData() {
+        return Promise.resolve(new MockAudioBuffer());
+      }
+
+      async resume() {}
+
+      async close() {
+        this.state = 'closed';
+      }
+
+      addEventListener() {}
+      removeEventListener() {}
+    }
+
+    Object.defineProperty(window, 'AudioContext', {
+      configurable: true,
+      value: MockAudioContext,
+    });
+    Object.defineProperty(window, 'webkitAudioContext', {
+      configurable: true,
+      value: MockAudioContext,
     });
   });
 }
@@ -144,5 +244,122 @@ test.describe('Welcome voice-first (#616)', () => {
     await expect
       .poll(async () => (await getMediaRequestCounts(page)).video, { timeout: 5_000 })
       .toBeGreaterThanOrEqual(1);
+  });
+});
+
+test.describe('Welcome voice button recovery (#817)', () => {
+  test('voice button starts recording instead of replaying pending Welcome TTS', async ({ page }) => {
+    let sttCount = 0;
+
+    await installIOSUserAgent(page);
+    await installSuspendedAudioContext(page);
+    await installDeterministicVoiceRecorder(page);
+
+    await page.route(`**${RECEPTION_START_URL}`, async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({
+          reception_session_id: 'mock-welcome-pending-audio',
+          greeting: 'エンジニアカフェへようこそ！ご用件をお聞かせください。',
+          stage: 'greeting',
+        }),
+      });
+    });
+
+    await page.route('**/api/voice/filler', async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({ success: true }),
+      });
+    });
+
+    await page.route('**/api/character**', async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({ success: true, vrm_control: null }),
+      });
+    });
+
+    await page.route('**/api/voice', async (route) => {
+      const action = parseVoiceAction(route.request());
+
+      if (action === 'text_to_speech') {
+        await route.fulfill({
+          status: 200,
+          contentType: 'application/json',
+          body: JSON.stringify(MOCK_VOICE_RESPONSE),
+        });
+        return;
+      }
+
+      if (action === 'speech_to_text') {
+        sttCount += 1;
+        await route.fulfill({
+          status: 200,
+          contentType: 'application/json',
+          body: JSON.stringify({
+            success: true,
+            transcript: 'エンジニアカフェの営業時間を教えてください。',
+          }),
+        });
+        return;
+      }
+
+      if (action === 'warmup' || action === 'interrupt' || action === 'client_telemetry') {
+        await route.fulfill({
+          status: 200,
+          contentType: 'application/json',
+          body: JSON.stringify({ success: true, sttWarmupStatus: 'ready' }),
+        });
+        return;
+      }
+
+      await failUnexpectedVoiceAction(route, action, [
+        'text_to_speech',
+        'speech_to_text',
+        'warmup',
+        'interrupt',
+        'client_telemetry',
+      ]);
+    });
+
+    await page.route('**/api/qa', async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({
+          success: true,
+          answer: 'エンジニアカフェの営業時間は10時から22時です。',
+          emotion: 'neutral',
+          metadata: {},
+        }),
+      });
+    });
+
+    await page.goto('/', { waitUntil: 'domcontentloaded' });
+    await dismissInitialModal(page);
+
+    await page.getByRole('button', { name: 'Welcome' }).click();
+    await expect(page.getByTestId('response-text')).toContainText('エンジニアカフェへようこそ', {
+      timeout: 8_000,
+    });
+    await expect(page.getByTestId('kiosk-voice-status')).toContainText(
+      /音声を有効|enable audio/i,
+      { timeout: 8_000 },
+    );
+
+    const voiceButton = page.getByTestId('kiosk-voice-button');
+    const voiceStatus = page.getByTestId('kiosk-voice-status');
+
+    await voiceButton.click();
+    await expect(voiceStatus).toHaveAttribute('data-session-state', 'listening', {
+      timeout: 8_000,
+    });
+
+    await voiceButton.dispatchEvent('click');
+    await expect.poll(() => sttCount, { timeout: 15_000 }).toBe(1);
   });
 });

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "dev": "next dev",
     "dev:network": "next dev -H 0.0.0.0",
-    "build": "next build",
+    "build": "pnpm env:check:production && next build",
     "start": "next start",
     "lint": "next lint",
     "typecheck": "tsc --noEmit",
@@ -16,6 +16,7 @@
     "migrate:embeddings": "tsx -r dotenv/config scripts/migrate-embeddings.ts",
     "import:markdown": "tsx -r dotenv/config scripts/import-markdown-knowledge.ts",
     "setup:admin": "tsx -r dotenv/config scripts/setup-admin-knowledge.ts",
+    "env:check:production": "tsx scripts/check-vercel-production-env.ts",
     "test": "cd scripts/tests && tsx run-tests.ts",
     "test:node": "tsx scripts/tests/run-tests.ts node",
     "test:e2e": "playwright test --config=playwright.config.ts",

--- a/frontend/scripts/check-vercel-production-env.ts
+++ b/frontend/scripts/check-vercel-production-env.ts
@@ -1,0 +1,50 @@
+#!/usr/bin/env tsx
+
+import {
+  getMissingProductionRequiredVercelEnvKeys,
+  productionRequiredVercelEnvKeys,
+  validateServerEnv,
+} from "../src/lib/env";
+
+const args = new Set(process.argv.slice(2));
+const shouldForce = args.has("--force") || args.has("--production");
+const shouldCheck = shouldForce || process.env.VERCEL_ENV === "production";
+
+if (args.has("--help") || args.has("-h")) {
+  console.log(`Usage: pnpm env:check:production [--force]
+
+Checks Vercel production-required frontend env vars without printing values.
+By default this runs only when VERCEL_ENV=production. Use --force in CI or local smoke checks.`);
+  process.exit(0);
+}
+
+if (!shouldCheck) {
+  console.log(
+    `[env-check] skipped: VERCEL_ENV=${process.env.VERCEL_ENV ?? "(unset)"} is not production.`
+  );
+  process.exit(0);
+}
+
+const missingKeys = getMissingProductionRequiredVercelEnvKeys();
+const result = validateServerEnv();
+
+if (!result.success) {
+  console.error("[env-check] Vercel production env check failed.");
+
+  if (missingKeys.length > 0) {
+    console.error(
+      `[env-check] Missing required env var(s): ${missingKeys.join(", ")}`
+    );
+  }
+
+  for (const error of result.errors) {
+    console.error(`[env-check] ${error}`);
+  }
+
+  console.error("[env-check] Secret values are intentionally not printed.");
+  process.exit(1);
+}
+
+console.log(
+  `[env-check] Vercel production env check passed (${productionRequiredVercelEnvKeys.length} required vars checked).`
+);

--- a/frontend/src/__tests__/env-validation.test.ts
+++ b/frontend/src/__tests__/env-validation.test.ts
@@ -1,0 +1,86 @@
+import assert from 'node:assert/strict';
+import { afterEach, test } from 'node:test';
+
+import {
+  getMissingProductionRequiredVercelEnvKeys,
+  productionRequiredVercelEnvKeys,
+  validateServerEnv,
+} from '../lib/env';
+
+const env = process.env as Record<string, string | undefined>;
+const managedKeys = [
+  ...productionRequiredVercelEnvKeys,
+  'ADMIN_API_SECRET',
+  'CRON_SECRET',
+  'OPENROUTER_API_KEY',
+  'SUPABASE_SERVICE_ROLE_KEY',
+] as const;
+const originalValues = new Map<string, string | undefined>(
+  managedKeys.map((key) => [key, env[key]]),
+);
+
+function restoreEnv() {
+  originalValues.forEach((value, key) => {
+    if (value === undefined) {
+      delete env[key];
+    } else {
+      env[key] = value;
+    }
+  });
+}
+
+function setValidRequiredEnv() {
+  env.NEXT_PUBLIC_SUPABASE_URL = 'https://project-ref.supabase.co';
+  env.NEXT_PUBLIC_SUPABASE_ANON_KEY = 'test-anon-key';
+  env.BACKEND_API_URL = 'https://backend.example.com';
+  env.BACKEND_API_KEY = 'test-backend-key';
+}
+
+afterEach(restoreEnv);
+
+test('Vercel production required env contract includes public Supabase config', () => {
+  assert.ok(productionRequiredVercelEnvKeys.includes('NEXT_PUBLIC_SUPABASE_URL'));
+  assert.ok(productionRequiredVercelEnvKeys.includes('NEXT_PUBLIC_SUPABASE_ANON_KEY'));
+});
+
+test('detects missing Vercel production required Supabase env vars by name only', () => {
+  setValidRequiredEnv();
+  delete env.NEXT_PUBLIC_SUPABASE_URL;
+  delete env.NEXT_PUBLIC_SUPABASE_ANON_KEY;
+
+  assert.deepEqual(getMissingProductionRequiredVercelEnvKeys(), [
+    'NEXT_PUBLIC_SUPABASE_URL',
+    'NEXT_PUBLIC_SUPABASE_ANON_KEY',
+  ]);
+
+  const result = validateServerEnv();
+  const errors = result.errors.join('\n');
+
+  assert.equal(result.success, false);
+  assert.match(errors, /NEXT_PUBLIC_SUPABASE_URL/);
+  assert.match(errors, /NEXT_PUBLIC_SUPABASE_ANON_KEY/);
+  assert.doesNotMatch(errors, /test-backend-key/);
+});
+
+test('treats blank production required env values as missing', () => {
+  setValidRequiredEnv();
+  env.NEXT_PUBLIC_SUPABASE_ANON_KEY = '   ';
+
+  assert.deepEqual(getMissingProductionRequiredVercelEnvKeys(), [
+    'NEXT_PUBLIC_SUPABASE_ANON_KEY',
+  ]);
+
+  const result = validateServerEnv();
+
+  assert.equal(result.success, false);
+  assert.match(result.errors.join('\n'), /NEXT_PUBLIC_SUPABASE_ANON_KEY is required/);
+});
+
+test('passes required env validation when Vercel production required vars are present', () => {
+  setValidRequiredEnv();
+
+  const result = validateServerEnv();
+
+  assert.equal(result.success, true);
+  assert.deepEqual(getMissingProductionRequiredVercelEnvKeys(), []);
+});

--- a/frontend/src/__tests__/reception-identity.test.ts
+++ b/frontend/src/__tests__/reception-identity.test.ts
@@ -1,0 +1,51 @@
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+
+import type { OcrResponse } from '../lib/api/ocr-api';
+import { createVisitorIdentityFromOcr } from '../lib/reception-identity';
+
+function createOcrResponse(
+  overrides: Partial<OcrResponse> = {},
+): OcrResponse {
+  return {
+    success: true,
+    mode: 'member_card',
+    member_number: 12345,
+    recognized_text: null,
+    confidence: 0.99,
+    language: null,
+    expression: null,
+    processing_time_ms: 120,
+    visitor_identity: null,
+    error: null,
+    ...overrides,
+  };
+}
+
+test('does not treat a raw member number as a resolved returning visitor', () => {
+  const identity = createVisitorIdentityFromOcr(createOcrResponse());
+
+  assert.equal(identity, undefined);
+});
+
+test('uses only resolved OCR visitor identity when a user_id is present', () => {
+  const identity = createVisitorIdentityFromOcr(
+    createOcrResponse({
+      member_number: 99999,
+      recognized_text: 'Fallback Name',
+      visitor_identity: {
+        user_id: 7,
+        name: 'Resolved User',
+        visit_count: 3,
+        last_purpose: { category: 'facility_use', detail: 'coworking' },
+      },
+    }),
+  );
+
+  assert.deepEqual(identity, {
+    user_id: 7,
+    name: 'Resolved User',
+    visit_count: 3,
+    last_purpose: { category: 'facility_use', detail: 'coworking' },
+  });
+});

--- a/frontend/src/app/api/voice/route.ts
+++ b/frontend/src/app/api/voice/route.ts
@@ -8,6 +8,21 @@ import { backendFetch } from '@/lib/api/backend-proxy';
 
 const VOICE_PROXY_TIMEOUT_MS = 110_000;
 
+function sanitizeTelemetryValue(value: unknown): unknown {
+  if (typeof value === 'string') {
+    return value.slice(0, 500);
+  }
+  if (
+    typeof value === 'number' ||
+    typeof value === 'boolean' ||
+    value === null ||
+    value === undefined
+  ) {
+    return value;
+  }
+  return String(value).slice(0, 500);
+}
+
 export async function POST(request: NextRequest) {
   try {
     const body = await request.json();
@@ -29,6 +44,26 @@ export async function POST(request: NextRequest) {
       ttsProvider,
       includeVrmControl,
     } = body as Record<string, unknown>;
+
+    if (action === 'client_telemetry') {
+      const telemetry = {
+        event: sanitizeTelemetryValue(body.event),
+        phase: sanitizeTelemetryValue(body.phase),
+        sessionId: sanitizeTelemetryValue(body.sessionId),
+        userAgent: sanitizeTelemetryValue(body.userAgent),
+        errorName: sanitizeTelemetryValue(body.errorName),
+        errorMessage: sanitizeTelemetryValue(body.errorMessage),
+        deviceIdMode: sanitizeTelemetryValue(body.deviceIdMode),
+        recorderState: sanitizeTelemetryValue(body.recorderState),
+        retryWithDefaultDevice: sanitizeTelemetryValue(body.retryWithDefaultDevice),
+        retryOutcome: sanitizeTelemetryValue(body.retryOutcome),
+        retryErrorName: sanitizeTelemetryValue(body.retryErrorName),
+        retryErrorMessage: sanitizeTelemetryValue(body.retryErrorMessage),
+        timestamp: sanitizeTelemetryValue(body.timestamp),
+      };
+      console.warn('[VoiceClientTelemetry]', telemetry);
+      return NextResponse.json({ success: true });
+    }
 
     const response = await backendFetch('/api/voice', {
       body: {

--- a/frontend/src/app/components/KioskBottomBar.tsx
+++ b/frontend/src/app/components/KioskBottomBar.tsx
@@ -78,10 +78,6 @@ export function KioskBottomBar({
     if (Date.now() < voiceRestartSuppressedUntilRef.current) {
       return;
     }
-    if (voice.unlockAudioPlayback()) {
-      return;
-    }
-
     if (controlsInterruptible) {
       voice.cancelSession();
     }

--- a/frontend/src/app/components/VoiceInterface.tsx
+++ b/frontend/src/app/components/VoiceInterface.tsx
@@ -317,6 +317,7 @@ export default function VoiceInterface({
     metadata: VoiceInterfaceMetadata | null;
   } | null>(null);
   const isReplayingPendingIOSAudioRef = useRef(false);
+  const pendingIOSPlaybackReplayTokenRef = useRef(0);
 
   useEffect(() => {
     visitorIdRef.current = getOrCreateVisitorId();
@@ -724,13 +725,21 @@ export default function VoiceInterface({
 
     pendingIOSPlaybackRef.current = null;
     isReplayingPendingIOSAudioRef.current = true;
+    const replayToken = pendingIOSPlaybackReplayTokenRef.current + 1;
+    pendingIOSPlaybackReplayTokenRef.current = replayToken;
     setError(null);
 
     void (async () => {
       try {
         await AudioInteractionManager.getInstance().forceInitialize();
+        if (pendingIOSPlaybackReplayTokenRef.current !== replayToken) {
+          return;
+        }
         await playAssistantAudio(pendingPlayback.audioBase64, pendingPlayback.metadata);
       } catch (error) {
+        if (pendingIOSPlaybackReplayTokenRef.current !== replayToken) {
+          return;
+        }
         if (isAudioGestureRequiredError(error)) {
           pendingIOSPlaybackRef.current = pendingPlayback;
           setError(getTapToEnableAudioMessage(currentLanguage));
@@ -738,12 +747,24 @@ export default function VoiceInterface({
           setError(formatError(error, currentLanguage));
         }
       } finally {
-        isReplayingPendingIOSAudioRef.current = false;
+        if (pendingIOSPlaybackReplayTokenRef.current === replayToken) {
+          isReplayingPendingIOSAudioRef.current = false;
+        }
       }
     })();
 
     return true;
   }, [currentLanguage, playAssistantAudio, sessionState]);
+
+  const cancelPendingIOSPlaybackReplay = useCallback(() => {
+    if (!pendingIOSPlaybackRef.current && !isReplayingPendingIOSAudioRef.current) {
+      return;
+    }
+
+    pendingIOSPlaybackRef.current = null;
+    isReplayingPendingIOSAudioRef.current = false;
+    pendingIOSPlaybackReplayTokenRef.current += 1;
+  }, []);
 
   const processVoiceTurnWithParallelFiller = useCallback(
     async (trimmed: string, abortController: AbortController) => {
@@ -1354,6 +1375,9 @@ export default function VoiceInterface({
         setMediaStream(null);
         isRecordingRef.current = false;
       },
+      {
+        getSessionId: () => sessionIdRef.current,
+      },
     );
 
     setIsLoading(true);
@@ -1400,6 +1424,7 @@ export default function VoiceInterface({
         return false;
       }
       if (recorder.getState() === 'recording') {
+        isRecordingRef.current = true;
         return true;
       }
 
@@ -1453,10 +1478,8 @@ export default function VoiceInterface({
   }, [sessionState, startRecorderCapture, stopRecorderCapture, voiceController.shouldListen]);
 
   const startListening = useCallback(async (): Promise<boolean> => {
-    if (unlockAudioPlayback() || isReplayingPendingIOSAudioRef.current) {
-      return true;
-    }
-
+    unlockAudioForUserGesture();
+    cancelPendingIOSPlaybackReplay();
     shouldListenRef.current = true;
     isStoppingRecorderRef.current = false;
     forceSkipAutoResumeRef.current = false;
@@ -1473,10 +1496,10 @@ export default function VoiceInterface({
     return true;
   }, [
     cancelPendingRequest,
+    cancelPendingIOSPlaybackReplay,
     currentLanguage,
     startRecorderCapture,
     stopPlayback,
-    unlockAudioPlayback,
     voiceController,
   ]);
 
@@ -1489,8 +1512,7 @@ export default function VoiceInterface({
   }, [stopRecorderCapture, voiceController]);
 
   const cancelSession = useCallback(() => {
-    pendingIOSPlaybackRef.current = null;
-    isReplayingPendingIOSAudioRef.current = false;
+    cancelPendingIOSPlaybackReplay();
     cancelSttWarmup();
     cancelFastFiller();
     requestBackendInterrupt();
@@ -1509,6 +1531,7 @@ export default function VoiceInterface({
   }, [
     cancelFastFiller,
     cancelPendingRequest,
+    cancelPendingIOSPlaybackReplay,
     requestBackendInterrupt,
     stopPlayback,
     stopRecorderCapture,
@@ -1585,6 +1608,7 @@ export default function VoiceInterface({
     return () => {
       pendingIOSPlaybackRef.current = null;
       isReplayingPendingIOSAudioRef.current = false;
+      pendingIOSPlaybackReplayTokenRef.current += 1;
       cancelFastFiller();
       cancelPendingRequest();
       cleanupAudioPlayback();
@@ -1701,8 +1725,8 @@ export default function VoiceInterface({
       <div className="mt-6 flex items-center justify-center gap-3">
         <button
           type="button"
-          onPointerDown={unlockAudioPlayback}
-          onTouchEnd={unlockAudioPlayback}
+          onPointerDown={unlockAudioForUserGesture}
+          onTouchEnd={unlockAudioForUserGesture}
           onClick={isListening ? stopListening : startListening}
           disabled={isBusy && !isListening}
           aria-label={isListening ? '録音を停止' : '録音を開始'}

--- a/frontend/src/app/layout.tsx
+++ b/frontend/src/app/layout.tsx
@@ -1,17 +1,5 @@
 import type { Metadata, Viewport } from 'next'
-import { Inter, Noto_Sans_JP } from 'next/font/google'
 import './globals.css'
-
-const inter = Inter({ 
-  subsets: ['latin'],
-  variable: '--font-inter',
-})
-
-const notoSansJP = Noto_Sans_JP({ 
-  subsets: ['latin'],
-  variable: '--font-noto-jp',
-  weight: ['300', '400', '500', '700']
-})
 
 export const metadata: Metadata = {
   title: 'Engineer Cafe Navigator',
@@ -36,7 +24,7 @@ export default function RootLayout({
   children: React.ReactNode
 }) {
   return (
-    <html lang="ja" className={`${inter.variable} ${notoSansJP.variable}`}>
+    <html lang="ja">
       <head>
         <link rel="icon" href="/assets/images/favicon.ico" />
       </head>

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -44,6 +44,7 @@ import VoiceInterface, {
   type VoiceInterfaceRenderProps,
 } from './components/VoiceInterface';
 import type { OcrResponse } from '@/lib/api/ocr-api';
+import { createVisitorIdentityFromOcr } from '@/lib/reception-identity';
 import { startReception } from '@/lib/reception-api';
 import { cancelSttWarmup, sendSttWarmup } from '@/lib/stt-warmup';
 
@@ -73,6 +74,13 @@ function kioskVoiceModeBadgeLabel(
     return labels.voiceModeStt;
   }
   return labels.voiceModeIdle;
+}
+
+function formatMemberNumberSuccess(
+  labels: (typeof overlayLabels)['ja'] | (typeof overlayLabels)['en'],
+  memberNumber: number,
+): string {
+  return labels.ocrMemberReadSuccess.replace('{memberNumber}', String(memberNumber));
 }
 
 
@@ -451,14 +459,50 @@ export default function Home() {
             });
           };
 
+          const startMemberCardReceptionFromOcr = async (result: OcrResponse) => {
+            clearReturnToIdleTimer();
+            setWelcomeMemberOcrOpen(false);
+
+            const memberNumber = result.member_number;
+            if (memberNumber === null) {
+              returnToIdle();
+              setOcrStatusMessage('error', labels.ocrReadFailed);
+              return;
+            }
+
+            setOcrStatusMessage(
+              'member_card',
+              formatMemberNumberSuccess(labels, memberNumber),
+            );
+            setKioskPhaseSynced('voice');
+            setKioskVoiceLocked(micInputMode !== 'push_to_talk');
+            sendSttWarmup({ language: voice.currentLanguage, sessionId: voice.sessionId });
+
+            try {
+              const visitorIdentity = createVisitorIdentityFromOcr(result);
+              const reception = await startReception({
+                session_id: voice.sessionId,
+                language: voice.currentLanguage,
+                trigger_type: receptionTriggerType,
+                ...(visitorIdentity ? { visitor_identity: visitorIdentity } : {}),
+              });
+              await voice.speakPreparedText(reception.greeting, null);
+            } catch {
+              const fallback =
+                voice.currentLanguage === 'ja'
+                  ? `会員番号 ${memberNumber} を読み取りました。ご用件をお聞かせください。`
+                  : `Read member number ${memberNumber}. How can I help you today?`;
+              await voice.speakPreparedText(fallback, null);
+            } finally {
+              scheduleReturnToIdle();
+            }
+          };
+
           const handleOcrSuccess = (result: OcrResponse) => {
             clearReturnToIdleTimer();
 
             if (result.mode === 'member_card') {
-              returnToIdle();
-              if (result.member_number === null) {
-                setOcrStatusMessage('error', labels.ocrReadFailed);
-              }
+              void startMemberCardReceptionFromOcr(result);
               return;
             }
 
@@ -476,11 +520,7 @@ export default function Home() {
           };
 
           const handleWelcomeMemberOcrSuccess = (result: OcrResponse) => {
-            clearReturnToIdleTimer();
-            returnToIdle();
-            if (result.member_number === null) {
-              setOcrStatusMessage('error', labels.ocrReadFailed);
-            }
+            void startMemberCardReceptionFromOcr(result);
           };
 
           const handleWelcomeMemberOcrEndSilent = () => {

--- a/frontend/src/components/reception/OcrCameraView.tsx
+++ b/frontend/src/components/reception/OcrCameraView.tsx
@@ -180,7 +180,7 @@ export function OcrCameraView({
             compact ? 'max-w-[200px] p-2' : 'max-w-md p-4',
           )}
         >
-          {mode === 'member_card' && lastResult.member_number && (
+          {mode === 'member_card' && lastResult.member_number !== null && (
             <p
               className={cn(
                 'text-center font-bold text-green-800',

--- a/frontend/src/hooks/useReception.ts
+++ b/frontend/src/hooks/useReception.ts
@@ -11,6 +11,7 @@ import {
   type VisitorIdentity,
 } from '@/lib/reception-api';
 import type { OcrResponse } from '@/lib/api/ocr-api';
+import { createVisitorIdentityFromOcr } from '@/lib/reception-identity';
 
 export interface ReceptionMessage {
   id: string;
@@ -120,12 +121,7 @@ export function useReception({
 
   const handleOcrSuccess = useCallback(
     (result: OcrResponse) => {
-      const identity: VisitorIdentity = {
-        user_id: result.member_number ?? undefined,
-        name: result.recognized_text ?? undefined,
-        ...(result.visitor_identity as Partial<VisitorIdentity> | undefined),
-      };
-      void startReception(identity);
+      void startReception(createVisitorIdentityFromOcr(result));
     },
     [startReception],
   );

--- a/frontend/src/lib/api/ocr-api.ts
+++ b/frontend/src/lib/api/ocr-api.ts
@@ -21,6 +21,7 @@ export interface OcrResponse {
   expression: string | null;
   processing_time_ms: number;
   visitor_identity: Record<string, unknown> | null;
+  identity_lookup?: Record<string, unknown> | null;
   error: string | null;
 }
 

--- a/frontend/src/lib/env-client.ts
+++ b/frontend/src/lib/env-client.ts
@@ -15,9 +15,11 @@ export const clientEnvSchema = z.object({
   // Supabase (required for client-side DB access)
   NEXT_PUBLIC_SUPABASE_URL: z
     .string()
+    .trim()
     .url("NEXT_PUBLIC_SUPABASE_URL must be a valid URL (e.g. https://xxx.supabase.co)"),
   NEXT_PUBLIC_SUPABASE_ANON_KEY: z
     .string()
+    .trim()
     .min(1, "NEXT_PUBLIC_SUPABASE_ANON_KEY is required"),
 
   // Backend URL visible to the browser. Used only by direct-call feature flags.

--- a/frontend/src/lib/env.ts
+++ b/frontend/src/lib/env.ts
@@ -13,6 +13,18 @@
 
 import { z } from "zod";
 
+export const productionRequiredVercelEnvKeys = [
+  "NEXT_PUBLIC_SUPABASE_URL",
+  "NEXT_PUBLIC_SUPABASE_ANON_KEY",
+  "BACKEND_API_URL",
+  "BACKEND_API_KEY",
+] as const;
+
+export type ProductionRequiredVercelEnvKey =
+  (typeof productionRequiredVercelEnvKeys)[number];
+
+const requiredString = (message: string) => z.string().trim().min(1, message);
+
 // ---------------------------------------------------------------------------
 // Schema: required server-side env vars (core functionality)
 // ---------------------------------------------------------------------------
@@ -21,18 +33,19 @@ const requiredServerEnvSchema = z.object({
   // Supabase
   NEXT_PUBLIC_SUPABASE_URL: z
     .string()
+    .trim()
     .url("NEXT_PUBLIC_SUPABASE_URL must be a valid URL (e.g. https://xxx.supabase.co)"),
   NEXT_PUBLIC_SUPABASE_ANON_KEY: z
     .string()
+    .trim()
     .min(1, "NEXT_PUBLIC_SUPABASE_ANON_KEY is required"),
 
   // Backend proxy
   BACKEND_API_URL: z
     .string()
+    .trim()
     .url("BACKEND_API_URL must be a valid URL"),
-  BACKEND_API_KEY: z
-    .string()
-    .min(1, "BACKEND_API_KEY is required"),
+  BACKEND_API_KEY: requiredString("BACKEND_API_KEY is required"),
 });
 
 // ---------------------------------------------------------------------------
@@ -81,6 +94,12 @@ export interface EnvValidationResult {
   data?: ServerEnv;
   errors: string[];
   warnings: string[];
+}
+
+export function getMissingProductionRequiredVercelEnvKeys(
+  env: NodeJS.ProcessEnv = process.env
+): ProductionRequiredVercelEnvKey[] {
+  return productionRequiredVercelEnvKeys.filter((key) => !env[key]?.trim());
 }
 
 /**

--- a/frontend/src/lib/kiosk-labels.ts
+++ b/frontend/src/lib/kiosk-labels.ts
@@ -51,6 +51,7 @@ export const overlayLabels = {
     voiceModeSpeaking: 'モード: 再生中',
     ocrMemberResult: '会員証読み取り結果',
     ocrHandwritingResult: '筆談読み取り結果',
+    ocrMemberReadSuccess: '会員番号 {memberNumber} を読み取りました。受付を開始します。',
     ocrReadFailed: '読み取りに失敗しました。再度お試しください。',
   },
   en: {
@@ -104,6 +105,7 @@ export const overlayLabels = {
     voiceModeSpeaking: 'Mode: Speaking',
     ocrMemberResult: 'Member card result',
     ocrHandwritingResult: 'Handwriting result',
+    ocrMemberReadSuccess: 'Read member number {memberNumber}. Starting reception.',
     ocrReadFailed: 'OCR failed. Please try again.',
   },
 } as const;

--- a/frontend/src/lib/reception-identity.ts
+++ b/frontend/src/lib/reception-identity.ts
@@ -1,0 +1,59 @@
+import type { OcrResponse } from '@/lib/api/ocr-api';
+import type { VisitorIdentity } from '@/lib/reception-api';
+
+function readFiniteNumber(value: unknown): number | undefined {
+  return typeof value === 'number' && Number.isFinite(value) ? value : undefined;
+}
+
+function readNonEmptyString(value: unknown): string | undefined {
+  return typeof value === 'string' && value.trim().length > 0 ? value.trim() : undefined;
+}
+
+function readLastPurpose(value: unknown): VisitorIdentity['last_purpose'] | undefined {
+  if (!value || typeof value !== 'object') {
+    return undefined;
+  }
+
+  const category = readNonEmptyString((value as { category?: unknown }).category);
+  if (!category) {
+    return undefined;
+  }
+
+  return {
+    category,
+    detail: readNonEmptyString((value as { detail?: unknown }).detail),
+  };
+}
+
+export function createVisitorIdentityFromOcr(
+  result: OcrResponse,
+): VisitorIdentity | undefined {
+  const rawIdentity = result.visitor_identity;
+  if (!rawIdentity || typeof rawIdentity !== 'object') {
+    return undefined;
+  }
+
+  const userId = readFiniteNumber(rawIdentity.user_id);
+  if (userId === undefined) {
+    return undefined;
+  }
+
+  const identity: VisitorIdentity = {
+    user_id: userId,
+  };
+  const name = readNonEmptyString(rawIdentity.name) ?? readNonEmptyString(result.recognized_text);
+  const visitCount = readFiniteNumber(rawIdentity.visit_count);
+  const lastPurpose = readLastPurpose(rawIdentity.last_purpose);
+
+  if (name) {
+    identity.name = name;
+  }
+  if (visitCount !== undefined) {
+    identity.visit_count = visitCount;
+  }
+  if (lastPurpose) {
+    identity.last_purpose = lastPurpose;
+  }
+
+  return identity;
+}

--- a/frontend/src/lib/voice-recorder.ts
+++ b/frontend/src/lib/voice-recorder.ts
@@ -5,6 +5,13 @@ declare global {
   }
 }
 
+interface VoiceRecorderOptions {
+  getSessionId?: () => string;
+  telemetryEndpoint?: string;
+}
+
+type DeviceIdMode = 'unset' | 'default' | 'custom';
+
 export class VoiceRecorder {
   private mediaRecorder: MediaRecorder | null = null;
   private audioChunks: Blob[] = [];
@@ -16,6 +23,7 @@ export class VoiceRecorder {
     private onDataAvailable: (audioBlob: Blob) => void,
     private onError: (error: Error) => void,
     private onHardwareReleased?: () => void,
+    private options: VoiceRecorderOptions = {},
   ) {}
 
   private createRecorderError(message: string, source?: unknown): Error & { originalName?: string } {
@@ -35,6 +43,112 @@ export class VoiceRecorder {
       error.originalName = originalName;
     }
     return error;
+  }
+
+  private resolveSessionId(): string | undefined {
+    try {
+      const sessionId = this.options.getSessionId?.();
+      return typeof sessionId === 'string' && sessionId.length > 0 ? sessionId : undefined;
+    } catch {
+      return undefined;
+    }
+  }
+
+  private getDeviceIdMode(selectedDeviceId: string | null | undefined): DeviceIdMode {
+    if (!selectedDeviceId) {
+      return 'unset';
+    }
+    return selectedDeviceId === 'default' ? 'default' : 'custom';
+  }
+
+  private getErrorName(source: unknown): string | undefined {
+    if (source && typeof source === 'object' && 'name' in source) {
+      const name = String((source as { name?: unknown }).name ?? '');
+      return name || undefined;
+    }
+    return undefined;
+  }
+
+  private getErrorMessage(source: unknown): string | undefined {
+    if (source && typeof source === 'object' && 'message' in source) {
+      const message = String((source as { message?: unknown }).message ?? '');
+      return message ? message.slice(0, 500) : undefined;
+    }
+    if (typeof source === 'string') {
+      return source.slice(0, 500);
+    }
+    return undefined;
+  }
+
+  private reportClientTelemetry(
+    phase: string,
+    source?: unknown,
+    extra: Record<string, unknown> = {},
+  ): void {
+    if (typeof window === 'undefined') {
+      return;
+    }
+
+    const payload = {
+      action: 'client_telemetry',
+      event: 'voice_recorder_error',
+      phase,
+      sessionId: this.resolveSessionId(),
+      userAgent: typeof navigator !== 'undefined' ? navigator.userAgent : undefined,
+      errorName: this.getErrorName(source),
+      errorMessage: this.getErrorMessage(source),
+      timestamp: new Date().toISOString(),
+      ...extra,
+    };
+
+    window.dispatchEvent(new CustomEvent('voice-recorder-telemetry', { detail: payload }));
+
+    const endpoint = this.options.telemetryEndpoint ?? '/api/voice';
+    window
+      .fetch(endpoint, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify(payload),
+        keepalive: true,
+      })
+      .catch(() => {
+        /* best-effort client telemetry */
+      });
+  }
+
+  private isSelectedDeviceFailure(error: unknown): boolean {
+    const name = this.getErrorName(error);
+    return name === 'NotFoundError' || name === 'OverconstrainedError';
+  }
+
+  private handleGetUserMediaError(error: unknown): void {
+    const errorName = this.getErrorName(error);
+
+    if (errorName === 'NotAllowedError') {
+      this.onError(
+        this.createRecorderError(
+          'Microphone permission denied. Please allow microphone access and try again.',
+          error,
+        ),
+      );
+    } else if (errorName === 'NotFoundError') {
+      this.onError(this.createRecorderError('No microphone found. Please connect a microphone and try again.', error));
+    } else if (errorName === 'NotReadableError') {
+      this.onError(
+        this.createRecorderError(
+          'Microphone is in use by another application. Please close other apps using the microphone.',
+          error,
+        ),
+      );
+    } else if (errorName === 'OverconstrainedError') {
+      this.onError(this.createRecorderError('Selected microphone is unavailable. Please choose another microphone.', error));
+    } else if (errorName === 'InvalidStateError') {
+      this.onError(this.createRecorderError('Microphone is in an invalid state. Try reloading the page.', error));
+    } else {
+      this.onError(this.createRecorderError('Failed to access microphone', error));
+    }
   }
 
   private createDeterministicMediaRecorder(audioBase64: string): MediaRecorder {
@@ -86,11 +200,11 @@ export class VoiceRecorder {
 
       if (typeof playwrightRecorderErrorName === 'string' && playwrightRecorderErrorName.length > 0) {
         delete window.__PLAYWRIGHT_VOICE_RECORDER_ERROR_NAME__;
-        this.onError(
-          this.createRecorderError('Playwright injected recorder failure', {
-            name: playwrightRecorderErrorName,
-          }),
-        );
+        const recorderError = this.createRecorderError('Playwright injected recorder failure', {
+          name: playwrightRecorderErrorName,
+        });
+        this.reportClientTelemetry('playwright-injected-recorder-failure', recorderError);
+        this.onError(recorderError);
         return;
       }
 
@@ -99,7 +213,9 @@ export class VoiceRecorder {
         this.mediaRecorder = this.createDeterministicMediaRecorder(playwrightAudioBase64);
       } else {
         if (typeof navigator === 'undefined') {
-          this.onError(new Error('navigator is undefined'));
+          const recorderError = new Error('navigator is undefined');
+          this.reportClientTelemetry('navigator-unavailable', recorderError);
+          this.onError(recorderError);
           return;
         }
 
@@ -112,22 +228,22 @@ export class VoiceRecorder {
 
         // Check if we're on HTTPS (required for getUserMedia outside local development).
         if (window.location.protocol !== 'https:' && !isLocalDevHost) {
-          this.onError(
-            this.createRecorderError(
-              'Microphone access requires HTTPS connection. Please use HTTPS or localhost.',
-              { name: 'SecurityError' },
-            ),
+          const recorderError = this.createRecorderError(
+            'Microphone access requires HTTPS connection. Please use HTTPS or localhost.',
+            { name: 'SecurityError' },
           );
+          this.reportClientTelemetry('secure-context-check', recorderError);
+          this.onError(recorderError);
           return;
         }
 
         // Check if mediaDevices is available
         if (!navigator.mediaDevices) {
-          this.onError(
-            new Error(
-              'navigator.mediaDevices is not available. Please ensure you are using a modern browser.',
-            ),
+          const recorderError = new Error(
+            'navigator.mediaDevices is not available. Please ensure you are using a modern browser.',
           );
+          this.reportClientTelemetry('media-devices-unavailable', recorderError);
+          this.onError(recorderError);
           return;
         }
 
@@ -148,9 +264,11 @@ export class VoiceRecorder {
         }
 
         if (!getUserMediaFunc) {
-          this.onError(
-            new Error('getUserMedia API is not available. Please check browser permissions.'),
+          const recorderError = new Error(
+            'getUserMedia API is not available. Please check browser permissions.',
           );
+          this.reportClientTelemetry('get-user-media-unavailable', recorderError);
+          this.onError(recorderError);
           return;
         }
 
@@ -171,51 +289,62 @@ export class VoiceRecorder {
               autoGainControl: true,
             };
 
+        const selectedDeviceId =
+          typeof window !== 'undefined'
+            ? window.localStorage.getItem(VoiceRecorder.SELECTED_MIC_DEVICE_ID_STORAGE_KEY)
+            : null;
+        const deviceIdMode = this.getDeviceIdMode(selectedDeviceId);
+        const selectedAudioConstraints =
+          selectedDeviceId && selectedDeviceId !== 'default'
+            ? { ...audioConstraints, deviceId: { exact: selectedDeviceId } }
+            : audioConstraints;
+
         try {
-          const selectedDeviceId =
-            typeof window !== 'undefined'
-              ? window.localStorage.getItem(VoiceRecorder.SELECTED_MIC_DEVICE_ID_STORAGE_KEY)
-              : null;
-          const audio =
-            selectedDeviceId && selectedDeviceId !== 'default'
-              ? { ...audioConstraints, deviceId: { exact: selectedDeviceId } }
-              : audioConstraints;
-          this.stream = await getUserMediaFunc({ audio });
-        } catch (error: any) {
-          // Handle specific error cases
-          if (error.name === 'NotAllowedError') {
-            this.onError(
-              this.createRecorderError(
-                'Microphone permission denied. Please allow microphone access and try again.',
-                error,
-              ),
-            );
-          } else if (error.name === 'NotFoundError') {
-            this.onError(this.createRecorderError('No microphone found. Please connect a microphone and try again.', error));
-          } else if (error.name === 'NotReadableError') {
-            this.onError(
-              this.createRecorderError(
-                'Microphone is in use by another application. Please close other apps using the microphone.',
-                error,
-              ),
-            );
-          } else if (error.name === 'OverconstrainedError') {
-            this.onError(this.createRecorderError('Selected microphone is unavailable. Please choose another microphone.', error));
-          } else if (error.name === 'InvalidStateError') {
-            this.onError(this.createRecorderError('Microphone is in an invalid state. Try reloading the page.', error));
+          this.stream = await getUserMediaFunc({ audio: selectedAudioConstraints });
+        } catch (error) {
+          if (selectedDeviceId && selectedDeviceId !== 'default' && this.isSelectedDeviceFailure(error)) {
+            try {
+              this.stream = await getUserMediaFunc({ audio: audioConstraints });
+              window.localStorage.removeItem(VoiceRecorder.SELECTED_MIC_DEVICE_ID_STORAGE_KEY);
+              this.reportClientTelemetry('get-user-media-selected-device', error, {
+                deviceIdMode,
+                retryWithDefaultDevice: true,
+                retryOutcome: 'success',
+              });
+            } catch (retryError) {
+              this.reportClientTelemetry('get-user-media-selected-device', error, {
+                deviceIdMode,
+                retryWithDefaultDevice: true,
+                retryOutcome: 'failed',
+                retryErrorName: this.getErrorName(retryError),
+                retryErrorMessage: this.getErrorMessage(retryError),
+              });
+              this.reportClientTelemetry('get-user-media-default-retry', retryError, {
+                deviceIdMode: 'default',
+                retryWithDefaultDevice: false,
+              });
+              this.handleGetUserMediaError(retryError);
+              return;
+            }
           } else {
-            this.onError(this.createRecorderError('Failed to access microphone', error));
+            this.reportClientTelemetry('get-user-media', error, {
+              deviceIdMode,
+              retryWithDefaultDevice: false,
+            });
+            this.handleGetUserMediaError(error);
+            return;
           }
-          return;
         }
 
         // Check if MediaRecorder is available
         if (typeof MediaRecorder === 'undefined') {
-          this.onError(
-            new Error(
-              'MediaRecorder API is not available. Please use a browser that supports audio recording.',
-            ),
+          const recorderError = new Error(
+            'MediaRecorder API is not available. Please use a browser that supports audio recording.',
           );
+          this.reportClientTelemetry('media-recorder-unavailable', recorderError, {
+            deviceIdMode,
+          });
+          this.onError(recorderError);
           this.stream.getTracks().forEach((track) => track.stop());
           this.stream = null;
           return;
@@ -224,7 +353,11 @@ export class VoiceRecorder {
         const recorderResult = this.createMediaRecorder(this.stream);
         if (!recorderResult.recorder) {
           console.error('MediaRecorder creation failed:', recorderResult.error);
-          this.onError(this.createRecorderError(recorderResult.error, { name: 'NotSupportedError' }));
+          const recorderError = this.createRecorderError(recorderResult.error, { name: 'NotSupportedError' });
+          this.reportClientTelemetry('media-recorder-create', recorderError, {
+            deviceIdMode,
+          });
+          this.onError(recorderError);
           this.stream.getTracks().forEach((track) => track.stop());
           this.stream = null;
           return;
@@ -255,10 +388,16 @@ export class VoiceRecorder {
 
       this.mediaRecorder.onerror = (event) => {
         const errorEvent = event as Event & { error?: unknown };
-        this.onError(this.createRecorderError('MediaRecorder error', errorEvent.error ?? event));
+        const recorderError = this.createRecorderError('MediaRecorder error', errorEvent.error ?? event);
+        this.reportClientTelemetry('media-recorder-runtime', recorderError, {
+          recorderState: this.mediaRecorder?.state,
+        });
+        this.onError(recorderError);
       };
     } catch (error) {
-      this.onError(this.createRecorderError('Failed to initialize recorder', error));
+      const recorderError = this.createRecorderError('Failed to initialize recorder', error);
+      this.reportClientTelemetry('recorder-initialize', recorderError);
+      this.onError(recorderError);
     }
   }
 
@@ -282,10 +421,25 @@ export class VoiceRecorder {
     try {
       this.audioChunks = [];
       this.mediaRecorder.start();
-      this.isRecording = true;
+      const recorderState = this.mediaRecorder.state as RecordingState;
+      this.isRecording = recorderState === 'recording';
+      if (!this.isRecording) {
+        const recorderError = this.createRecorderError('MediaRecorder did not enter recording state', {
+          name: 'InvalidStateError',
+          message: `state=${recorderState}`,
+        });
+        this.reportClientTelemetry('media-recorder-start-state', recorderError, {
+          recorderState,
+        });
+        this.onError(recorderError);
+      }
     } catch (error) {
       this.isRecording = false;
-      this.onError(this.createRecorderError('Failed to start recording', error));
+      const recorderError = this.createRecorderError('Failed to start recording', error);
+      this.reportClientTelemetry('media-recorder-start', recorderError, {
+        recorderState: this.mediaRecorder.state,
+      });
+      this.onError(recorderError);
     }
   }
 
@@ -298,7 +452,11 @@ export class VoiceRecorder {
       this.mediaRecorder.stop();
       this.isRecording = false;
     } catch (error) {
-      this.onError(this.createRecorderError('Failed to stop recording', error));
+      const recorderError = this.createRecorderError('Failed to stop recording', error);
+      this.reportClientTelemetry('media-recorder-stop', recorderError, {
+        recorderState: this.mediaRecorder.state,
+      });
+      this.onError(recorderError);
     }
   }
 
@@ -319,7 +477,11 @@ export class VoiceRecorder {
     try {
       this.mediaRecorder.pause();
     } catch (error) {
-      this.onError(this.createRecorderError('Failed to pause recording', error));
+      const recorderError = this.createRecorderError('Failed to pause recording', error);
+      this.reportClientTelemetry('media-recorder-pause', recorderError, {
+        recorderState: this.mediaRecorder.state,
+      });
+      this.onError(recorderError);
     }
   }
 
@@ -331,7 +493,11 @@ export class VoiceRecorder {
     try {
       this.mediaRecorder.resume();
     } catch (error) {
-      this.onError(this.createRecorderError('Failed to resume recording', error));
+      const recorderError = this.createRecorderError('Failed to resume recording', error);
+      this.reportClientTelemetry('media-recorder-resume', recorderError, {
+        recorderState: this.mediaRecorder.state,
+      });
+      this.onError(recorderError);
     }
   }
 
@@ -360,7 +526,7 @@ export class VoiceRecorder {
   }
 
   isCurrentlyRecording(): boolean {
-    return this.isRecording;
+    return this.isRecording && this.mediaRecorder?.state === 'recording';
   }
 
   isInitialized(): boolean {


### PR DESCRIPTION
## Summary

This PR fixes the two production regressions found during the May 10-14 log investigation and hardens the Vercel production env contract.

- Fixes member-card OCR success so the kiosk starts reception and speaks/displays the greeting instead of returning to idle.
- Keeps raw member numbers out of `visitor_identity.user_id` unless the OCR lookup actually resolves a user record, avoiding false returning-visitor classification.
- Adds explicit OCR lookup metadata for `public.users` missing/not found/failure cases while preserving OCR success and `member_number`.
- Fixes the Welcome-to-voice button path so pending iOS audio replay no longer consumes the user gesture before recorder startup.
- Adds client-side voice recorder telemetry for permission/device/MediaRecorder failures.
- Adds Vercel production env validation for Supabase and backend proxy env vars, and makes `pnpm build` run the production-gated check.
- Removes `next/font/google` dependency from the root layout so local/Vercel builds do not depend on fetching Google Fonts during compilation.

Refs #816
Refs #817
Refs #818

## Validation

- `python -m black --check backend/services/visitor_identification_service.py backend/api/ocr.py backend/api/reception.py backend/tests/services/test_visitor_identification_service.py backend/tests/api/test_ocr_api.py backend/tests/api/test_reception_api.py`
- `python -m ruff check backend/services/visitor_identification_service.py backend/api/ocr.py backend/api/reception.py backend/tests/services/test_visitor_identification_service.py backend/tests/api/test_ocr_api.py backend/tests/api/test_reception_api.py`
- `python -m pytest backend/tests/services/test_visitor_identification_service.py backend/tests/api/test_ocr_api.py backend/tests/api/test_reception_api.py -q` (76 passed)
- `mise exec -- pnpm --dir frontend exec tsx --test --import ./src/__tests__/node-test-setup.ts src/__tests__/env-validation.test.ts src/__tests__/reception-identity.test.ts` (6 passed)
- `mise exec -- pnpm --dir frontend lint`
- `mise exec -- pnpm --dir frontend typecheck`
- `git diff --check`
- `mise exec -- pnpm --dir frontend exec playwright test --config=playwright.config.ts --project=chromium e2e/reception-flow.spec.ts e2e/welcome-voice-first.spec.ts -g "member_number success|handwriting OCR sends|voice button starts recording"` (3 passed)
- `mise exec -- pnpm --dir frontend exec playwright test --config=playwright.config.ts e2e/voice-permission-denial.spec.ts --project=webkit-permissions` (5 passed)
- `VERCEL_ENV=production pnpm --dir frontend build` with required env provided (production build passed)
- Playwright production-server smoke against `http://127.0.0.1:3103` confirmed Welcome, member-card, handwriting, and voice buttons render.

## Deployment notes

Vercel Production was missing `NEXT_PUBLIC_SUPABASE_URL` and `NEXT_PUBLIC_SUPABASE_ANON_KEY`. I added both via `vercel env add` without printing values. `vercel env ls production` now shows the Supabase public env vars plus `ADMIN_API_SECRET`, `BACKEND_API_URL`, and `BACKEND_API_KEY` present.

A local `vercel build --prod` attempt still failed before app build with `spawn sh ENOENT` during the Vercel CLI install step, which appears to be a local CLI/sandbox PATH issue rather than an application build failure. The app build itself passes with production env validation enabled.
