### PR TITLE
Wave 2 operational guardrails

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -372,13 +372,14 @@ jobs:
           path: backend/coverage.xml
           retention-days: 30
 
-  # Backend: RAGAS tests (optional, informational only)
-  # Only runs on push to main/develop when OPENAI_API_KEY secret is available
+  # Backend: RAGAS contract tests (optional, informational only)
+  # Live/provider RAGAS evaluation runs in the dedicated scheduled workflow.
   backend-test-ragas:
     needs: [changes, backend-test]
     if: needs.changes.outputs.backend == 'true' && github.event_name == 'push'
     runs-on: ubuntu-latest
     continue-on-error: true
+    timeout-minutes: 15
     steps:
       - uses: actions/checkout@v6.0.2
 
@@ -393,9 +394,17 @@ jobs:
           pip install -e ".[dev,evaluation]"
         working-directory: backend
 
-      - name: Run RAGAS tests
-        if: env.OPENAI_API_KEY != ''
-        run: pytest -m "ragas" --tb=short -q
+      - name: Run RAGAS contract tests
+        run: |
+          pytest \
+            tests/evaluation/test_ragas_pipeline.py \
+            tests/evaluation/test_ragas_pipeline_timeout_guard.py \
+            tests/evaluation/test_ragas_ci_integration.py \
+            tests/evaluation/test_multilingual_ragas.py \
+            --ignore=tests/evaluation/test_ragas_live.py \
+            --ignore=tests/evaluation/test_ragas_phase_b.py \
+            -m "not ragas" \
+            --tb=short -q
         working-directory: backend
         env:
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}

--- a/.github/workflows/db-schema-drift.yml
+++ b/.github/workflows/db-schema-drift.yml
@@ -26,7 +26,9 @@ jobs:
       - uses: actions/checkout@v6.0.2
 
       - name: Install Supabase CLI
-        run: npm i -g supabase@^1
+        uses: supabase/setup-cli@v2
+        with:
+          version: latest
 
       - name: Check drift
         env:

