### PR TITLE
[codex] gate deploy success and restore DB drift checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -455,7 +455,7 @@ jobs:
 
   # Backend: Deploy to Cloud Run
   # Only runs on push to develop after backend tests pass
-  # NOTE: This is an optional deploy job - not included in ci-success gate
+  # NOTE: ci-success requires this job to pass for develop pushes with backend changes.
   #
   # Deployment strategy:
   #   - develop branch -> Cloud Run (asia-northeast1) with ENVIRONMENT=production
@@ -587,6 +587,7 @@ jobs:
   # Final status check for branch protection
   ci-success:
     needs:
+      - changes
       - frontend-lint
       - frontend-typecheck
       - frontend-timeout-guard
@@ -595,6 +596,7 @@ jobs:
       - frontend-playwright-voice-live
       - backend-lint
       - backend-test
+      - backend-deploy-staging
     if: always()
     runs-on: ubuntu-latest
     steps:
@@ -613,13 +615,21 @@ jobs:
             "${{ needs.frontend-playwright-e2e.result }}" \
             "${{ needs.frontend-playwright-voice-live.result }}" \
             "${{ needs.backend-lint.result }}" \
-            "${{ needs.backend-test.result }}"; do
+            "${{ needs.backend-test.result }}" \
+            "${{ needs.backend-deploy-staging.result }}"; do
             if [[ "$job_result" == "failure" ]] || [[ "$job_result" == "cancelled" ]]; then
               FAILED=true
             fi
           done
           if [[ "$FAILED" == "true" ]]; then
             echo "One or more jobs failed or were cancelled"
+            exit 1
+          fi
+          if [[ "${{ needs.changes.outputs.backend }}" == "true" \
+            && "${{ github.event_name }}" == "push" \
+            && "${{ github.ref }}" == "refs/heads/develop" \
+            && "${{ needs.backend-deploy-staging.result }}" != "success" ]]; then
+            echo "backend-deploy-staging must complete successfully for develop pushes with backend changes"
             exit 1
           fi
           echo "All CI checks passed (skipped jobs are OK — no changes in that area)"

--- a/.github/workflows/db-schema-drift.yml
+++ b/.github/workflows/db-schema-drift.yml
@@ -7,6 +7,8 @@ on:
   pull_request:
     paths:
       - 'backend/supabase/migrations/**'
+      - 'scripts/check-db-schema-drift.sh'
+      - '.github/workflows/db-schema-drift.yml'
 
 permissions:
   contents: read
@@ -30,8 +32,14 @@ jobs:
         with:
           version: latest
 
+      - name: Skip drift for forked pull requests
+        if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository
+        run: echo "Skipping live drift check because repository secrets are not available to forked pull requests."
+
       - name: Check drift
+        if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
         env:
+          SUPABASE_DB_URI: ${{ secrets.SUPABASE_DB_URI }}
           SUPABASE_ACCESS_TOKEN: ${{ secrets.SUPABASE_ACCESS_TOKEN }}
           SUPABASE_PROJECT_ID: ${{ secrets.SUPABASE_PROJECT_ID }}
           SUPABASE_DB_PASSWORD: ${{ secrets.SUPABASE_DB_PASSWORD }}

