### PR TITLE
Gate live RAGAS on retrieved contexts

### DIFF
--- a/.github/workflows/ragas-evaluation.yml
+++ b/.github/workflows/ragas-evaluation.yml
@@ -2,20 +2,46 @@ name: RAGAS Evaluation
 
 on:
   schedule:
-    - cron: '0 9 * * 1'  # 毎週月曜 9:00 UTC
+    - cron: '0 9 * * 1'  # Weekly Monday 09:00 UTC
   workflow_dispatch:
     inputs:
-      max_cases:
-        description: 'Max evaluation cases'
-        default: '20'
+      mode:
+        description: 'Evaluation mode'
+        default: 'live-api'
+        type: choice
+        options:
+          - offline
+          - live-api
+      case_suite:
+        description: 'Live API case suite'
+        default: 'diagnostic-29'
+        type: choice
+        options:
+          - diagnostic-29
+          - alpha-127
+      base_url:
+        description: 'Live backend base URL. Empty uses the production Cloud Run URL.'
+        default: ''
         type: string
+      languages:
+        description: 'Live API languages as comma or space separated values'
+        default: 'ja,en,zh,ko'
+        type: string
+      check_targets:
+        description: 'Fail live API runs when configured targets are missed'
+        default: true
+        type: boolean
   pull_request:
-    branches: [main]
+    branches: [develop, main]
     paths:
-      - 'backend/tools/enhanced_rag.py'
-      - 'backend/knowledge/**'
+      - '.github/workflows/**'
+      - 'backend/agents/**'
       - 'backend/evaluation/**'
-      - 'backend/tests/fixtures/golden_datasets/**'
+      - 'backend/knowledge/**'
+      - 'backend/tests/evaluation/**'
+      - 'backend/tests/fixtures/**'
+      - 'backend/tools/**'
+      - 'backend/workflows/**'
 
 concurrency:
   group: ragas-${{ github.event.pull_request.number || github.ref }}
@@ -27,13 +53,14 @@ permissions:
 
 env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: 'true'
+  DEFAULT_BACKEND_URL: https://engineer-cafe-backend-639959525777.asia-northeast1.run.app
+  DEFAULT_LANGUAGES: ja,en,zh,ko
 
 jobs:
   ragas-eval:
     name: RAGAS Quality Evaluation
     runs-on: ubuntu-latest
-    continue-on-error: true
-    timeout-minutes: 30
+    timeout-minutes: 180
 
     steps:
       - name: Checkout
@@ -48,22 +75,121 @@ jobs:
         uses: astral-sh/setup-uv@v3
 
       - name: Install dependencies
-        working-directory: backend
         run: |
-          uv pip install -e ".[evaluation]" --system
+          uv pip install -e "./backend[evaluation]" --system
 