--- a/backend/engineercafe-device/README.md
+++ b/backend/engineercafe-device/README.md
@@ -28,13 +28,27 @@ PIR と VL53L0X（ToF）で来訪を検知し、バックエンドの reception 
    ```
 
 2. `secrets.h` を編集し、`SSID` / `PASSWORD` / `WEBHOOK_URL_BACKEND` / `API_SECRET_KEY` / `DEVICE_ID` を実環境の値に置き換える。
-3. **`secrets.h` はコミットしない。** `.gitignore` で無視されていることを確認する。
+3. `BACKEND_ROOT_CA` を `WEBHOOK_URL_BACKEND` のサーバ証明書チェーンを署名している **ルート CA** の PEM に置き換える。
+   - `-----BEGIN CERTIFICATE-----` / `-----END CERTIFICATE-----` を含め、各行末に `\n` を入れる。
+   - leaf 証明書ではなく、信頼アンカーになるルート CA を設定する。
+   - デプロイ先の証明書チェーンを変更した場合は、`BACKEND_ROOT_CA` も再確認する。
+
+   例:
+
+   ```c
+   #define BACKEND_ROOT_CA \
+   "-----BEGIN CERTIFICATE-----\n" \
+   "...root CA PEM body...\n" \
+   "-----END CERTIFICATE-----\n"
+   ```
+
+4. **`secrets.h` はコミットしない。** `.gitignore` で無視されていることを確認する。
 
    ```bash
    git check-ignore -v backend/engineercafe-device/secrets.h
    ```
 
-4. `git ls-files backend/engineercafe-device | rg secrets` で **`secrets.h` が一覧に含まれない**ことをマージ前に確認する。
+5. `git ls-files backend/engineercafe-device | rg secrets` で **`secrets.h` が一覧に含まれない**ことをマージ前に確認する。
 
 ## API（バックエンド契約）
 
@@ -71,7 +85,7 @@ PIR と VL53L0X（ToF）で来訪を検知し、バックエンドの reception 
 
 ## セキュリティ（TLS）
 
-現状スケッチでは **`WiFiClientSecure::setInsecure()`** を使用しており、サーバ証明書の検証を行っていません。半公開 Wi-Fi 環境では MITM のリスクがあります。**ルート CA をバンドルして `setCACert()` に渡す**対応は別 Issue / PR（HIGH-2 follow-up）として扱う想定です。
+スケッチは **`WiFiClientSecure::setCACert(BACKEND_ROOT_CA)`** を使用し、`WEBHOOK_URL_BACKEND` の TLS 証明書を検証します。`BACKEND_ROOT_CA` が未設定、期限切れ、またはデプロイ先の証明書チェーンと不一致の場合、Webhook は TLS 接続に失敗します。
 
 ## トラブルシュート
 

--- a/backend/engineercafe-device/engineercafe-device.ino
+++ b/backend/engineercafe-device/engineercafe-device.ino
@@ -4,7 +4,7 @@
 #include <WiFiClientSecure.h>
 #include <Wire.h>
 #include <Adafruit_VL53L0X.h>
-#include "secrets.h"  // SSID, PASSWORD, WEBHOOK_URL_BACKEND, API_SECRET_KEY, DEVICE_ID
+#include "secrets.h"  // SSID, PASSWORD, WEBHOOK_URL_BACKEND, API_SECRET_KEY, DEVICE_ID, BACKEND_ROOT_CA
 
 const char* SENSOR_TYPE    = "pir_tof";  // ← 変更
 
@@ -63,7 +63,7 @@ bool sendToBackend(int tofMM) {
   );
 
   WiFiClientSecure client;
-  client.setInsecure();
+  client.setCACert(BACKEND_ROOT_CA);
 
   HTTPClient http;
   http.begin(client, WEBHOOK_URL_BACKEND);
@@ -143,6 +143,10 @@ void showWebhookFailure() {
 }
 
 void showDebug(bool pirOn, int tofMM, bool measuring) {
+  if (currentState == GREETING) {
+    return;
+  }
+
   M5.Lcd.fillScreen(TFT_BLACK);
   M5.Lcd.setTextSize(2);
 

--- a/backend/engineercafe-device/secrets.example.h
+++ b/backend/engineercafe-device/secrets.example.h
@@ -5,3 +5,10 @@
 #define WEBHOOK_URL_BACKEND "https://YOUR_SERVICE.run.app/api/reception/sensor-trigger"
 #define API_SECRET_KEY "YOUR_API_SECRET_KEY"
 #define DEVICE_ID "m5stack-001"
+
+// Replace this with the PEM-encoded root CA that signs WEBHOOK_URL_BACKEND's
+// server certificate chain. Keep the BEGIN/END lines and trailing newlines.
+#define BACKEND_ROOT_CA \
+"-----BEGIN CERTIFICATE-----\n" \
+"REPLACE_WITH_ROOT_CA_PEM_BODY\n" \
+"-----END CERTIFICATE-----\n"

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -153,6 +153,9 @@ target-version = "py311"
 select = ["E", "F", "W", "G", "LOG"]
 ignore = []
 
+[tool.ruff.lint.per-file-ignores]
+"tests/**/*.py" = ["E402"]
+
 [tool.mypy]
 python_version = "3.11"
 warn_return_any = true

--- a/frontend/e2e/fixtures/m5stack-payloads.ts
+++ b/frontend/e2e/fixtures/m5stack-payloads.ts
@@ -1,19 +1,31 @@
 /**
  * Shared POST bodies for /api/reception/sensor-trigger contract tests.
- * Schema matches backend SensorTriggerRequest (required distance_mm + device_id).
+ * Schema matches backend SensorTriggerRequest and M5Stack firmware payloads.
  */
+const DEFAULT_FIRMWARE_DEVICE_ID = 'm5stack-001';
+const FIRMWARE_SENSOR_TYPE = 'pir_tof';
+
+function firmwarePayload(deviceId = DEFAULT_FIRMWARE_DEVICE_ID, distanceMm = 280) {
+  return {
+    sensor_type: FIRMWARE_SENSOR_TYPE,
+    distance_mm: distanceMm,
+    device_id: deviceId,
+  };
+}
+
 export const m5stackPayloads = {
-  /** Matches frontend DEFAULT_DEVICE_ID in device-webhook polling. */
-  tofClose: { sensor_type: 'ToF', distance_mm: 350, device_id: 'm5stack-001' },
-  tofFar: { sensor_type: 'ToF', distance_mm: 800, device_id: 'm5stack-001' },
+  /** Matches firmware SENSOR_TYPE and frontend default kiosk device_id. */
+  firmwareClose: firmwarePayload,
+  tofClose: firmwarePayload(),
+  tofFar: firmwarePayload(DEFAULT_FIRMWARE_DEVICE_ID, 800),
   invalidLongSensorType: {
     sensor_type: 'X'.repeat(51),
-    distance_mm: 350,
+    distance_mm: 280,
     device_id: 'm5stack-validation',
   },
   rateLimitDevice: (suffix: string = String(Date.now())) => ({
-    sensor_type: 'ToF',
-    distance_mm: 500,
+    sensor_type: FIRMWARE_SENSOR_TYPE,
+    distance_mm: 280,
     device_id: `m5stack-e2e-rate-limit-${suffix}`,
   }),
 };

--- a/frontend/e2e/m5stack-reception-flow.spec.ts
+++ b/frontend/e2e/m5stack-reception-flow.spec.ts
@@ -6,8 +6,8 @@ import { expect, test } from '@playwright/test';
 import { m5stackPayloads } from './fixtures/m5stack-payloads';
 
 test.skip(
-  !process.env.BACKEND_API_URL && !process.env.PLAYWRIGHT_BASE_URL,
-  'M5Stack E2E requires a reachable backend (BACKEND_API_URL or PLAYWRIGHT_BASE_URL must be set)',
+  !process.env.BACKEND_API_URL,
+  'M5Stack E2E requires a reachable backend (BACKEND_API_URL must be set)',
 );
 
 /**
@@ -31,9 +31,9 @@ function backendRequestHeaders(): Record<string, string> {
   const headers: Record<string, string> = {
     'Content-Type': 'application/json',
   };
-  const key = process.env.BACKEND_API_KEY;
+  const key = process.env.API_SECRET_KEY ?? process.env.BACKEND_API_KEY;
   if (key) {
-    headers['X-API-Key'] = key;
+    headers.Authorization = `Bearer ${key}`;
   }
   return headers;
 }
@@ -107,9 +107,12 @@ test.describe('M5Stack reception sensor webhook (API + kiosk polling)', () => {
     page,
     request,
   }) => {
-    await page.addInitScript(() => {
+    const payload = m5stackPayloads.firmwareClose(`m5stack-e2e-pir-tof-${Date.now()}`);
+
+    await page.addInitScript(({ deviceId }) => {
       window.localStorage.setItem('engineer_cafe_kiosk_trigger_mode', 'device');
-    });
+      window.localStorage.setItem('engineer_cafe_kiosk_device_id', deviceId);
+    }, { deviceId: payload.device_id });
     await installDeterministicVoiceRecorder(page);
     await keepOcrCameraPending(page);
     await mockReceptionStart(page);
@@ -133,7 +136,7 @@ test.describe('M5Stack reception sensor webhook (API + kiosk polling)', () => {
 
     const triggerUrl = backendTriggerUrl();
     const res = await request.post(triggerUrl, {
-      data: m5stackPayloads.tofClose,
+      data: payload,
       headers: backendRequestHeaders(),
     });
     expect(res.status(), await res.text()).toBe(200);
@@ -154,7 +157,7 @@ test.describe('M5Stack reception sensor webhook (API + kiosk polling)', () => {
     const url = backendTriggerUrl();
 
     const missingType = await request.post(url, {
-      data: { distance_mm: 350, device_id: 'm5stack-schema-missing-type' },
+      data: { distance_mm: 280, device_id: 'm5stack-schema-missing-type' },
       headers,
     });
     expect(missingType.status()).toBe(422);

--- a/frontend/src/__tests__/vercel-timeout-hierarchy.test.ts
+++ b/frontend/src/__tests__/vercel-timeout-hierarchy.test.ts
@@ -4,10 +4,20 @@ import path from 'node:path';
 import { test } from 'node:test';
 
 type VercelConfig = {
+  crons?: Array<{ path?: string; schedule?: string }>;
   functions?: Record<string, { maxDuration?: number }>;
 };
 
 const frontendRoot = path.resolve(__dirname, '..', '..');
+const REQUIRED_FUNCTION_MAX_DURATIONS: Record<string, number> = {
+  'src/app/api/cron/update-knowledge-base/route.ts': 300,
+  'src/app/api/ocr/route.ts': 120,
+  'src/app/api/reception/start/route.ts': 120,
+  'src/app/api/reception/respond/route.ts': 120,
+  'src/app/api/reception/complete/route.ts': 120,
+  'src/app/api/reception/status/[receptionSessionId]/route.ts': 120,
+  'src/app/api/reception/sensor-status/route.ts': 120,
+};
 
 async function readText(relativePath: string): Promise<string> {
   return readFile(path.join(frontendRoot, relativePath), 'utf-8');
@@ -40,6 +50,14 @@ function explicitTimeouts(source: string): number[] {
 test('frontend API proxy timeouts stay below their Vercel maxDuration', async () => {
   const config = JSON.parse(await readText('vercel.json')) as VercelConfig;
   const functions = config.functions ?? {};
+
+  for (const [routePath, maxDuration] of Object.entries(REQUIRED_FUNCTION_MAX_DURATIONS)) {
+    assert.equal(
+      functions[routePath]?.maxDuration,
+      maxDuration,
+      `${routePath} must explicitly declare maxDuration ${maxDuration}`
+    );
+  }
 
   for (const [routePath, settings] of Object.entries(functions)) {
     const maxDurationMs = (settings.maxDuration ?? 0) * 1000;
@@ -81,4 +99,11 @@ test('voice proxy timeout covers observed Cloud Run cold starts without exceedin
   assert.ok(proxyTimeoutMs < voiceMaxDurationMs);
   assert.ok(proxyTimeoutMs < fillerMaxDurationMs);
   assert.ok(voiceMaxDurationMs < cloudRunTimeoutMs);
+});
+
+test('knowledge base cron runs outside JST business hours', async () => {
+  const config = JSON.parse(await readText('vercel.json')) as VercelConfig;
+  const cron = config.crons?.find((entry) => entry.path === '/api/cron/update-knowledge-base');
+
+  assert.equal(cron?.schedule, '30 19 * * *');
 });

--- a/frontend/src/app/api/cron/update-knowledge-base/route.ts
+++ b/frontend/src/app/api/cron/update-knowledge-base/route.ts
@@ -4,6 +4,44 @@ import { dispatchCronAlert } from '@/lib/monitoring/cron-alerts';
 import { ragMetrics } from '@/lib/monitoring/rag-metrics';
 
 const CRON_NAME = '/api/cron/update-knowledge-base';
+const CRON_ROUTE_TIMEOUT_MS = 290_000;
+
+function createTimeoutError(timeoutMs: number): Error {
+  return new Error(`Knowledge base update timed out after ${timeoutMs}ms`);
+}
+
+async function runKnowledgeBaseUpdateWithTimeout({
+  timeoutMs,
+}: {
+  timeoutMs: number;
+}): Promise<void> {
+  let timeoutId: ReturnType<typeof setTimeout> | undefined;
+  let timedOut = false;
+  const updatePromise = knowledgeBaseUpdater.runUpdate();
+
+  updatePromise.catch((error) => {
+    if (timedOut) {
+      console.error('[CRON] Knowledge base update failed after route timeout:', error);
+    }
+  });
+
+  try {
+    await Promise.race([
+      updatePromise,
+      new Promise<never>((_, reject) => {
+        timeoutId = setTimeout(() => {
+          timedOut = true;
+          reject(createTimeoutError(timeoutMs));
+        }, timeoutMs);
+        timeoutId.unref?.();
+      }),
+    ]);
+  } finally {
+    if (timeoutId) {
+      clearTimeout(timeoutId);
+    }
+  }
+}
 
 /**
  * CRON endpoint for automated knowledge base updates
@@ -28,7 +66,7 @@ export async function GET(request: NextRequest) {
   
   try {
     // Run the update
-    await knowledgeBaseUpdater.runUpdate();
+    await runKnowledgeBaseUpdateWithTimeout({ timeoutMs: CRON_ROUTE_TIMEOUT_MS });
     
     const duration = Date.now() - startTime;
     

--- a/frontend/src/jobs/update-knowledge-base.ts
+++ b/frontend/src/jobs/update-knowledge-base.ts
@@ -8,9 +8,23 @@ const CONNPASS_KNOWLEDGE_CATEGORY = 'event';
 const OPENROUTER_EMBEDDING_URL = 'https://openrouter.ai/api/v1/embeddings';
 const OPENROUTER_EMBEDDING_MODEL = 'openai/text-embedding-3-small';
 const OPENROUTER_EMBEDDING_DIMENSIONS = 1536;
+const OPENROUTER_EMBEDDING_TIMEOUT_MS = 15_000;
+const KNOWLEDGE_BASE_UPDATE_CRON_JST = '30 4 * * *';
+const KNOWLEDGE_BASE_UPDATE_LOCK_METRIC_TYPE = 'knowledge_base_update_lock';
+const KNOWLEDGE_BASE_UPDATE_LOCK_TTL_MS = 20 * 60 * 1000;
 
 type ConnpassClient = typeof connpassClient;
 type SupabaseAdmin = typeof supabaseAdmin;
+type UpdateLease = {
+  acquired: boolean;
+  distributed: boolean;
+  ownerId: string;
+  expiresAt: string;
+};
+type MetricRow = {
+  created_at?: string;
+  metadata?: unknown;
+};
 
 interface KnowledgeBaseUpdaterDependencies {
   connpassClient?: ConnpassClient;
@@ -39,15 +53,14 @@ export class KnowledgeBaseUpdater {
     this.fetchImpl = dependencies.fetch ?? fetch;
     this.getOpenRouterApiKey = dependencies.getOpenRouterApiKey ?? (() => process.env.OPENROUTER_API_KEY);
 
-    // Run every 6 hours: "0 */6 * * *"
-    // For testing, can use every 5 minutes: "*/5 * * * *"
-    this.job = new CronJob('0 */6 * * *', async () => {
+    // Mirrors Vercel's 19:30 UTC cron, which is 04:30 JST and outside kiosk business hours.
+    this.job = new CronJob(KNOWLEDGE_BASE_UPDATE_CRON_JST, async () => {
       try {
         await this.runUpdate();
       } catch (error) {
         console.error('[KnowledgeBaseUpdater] Scheduled update failed:', error);
       }
-    });
+    }, null, false, 'Asia/Tokyo');
   }
   
   /**
@@ -74,8 +87,14 @@ export class KnowledgeBaseUpdater {
     
     this.isRunning = true;
     const startTime = Date.now();
+    let lease: UpdateLease | undefined;
     
     try {
+      lease = await this.acquireUpdateLease();
+      if (!lease.acquired) {
+        console.warn('[KnowledgeBaseUpdater] Update skipped because another instance holds the lease');
+        return;
+      }
       
       // Run all updates in parallel
       const results = await Promise.allSettled([
@@ -117,6 +136,9 @@ export class KnowledgeBaseUpdater {
       console.error('[KnowledgeBaseUpdater] Update failed:', error);
       throw error;
     } finally {
+      if (lease?.acquired) {
+        await this.releaseUpdateLease(lease);
+      }
       this.isRunning = false;
     }
   }
@@ -294,18 +316,33 @@ export class KnowledgeBaseUpdater {
   }
 
   private async generateEmbedding(text: string, apiKey: string): Promise<number[]> {
-    const response = await this.fetchImpl(OPENROUTER_EMBEDDING_URL, {
-      method: 'POST',
-      headers: {
-        Authorization: `Bearer ${apiKey}`,
-        'Content-Type': 'application/json',
-      },
-      body: JSON.stringify({
-        model: OPENROUTER_EMBEDDING_MODEL,
-        input: text,
-        dimensions: OPENROUTER_EMBEDDING_DIMENSIONS,
-      }),
-    });
+    const controller = new AbortController();
+    const timeoutId = setTimeout(() => controller.abort(), OPENROUTER_EMBEDDING_TIMEOUT_MS);
+    timeoutId.unref?.();
+
+    let response: Response;
+    try {
+      response = await this.fetchImpl(OPENROUTER_EMBEDDING_URL, {
+        method: 'POST',
+        headers: {
+          Authorization: `Bearer ${apiKey}`,
+          'Content-Type': 'application/json',
+        },
+        signal: controller.signal,
+        body: JSON.stringify({
+          model: OPENROUTER_EMBEDDING_MODEL,
+          input: text,
+          dimensions: OPENROUTER_EMBEDDING_DIMENSIONS,
+        }),
+      });
+    } catch (error) {
+      if (this.isAbortLikeError(error)) {
+        throw new Error(`OpenRouter embedding request timed out after ${OPENROUTER_EMBEDDING_TIMEOUT_MS}ms`);
+      }
+      throw error;
+    } finally {
+      clearTimeout(timeoutId);
+    }
 
     if (!response.ok) {
       const details = await response.text().catch(() => '');
@@ -324,6 +361,180 @@ export class KnowledgeBaseUpdater {
     }
 
     return embedding;
+  }
+
+  private async acquireUpdateLease(): Promise<UpdateLease> {
+    const ownerId = uuidv4();
+    const now = Date.now();
+    const expiresAt = new Date(now + KNOWLEDGE_BASE_UPDATE_LOCK_TTL_MS).toISOString();
+
+    if (process.env.NODE_ENV !== 'production') {
+      return { acquired: true, distributed: false, ownerId, expiresAt };
+    }
+
+    try {
+      const activeSince = new Date(now - KNOWLEDGE_BASE_UPDATE_LOCK_TTL_MS).toISOString();
+      const activeRows = await this.readRecentUpdateLeaseRows(activeSince);
+      const activeLease = this.findActiveUpdateLease(activeRows, now);
+
+      if (activeLease) {
+        return { acquired: false, distributed: true, ownerId, expiresAt };
+      }
+
+      await this.insertUpdateLeaseMetric({
+        ownerId,
+        status: 'running',
+        value: 1,
+        expiresAt,
+      });
+
+      const contenderRows = await this.readRecentUpdateLeaseRows(activeSince);
+      const contenders = this.activeUpdateLeaseContenders(contenderRows, now);
+      const winner = contenders[0];
+      if (winner && winner.ownerId !== ownerId) {
+        await this.insertUpdateLeaseMetric({
+          ownerId,
+          status: 'skipped',
+          value: 0,
+          expiresAt,
+        });
+        return { acquired: false, distributed: true, ownerId, expiresAt };
+      }
+
+      return { acquired: true, distributed: true, ownerId, expiresAt };
+    } catch (error) {
+      console.warn(
+        '[KnowledgeBaseUpdater] Distributed update lease unavailable; falling back to process-local guard:',
+        error
+      );
+      return { acquired: true, distributed: false, ownerId, expiresAt };
+    }
+  }
+
+  private async releaseUpdateLease(lease: UpdateLease): Promise<void> {
+    if (!lease.distributed) {
+      return;
+    }
+
+    try {
+      await this.insertUpdateLeaseMetric({
+        ownerId: lease.ownerId,
+        status: 'completed',
+        value: 0,
+        expiresAt: lease.expiresAt,
+      });
+    } catch (error) {
+      console.warn('[KnowledgeBaseUpdater] Failed to release distributed update lease:', error);
+    }
+  }
+
+  private async readRecentUpdateLeaseRows(activeSince: string): Promise<MetricRow[]> {
+    const query = (this.supabaseAdmin as any)
+      .from('system_metrics')
+      .select('created_at, metadata')
+      .eq('metric_type', KNOWLEDGE_BASE_UPDATE_LOCK_METRIC_TYPE)
+      .gte('created_at', activeSince)
+      .order('created_at', { ascending: true })
+      .limit(50);
+    const { data, error } = await query;
+
+    if (error) {
+      throw error;
+    }
+
+    return Array.isArray(data) ? data : [];
+  }
+
+  private async insertUpdateLeaseMetric(input: {
+    ownerId: string;
+    status: 'running' | 'completed' | 'skipped';
+    value: number;
+    expiresAt: string;
+  }): Promise<void> {
+    const { error } = await (this.supabaseAdmin as any)
+      .from('system_metrics')
+      .insert({
+        metric_type: KNOWLEDGE_BASE_UPDATE_LOCK_METRIC_TYPE,
+        value: input.value,
+        metadata: {
+          owner_id: input.ownerId,
+          status: input.status,
+          expires_at: input.expiresAt,
+          lock_ttl_ms: KNOWLEDGE_BASE_UPDATE_LOCK_TTL_MS,
+        },
+        created_at: new Date().toISOString(),
+      });
+
+    if (error) {
+      throw error;
+    }
+  }
+
+  private findActiveUpdateLease(rows: MetricRow[], now: number): { ownerId: string } | null {
+    return this.activeUpdateLeaseContenders(rows, now)[0] ?? null;
+  }
+
+  private activeUpdateLeaseContenders(rows: MetricRow[], now: number): Array<{
+    acquiredAt: string;
+    ownerId: string;
+  }> {
+    const releasedOwners = new Set<string>();
+
+    for (const row of rows) {
+      const metadata = this.metricMetadata(row.metadata);
+      if (
+        metadata?.owner_id &&
+        (metadata.status === 'completed' || metadata.status === 'skipped')
+      ) {
+        releasedOwners.add(metadata.owner_id);
+      }
+    }
+
+    return rows
+      .map((row) => {
+        const metadata = this.metricMetadata(row.metadata);
+        return {
+          acquiredAt: row.created_at ?? '',
+          ownerId: metadata?.owner_id ?? '',
+          status: metadata?.status,
+          expiresAt: metadata?.expires_at,
+        };
+      })
+      .filter((row) => {
+        if (!row.ownerId || row.status !== 'running' || releasedOwners.has(row.ownerId)) {
+          return false;
+        }
+        return row.expiresAt ? Date.parse(row.expiresAt) > now : false;
+      })
+      .sort((a, b) => {
+        const timeDiff = Date.parse(a.acquiredAt) - Date.parse(b.acquiredAt);
+        return timeDiff === 0 ? a.ownerId.localeCompare(b.ownerId) : timeDiff;
+      })
+      .map((row) => ({ acquiredAt: row.acquiredAt, ownerId: row.ownerId }));
+  }
+
+  private metricMetadata(metadata: unknown): {
+    owner_id?: string;
+    status?: string;
+    expires_at?: string;
+  } | null {
+    if (!metadata || typeof metadata !== 'object') {
+      return null;
+    }
+
+    return metadata as {
+      owner_id?: string;
+      status?: string;
+      expires_at?: string;
+    };
+  }
+
+  private isAbortLikeError(error: unknown): boolean {
+    if (!(error instanceof Error || error instanceof DOMException)) {
+      return false;
+    }
+
+    return error.name === 'AbortError' || error.name === 'TimeoutError';
   }
 
   private formatConnpassUpdateResult(result: {

--- a/frontend/src/lib/api/device-webhook.ts
+++ b/frontend/src/lib/api/device-webhook.ts
@@ -7,7 +7,8 @@ export interface DeviceDetectionEvent {
   data?: Record<string, unknown>;
 }
 
-const DEFAULT_DEVICE_ID = 'm5stack-001';
+export const DEFAULT_KIOSK_DEVICE_ID = 'm5stack-001';
+export const KIOSK_DEVICE_ID_STORAGE_KEY = 'engineer_cafe_kiosk_device_id';
 const DEFAULT_SENSOR_POLL_INTERVAL_MS = 1000;
 
 let sensorPollingIntervalId: number | null = null;
@@ -71,24 +72,54 @@ async function pollSensorStatus(deviceId: string, sessionToken: number): Promise
   }
 }
 
+function readConfiguredKioskDeviceId(): string | null {
+  if (typeof window === 'undefined') {
+    return null;
+  }
+
+  try {
+    const stored = window.localStorage.getItem(KIOSK_DEVICE_ID_STORAGE_KEY)?.trim();
+    return stored ? stored : null;
+  } catch {
+    return null;
+  }
+}
+
+export function resolveKioskDeviceId(deviceId?: string): string {
+  const explicitDeviceId = deviceId?.trim();
+  if (explicitDeviceId) {
+    return explicitDeviceId;
+  }
+
+  const storedDeviceId = readConfiguredKioskDeviceId();
+  if (storedDeviceId) {
+    return storedDeviceId;
+  }
+
+  const envDeviceId = process.env.NEXT_PUBLIC_KIOSK_DEVICE_ID?.trim();
+  return envDeviceId || DEFAULT_KIOSK_DEVICE_ID;
+}
+
 export function startSensorPolling(
-  deviceId = DEFAULT_DEVICE_ID,
+  deviceId?: string,
   intervalMs = DEFAULT_SENSOR_POLL_INTERVAL_MS
 ): void {
   if (typeof window === 'undefined') {
     return;
   }
 
+  const resolvedDeviceId = resolveKioskDeviceId(deviceId);
+
   stopSensorPolling();
   activePollingSessionToken += 1;
   const sessionToken = activePollingSessionToken;
   // Initialize since to now so pre-existing (stale) events are ignored
-  if (!lastSeenSensorTimestampByDevice.has(deviceId)) {
-    lastSeenSensorTimestampByDevice.set(deviceId, Date.now() / 1000);
+  if (!lastSeenSensorTimestampByDevice.has(resolvedDeviceId)) {
+    lastSeenSensorTimestampByDevice.set(resolvedDeviceId, Date.now() / 1000);
   }
-  void pollSensorStatus(deviceId, sessionToken);
+  void pollSensorStatus(resolvedDeviceId, sessionToken);
   sensorPollingIntervalId = window.setInterval(() => {
-    void pollSensorStatus(deviceId, sessionToken);
+    void pollSensorStatus(resolvedDeviceId, sessionToken);
   }, intervalMs);
 }
 

--- a/frontend/vercel.json
+++ b/frontend/vercel.json
@@ -5,10 +5,31 @@
   "crons": [
     {
       "path": "/api/cron/update-knowledge-base",
-      "schedule": "0 2 * * *"
+      "schedule": "30 19 * * *"
     }
   ],
   "functions": {
+    "src/app/api/cron/update-knowledge-base/route.ts": {
+      "maxDuration": 300
+    },
+    "src/app/api/ocr/route.ts": {
+      "maxDuration": 120
+    },
+    "src/app/api/reception/start/route.ts": {
+      "maxDuration": 120
+    },
+    "src/app/api/reception/respond/route.ts": {
+      "maxDuration": 120
+    },
+    "src/app/api/reception/complete/route.ts": {
+      "maxDuration": 120
+    },
+    "src/app/api/reception/status/[receptionSessionId]/route.ts": {
+      "maxDuration": 120
+    },
+    "src/app/api/reception/sensor-status/route.ts": {
+      "maxDuration": 120
+    },
     "src/app/api/voice/route.ts": {
       "maxDuration": 120
     },

--- a/infra/terraform/alerts.tf
+++ b/infra/terraform/alerts.tf
@@ -323,3 +323,73 @@ resource "google_monitoring_alert_policy" "memory_helper_errors" {
     }
   }
 }
+
+resource "google_monitoring_alert_policy" "critical_api_errors" {
+  display_name = "Engineer Cafe critical API errors"
+  combiner     = "OR"
+  enabled      = var.alert_enabled
+
+  notification_channels = var.notification_channel_ids
+
+  documentation {
+    content   = "/api/voice, /api/chat, /api/slides, or /api/error emitted ERROR/5xx logs. See docs/observability-runbook.md."
+    mime_type = "text/markdown"
+  }
+
+  conditions {
+    display_name = "critical API ERROR/5xx count > 0"
+
+    condition_threshold {
+      filter                  = "metric.type=\"logging.googleapis.com/user/${google_logging_metric.api_error_count.name}\" ${local.cloud_run_metric_scope}"
+      comparison              = "COMPARISON_GT"
+      threshold_value         = 0
+      duration                = "0s"
+      evaluation_missing_data = "EVALUATION_MISSING_DATA_INACTIVE"
+
+      aggregations {
+        alignment_period     = "900s"
+        per_series_aligner   = "ALIGN_DELTA"
+        cross_series_reducer = "REDUCE_SUM"
+      }
+
+      trigger {
+        count = 1
+      }
+    }
+  }
+}
+
+resource "google_monitoring_alert_policy" "ltm_connection_errors" {
+  display_name = "Engineer Cafe LTM connection errors"
+  combiner     = "OR"
+  enabled      = var.alert_enabled
+
+  notification_channels = var.notification_channel_ids
+
+  documentation {
+    content   = "Long-term memory connection or timeout errors were logged. See docs/observability-runbook.md."
+    mime_type = "text/markdown"
+  }
+
+  conditions {
+    display_name = "LTM connection/timeout count > 0"
+
+    condition_threshold {
+      filter                  = "metric.type=\"logging.googleapis.com/user/${google_logging_metric.ltm_connection_error_count.name}\" ${local.cloud_run_metric_scope}"
+      comparison              = "COMPARISON_GT"
+      threshold_value         = 0
+      duration                = "0s"
+      evaluation_missing_data = "EVALUATION_MISSING_DATA_INACTIVE"
+
+      aggregations {
+        alignment_period     = "900s"
+        per_series_aligner   = "ALIGN_DELTA"
+        cross_series_reducer = "REDUCE_SUM"
+      }
+
+      trigger {
+        count = 1
+      }
+    }
+  }
+}

--- a/infra/terraform/dashboard.tf
+++ b/infra/terraform/dashboard.tf
@@ -203,6 +203,70 @@ resource "google_monitoring_dashboard" "observability_phase1b" {
               }
             }
           }
+        },
+        {
+          xPos   = 0
+          yPos   = 12
+          width  = 6
+          height = 4
+          widget = {
+            title = "Critical API errors"
+            xyChart = {
+              dataSets = [
+                {
+                  plotType   = "STACKED_BAR"
+                  targetAxis = "Y1"
+                  timeSeriesQuery = {
+                    timeSeriesFilter = {
+                      filter = "metric.type=\"logging.googleapis.com/user/${google_logging_metric.api_error_count.name}\" ${local.cloud_run_metric_scope}"
+                      aggregation = {
+                        alignmentPeriod    = "900s"
+                        perSeriesAligner   = "ALIGN_DELTA"
+                        crossSeriesReducer = "REDUCE_SUM"
+                        groupByFields      = ["metric.label.path", "metric.label.event"]
+                      }
+                    }
+                  }
+                }
+              ]
+              yAxis = {
+                label = "errors / 15m"
+                scale = "LINEAR"
+              }
+            }
+          }
+        },
+        {
+          xPos   = 6
+          yPos   = 12
+          width  = 6
+          height = 4
+          widget = {
+            title = "LTM connection errors"
+            xyChart = {
+              dataSets = [
+                {
+                  plotType   = "STACKED_BAR"
+                  targetAxis = "Y1"
+                  timeSeriesQuery = {
+                    timeSeriesFilter = {
+                      filter = "metric.type=\"logging.googleapis.com/user/${google_logging_metric.ltm_connection_error_count.name}\" ${local.cloud_run_metric_scope}"
+                      aggregation = {
+                        alignmentPeriod    = "900s"
+                        perSeriesAligner   = "ALIGN_DELTA"
+                        crossSeriesReducer = "REDUCE_SUM"
+                        groupByFields      = ["metric.label.logger", "metric.label.event"]
+                      }
+                    }
+                  }
+                }
+              ]
+              yAxis = {
+                label = "errors / 15m"
+                scale = "LINEAR"
+              }
+            }
+          }
         }
       ]
     }

--- a/infra/terraform/log_metrics.tf
+++ b/infra/terraform/log_metrics.tf
@@ -335,3 +335,136 @@ resource "google_logging_metric" "memory_helper_error_count" {
     unit        = "1"
   }
 }
+
+resource "google_logging_metric" "api_error_count" {
+  name        = "engineer_cafe_api_error_count"
+  description = "Count of Cloud Run ERROR/5xx logs for critical API routes."
+  filter      = <<-EOT
+    ${local.cloud_run_filter}
+    (
+      (
+        (
+          httpRequest.requestUrl:"/api/voice"
+          OR httpRequest.requestUrl:"/api/chat"
+          OR httpRequest.requestUrl:"/api/slides"
+          OR httpRequest.requestUrl:"/api/error"
+        )
+        AND httpRequest.status>=500
+      )
+      OR (
+        (
+          jsonPayload.path="/api/voice"
+          OR jsonPayload.path="/api/chat"
+          OR jsonPayload.path="/api/slides"
+          OR jsonPayload.path="/api/error"
+          OR jsonPayload.extra.path="/api/voice"
+          OR jsonPayload.extra.path="/api/chat"
+          OR jsonPayload.extra.path="/api/slides"
+          OR jsonPayload.extra.path="/api/error"
+        )
+        AND (
+          jsonPayload.status_code>=500
+          OR jsonPayload.extra.status_code>=500
+          OR severity>=ERROR
+        )
+      )
+      OR (
+        (
+          textPayload:"/api/voice"
+          OR textPayload:"/api/chat"
+          OR textPayload:"/api/slides"
+          OR textPayload:"/api/error"
+        )
+        AND severity>=ERROR
+      )
+    )
+  EOT
+
+  label_extractors = {
+    event       = "EXTRACT(jsonPayload.event)"
+    path        = "EXTRACT(jsonPayload.path)"
+    status_code = "EXTRACT(jsonPayload.status_code)"
+  }
+
+  metric_descriptor {
+    metric_kind = "DELTA"
+    value_type  = "INT64"
+    unit        = "1"
+
+    labels {
+      key         = "event"
+      value_type  = "STRING"
+      description = "Structured event name when present."
+    }
+    labels {
+      key         = "path"
+      value_type  = "STRING"
+      description = "Structured request path when present."
+    }
+    labels {
+      key         = "status_code"
+      value_type  = "STRING"
+      description = "Structured HTTP status code when present."
+    }
+  }
+}
+
+resource "google_logging_metric" "ltm_connection_error_count" {
+  name        = "engineer_cafe_ltm_connection_error_count"
+  description = "Count of long-term memory connection/timeout errors."
+  filter      = <<-EOT
+    ${local.cloud_run_filter}
+    (
+      jsonPayload.event="ltm_connection_error"
+      OR jsonPayload.event="memory_helper_connection_error"
+      OR (
+        (
+          jsonPayload.logger="backend.utils.memory_helper"
+          OR jsonPayload.logger:"memory_helper"
+          OR jsonPayload.message:"LTM"
+          OR jsonPayload.message:"long-term memory"
+          OR textPayload:"memory_helper"
+          OR textPayload:"LTM"
+          OR textPayload:"long-term memory"
+        )
+        AND (
+          jsonPayload.message:"connection"
+          OR jsonPayload.message:"ConnectionError"
+          OR jsonPayload.message:"connection refused"
+          OR jsonPayload.message:"timeout"
+          OR jsonPayload.exception.message:"connection"
+          OR jsonPayload.exception.message:"ConnectionError"
+          OR jsonPayload.exception.message:"connection refused"
+          OR jsonPayload.exception.message:"timeout"
+          OR textPayload:"connection"
+          OR textPayload:"ConnectionError"
+          OR textPayload:"connection refused"
+          OR textPayload:"timeout"
+        )
+        AND severity>=ERROR
+      )
+    )
+  EOT
+
+  label_extractors = {
+    event  = "EXTRACT(jsonPayload.event)"
+    logger = "EXTRACT(jsonPayload.logger)"
+  }
+
+  metric_descriptor {
+    metric_kind = "DELTA"
+    value_type  = "INT64"
+    unit        = "1"
+
+    labels {
+      key         = "event"
+      value_type  = "STRING"
+      description = "Structured event name when present."
+    }
+    labels {
+      key         = "logger"
+      value_type  = "STRING"
+      description = "Logger name when present."
+    }
+  }
+}

--- a/scripts/cloud-logging-verify.sh
+++ b/scripts/cloud-logging-verify.sh
@@ -38,7 +38,7 @@ Options:
   --timestamp VALUE      Stable timestamp for output names
   --since RFC3339        Override lookback start timestamp
   --until RFC3339        Optional inclusive end timestamp
-  --error-gate-only      Only fail on /api/chat 5xx or persistence error rows
+  --error-gate-only      Only fail on critical API, LTM, or persistence error rows
   --input-dir DIR        Read pre-fetched JSON logs from DIR instead of gcloud (tests)
   --dry-run              Validate local checks and print gcloud filters only
   -h, --help             Show this usage
@@ -129,7 +129,9 @@ event_filter() {
 
 chat_filter="$BASE_FILTER AND (jsonPayload.event=\"chat_response\" OR labels.event=\"chat_response\" OR textPayload:\"chat_response\")"
 chat_5xx_filter="$BASE_FILTER AND ((httpRequest.requestMethod=\"POST\" AND httpRequest.requestUrl:\"/api/chat\" AND httpRequest.status>=500) OR (jsonPayload.path=\"/api/chat\" AND jsonPayload.status_code>=500) OR (jsonPayload.extra.path=\"/api/chat\" AND jsonPayload.extra.status_code>=500) OR (jsonPayload.event=\"request_failed\" AND jsonPayload.path=\"/api/chat\") OR (jsonPayload.event=\"request_completed_slow\" AND jsonPayload.path=\"/api/chat\" AND jsonPayload.status_code>=500) OR (textPayload:\"/api/chat\" AND severity>=ERROR))"
+api_error_filter="$BASE_FILTER AND (((httpRequest.requestUrl:\"/api/voice\" OR httpRequest.requestUrl:\"/api/chat\" OR httpRequest.requestUrl:\"/api/slides\" OR httpRequest.requestUrl:\"/api/error\") AND httpRequest.status>=500) OR ((jsonPayload.path=\"/api/voice\" OR jsonPayload.path=\"/api/chat\" OR jsonPayload.path=\"/api/slides\" OR jsonPayload.path=\"/api/error\" OR jsonPayload.extra.path=\"/api/voice\" OR jsonPayload.extra.path=\"/api/chat\" OR jsonPayload.extra.path=\"/api/slides\" OR jsonPayload.extra.path=\"/api/error\") AND (jsonPayload.status_code>=500 OR jsonPayload.extra.status_code>=500 OR severity>=ERROR)) OR ((textPayload:\"/api/voice\" OR textPayload:\"/api/chat\" OR textPayload:\"/api/slides\" OR textPayload:\"/api/error\") AND severity>=ERROR))"
 memory_filter="$BASE_FILTER AND ((jsonPayload.logger=\"backend.utils.memory_helper\" AND jsonPayload.level=\"ERROR\") OR jsonPayload.event=\"memory_helper_error\" OR (jsonPayload.logger:\"memory_helper\" AND severity>=ERROR) OR (textPayload:\"memory_helper\" AND severity>=ERROR))"
+ltm_connection_filter="$BASE_FILTER AND (jsonPayload.event=\"ltm_connection_error\" OR jsonPayload.event=\"memory_helper_connection_error\" OR ((jsonPayload.logger=\"backend.utils.memory_helper\" OR jsonPayload.logger:\"memory_helper\" OR jsonPayload.message:\"LTM\" OR jsonPayload.message:\"long-term memory\" OR textPayload:\"memory_helper\" OR textPayload:\"LTM\" OR textPayload:\"long-term memory\") AND (jsonPayload.message:\"connection\" OR jsonPayload.message:\"ConnectionError\" OR jsonPayload.message:\"connection refused\" OR jsonPayload.message:\"timeout\" OR jsonPayload.exception.message:\"connection\" OR jsonPayload.exception.message:\"ConnectionError\" OR jsonPayload.exception.message:\"connection refused\" OR jsonPayload.exception.message:\"timeout\" OR textPayload:\"connection\" OR textPayload:\"ConnectionError\" OR textPayload:\"connection refused\" OR textPayload:\"timeout\") AND severity>=ERROR))"
 uuid_hygiene_filter="$BASE_FILTER AND (textPayload:\"invalid input syntax for type uuid\" OR jsonPayload.message:\"invalid input syntax for type uuid\" OR jsonPayload.exception.message:\"invalid input syntax for type uuid\")"
 reception_hygiene_filter="$BASE_FILTER AND (textPayload:\"Reception session persistence failed\" OR jsonPayload.message:\"Reception session persistence failed\")"
 
@@ -147,7 +149,9 @@ if [ "$DRY_RUN" = "1" ]; then
   fi
   echo "Filter[chat_response]: $chat_filter"
   echo "Filter[chat_api_5xx]: $chat_5xx_filter"
+  echo "Filter[critical_api_errors]: $api_error_filter"
   echo "Filter[memory_helper_error]: $memory_filter"
+  echo "Filter[ltm_connection_error]: $ltm_connection_filter"
   echo "Filter[uuid_hygiene]: $uuid_hygiene_filter"
   echo "Filter[reception_hygiene]: $reception_hygiene_filter"
   exit 0
@@ -179,7 +183,9 @@ if [ -z "$INPUT_DIR" ]; then
   fi
   read_logs "$chat_filter" "$TMP_DIR/chat_response.json"
   read_logs "$chat_5xx_filter" "$TMP_DIR/chat_api_5xx.json"
+  read_logs "$api_error_filter" "$TMP_DIR/critical_api_errors.json"
   read_logs "$memory_filter" "$TMP_DIR/memory_helper_errors.json"
+  read_logs "$ltm_connection_filter" "$TMP_DIR/ltm_connection_errors.json"
   read_logs "$uuid_hygiene_filter" "$TMP_DIR/uuid_hygiene.json"
   read_logs "$reception_hygiene_filter" "$TMP_DIR/reception_hygiene.json"
 fi
@@ -329,6 +335,7 @@ for index, data in enumerate(chat_entries):
         chat_missing.append({"index": index, "missing": missing, "data": data})
 
 chat_api_5xx_entries = load("chat_api_5xx")
+critical_api_error_entries = load("critical_api_errors")
 ltm_store_failed = [
     data for data in chat_entries if str(field_value(data, "ltm_store_write")).lower() == "failed"
 ]
@@ -342,6 +349,11 @@ for entry in load("memory_helper_errors"):
         or "memory_helper" in str(entry.get("textPayload", ""))
     ):
         memory_errors.append({**data, "_timestamp": entry.get("timestamp"), "_severity": entry.get("severity")})
+
+ltm_connection_errors = []
+for entry in load("ltm_connection_errors"):
+    data = payload(entry)
+    ltm_connection_errors.append({**data, "_timestamp": entry.get("timestamp"), "_severity": entry.get("severity")})
 
 uuid_hygiene_entries = load("uuid_hygiene")
 reception_hygiene_entries = load("reception_hygiene")
@@ -361,10 +373,14 @@ if not error_gate_only:
         failures.append(f"{len(chat_missing)} chat_response log(s) are missing required fields.")
 if chat_api_5xx_entries:
     failures.append(f"{len(chat_api_5xx_entries)} /api/chat 5xx log row(s) found.")
+if critical_api_error_entries:
+    failures.append(f"{len(critical_api_error_entries)} critical API ERROR/5xx log row(s) found.")
 if ltm_store_failed:
     failures.append(f"{len(ltm_store_failed)} chat_response log(s) reported ltm_store_write=failed.")
 if memory_errors:
     failures.append(f"{len(memory_errors)} memory_helper error log(s) found.")
+if ltm_connection_errors:
+    failures.append(f"{len(ltm_connection_errors)} LTM connection/timeout error log row(s) found.")
 if uuid_hygiene_entries:
     failures.append(
         f"{len(uuid_hygiene_entries)} invalid UUID syntax log(s) found; synthetic alpha IDs are still leaking into UUID queries."
@@ -411,12 +427,20 @@ lines.append(
     f"{len(chat_api_5xx_entries)} matching log row(s) |"
 )
 lines.append(
+    f"| critical API ERROR/5xx rows | {'FAIL' if critical_api_error_entries else 'PASS'} | "
+    f"{len(critical_api_error_entries)} matching /api/voice, /api/chat, /api/slides, or /api/error log row(s) |"
+)
+lines.append(
     f"| `ltm_store_write=failed` rows | {'FAIL' if ltm_store_failed else 'PASS'} | "
     f"{len(ltm_store_failed)} matching chat_response log row(s) |"
 )
 lines.append(
     f"| `memory_helper` ERROR samples | {'FAIL' if memory_errors else 'PASS'} | "
     f"{len(memory_errors)} error log(s) found; samples listed below if present |"
+)
+lines.append(
+    f"| LTM connection/timeout errors | {'FAIL' if ltm_connection_errors else 'PASS'} | "
+    f"{len(ltm_connection_errors)} matching log row(s) |"
 )
 lines.append(
     f"| `invalid input syntax for type uuid` hygiene | {'FAIL' if uuid_hygiene_entries else 'PASS'} | "
@@ -464,11 +488,19 @@ lines.extend([
     "## Cloud Run Error Rows",
     "",
     f"- `/api/chat` 5xx rows: {len(chat_api_5xx_entries)}",
+    f"- Critical API ERROR/5xx rows: {len(critical_api_error_entries)}",
     f"- `ltm_store_write=failed` rows: {len(ltm_store_failed)}",
 ])
 if chat_api_5xx_entries:
     lines.extend(["", "| Timestamp | Severity | Status | Path | Message |", "| --- | --- | ---: | --- | --- |"])
     for entry in chat_api_5xx_entries[:10]:
+        lines.append(
+            f"| {md(entry.get('timestamp'))} | {md(entry.get('severity'))} | "
+            f"{md(entry_http_status(entry))} | {md(entry_path(entry))[:160]} | {md(entry_message(entry))[:500]} |"
+        )
+if critical_api_error_entries:
+    lines.extend(["", "| Timestamp | Severity | Status | Path | Message |", "| --- | --- | ---: | --- | --- |"])
+    for entry in critical_api_error_entries[:10]:
         lines.append(
             f"| {md(entry.get('timestamp'))} | {md(entry.get('severity'))} | "
             f"{md(entry_http_status(entry))} | {md(entry_path(entry))[:160]} | {md(entry_message(entry))[:500]} |"
@@ -494,6 +526,23 @@ if memory_errors:
         lines.append(f"| {md(item.get('_timestamp'))} | {md(item.get('_severity') or item.get('level'))} | {md(message)[:500]} |")
 else:
     lines.append("- No memory_helper error samples in the lookback window.")
+
+lines.extend([
+    "",
+    "## LTM Connection Error Samples",
+    "",
+    f"- Error rows found: {len(ltm_connection_errors)}",
+])
+if ltm_connection_errors:
+    lines.extend(["", "| Timestamp | Severity | Event | Logger | Message |", "| --- | --- | --- | --- | --- |"])
+    for item in ltm_connection_errors[:5]:
+        message = item.get("message") or item.get("msg") or item.get("error") or item.get("event") or ""
+        lines.append(
+            f"| {md(item.get('_timestamp'))} | {md(item.get('_severity') or item.get('level'))} | "
+            f"{md(item.get('event'))} | {md(item.get('logger'))} | {md(message)[:500]} |"
+        )
+else:
+    lines.append("- No LTM connection error samples in the lookback window.")
 
 lines.extend([
     "",

--- a/scripts/validate-p0-cloudrun-vercel-timeouts.mjs
+++ b/scripts/validate-p0-cloudrun-vercel-timeouts.mjs
@@ -8,6 +8,59 @@ const vercelConfigPath = resolve(repoRoot, 'frontend/vercel.json');
 const proxyConfigPath = resolve(repoRoot, 'frontend/src/lib/api/backend-proxy.ts');
 const workflowPath = resolve(repoRoot, '.github/workflows/ci.yml');
 
+function usage() {
+  console.log(`Usage: node scripts/validate-p0-cloudrun-vercel-timeouts.mjs [options]
+
+Options:
+  --live                         Describe live Cloud Run services with gcloud.
+  --skip-live                    Skip live Cloud Run checks.
+  --project ID                   GCP project for live checks.
+  --service NAME                 Backend Cloud Run service.
+  --region REGION                Backend Cloud Run region.
+  --piper-plus-service NAME      Piper Plus Cloud Run service.
+  --piper-plus-region REGION     Piper Plus Cloud Run region.
+  -h, --help                     Show this help.
+
+Environment:
+  CHECK_LIVE_CLOUD_RUN=1         Enables live checks when --live is not passed.
+  CLOUD_RUN_PROJECT              Default project for live checks.
+`);
+}
+
+const args = process.argv.slice(2);
+const cli = {
+  live: process.env.CHECK_LIVE_CLOUD_RUN === '1',
+  project: process.env.CLOUD_RUN_PROJECT || process.env.GCP_PROJECT || process.env.GOOGLE_CLOUD_PROJECT || '',
+};
+
+for (let index = 0; index < args.length; index += 1) {
+  const arg = args[index];
+  const next = () => {
+    index += 1;
+    if (index >= args.length || args[index].startsWith('-')) {
+      console.error(`Missing value for ${arg}`);
+      process.exit(2);
+    }
+    return args[index];
+  };
+
+  if (arg === '--live') cli.live = true;
+  else if (arg === '--skip-live') cli.live = false;
+  else if (arg === '--project') cli.project = next();
+  else if (arg === '--service') process.env.CLOUD_RUN_SERVICE = next();
+  else if (arg === '--region') process.env.CLOUD_RUN_REGION = next();
+  else if (arg === '--piper-plus-service') process.env.PIPER_PLUS_SERVICE = next();
+  else if (arg === '--piper-plus-region') process.env.PIPER_PLUS_REGION = next();
+  else if (arg === '-h' || arg === '--help') {
+    usage();
+    process.exit(0);
+  } else {
+    console.error(`Unknown option: ${arg}`);
+    usage();
+    process.exit(2);
+  }
+}
+
 const expected = {
   service: process.env.CLOUD_RUN_SERVICE || 'engineer-cafe-backend',
   region: process.env.CLOUD_RUN_REGION || 'asia-northeast1',
@@ -75,17 +128,22 @@ if (expected.vercelMaxDurationSeconds >= expected.timeoutSeconds) {
 }
 
 function describeCloudRunService(serviceName, region) {
+  const commandArgs = [
+    'run',
+    'services',
+    'describe',
+    serviceName,
+    '--region',
+    region,
+    '--format=json',
+  ];
+  if (cli.project) {
+    commandArgs.push('--project', cli.project);
+  }
+
   const output = execFileSync(
     'gcloud',
-    [
-      'run',
-      'services',
-      'describe',
-      serviceName,
-      '--region',
-      region,
-      '--format=json',
-    ],
+    commandArgs,
     { encoding: 'utf8' },
   );
   return JSON.parse(output);
@@ -114,7 +172,7 @@ function validateLiveService(service, config) {
   if (cpuThrottling !== config.cpuThrottling) fail(`${config.service} CPU throttling must be disabled`);
 }
 
-if (process.env.CHECK_LIVE_CLOUD_RUN === '1') {
+if (cli.live) {
   try {
     validateLiveService(describeCloudRunService(expected.service, expected.region), expected);
     validateLiveService(describeCloudRunService(expectedPiperPlus.service, expectedPiperPlus.region), expectedPiperPlus);
@@ -122,7 +180,7 @@ if (process.env.CHECK_LIVE_CLOUD_RUN === '1') {
     fail(`could not describe live Cloud Run services: ${error instanceof Error ? error.message : String(error)}`);
   }
 } else {
-  console.log('Skipping live Cloud Run describe; set CHECK_LIVE_CLOUD_RUN=1 to verify deployed service settings.');
+  console.log('Skipping live Cloud Run describe; pass --live or set CHECK_LIVE_CLOUD_RUN=1 to verify deployed service settings.');
 }
 
 if (process.exitCode) {


### PR DESCRIPTION
## Summary
- replace failing DB drift Supabase CLI global install with supabase/setup-cli
- keep CI RAGAS to fast contract tests and cap the optional job at 15 minutes
- harden M5Stack firmware TLS validation / GREETING LCD behavior and add live payload proof support
- move knowledge-base cron outside kiosk hours, add route/embedding timeouts and a production lease guard
- add Cloud Logging metrics, dashboard widgets, alert policies, and validation script coverage for critical API/LTM errors

## Issue closure
Fixes #820
Fixes #821
Fixes #761
Refs #774
Refs #483
Refs #489
Refs #358

## Local validation
- git diff --check
- mise exec -- pnpm lint
- mise exec -- pnpm typecheck
- mise exec -- pnpm build
- mise exec -- pnpm exec tsx --test --import ./src/__tests__/node-test-setup.ts src/__tests__/device-webhook.test.ts src/__tests__/vercel-timeout-hierarchy.test.ts src/__tests__/update-knowledge-base.test.ts
- mise exec -- pnpm exec playwright test --config=playwright.config.ts e2e/m5stack-reception-flow.spec.ts --project=chromium --list
- python -m pytest backend/tests/evaluation/test_ragas_pipeline.py backend/tests/evaluation/test_ragas_pipeline_timeout_guard.py backend/tests/evaluation/test_ragas_ci_integration.py backend/tests/evaluation/test_multilingual_ragas.py -m "not ragas" --tb=short -q
- ruff check . (backend)
- black --check . (backend)
- terraform -chdir=infra/terraform fmt -check
- terraform -chdir=infra/terraform init -backend=false
- terraform -chdir=infra/terraform validate
- node scripts/validate-p0-cloudrun-vercel-timeouts.mjs --skip-live
- scripts/cloud-logging-verify.sh --dry-run --minutes 5 --error-gate-only
- arduino-cli compile --fqbn esp32:esp32:m5stack-core2 /tmp/engineercafe-arduino-sketch/engineercafe-device (isolated config, esp32:esp32@2.0.17, dummy secrets.h)

## Notes
- Full backend test suite was also run locally once; the only failures were integration checkpointer tests attempting to use local .env.local Supabase at 127.0.0.1:54322 while Supabase was not running. With CI-style SUPABASE_DB_URI=postgresql://test:test@localhost:0/test, the affected checkpointer tests skip as expected.