--- a/backend/tests/scripts/test_check_db_schema_drift.py
+++ b/backend/tests/scripts/test_check_db_schema_drift.py
@@ -1,0 +1,124 @@
+import os
+import subprocess
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[3]
+SCRIPT = ROOT / "scripts" / "check-db-schema-drift.sh"
+
+
+def _fake_supabase(tmp_path: Path, output: str = "No schema changes found\n") -> dict[str, str]:
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir()
+    calls_file = tmp_path / "supabase-calls.txt"
+    fake = bin_dir / "supabase"
+    fake.write_text(
+        "\n".join(
+            [
+                "#!/usr/bin/env bash",
+                'printf \'%s\\n\' "$*" >> "$SUPABASE_CALLS_FILE"',
+                'if [[ -n "${SUPABASE_FAKE_STDERR:-}" ]]; then',
+                "  printf '%s' \"$SUPABASE_FAKE_STDERR\" >&2",
+                "fi",
+                'if [[ "$1 $2" == "db diff" ]]; then',
+                "  printf '%s' \"$SUPABASE_FAKE_OUTPUT\"",
+                "fi",
+                'exit "${SUPABASE_FAKE_EXIT:-0}"',
+            ]
+        ),
+        encoding="utf-8",
+    )
+    fake.chmod(0o755)
+    return {
+        "PATH": f"{bin_dir}{os.pathsep}{os.environ['PATH']}",
+        "SUPABASE_CALLS_FILE": str(calls_file),
+        "SUPABASE_FAKE_OUTPUT": output,
+    }
+
+
+def _run(tmp_path: Path, env: dict[str, str]) -> subprocess.CompletedProcess[str]:
+    full_env = os.environ.copy()
+    for name in (
+        "SUPABASE_DB_URI",
+        "SUPABASE_DB_URL",
+        "SUPABASE_ACCESS_TOKEN",
+        "SUPABASE_PROJECT_ID",
+        "SUPABASE_DB_PASSWORD",
+    ):
+        full_env.pop(name, None)
+    full_env.update(env)
+    return subprocess.run(
+        ["bash", str(SCRIPT)],
+        cwd=ROOT,
+        env=full_env,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+
+
+def test_requires_db_url_or_legacy_supabase_credentials(tmp_path: Path) -> None:
+    result = _run(tmp_path, _fake_supabase(tmp_path))
+
+    assert result.returncode == 2
+    assert "SUPABASE_DB_URI" in result.stderr
+    assert "SUPABASE_ACCESS_TOKEN" in result.stderr
+
+
+def test_uses_direct_db_uri_to_diff_migrations_against_remote(tmp_path: Path) -> None:
+    env = _fake_supabase(tmp_path)
+    env["SUPABASE_DB_URI"] = "postgresql://postgres:p!ss@example.supabase.co:5432/postgres"
+
+    result = _run(tmp_path, env)
+
+    assert result.returncode == 0, result.stderr
+    calls = Path(env["SUPABASE_CALLS_FILE"]).read_text(encoding="utf-8")
+    assert (
+        "db diff --from migrations --to "
+        "postgresql://postgres:p%21ss@example.supabase.co:5432/postgres --schema public"
+    ) in calls
+    assert "No Supabase schema drift detected." in result.stdout
+
+
+def test_reports_schema_drift_when_direct_diff_outputs_sql(tmp_path: Path) -> None:
+    env = _fake_supabase(tmp_path, output="create table public.example(id bigint);\n")
+    env["SUPABASE_DB_URI"] = "postgresql://postgres:secret@example.supabase.co:5432/postgres"
+
+    result = _run(tmp_path, env)
+
+    assert result.returncode == 1
+    assert "create table public.example" in result.stdout
+    assert "Supabase schema drift detected" in result.stderr
+
+
+def test_redacts_normalized_db_uri_from_supabase_errors(tmp_path: Path) -> None:
+    env = _fake_supabase(tmp_path)
+    env["SUPABASE_DB_URI"] = "postgresql://postgres:p!ss@example.supabase.co:5432/postgres"
+    env["SUPABASE_FAKE_EXIT"] = "1"
+    env["SUPABASE_FAKE_STDERR"] = (
+        "failed to connect to postgresql://postgres:p%21ss@example.supabase.co:5432/postgres"
+    )
+
+    result = _run(tmp_path, env)
+
+    assert result.returncode == 2
+    assert "p!ss" not in result.stderr
+    assert "p%21ss" not in result.stderr
+    assert "<redacted>" in result.stderr
+
+
+def test_keeps_legacy_linked_project_flow(tmp_path: Path) -> None:
+    env = _fake_supabase(tmp_path)
+    env.update(
+        {
+            "SUPABASE_ACCESS_TOKEN": "token",
+            "SUPABASE_PROJECT_ID": "project-ref",
+            "SUPABASE_DB_PASSWORD": "password",
+        }
+    )
+
+    result = _run(tmp_path, env)
+
+    assert result.returncode == 0, result.stderr
+    calls = Path(env["SUPABASE_CALLS_FILE"]).read_text(encoding="utf-8")
+    assert "link --project-ref project-ref --password password" in calls
+    assert "db diff --linked --schema public" in calls

--- a/scripts/check-db-schema-drift.sh
+++ b/scripts/check-db-schema-drift.sh
@@ -1,27 +1,17 @@
 #!/usr/bin/env bash
 # Usage: ./scripts/check-db-schema-drift.sh
-# Required env: SUPABASE_ACCESS_TOKEN, SUPABASE_PROJECT_ID, SUPABASE_DB_PASSWORD
-# Exit 0: no drift / Exit 1: drift detected / Exit 2: missing config or tooling failure
+#
+# Preferred env:
+#   SUPABASE_DB_URI or SUPABASE_DB_URL
+#
+# Legacy env, kept for existing local/operator workflows:
+#   SUPABASE_ACCESS_TOKEN, SUPABASE_PROJECT_ID, SUPABASE_DB_PASSWORD
+#
+# Exit 0: no drift
+# Exit 1: drift detected
+# Exit 2: missing config or tooling failure
 
 set -euo pipefail
-
-required_env=(
-  "SUPABASE_ACCESS_TOKEN"
-  "SUPABASE_PROJECT_ID"
-  "SUPABASE_DB_PASSWORD"
-)
-
-missing_env=()
-for name in "${required_env[@]}"; do
-  if [[ -z "${!name:-}" ]]; then
-    missing_env+=("${name}")
-  fi
-done
-
-if (( ${#missing_env[@]} > 0 )); then
-  printf 'Missing required environment variables: %s\n' "${missing_env[*]}" >&2
-  exit 2
-fi
 
 if ! command -v supabase >/dev/null 2>&1; then
   printf 'Supabase CLI is required. Install it before running this check.\n' >&2
@@ -36,21 +26,113 @@ if [[ ! -f "${supabase_dir}/config.toml" ]]; then
   exit 2
 fi
 
+normalize_db_url() {
+  python3 - "$1" <<'PY'
+import sys
+from urllib.parse import quote, urlsplit, urlunsplit
+
+raw = sys.argv[1]
+parts = urlsplit(raw)
+if not parts.scheme or not parts.hostname:
+    raise SystemExit("invalid database URL")
+
+username = quote(parts.username or "", safe="%")
+password = quote(parts.password or "", safe="%")
+auth = username
+if password:
+    auth = f"{auth}:{password}" if auth else f":{password}"
+
+host = parts.hostname
+if ":" in host and not host.startswith("["):
+    host = f"[{host}]"
+if parts.port:
+    host = f"{host}:{parts.port}"
+
+netloc = f"{auth}@{host}" if auth else host
+print(urlunsplit((parts.scheme, netloc, parts.path, parts.query, parts.fragment)))
+PY
+}
+
+run_supabase() {
+  if command -v timeout >/dev/null 2>&1; then
+    timeout "${SUPABASE_DIFF_TIMEOUT_SECONDS:-540}" supabase "$@"
+  else
+    supabase "$@"
+  fi
+}
+
+mask_secret() {
+  if [[ "${GITHUB_ACTIONS:-}" == "true" && -n "${1:-}" ]]; then
+    printf '::add-mask::%s\n' "$1"
+  fi
+}
+
+redact_stderr_file() {
+  python3 - "$@" <<'PY'
+import sys
+
+path = sys.argv[1]
+secrets = [value for value in sys.argv[2:] if value]
+with open(path, encoding="utf-8", errors="replace") as f:
+    text = f.read()
+for secret in secrets:
+    text = text.replace(secret, "<redacted>")
+sys.stderr.write(text)
+PY
+}
+
+db_url="${SUPABASE_DB_URI:-${SUPABASE_DB_URL:-}}"
+legacy_env_ready=false
+if [[ -n "${SUPABASE_ACCESS_TOKEN:-}" && -n "${SUPABASE_PROJECT_ID:-}" && -n "${SUPABASE_DB_PASSWORD:-}" ]]; then
+  legacy_env_ready=true
+fi
+
+if [[ -z "${db_url}" && "${legacy_env_ready}" != "true" ]]; then
+  printf 'Missing Supabase drift credentials. Set SUPABASE_DB_URI (preferred) or all of: SUPABASE_ACCESS_TOKEN SUPABASE_PROJECT_ID SUPABASE_DB_PASSWORD\n' >&2
+  exit 2
+fi
+
 diff_output_file="$(mktemp)"
-trap 'rm -f "${diff_output_file}"' EXIT
+diff_error_file="$(mktemp)"
+trap 'rm -f "${diff_output_file}" "${diff_error_file}"' EXIT
 
-(
-  cd "${supabase_dir}"
-  supabase link \
+original_pwd="${PWD}"
+diff_status=0
+normalized_db_url=""
+
+cd "${supabase_dir}"
+if [[ -n "${db_url}" ]]; then
+  normalized_db_url="$(normalize_db_url "${db_url}")"
+  mask_secret "${db_url}"
+  mask_secret "${normalized_db_url}"
+  set +e
+  run_supabase db diff --from migrations --to "${normalized_db_url}" --schema public >"${diff_output_file}" 2>"${diff_error_file}"
+  diff_status=$?
+  set -e
+else
+  mask_secret "${SUPABASE_DB_PASSWORD}"
+  set +e
+  run_supabase link \
     --project-ref "${SUPABASE_PROJECT_ID}" \
-    --password "${SUPABASE_DB_PASSWORD}" >/dev/null
+    --password "${SUPABASE_DB_PASSWORD}" >/dev/null 2>"${diff_error_file}"
+  diff_status=$?
+  if [[ "${diff_status}" -eq 0 ]]; then
+    run_supabase db diff --linked --schema public >"${diff_output_file}" 2>>"${diff_error_file}"
+    diff_status=$?
+  fi
+  set -e
+fi
+cd "${original_pwd}"
 
-  supabase db diff --linked --schema public > "${diff_output_file}"
-) || {
+if [[ -s "${diff_error_file}" ]]; then
+  redact_stderr_file "${diff_error_file}" "${db_url}" "${normalized_db_url}" "${SUPABASE_DB_PASSWORD:-}"
+fi
+
+if [[ "${diff_status}" -ne 0 ]]; then
   cat "${diff_output_file}" >&2 || true
   printf 'Supabase schema drift check failed before a reliable drift verdict was produced.\n' >&2
   exit 2
-}
+fi
 
 cat "${diff_output_file}"
 


### PR DESCRIPTION
## Summary

- make `ci-success` wait for `backend-deploy-staging` on develop pushes with backend changes, so the green gate cannot precede Cloud Run deploy/smoke
- restore DB Schema Drift Check with `SUPABASE_DB_URI` support, keeping the legacy linked-project env path as a fallback
- mask both raw and percent-encoded DB URI values and redact Supabase CLI stderr before emitting logs
- skip live drift checks for forked PRs where repository secrets are unavailable, and make drift workflow changes trigger the workflow
- add regression tests for direct DB URI drift checks, redaction, drift detection, missing config, and the legacy flow
- restored the repository `SUPABASE_DB_URI` Actions secret from GCP Secret Manager so the workflow can run without the missing Supabase access-token triplet

## Issues

Refs #824
Refs #823

I am intentionally not using an auto-close keyword so the issues can be closed only after PR CI, develop deploy, and live workflow verification pass.

## Validation

- `go run github.com/rhysd/actionlint/cmd/actionlint@latest .github/workflows/ci.yml .github/workflows/db-schema-drift.yml`
- `ruby` workflow structure check for `ci-success` and `SUPABASE_DB_URI`
- `python -m pytest backend/tests/scripts/test_check_db_schema_drift.py backend/tests/scripts/test_cloud_logging_verify.py -q`
- `ruff check tests/scripts/test_check_db_schema_drift.py`
- `black --check tests/scripts/test_check_db_schema_drift.py`
- `node scripts/validate-p0-cloudrun-vercel-timeouts.mjs --skip-live`

## Notes

Local direct Supabase diff using the remote DB URI reached the command path but did not complete inside a short local 90s cap. The Actions workflow has the normal 10 minute job timeout and the script-level 540s guard; final close for #823 depends on the workflow_dispatch result after this branch is pushed.