-      - name: Run RAGAS evaluation
-        id: ragas
-        working-directory: backend
+      - name: Resolve evaluation inputs
+        id: inputs
+        shell: bash
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          INPUT_MODE: ${{ github.event.inputs.mode }}
+          INPUT_CASE_SUITE: ${{ github.event.inputs.case_suite }}
+          INPUT_BASE_URL: ${{ github.event.inputs.base_url }}
+          INPUT_LANGUAGES: ${{ github.event.inputs.languages }}
+          INPUT_CHECK_TARGETS: ${{ github.event.inputs.check_targets }}
+        run: |
+          set -euo pipefail
+
+          mode="${INPUT_MODE:-live-api}"
+          case_suite="${INPUT_CASE_SUITE:-diagnostic-29}"
+          base_url="${INPUT_BASE_URL:-$DEFAULT_BACKEND_URL}"
+          languages="${INPUT_LANGUAGES:-$DEFAULT_LANGUAGES}"
+          check_targets="${INPUT_CHECK_TARGETS:-true}"
+
+          if [[ "$EVENT_NAME" == "pull_request" ]]; then
+            mode="offline"
+            check_targets="false"
+          fi
+
+          if [[ "$EVENT_NAME" == "schedule" ]]; then
+            mode="live-api"
+            case_suite="alpha-127"
+            base_url="$DEFAULT_BACKEND_URL"
+            languages="$DEFAULT_LANGUAGES"
+            check_targets="true"
+          fi
+
+          if [[ "$mode" != "offline" && "$mode" != "live-api" ]]; then
+            echo "mode must be offline or live-api, got: $mode" >&2
+            exit 2
+          fi
+
+          if [[ "$case_suite" != "diagnostic-29" && "$case_suite" != "alpha-127" ]]; then
+            echo "case_suite must be diagnostic-29 or alpha-127, got: $case_suite" >&2
+            exit 2
+          fi
+
+          case "$check_targets" in
+            true|false) ;;
+            *) echo "check_targets must be true or false, got: $check_targets" >&2; exit 2 ;;
+          esac
+
+          normalized_languages="$(printf '%s' "$languages" | tr ',' ' ' | xargs)"
+          if [[ -z "$normalized_languages" ]]; then
+            echo "languages must not be empty" >&2
+            exit 2
+          fi
+          for language in $normalized_languages; do
+            case "$language" in
+              ja|en|zh|ko) ;;
+              *) echo "Unsupported language: $language" >&2; exit 2 ;;
+            esac
+          done
+
+          echo "mode=$mode" >> "$GITHUB_OUTPUT"
+          echo "case_suite=$case_suite" >> "$GITHUB_OUTPUT"
+          echo "base_url=$base_url" >> "$GITHUB_OUTPUT"
+          echo "languages=$normalized_languages" >> "$GITHUB_OUTPUT"
+          echo "check_targets=$check_targets" >> "$GITHUB_OUTPUT"
+
+      - name: Run live API RAGAS evaluation
+        id: ragas-live
+        if: steps.inputs.outputs.mode == 'live-api'
+        env:
+          API_SECRET_KEY: ${{ secrets.BACKEND_API_KEY }}
+          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+          OPENROUTER_API_KEY: ${{ secrets.OPENROUTER_API_KEY }}
+          SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
+          SUPABASE_KEY: ${{ secrets.SUPABASE_KEY }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          cmd=(
+            python -m backend.evaluation.run_live_api_eval
+            --base-url "${{ steps.inputs.outputs.base_url }}"
+            --case-suite "${{ steps.inputs.outputs.case_suite }}"
+            --languages ${{ steps.inputs.outputs.languages }}
+            --output-dir ./backend/reports
+            --report-timestamp "run-${{ github.run_id }}-${{ github.run_attempt }}"
+          )
+          if [[ "${{ steps.inputs.outputs.check_targets }}" == "true" ]]; then
+            cmd+=(--check-targets)
+          fi
+          "${cmd[@]}"
+
+      - name: Run PR offline quality gate
+        id: ragas-pr-offline
+        if: steps.inputs.outputs.mode == 'offline' && github.event_name == 'pull_request'
+        run: |
+          python -m backend.evaluation.run_offline_quality_gate \
+            --languages ${{ steps.inputs.outputs.languages }} \
+            --max-cases 2 \
+            --output-dir ./backend/reports \
+            --enforce
+
+      - name: Run manual offline RAGAS evaluation
+        id: ragas-offline
+        if: steps.inputs.outputs.mode == 'offline' && github.event_name != 'pull_request'
         env:
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
           OPENROUTER_API_KEY: ${{ secrets.OPENROUTER_API_KEY }}
           SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
           SUPABASE_KEY: ${{ secrets.SUPABASE_KEY }}
         run: |
-          python -m tests.evaluation.run_ragas_evaluation \
-            --max-cases ${{ github.event.inputs.max_cases || '20' }} \
-            --output-dir ./reports \
+          python -m backend.tests.evaluation.run_ragas_evaluation \
+            --max-cases 20 \
+            --output-dir ./backend/reports \
             --ci-mode
 
       - name: Upload reports
@@ -75,21 +201,47 @@ jobs:
           retention-days: 30
 
       - name: Comment PR with results
-        if: github.event_name == 'pull_request'
+        if: always() && github.event_name == 'pull_request'
         uses: actions/github-script@v9.0.0
         with:
           script: |
             const fs = require('fs');
             const path = require('path');
 
-            // Read the latest report
             const reportsDir = 'backend/reports';
             let summaryContent = '## RAGAS Evaluation Results\n\n';
+            summaryContent += `**Mode**: ${{ steps.inputs.outputs.mode }}\n`;
+            summaryContent += `**Case suite**: ${{ steps.inputs.outputs.case_suite }}\n`;
+            summaryContent += `**Languages**: ${{ steps.inputs.outputs.languages }}\n`;
+            summaryContent += `**Check targets**: ${{ steps.inputs.outputs.check_targets }}\n\n`;
 
             try {
-              const files = fs.readdirSync(reportsDir).filter(f => f.startsWith('ragas_report_'));
-              if (files.length > 0) {
-                const latestReport = files.sort().pop();
+              const files = fs.readdirSync(reportsDir);
+              const liveReports = files.filter(f => f.startsWith('live_api_eval_') && f.endsWith('.json'));
+              const offlineReports = files.filter(f => f.startsWith('ragas_report_') && f.endsWith('.json'));
+              const offlineQualityReports = files.filter(f => f.startsWith('offline_quality_gate_') && f.endsWith('.json'));
+
+              if (liveReports.length > 0) {
+                const latestReport = liveReports.sort().pop();
+                const report = JSON.parse(fs.readFileSync(path.join(reportsDir, latestReport), 'utf8'));
+                const comparison = report.comparison || {};
+                const evalSummary = report.evaluation_summary || comparison.evaluation_summary || {};
+
+                summaryContent += `**All targets met**: ${comparison.all_targets_met ? 'YES' : 'NO'}\n`;
+                summaryContent += `**Alpha release gate met**: ${comparison.alpha_release_gate_met ? 'YES' : 'NO'}\n`;
+                summaryContent += `**Cases**: requested ${evalSummary.requested_total_cases || 0}, collected ${evalSummary.collected_total_cases || 0}, evaluated ${evalSummary.evaluated_total_cases || 0}\n\n`;
+
+                const perLanguage = report.per_language || {};
+                summaryContent += '| Language | Answer Correctness | Target | Status |\n';
+                summaryContent += '|----------|--------------------|--------|--------|\n';
+                for (const [language, result] of Object.entries(perLanguage)) {
+                  const actual = result.metrics?.answer_correctness;
+                  const target = comparison.per_language?.[language]?.answer_correctness?.target;
+                  const passed = comparison.per_language?.[language]?.passed;
+                  summaryContent += `| ${language} | ${typeof actual === 'number' ? actual.toFixed(3) : 'n/a'} | ${typeof target === 'number' ? target.toFixed(2) : 'n/a'} | ${passed ? 'PASS' : 'FAIL'} |\n`;
+                }
+              } else if (offlineReports.length > 0) {
+                const latestReport = offlineReports.sort().pop();
                 const report = JSON.parse(fs.readFileSync(path.join(reportsDir, latestReport), 'utf8'));
 
                 if (report.metrics) {
@@ -100,6 +252,20 @@ jobs:
                   summaryContent += `\n**Cases**: ${report.evaluated_cases || 0} evaluated, ${report.skipped_cases || 0} skipped\n`;
                 } else {
                   summaryContent += '_No metrics available. Check the evaluation logs._\n';
+                }
+              } else if (offlineQualityReports.length > 0) {
+                const latestReport = offlineQualityReports.sort().pop();
+                const report = JSON.parse(fs.readFileSync(path.join(reportsDir, latestReport), 'utf8'));
+                const signals = report.quality_signals || {};
+                const overall = signals.overall || {};
+
+                summaryContent += `**Deterministic PR quality gate**: ${overall.passed ? 'PASS' : 'FAIL'}\n`;
+                summaryContent += `**Cases**: ${overall.case_count || 0} scored, ${overall.failed_case_count || 0} failed\n\n`;
+                summaryContent += '| Scope | Cases | Failed | Language | Grounded | Hallucination Risk | Toxicity | Status |\n';
+                summaryContent += '|-------|------:|-------:|---------:|---------:|-------------------:|---------:|--------|\n';
+                const rows = [['overall', overall], ...Object.entries(signals.per_language || {})];
+                for (const [scope, row] of rows) {
+                  summaryContent += `| ${scope} | ${row.case_count || 0} | ${row.failed_case_count || 0} | ${typeof row.language_match === 'number' ? row.language_match.toFixed(3) : 'n/a'} | ${typeof row.groundedness === 'number' ? row.groundedness.toFixed(3) : 'n/a'} | ${typeof row.hallucination_risk === 'number' ? row.hallucination_risk.toFixed(3) : 'n/a'} | ${typeof row.toxicity === 'number' ? row.toxicity.toFixed(3) : 'n/a'} | ${row.passed ? 'PASS' : 'FAIL'} |\n`;
                 }
               } else {
                 summaryContent += '_No report files found._\n';

--- a/backend/agents/event_agent.py
+++ b/backend/agents/event_agent.py
@@ -54,7 +54,12 @@ class EventAgent:
         self.llm_provider = get_llm_provider()
 
     async def answer_event_query(
-        self, query: str, language: str = "ja", session_id: Optional[str] = None
+        self,
+        query: str,
+        language: str = "ja",
+        session_id: Optional[str] = None,
+        *,
+        include_evidence: bool = False,
     ) -> Dict:
         """イベントクエリに回答
 
@@ -197,16 +202,33 @@ class EventAgent:
                 )
                 if count > 0
             ] or ["google_calendar", "connpass"]
+            metadata = {
+                "agent": "EventAgent",
+                "time_range": time_range,
+                "event_count": event_count,
+                "sources": sources,
+            }
+            if include_evidence:
+                metadata["rag_evidence"] = {
+                    "source": "event_agent",
+                    "category": "event",
+                    "context_char_count": len(events_text),
+                    "contexts": [events_text],
+                    "results": [
+                        {
+                            "source": event.get("source", "unknown"),
+                            "title": event.get("title"),
+                            "start": event.get("start"),
+                            "content": self._format_event_evidence_line(event, language),
+                        }
+                        for event in events[:10]
+                    ],
+                }
 
             return {
                 "answer": response_text,
                 "emotion": emotion,
-                "metadata": {
-                    "agent": "EventAgent",
-                    "time_range": time_range,
-                    "event_count": event_count,
-                    "sources": sources,
-                },
+                "metadata": metadata,
             }
 
         except Exception as e:
@@ -234,6 +256,15 @@ class EventAgent:
             rest = stripped[len("[happy]") :]
             return f"{leading_ws}[sad]{rest}"
         return response_text
+
+    @staticmethod
+    def _format_event_evidence_line(event: Dict, language: str) -> str:
+        title = event.get("title") or event.get("event_title") or "Untitled event"
+        start = event.get("start") or event.get("started_at") or ""
+        source = event.get("source") or "unknown"
+        if language == "ja":
+            return f"{title} / 開始: {start} / source: {source}"
+        return f"{title} / starts: {start} / source: {source}"
 
     def _format_calendar_events(self, events: list, language: str) -> str:
         """イベントを整形（Google Calendar + Connpass両対応）

--- a/backend/evaluation/quality_signals.py
+++ b/backend/evaluation/quality_signals.py
@@ -53,6 +53,8 @@ class QualitySignalCaseResult:
     toxicity: float
     passed: bool
     failures: list[str] = field(default_factory=list)
+    cross_lingual_context: bool = False
+    reference_grounding_context: bool = False
 
 
 def script_counts(text: str) -> Counter[str]:
@@ -124,6 +126,47 @@ def evidence_units(text: str) -> set[str]:
     return units
 
 
+def _dominant_language_hint(text: str) -> str | None:
+    counts = script_counts(text)
+    latin_words = _LATIN_WORD_RE.findall(text)
+    non_latin = counts["kana"] + counts["cjk"] + counts["hangul"]
+    if counts["hangul"] > 0 and counts["hangul"] >= counts["kana"] + counts["cjk"]:
+        return "ko"
+    if counts["kana"] > 0:
+        return "ja"
+    if len(latin_words) >= 3 and non_latin == 0:
+        return "en"
+    if counts["cjk"] > 0 and counts["hangul"] == 0 and counts["kana"] == 0:
+        return "zh"
+    return None
+
+
+def _is_cross_lingual_context(expected_language: str, contexts: Iterable[str]) -> bool:
+    context_text = "\n".join(str(context) for context in contexts if str(context).strip())
+    if not context_text.strip() or expected_language not in SUPPORTED_LANGUAGES:
+        return False
+
+    context_language = _dominant_language_hint(context_text)
+    if context_language is None:
+        return False
+    if expected_language == context_language:
+        return False
+
+    # Kanji-only context is ambiguous between Japanese and Chinese; do not
+    # exempt Japanese answers from grounding on that weak signal alone.
+    if expected_language == "ja" and context_language == "zh":
+        return False
+    return True
+
+
+def _reference_grounding_text(case: dict[str, Any]) -> str:
+    for key in ("reference_answer", "ground_truth"):
+        text = str(case.get(key) or "").strip()
+        if text:
+            return text
+    return ""
+
+
 def _char_ngrams(text: str, *, size: int) -> set[str]:
     compact = "".join(char for char in text if not char.isspace())
     if not compact:
@@ -157,18 +200,27 @@ def score_case(
     case: dict[str, Any],
     *,
     thresholds: dict[str, float] | None = None,
+    include_ground_truth_context: bool = True,
 ) -> QualitySignalCaseResult:
     """Score one evaluation case and apply offline gate thresholds."""
     gate = {**DEFAULT_THRESHOLDS, **(thresholds or {})}
     answer = str(case.get("answer") or "")
-    contexts = [str(context) for context in case.get("contexts") or []]
-    if case.get("ground_truth"):
-        contexts.append(str(case["ground_truth"]))
     language = str(case.get("language") or "unknown")
     case_id = str(case.get("query_id") or case.get("id") or case.get("ground_truth_id") or "")
+    contexts = [str(context) for context in case.get("contexts") or []]
+    cross_lingual_context = _is_cross_lingual_context(language, contexts)
+    reference_text = _reference_grounding_text(case)
+    reference_grounding_context = False
+    grounding_contexts = list(contexts)
+    if include_ground_truth_context and reference_text:
+        grounding_contexts.append(reference_text)
+        reference_grounding_context = True
+    elif cross_lingual_context and reference_text:
+        grounding_contexts.append(reference_text)
+        reference_grounding_context = True
 
     language_match = language_match_score(answer, language)
-    groundedness = groundedness_score(answer, contexts)
+    groundedness = groundedness_score(answer, grounding_contexts)
     hallucination_risk = 1.0 - groundedness if answer.strip() else 1.0
     toxicity = toxicity_score(answer)
 
@@ -191,6 +243,8 @@ def score_case(
         toxicity=round(toxicity, 4),
         passed=not failures,
         failures=failures,
+        cross_lingual_context=cross_lingual_context,
+        reference_grounding_context=reference_grounding_context,
     )
 
 
@@ -198,9 +252,17 @@ def summarize_quality_signals(
     cases: Iterable[dict[str, Any]],
     *,
     thresholds: dict[str, float] | None = None,
+    include_ground_truth_context: bool = True,
 ) -> dict[str, Any]:
     """Aggregate offline signal scores across multilingual RAG cases."""
-    results = [score_case(case, thresholds=thresholds) for case in cases]
+    results = [
+        score_case(
+            case,
+            thresholds=thresholds,
+            include_ground_truth_context=include_ground_truth_context,
+        )
+        for case in cases
+    ]
     by_language: dict[str, list[QualitySignalCaseResult]] = defaultdict(list)
     for result in results:
         by_language[result.language].append(result)
@@ -238,6 +300,8 @@ def _summarize_results(results: list[QualitySignalCaseResult]) -> dict[str, Any]
             "groundedness": 0.0,
             "hallucination_risk": 0.0,
             "toxicity": 0.0,
+            "cross_lingual_context_case_count": 0,
+            "reference_grounding_context_case_count": 0,
         }
 
     return {
@@ -248,6 +312,12 @@ def _summarize_results(results: list[QualitySignalCaseResult]) -> dict[str, Any]
         "groundedness": _average(result.groundedness for result in results),
         "hallucination_risk": _average(result.hallucination_risk for result in results),
         "toxicity": _average(result.toxicity for result in results),
+        "cross_lingual_context_case_count": sum(
+            1 for result in results if result.cross_lingual_context
+        ),
+        "reference_grounding_context_case_count": sum(
+            1 for result in results if result.reference_grounding_context
+        ),
     }
 
 
@@ -268,4 +338,6 @@ def _result_to_dict(result: QualitySignalCaseResult) -> dict[str, Any]:
         "toxicity": result.toxicity,
         "passed": result.passed,
         "failures": result.failures,
+        "cross_lingual_context": result.cross_lingual_context,
+        "reference_grounding_context": result.reference_grounding_context,
     }

--- a/backend/evaluation/run_live_api_eval.py
+++ b/backend/evaluation/run_live_api_eval.py
@@ -50,6 +50,9 @@ LOCAL_KNOWLEDGE_SOURCE_REQUIREMENT = "enhanced_rag|knowledge_base|knowledge_base
 EVENT_SOURCE_REQUIREMENT = f"google_calendar|connpass|{LOCAL_KNOWLEDGE_SOURCE_REQUIREMENT}"
 NO_SOURCE_REQUIRED_CATEGORIES = {"emergency", "farewell", "reception"}
 EVENT_LIKE_CATEGORIES = {"event", "community", "clarification"}
+LIVE_CONTEXT_REQUIRED_SOURCE_LABEL = "live_api_metadata"
+MISSING_LIVE_CONTEXT_SOURCE_LABEL = "missing_live_contexts"
+GOLDEN_NO_SOURCE_CONTEXT_LABEL = "golden_dataset_no_live_source_required"
 EMERGENCY_TERMS = (
     "緊急",
     "避難",
@@ -111,6 +114,205 @@ def _source_requirement_ok(
         if not any(alt in actual_sources for alt in alternatives):
             missing.append(requirement)
     return not missing, missing, actual_sources
+
+
+def _dedupe_contexts(contexts: Sequence[str]) -> List[str]:
+    seen: set[str] = set()
+    deduped: List[str] = []
+    for context in contexts:
+        text = str(context or "").strip()
+        if not text or text in seen:
+            continue
+        seen.add(text)
+        deduped.append(text)
+    return deduped
+
+
+def _contexts_from_result_items(value: Any) -> List[str]:
+    contexts: List[str] = []
+    if not isinstance(value, list):
+        return contexts
+    for item in value:
+        if not isinstance(item, dict):
+            continue
+        for key in ("content", "text", "snippet", "summary"):
+            text = str(item.get(key) or "").strip()
+            if text:
+                contexts.append(text)
+                break
+    return contexts
+
+
+def _contexts_from_container(value: Any) -> List[str]:
+    if isinstance(value, str):
+        return [value]
+    if isinstance(value, list):
+        contexts: List[str] = []
+        for item in value:
+            if isinstance(item, str):
+                contexts.append(item)
+            elif isinstance(item, dict):
+                contexts.extend(_contexts_from_container(item))
+        return contexts
+    if not isinstance(value, dict):
+        return []
+
+    contexts: List[str] = []
+    for key in ("contexts", "retrieved_contexts", "rag_contexts"):
+        contexts.extend(_contexts_from_container(value.get(key)))
+    for key in ("context", "context_string", "text", "content"):
+        text = str(value.get(key) or "").strip()
+        if text:
+            contexts.append(text)
+    contexts.extend(_contexts_from_result_items(value.get("results")))
+    contexts.extend(_contexts_from_result_items(value.get("chunks")))
+    return contexts
+
+
+def _extract_live_contexts(metadata: Dict[str, Any]) -> Dict[str, Any]:
+    """Extract retrieved context evidence exposed by live /api/chat metadata."""
+    candidates: list[tuple[str, Any]] = [
+        ("rag_evidence", metadata.get("rag_evidence")),
+        ("retrieved_contexts", metadata.get("retrieved_contexts")),
+        ("evidence", metadata.get("evidence")),
+        ("retrieval_evidence", metadata.get("retrieval_evidence")),
+        ("evaluation_context", metadata.get("evaluation_context")),
+        ("knowledge_results", metadata.get("knowledge_results")),
+        ("metadata", metadata),
+    ]
+    for source, value in candidates:
+        contexts = _dedupe_contexts(_contexts_from_container(value))
+        if contexts:
+            return {
+                "source": source,
+                "contexts": contexts,
+                "context_count": len(contexts),
+                "context_char_count": sum(len(context) for context in contexts),
+            }
+    return {
+        "source": None,
+        "contexts": [],
+        "context_count": 0,
+        "context_char_count": 0,
+    }
+
+
+def _live_context_check(
+    *,
+    required_sources: Sequence[str],
+    live_contexts: Dict[str, Any],
+    enabled: bool,
+) -> Dict[str, Any]:
+    gate_enabled = enabled and bool(required_sources)
+    context_count = int(live_contexts.get("context_count", 0) or 0)
+    return {
+        "enabled": gate_enabled,
+        "passed": (not gate_enabled) or context_count > 0,
+        "required_sources": list(required_sources),
+        "context_source": live_contexts.get("source"),
+        "context_count": context_count,
+        "context_char_count": int(live_contexts.get("context_char_count", 0) or 0),
+    }
+
+
+def _evaluation_contexts_for_case(
+    *,
+    live_contexts: Dict[str, Any],
+    golden_contexts: Sequence[str],
+    required_sources: Sequence[str],
+) -> tuple[List[str], str]:
+    contexts = [str(context) for context in live_contexts.get("contexts", []) if context]
+    if contexts:
+        return contexts, LIVE_CONTEXT_REQUIRED_SOURCE_LABEL
+    if required_sources:
+        return [], MISSING_LIVE_CONTEXT_SOURCE_LABEL
+    return [str(context) for context in golden_contexts], GOLDEN_NO_SOURCE_CONTEXT_LABEL
+
+
+def _summarize_live_quality_signals(cases: Sequence[Dict[str, Any]]) -> Dict[str, Any]:
+    quality_cases = [case for case in cases if case.get("quality_signal_enabled")]
+    scorable_cases = [
+        case for case in quality_cases if (case.get("live_context_check") or {}).get("passed", True)
+    ]
+    missing_context_failures = [
+        {
+            "case_id": str(case.get("query_id") or case.get("id") or case.get("ground_truth_id")),
+            "language": str(case.get("language") or "unknown"),
+            "failures": [MISSING_LIVE_CONTEXT_SOURCE_LABEL],
+        }
+        for case in quality_cases
+        if (case.get("live_context_check") or {}).get("enabled")
+        and not (case.get("live_context_check") or {}).get("passed")
+    ]
+    try:
+        from backend.evaluation.quality_signals import summarize_quality_signals
+    except ImportError:
+        from evaluation.quality_signals import summarize_quality_signals
+
+    summary = summarize_quality_signals(
+        scorable_cases,
+        include_ground_truth_context=False,
+    )
+    if missing_context_failures:
+        _inject_missing_context_quality_failures(summary, missing_context_failures)
+    summary["enabled"] = True
+    summary["source"] = "live_retrieved_context"
+    return summary
+
+
+def _inject_missing_context_quality_failures(
+    summary: Dict[str, Any],
+    missing_context_failures: Sequence[Dict[str, Any]],
+) -> None:
+    """Add live context gate failures to deterministic quality-signal output."""
+    summary["failed_cases"] = list(summary.get("failed_cases", [])) + list(missing_context_failures)
+    summary_cases = list(summary.get("cases", []))
+    for failure in missing_context_failures:
+        summary_cases.append(
+            {
+                "case_id": failure["case_id"],
+                "language": failure["language"],
+                "language_match": 0.0,
+                "groundedness": 0.0,
+                "hallucination_risk": 1.0,
+                "toxicity": 0.0,
+                "passed": False,
+                "failures": [MISSING_LIVE_CONTEXT_SOURCE_LABEL],
+            }
+        )
+    summary["cases"] = summary_cases
+
+    by_language: Dict[str, int] = {}
+    for failure in missing_context_failures:
+        language = str(failure["language"])
+        by_language[language] = by_language.get(language, 0) + 1
+
+    overall = summary.setdefault("overall", {})
+    overall["case_count"] = int(overall.get("case_count", 0) or 0) + len(missing_context_failures)
+    overall["failed_case_count"] = int(overall.get("failed_case_count", 0) or 0) + len(
+        missing_context_failures
+    )
+    overall["passed"] = False
+
+    per_language = summary.setdefault("per_language", {})
+    for language, count in by_language.items():
+        language_summary = per_language.setdefault(
+            language,
+            {
+                "case_count": 0,
+                "passed": True,
+                "failed_case_count": 0,
+                "language_match": 0.0,
+                "groundedness": 0.0,
+                "hallucination_risk": 0.0,
+                "toxicity": 0.0,
+            },
+        )
+        language_summary["case_count"] = int(language_summary.get("case_count", 0) or 0) + count
+        language_summary["failed_case_count"] = (
+            int(language_summary.get("failed_case_count", 0) or 0) + count
+        )
+        language_summary["passed"] = False
 
 
 def _load_multilingual_config() -> Dict[str, Any]:
@@ -422,6 +624,9 @@ async def _call_chat_api(
     payload = {
         "query": question,
         "language": language,
+        "context": {
+            "include_rag_evidence": True,
+        },
     }
 
     url = f"{base_url.rstrip('/')}/api/chat"
@@ -621,6 +826,17 @@ async def run_live_api_evaluation(
                     sources_ok, missing_sources, actual_sources = _source_requirement_ok(
                         metadata_dict, required_sources
                     )
+                    live_contexts = _extract_live_contexts(metadata_dict)
+                    evaluation_contexts, evaluation_context_source = _evaluation_contexts_for_case(
+                        live_contexts=live_contexts,
+                        golden_contexts=gt_case.get("contexts", []),
+                        required_sources=required_sources,
+                    )
+                    live_context_check = _live_context_check(
+                        required_sources=required_sources,
+                        live_contexts=live_contexts,
+                        enabled=check_live_sources,
+                    )
 
                     lang_cases.append(
                         {
@@ -628,12 +844,15 @@ async def run_live_api_evaluation(
                             "ground_truth_id": gt_id,
                             "question": query["question"],
                             "answer": answer,
-                            "contexts": gt_case.get("contexts", []),
+                            "contexts": evaluation_contexts,
                             "ground_truth": gt_case.get("ground_truth", ""),
+                            "reference_answer": gt_case.get("answer", ""),
                             "language": lang,
                             "category": query["category"],
                             "metadata": query["metadata"],
-                            "evaluation_context_source": "golden_dataset",
+                            "evaluation_context_source": evaluation_context_source,
+                            "quality_signal_enabled": check_live_sources and bool(required_sources),
+                            "live_context_check": live_context_check,
                             "live_source_check": {
                                 "enabled": check_live_sources,
                                 "passed": sources_ok,
@@ -647,6 +866,8 @@ async def run_live_api_evaluation(
                                 "route": metadata_dict.get("route"),
                                 "sources": metadata_dict.get("sources"),
                                 "elapsed_seconds": round(elapsed, 2),
+                                "live_context_source": live_contexts.get("source"),
+                                "live_context_count": live_contexts.get("context_count", 0),
                             },
                         }
                     )
@@ -814,6 +1035,7 @@ async def run_live_api_evaluation(
                         "answer": c["answer"][:200],
                         "api_metadata": c["api_metadata"],
                         "evaluation_context_source": c["evaluation_context_source"],
+                        "live_context_check": c["live_context_check"],
                         "live_source_check": c["live_source_check"],
                     }
                     for c in cases
@@ -869,6 +1091,7 @@ async def run_live_api_evaluation(
                     "error": result.error,
                     "api_metadata": case["api_metadata"],
                     "evaluation_context_source": case["evaluation_context_source"],
+                    "live_context_check": case["live_context_check"],
                     "live_source_check": case["live_source_check"],
                 }
             )
@@ -925,11 +1148,18 @@ async def run_live_api_evaluation(
         requested_total=requested_total,
     )
     evaluation_summary = _evaluation_summary(per_language_results, selected_languages)
+    quality_signals = _summarize_live_quality_signals(
+        [case for cases in all_eval_cases.values() for case in cases]
+    )
     comparison = _compare_targets(
-        per_language_results, selected_languages, check_live_sources=check_live_sources
+        per_language_results,
+        selected_languages,
+        check_live_sources=check_live_sources,
+        quality_signals=quality_signals,
     )
     comparison["suite_coverage"] = suite_coverage
     comparison["evaluation_summary"] = evaluation_summary
+    comparison["quality_signals"] = quality_signals
     comparison["ragas_judge"] = ragas_judge_metadata
     comparison["alpha_release_gate_met"] = (
         comparison["all_targets_met"]
@@ -954,7 +1184,8 @@ async def run_live_api_evaluation(
         "base_url": base_url,
         "languages": selected_languages,
         "metrics": list(selected_metrics),
-        "ragas_context_source": "golden_dataset",
+        "ragas_context_source": LIVE_CONTEXT_REQUIRED_SOURCE_LABEL,
+        "quality_signals": quality_signals,
         "ragas_judge": ragas_judge_metadata,
         "live_source_gate_enabled": check_live_sources,
         "artifact_metadata": {
@@ -1002,11 +1233,13 @@ def _compare_targets(
     languages: Sequence[str],
     *,
     check_live_sources: bool,
+    quality_signals: Dict[str, Any],
 ) -> Dict[str, Any]:
     """Compare per-language answer_correctness against targets."""
     failed: List[Dict[str, Any]] = []
     failed_source_cases: List[Dict[str, Any]] = []
     per_language: Dict[str, Any] = {}
+    quality_by_language = quality_signals.get("per_language", {})
 
     for lang in languages:
         result = lang_results.get(lang, {})
@@ -1042,7 +1275,18 @@ def _compare_targets(
             and collection_error_count == 0
             and ragas_error_count == 0
         )
-        passed = answer_target_passed and not source_failures and evaluation_complete
+        language_quality_signals = quality_by_language.get(
+            lang,
+            {
+                "case_count": 0,
+                "passed": True,
+                "failed_case_count": 0,
+            },
+        )
+        quality_passed = bool(language_quality_signals.get("passed", True))
+        passed = (
+            answer_target_passed and not source_failures and evaluation_complete and quality_passed
+        )
         per_language[lang] = {
             "answer_correctness": {
                 "actual": (round(actual, 4) if isinstance(actual, (int, float)) else None),
@@ -1062,6 +1306,7 @@ def _compare_targets(
                 "failed_case_count": len(source_failures),
                 "passed": not source_failures,
             },
+            "quality_signals": language_quality_signals,
             "passed": passed,
         }
 
@@ -1083,6 +1328,9 @@ def _compare_targets(
                     "collection_errors": collection_error_count,
                     "ragas_errors": ragas_error_count,
                     "source_failures": len(source_failures),
+                    "quality_signal_failures": int(
+                        language_quality_signals.get("failed_case_count", 0) or 0
+                    ),
                 }
             )
         failed_source_cases.extend(source_failures)
@@ -1115,7 +1363,8 @@ def _format_report(
         "",
         f"Case suite: {case_suite}",
         f"Targets: {target_summary}",
-        "RAGAS contexts: golden_dataset references, not live retrieved chunks",
+        "RAGAS contexts: live /api/chat retrieved metadata when required; "
+        "golden contexts only for no-source-required diagnostic cases",
         f"Live source metadata gate: {'enabled' if check_live_sources else 'disabled'}",
         "",
     ]
@@ -1162,6 +1411,33 @@ def _format_report(
                 "",
             ]
         )
+
+    quality_signals = comparison.get("quality_signals", {})
+    if quality_signals:
+        overall_quality = quality_signals.get("overall", {})
+        status = "PASS" if overall_quality.get("passed") else "FAIL"
+        lines.extend(
+            [
+                "Quality signals:",
+                "  overall: "
+                f"cases={overall_quality.get('case_count', 0)} "
+                f"failed={overall_quality.get('failed_case_count', 0)} "
+                f"groundedness={overall_quality.get('groundedness', 0.0):.3f} "
+                f"hallucination_risk={overall_quality.get('hallucination_risk', 0.0):.3f} "
+                f"toxicity={overall_quality.get('toxicity', 0.0):.3f} "
+                f"[{status}]",
+            ]
+        )
+        failed_quality_cases = quality_signals.get("failed_cases", [])
+        if failed_quality_cases:
+            lines.append("  failed_cases:")
+            for item in failed_quality_cases[:40]:
+                lines.append(
+                    "    "
+                    f"{item.get('case_id')} ({item.get('language')}): "
+                    f"{','.join(item.get('failures', []))}"
+                )
+        lines.append("")
 
     ragas_judge = comparison.get("ragas_judge", {})
     if ragas_judge:
@@ -1237,6 +1513,17 @@ def _format_report(
                 "  live_source_gate: "
                 f"failed_cases={source_gate.get('failed_case_count', 0)} [{sg_status}]"
             )
+        quality_gate = comp.get("quality_signals", {})
+        if quality_gate:
+            q_status = "PASS" if quality_gate.get("passed") else "FAIL"
+            lines.append(
+                "  quality_signals: "
+                f"failed_cases={quality_gate.get('failed_case_count', 0)} "
+                f"groundedness={quality_gate.get('groundedness', 0.0):.3f} "
+                f"hallucination_risk={quality_gate.get('hallucination_risk', 0.0):.3f} "
+                f"toxicity={quality_gate.get('toxicity', 0.0):.3f} "
+                f"[{q_status}]"
+            )
 
         overall = "PASS" if comp.get("passed", False) else "FAIL"
         lines.append(f"  overall: {overall}")
@@ -1289,7 +1576,8 @@ def _format_report(
                 f"evaluation_complete={f.get('evaluation_complete')} "
                 f"collection_errors={f.get('collection_errors', 0)} "
                 f"ragas_errors={f.get('ragas_errors', 0)} "
-                f"source_failures={f.get('source_failures', 0)}"
+                f"source_failures={f.get('source_failures', 0)} "
+                f"quality_signal_failures={f.get('quality_signal_failures', 0)}"
             )
 
     failed_source_cases = comparison.get("failed_source_cases", [])

--- a/backend/tests/evaluation/test_offline_quality_gate.py
+++ b/backend/tests/evaluation/test_offline_quality_gate.py
@@ -82,6 +82,61 @@ def test_summarize_quality_signals_groups_by_language() -> None:
     assert summary["failed_cases"] == []
 
 
+def test_cross_lingual_live_context_uses_reference_grounding_context() -> None:
+    result = score_case(
+        {
+            "query_id": "en-cross-lingual",
+            "language": "en",
+            "answer": "Engineer Cafe is open from 9:00 to 22:00.",
+            "contexts": ["エンジニアカフェの開館時間は9:00から22:00です。"],
+            "ground_truth": "Engineer Cafe is open from 9:00 to 22:00.",
+        },
+        include_ground_truth_context=False,
+    )
+
+    assert result.language_match == 1.0
+    assert result.groundedness >= 0.55
+    assert result.cross_lingual_context is True
+    assert result.reference_grounding_context is True
+    assert result.passed is True
+    assert result.failures == []
+
+
+def test_cross_lingual_reference_grounding_still_fails_unsupported_answer() -> None:
+    result = score_case(
+        {
+            "query_id": "en-cross-lingual-unsupported",
+            "language": "en",
+            "answer": "Engineer Cafe is open from 7:00 and has a private sauna.",
+            "contexts": ["エンジニアカフェの開館時間は9:00から22:00です。"],
+            "ground_truth": "Engineer Cafe is open from 9:00 to 22:00.",
+        },
+        include_ground_truth_context=False,
+    )
+
+    assert result.cross_lingual_context is True
+    assert result.reference_grounding_context is True
+    assert result.passed is False
+    assert "groundedness" in result.failures
+    assert "hallucination_risk" in result.failures
+
+
+def test_cross_lingual_context_still_fails_wrong_language_answer() -> None:
+    result = score_case(
+        {
+            "query_id": "wrong-language-cross-lingual",
+            "language": "en",
+            "answer": "エンジニアカフェの開館時間は9:00から22:00です。",
+            "contexts": ["エンジニアカフェの開館時間は9:00から22:00です。"],
+        },
+        include_ground_truth_context=False,
+    )
+
+    assert result.reference_grounding_context is False
+    assert result.passed is False
+    assert "language_match" in result.failures
+
+
 def test_run_offline_quality_gate_writes_reports_without_ragas_or_live_secrets(tmp_path) -> None:
     result = run_offline_quality_gate(
         languages=["ja", "en"],

--- a/backend/tests/evaluation/test_ragas_live_case_suites.py
+++ b/backend/tests/evaluation/test_ragas_live_case_suites.py
@@ -36,6 +36,81 @@ NO_RAGAS_JUDGE_METADATA = {
 }
 
 
+def _install_small_live_eval_fixture(
+    monkeypatch: pytest.MonkeyPatch,
+    *,
+    queries,
+    ground_truth_cases,
+    chat_responses_by_question,
+    captured_ragas_cases,
+):
+    def fake_load_case_suite_config(case_suite):
+        return {
+            "case_suite": case_suite,
+            "expected_total_cases": len(queries),
+            "queries": queries,
+        }
+
+    def fake_load_ground_truth_lookup():
+        return {case["id"]: case for case in ground_truth_cases}
+
+    async def fake_call_chat_api(client, *, base_url, question, language, api_key=None, **kwargs):
+        return chat_responses_by_question[question]
+
+    class FakeRagasEvaluator:
+        is_available = True
+
+        def __init__(self, *, metrics, max_cases):
+            self.metrics = metrics
+            self.max_cases = max_cases
+
+        async def evaluate_batch(self, cases):
+            captured_ragas_cases.extend(cases)
+            return SimpleNamespace(
+                evaluated_cases=len(cases),
+                skipped_cases=0,
+                metrics={
+                    "context_precision": 1.0,
+                    "answer_correctness": 1.0,
+                    "answer_relevancy": 1.0,
+                    "faithfulness": 1.0,
+                },
+                errors=[],
+                results=[
+                    SimpleNamespace(
+                        question=case["question"],
+                        answer_correctness=1.0,
+                        answer_relevancy=1.0,
+                        faithfulness=1.0,
+                        context_precision=1.0,
+                        error=None,
+                    )
+                    for case in cases
+                ],
+            )
+
+    monkeypatch.setattr(
+        "backend.evaluation.run_live_api_eval._load_case_suite_config",
+        fake_load_case_suite_config,
+    )
+    monkeypatch.setattr(
+        "backend.evaluation.run_live_api_eval._load_ground_truth_lookup",
+        fake_load_ground_truth_lookup,
+    )
+    monkeypatch.setattr(
+        "backend.evaluation.run_live_api_eval._call_chat_api",
+        fake_call_chat_api,
+    )
+    monkeypatch.setitem(
+        __import__("sys").modules,
+        "evaluation.ragas_pipeline",
+        SimpleNamespace(
+            RagasEvaluator=FakeRagasEvaluator,
+            resolve_ragas_judge_metadata=lambda: NO_RAGAS_JUDGE_METADATA,
+        ),
+    )
+
+
 def test_diagnostic_case_suite_preserves_29_case_manifest():
     config = _load_case_suite_config(CASE_SUITE_DIAGNOSTIC_29)
     queries = config["queries"]
@@ -164,6 +239,280 @@ def test_source_requirement_accepts_knowledge_and_event_alternatives():
         [LOCAL_KNOWLEDGE_SOURCE_REQUIREMENT],
         ["fallback"],
     )
+
+
+@pytest.mark.asyncio()
+async def test_live_eval_uses_api_metadata_contexts_for_ragas_and_quality_signals(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path,
+):
+    queries = [
+        {
+            "id": "live-context-case",
+            "language": "ja",
+            "question": "エンジニアカフェの開館時間は？",
+            "category": "hours",
+            "ground_truth_id": "gt-live-context",
+            "metadata": {"intent": "hours"},
+        },
+        {
+            "id": "live-evidence-case",
+            "language": "ja",
+            "question": "メインホールは何席ありますか？",
+            "category": "facility-info",
+            "ground_truth_id": "gt-live-evidence",
+            "metadata": {"intent": "facility-info"},
+        },
+    ]
+    ground_truth_cases = [
+        {
+            "id": "gt-live-context",
+            "question": queries[0]["question"],
+            "contexts": ["GOLDEN_CONTEXT_SHOULD_NOT_BE_USED: 開館時間は10:00から18:00です。"],
+            "ground_truth": "開館時間は9:00から22:00です。",
+        },
+        {
+            "id": "gt-live-evidence",
+            "question": queries[1]["question"],
+            "contexts": ["GOLDEN_CONTEXT_SHOULD_NOT_BE_USED: メインホールは10席です。"],
+            "ground_truth": "メインホールは30席です。",
+        },
+    ]
+    live_context = "LIVE_RETRIEVED_CONTEXT: エンジニアカフェの開館時間は9:00から22:00です。"
+    live_evidence = "LIVE_EVIDENCE: 1階メインホールは30席のコワーキングスペースです。"
+    captured_ragas_cases = []
+    _install_small_live_eval_fixture(
+        monkeypatch,
+        queries=queries,
+        ground_truth_cases=ground_truth_cases,
+        chat_responses_by_question={
+            queries[0]["question"]: {
+                "answer": "エンジニアカフェの開館時間は9:00から22:00です。",
+                "metadata": {
+                    "agent": "BusinessInfoAgent",
+                    "route": "business_info",
+                    "sources": ["enhanced_rag"],
+                    "retrieved_contexts": [live_context],
+                },
+            },
+            queries[1]["question"]: {
+                "answer": "メインホールは30席です。",
+                "metadata": {
+                    "agent": "FacilityAgent",
+                    "route": "facility",
+                    "sources": ["enhanced_rag"],
+                    "evidence": [{"content": live_evidence}],
+                },
+            },
+        },
+        captured_ragas_cases=captured_ragas_cases,
+    )
+
+    result = await run_live_api_evaluation(
+        base_url="http://example.test",
+        languages=("ja",),
+        output_dir=tmp_path,
+        case_suite=CASE_SUITE_DIAGNOSTIC_29,
+        metrics=("answer_correctness",),
+        report_timestamp="live-context-quality",
+    )
+
+    ragas_cases_by_id = {case["query_id"]: case for case in captured_ragas_cases}
+    assert ragas_cases_by_id["live-context-case"]["contexts"] == [live_context]
+    assert ragas_cases_by_id["live-evidence-case"]["contexts"] == [live_evidence]
+    assert {case["evaluation_context_source"] for case in captured_ragas_cases} == {
+        "live_api_metadata"
+    }
+    assert result["ragas_context_source"] == "live_api_metadata"
+    assert result["quality_signals"]["overall"]["case_count"] == 2
+    assert result["quality_signals"]["overall"]["passed"] is True
+    assert result["comparison"]["quality_signals"]["overall"]["passed"] is True
+    assert result["comparison"]["per_language"]["ja"]["quality_signals"]["passed"] is True
+    assert "Quality signals:" in result["report"]
+
+
+@pytest.mark.asyncio()
+async def test_live_eval_uses_reference_grounding_for_cross_lingual_contexts(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path,
+):
+    query = {
+        "id": "en-cross-lingual-context",
+        "language": "en",
+        "question": "What are Engineer Cafe's opening hours?",
+        "category": "hours",
+        "ground_truth_id": "gt-en-cross-lingual-context",
+        "metadata": {"intent": "hours"},
+    }
+    live_context = "エンジニアカフェの開館時間は9:00から22:00です。"
+    captured_ragas_cases = []
+    _install_small_live_eval_fixture(
+        monkeypatch,
+        queries=[query],
+        ground_truth_cases=[
+            {
+                "id": "gt-en-cross-lingual-context",
+                "question": query["question"],
+                "contexts": ["GOLDEN_CONTEXT_SHOULD_NOT_BE_USED: open from 10:00 to 18:00."],
+                "answer": "Engineer Cafe is open from 9:00 to 22:00.",
+                "ground_truth": "Use the official opening-hours answer from the reference dataset.",
+            }
+        ],
+        chat_responses_by_question={
+            query["question"]: {
+                "answer": "Engineer Cafe is open from 9:00 to 22:00.",
+                "metadata": {
+                    "agent": "BusinessInfoAgent",
+                    "route": "business_info",
+                    "sources": ["enhanced_rag"],
+                    "retrieved_contexts": [live_context],
+                },
+            }
+        },
+        captured_ragas_cases=captured_ragas_cases,
+    )
+
+    result = await run_live_api_evaluation(
+        base_url="http://example.test",
+        languages=("en",),
+        output_dir=tmp_path,
+        case_suite=CASE_SUITE_DIAGNOSTIC_29,
+        metrics=("answer_correctness",),
+        report_timestamp="cross-lingual-context-quality",
+    )
+
+    quality_case = result["quality_signals"]["cases"][0]
+    assert captured_ragas_cases[0]["contexts"] == [live_context]
+    assert captured_ragas_cases[0]["reference_answer"] == (
+        "Engineer Cafe is open from 9:00 to 22:00."
+    )
+    assert quality_case["groundedness"] >= 0.55
+    assert quality_case["cross_lingual_context"] is True
+    assert quality_case["reference_grounding_context"] is True
+    assert result["quality_signals"]["overall"]["passed"] is True
+    assert result["comparison"]["per_language"]["en"]["quality_signals"]["passed"] is True
+
+
+@pytest.mark.asyncio()
+async def test_live_eval_cross_lingual_context_still_fails_unsupported_answer(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path,
+):
+    query = {
+        "id": "en-cross-lingual-unsupported",
+        "language": "en",
+        "question": "What are Engineer Cafe's opening hours?",
+        "category": "hours",
+        "ground_truth_id": "gt-en-cross-lingual-unsupported",
+        "metadata": {"intent": "hours"},
+    }
+    captured_ragas_cases = []
+    _install_small_live_eval_fixture(
+        monkeypatch,
+        queries=[query],
+        ground_truth_cases=[
+            {
+                "id": "gt-en-cross-lingual-unsupported",
+                "question": query["question"],
+                "contexts": ["GOLDEN_CONTEXT_SHOULD_NOT_BE_USED: open from 10:00 to 18:00."],
+                "answer": "Engineer Cafe is open from 9:00 to 22:00.",
+                "ground_truth": "Use the official opening-hours answer from the reference dataset.",
+            }
+        ],
+        chat_responses_by_question={
+            query["question"]: {
+                "answer": "Engineer Cafe is open from 7:00 and has a private sauna.",
+                "metadata": {
+                    "agent": "BusinessInfoAgent",
+                    "route": "business_info",
+                    "sources": ["enhanced_rag"],
+                    "retrieved_contexts": ["エンジニアカフェの開館時間は9:00から22:00です。"],
+                },
+            }
+        },
+        captured_ragas_cases=captured_ragas_cases,
+    )
+
+    result = await run_live_api_evaluation(
+        base_url="http://example.test",
+        languages=("en",),
+        output_dir=tmp_path,
+        case_suite=CASE_SUITE_DIAGNOSTIC_29,
+        metrics=("answer_correctness",),
+        report_timestamp="cross-lingual-context-unsupported",
+    )
+
+    quality_case = result["quality_signals"]["cases"][0]
+    assert quality_case["cross_lingual_context"] is True
+    assert quality_case["reference_grounding_context"] is True
+    assert result["quality_signals"]["overall"]["passed"] is False
+    assert {"groundedness", "hallucination_risk"}.issubset(set(quality_case["failures"]))
+    assert result["comparison"]["per_language"]["en"]["quality_signals"]["passed"] is False
+
+
+@pytest.mark.asyncio()
+async def test_live_eval_quality_gate_fails_required_rag_case_without_live_contexts(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path,
+):
+    query = {
+        "id": "missing-live-context-case",
+        "language": "ja",
+        "question": "雨の日にエンジニアカフェへ行く最短ルートは？",
+        "category": "access",
+        "ground_truth_id": "gt-missing-live-context",
+        "metadata": {"intent": "access"},
+    }
+    captured_ragas_cases = []
+    _install_small_live_eval_fixture(
+        monkeypatch,
+        queries=[query],
+        ground_truth_cases=[
+            {
+                "id": "gt-missing-live-context",
+                "question": query["question"],
+                "contexts": ["天神駅16番出口から天神地下街を経由します。"],
+                "ground_truth": "天神駅16番出口から天神地下街、アクロス福岡通路を経由します。",
+            }
+        ],
+        chat_responses_by_question={
+            query["question"]: {
+                "answer": "天神駅16番出口から天神地下街、アクロス福岡通路を経由します。",
+                "metadata": {
+                    "agent": "BusinessInfoAgent",
+                    "route": "business_info",
+                    "sources": ["enhanced_rag"],
+                },
+            }
+        },
+        captured_ragas_cases=captured_ragas_cases,
+    )
+
+    result = await run_live_api_evaluation(
+        base_url="http://example.test",
+        languages=("ja",),
+        output_dir=tmp_path,
+        case_suite=CASE_SUITE_DIAGNOSTIC_29,
+        metrics=("answer_correctness",),
+        report_timestamp="missing-live-context-quality",
+    )
+
+    assert captured_ragas_cases[0]["contexts"] == []
+    assert captured_ragas_cases[0]["evaluation_context_source"] == "missing_live_contexts"
+    assert result["quality_signals"]["overall"]["passed"] is False
+    assert result["quality_signals"]["failed_cases"] == [
+        {
+            "case_id": "missing-live-context-case",
+            "language": "ja",
+            "failures": ["missing_live_contexts"],
+        }
+    ]
+    assert result["comparison"]["quality_signals"]["overall"]["passed"] is False
+    assert result["comparison"]["per_language"]["ja"]["quality_signals"]["passed"] is False
+    assert result["comparison"]["per_language"]["ja"]["passed"] is False
+    assert result["comparison"]["all_targets_met"] is False
+    assert "Quality signals:" in result["report"]
+    assert "missing_live_contexts" in result["report"]
 
 
 @pytest.mark.asyncio()
@@ -320,13 +669,21 @@ async def test_alpha_127_release_gate_requires_direct_openai_provider(
     tmp_path,
 ):
     async def fake_call_chat_api(client, *, base_url, question, language, api_key=None, **kwargs):
+        answer_by_language = {
+            "ja": "エンジニアカフェは9:00から22:00まで開館しています。",
+            "en": "Engineer Cafe is open from 9:00 to 22:00.",
+            "zh": "工程师咖啡营业时间是9:00到22:00。",
+            "ko": "엔지니어 카페는 9:00부터 22:00까지 운영합니다.",
+        }
+        answer = answer_by_language.get(language, answer_by_language["ja"])
         return {
-            "answer": "grounded answer",
+            "answer": answer,
             "metadata": {
                 "agent": "FakeAgent",
                 "category": "test",
                 "route": "fake",
                 "sources": ["knowledge_base_cached", "google_calendar"],
+                "retrieved_contexts": [answer],
             },
         }
 

--- a/backend/tests/workflows/test_main_workflow.py
+++ b/backend/tests/workflows/test_main_workflow.py
@@ -43,6 +43,67 @@ class _StubOrchestrator:
         return OrchestratorAgent._is_memory_related_question(self, query)
 
 
+def test_rag_evidence_metadata_is_opt_in_and_bounded():
+    from backend.workflows.main_workflow import _build_rag_evidence_metadata
+
+    context = {
+        "include_rag_evidence": True,
+        "knowledge_results": {
+            "success": True,
+            "category": "hours",
+            "query": "営業時間は？",
+            "context_string": "営業時間は9:00から22:00です。",
+            "results": [
+                {
+                    "id": "kb-1",
+                    "category": "hours",
+                    "language": "ja",
+                    "source": "official",
+                    "score": 0.91,
+                    "content": "営業時間は9:00から22:00です。",
+                }
+            ],
+        },
+    }
+
+    evidence = _build_rag_evidence_metadata(context)
+
+    assert evidence == {
+        "source": "workflow_knowledge_results",
+        "query": "営業時間は？",
+        "translated_query": None,
+        "category": "hours",
+        "context_char_count": len("営業時間は9:00から22:00です。"),
+        "contexts": ["営業時間は9:00から22:00です。"],
+        "results": [
+            {
+                "id": "kb-1",
+                "category": "hours",
+                "language": "ja",
+                "source": "official",
+                "score": 0.91,
+                "content": "営業時間は9:00から22:00です。",
+            }
+        ],
+    }
+
+
+def test_rag_evidence_metadata_is_not_exposed_without_eval_flag():
+    from backend.workflows.main_workflow import _build_rag_evidence_metadata
+
+    assert (
+        _build_rag_evidence_metadata(
+            {
+                "knowledge_results": {
+                    "context_string": "営業時間は9:00から22:00です。",
+                    "results": [{"content": "営業時間は9:00から22:00です。"}],
+                }
+            }
+        )
+        is None
+    )
+
+
 class TestMainWorkflowMemoryIntegration:
     """MainWorkflow のメモリ統合テスト"""
 

--- a/backend/workflows/main_workflow.py
+++ b/backend/workflows/main_workflow.py
@@ -78,6 +78,10 @@ _TRAG_PREAMBLE_RE = re.compile(
     re.IGNORECASE,
 )
 
+RAG_EVIDENCE_MAX_CONTEXTS = 5
+RAG_EVIDENCE_MAX_CONTEXT_CHARS = 900
+RAG_EVIDENCE_MAX_CONTEXT_STRING_CHARS = 4000
+
 
 def _get_trag_client() -> "_httpx.AsyncClient":
     """Return a shared httpx client for tRAG translation."""
@@ -87,6 +91,81 @@ def _get_trag_client() -> "_httpx.AsyncClient":
             timeout=_httpx.Timeout(connect=5.0, read=15.0, write=5.0, pool=5.0),
         )
     return _trag_http_client
+
+
+def _truthy_context_flag(value: Any) -> bool:
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, str):
+        return value.strip().lower() in {"1", "true", "yes", "on"}
+    return False
+
+
+def _clip_evidence_text(value: Any, *, max_chars: int) -> str:
+    text = str(value or "").strip()
+    if len(text) <= max_chars:
+        return text
+    return text[: max_chars - 1].rstrip() + "…"
+
+
+def _rag_evidence_result(result: dict[str, Any]) -> dict[str, Any]:
+    evidence: dict[str, Any] = {}
+    for key in ("id", "category", "subcategory", "language", "source", "entity"):
+        if result.get(key) is not None:
+            evidence[key] = result.get(key)
+    for key in ("similarity", "score", "final_score"):
+        value = result.get(key)
+        if isinstance(value, (int, float)):
+            evidence[key] = round(float(value), 4)
+    content = _clip_evidence_text(
+        result.get("content", ""),
+        max_chars=RAG_EVIDENCE_MAX_CONTEXT_CHARS,
+    )
+    if content:
+        evidence["content"] = content
+    return evidence
+
+
+def _build_rag_evidence_metadata(context: dict[str, Any]) -> Optional[dict[str, Any]]:
+    """Build bounded, opt-in retrieval evidence for live quality evaluation."""
+    if not _truthy_context_flag(context.get("include_rag_evidence")):
+        return None
+
+    knowledge_results = context.get("knowledge_results")
+    if not isinstance(knowledge_results, dict):
+        return None
+
+    context_string = str(knowledge_results.get("context_string") or "")
+    raw_results = knowledge_results.get("results") or []
+    results = [item for item in raw_results if isinstance(item, dict)]
+    evidence_results = [
+        evidence
+        for evidence in (
+            _rag_evidence_result(result) for result in results[:RAG_EVIDENCE_MAX_CONTEXTS]
+        )
+        if evidence.get("content")
+    ]
+    contexts = [str(item["content"]) for item in evidence_results if item.get("content")]
+    if not contexts and context_string.strip():
+        contexts = [
+            _clip_evidence_text(
+                context_string,
+                max_chars=RAG_EVIDENCE_MAX_CONTEXT_STRING_CHARS,
+            )
+        ]
+
+    if not contexts:
+        return None
+
+    return {
+        "source": "workflow_knowledge_results",
+        "query": knowledge_results.get("query"),
+        "translated_query": knowledge_results.get("translated_query"),
+        "category": knowledge_results.get("category"),
+        "context_char_count": len(context_string),
+        "contexts": contexts,
+        "results": evidence_results,
+    }
 
 
 async def _translate_llm_with_retry(
@@ -1398,7 +1477,15 @@ class MainWorkflow:
         query = state.get("query", "")
         language = state.get("language", "ja")
         session_id = state.get("session_id", "")
-        result = await self._event_agent.answer_event_query(query, language, session_id)
+        include_evidence = _truthy_context_flag(
+            state.get("context", {}).get("include_rag_evidence")
+        )
+        result = await self._event_agent.answer_event_query(
+            query,
+            language,
+            session_id,
+            include_evidence=include_evidence,
+        )
 
         return {
             "answer": result.get("answer", ""),
@@ -1526,6 +1613,11 @@ class MainWorkflow:
             "vrm_control": vrm_control,
             "lipsync_data": lipsync_data,
         }
+        if "rag_evidence" not in metadata:
+            rag_evidence = _build_rag_evidence_metadata(state_context)
+            if rag_evidence is not None:
+                metadata["rag_evidence"] = rag_evidence
+
         # PII Defense-in-Depth: ワークフロー層でもスキャン（API層に加えて二重防御）
         try:
             masked, pii_items = scan_and_mask(answer)


### PR DESCRIPTION
## Summary
- Adds opt-in live retrieval evidence to `/api/chat` metadata for RAG/quality evaluation requests only.
- Switches live RAGAS evaluation to use live retrieved contexts from `/api/chat` metadata, with `missing_live_contexts` as a blocking quality failure for source-required cases.
- Wires deterministic `quality_signals` into live API reports and comparison gates for groundedness, hallucination risk, language match, and toxicity.
- Promotes the RAGAS workflow from informational to blocking, with live-api/offline modes and weekly alpha-127 scheduling.

## Issues
- Target close after deployed validation: #518
- Strong progress: #511

## Local verification
- `pytest backend/tests/evaluation/test_ragas_live_case_suites.py -q`
- `pytest backend/tests/evaluation/test_offline_quality_gate.py -q`
- `pytest backend/tests/workflows/test_main_workflow.py -q`
- `pytest backend/tests/agents/test_event_agent.py backend/tests/agents/test_event_agent_timeout.py -q`
- `ruff check backend/evaluation/run_live_api_eval.py backend/evaluation/quality_signals.py backend/workflows/main_workflow.py backend/agents/event_agent.py backend/tests/evaluation/test_ragas_live_case_suites.py backend/tests/workflows/test_main_workflow.py`
- `git diff --check`
- YAML parse for `.github/workflows/ragas-evaluation.yml`

## Deployment / close plan
After merge to `develop`, confirm Cloud Run deploy revision, run live RAGAS diagnostic/alpha gate against that deployed revision, then close #518 if the live quality gate reports pass. Keep #511 open until the scheduled alpha-127 gate has stable recurring proof.
