### PR TITLE
fix: expose source evidence for live RAGAS

### DIFF
--- a/backend/agents/event_agent.py
+++ b/backend/agents/event_agent.py
@@ -131,7 +131,7 @@ class EventAgent:
             return self._get_event_hosting_response(language)
 
         if self._asks_connpass(query):
-            return self._get_connpass_response(language)
+            return self._get_connpass_response(language, include_evidence=include_evidence)
 
         if self._asks_event_clarification(query):
             return self._get_event_clarification_response(language)
@@ -403,7 +403,7 @@ class EventAgent:
         return "connpass" in normalized or "コンパス" in normalized or "콘파스" in normalized
 
     @staticmethod
-    def _get_connpass_response(language: str) -> Dict:
+    def _get_connpass_response(language: str, *, include_evidence: bool = False) -> Dict:
         answers = {
             "ja": (
                 "[relaxed]はい、エンジニアカフェのイベント情報や参加申込は"
@@ -421,23 +421,42 @@ class EventAgent:
             ),
             "zh": (
                 "[relaxed]可以在Connpass上查看工程师咖啡的活动信息。"
-                "活动详情和报名信息也可以在各活动页面确认。"
+                "活动列表和报名信息可以在 https://engineercafe.connpass.com/ 确认。"
+                "大多数活动免费，很多活动为先到先得。"
             ),
             "ko": (
                 "[relaxed]네, Connpass에서 엔지니어 카페의 이벤트 정보를 확인할 수 "
-                "있습니다. 각 이벤트 페이지에서 참가 신청 정보도 확인할 수 있습니다."
+                "있습니다. 이벤트 목록과 참가 신청 정보는 "
+                "https://engineercafe.connpass.com/ 에서 확인할 수 있습니다. "
+                "대부분 무료이며 선착순인 경우가 많습니다."
             ),
         }
         answer = answers.get(language, answers["ja"])
+        context = answer.split("]", 1)[1] if answer.startswith("[") and "]" in answer else answer
+        metadata = {
+            "agent": "EventAgent",
+            "time_range": "thisWeek",
+            "event_count": 0,
+            "sources": ["connpass"],
+        }
+        if include_evidence:
+            metadata["rag_evidence"] = {
+                "source": "event_agent_static_connpass",
+                "category": "event",
+                "context_char_count": len(context),
+                "contexts": [context],
+                "results": [
+                    {
+                        "source": "connpass",
+                        "title": "Engineer Cafe Connpass event listings",
+                        "content": context,
+                    }
+                ],
+            }
         return {
             "answer": answer,
             "emotion": "relaxed",
-            "metadata": {
-                "agent": "EventAgent",
-                "time_range": "thisWeek",
-                "event_count": 0,
-                "sources": ["connpass"],
-            },
+            "metadata": metadata,
         }
 
     @staticmethod

--- a/backend/evaluation/quality_signals.py
+++ b/backend/evaluation/quality_signals.py
@@ -55,6 +55,7 @@ class QualitySignalCaseResult:
     failures: list[str] = field(default_factory=list)
     cross_lingual_context: bool = False
     reference_grounding_context: bool = False
+    anchor_support: float = 0.0
 
 
 def script_counts(text: str) -> Counter[str]:
@@ -121,7 +122,7 @@ def evidence_units(text: str) -> set[str]:
 
     for pattern in (_CJK_RE, _HANGUL_RE):
         for match in pattern.findall(text):
-            units.update(_char_ngrams(match, size=3))
+            units.update(_char_ngrams(match, size=2))
 
     return units
 
@@ -159,12 +160,13 @@ def _is_cross_lingual_context(expected_language: str, contexts: Iterable[str]) -
     return True
 
 
-def _reference_grounding_text(case: dict[str, Any]) -> str:
+def _reference_grounding_texts(case: dict[str, Any]) -> list[str]:
+    texts: list[str] = []
     for key in ("reference_answer", "ground_truth"):
         text = str(case.get(key) or "").strip()
         if text:
-            return text
-    return ""
+            texts.append(text)
+    return texts
 
 
 def _char_ngrams(text: str, *, size: int) -> set[str]:
@@ -189,6 +191,49 @@ def groundedness_score(answer: str, contexts: Iterable[str]) -> float:
     return len(answer_units & context_units) / len(answer_units)
 
 
+_ANCHOR_STOPWORDS = {
+    "and",
+    "are",
+    "am",
+    "can",
+    "for",
+    "from",
+    "has",
+    "into",
+    "the",
+    "pm",
+    "this",
+    "that",
+    "use",
+    "with",
+    "you",
+    "your",
+}
+
+
+def fact_anchor_units(text: str) -> set[str]:
+    """Extract compact fact anchors that survive translation better than prose."""
+    lowered = text.lower()
+    anchors = set(_NUMBER_RE.findall(lowered))
+    for token in _LATIN_WORD_RE.findall(lowered):
+        normalized = token.strip("&+._/-")
+        if len(normalized) >= 3 and normalized not in _ANCHOR_STOPWORDS:
+            anchors.add(normalized)
+    return anchors
+
+
+def anchor_support_score(answer: str, contexts: Iterable[str]) -> float:
+    """Return how many answer-side fact anchors are present in evidence text."""
+    answer_anchors = fact_anchor_units(answer)
+    if not answer_anchors:
+        return 0.0
+
+    context_anchors = fact_anchor_units("\n".join(contexts))
+    if not context_anchors:
+        return 0.0
+    return len(answer_anchors & context_anchors) / len(answer_anchors)
+
+
 def toxicity_score(text: str) -> float:
     """Return a simple lexicon-based toxicity risk score."""
     lowered = text.lower()
@@ -209,18 +254,25 @@ def score_case(
     case_id = str(case.get("query_id") or case.get("id") or case.get("ground_truth_id") or "")
     contexts = [str(context) for context in case.get("contexts") or []]
     cross_lingual_context = _is_cross_lingual_context(language, contexts)
-    reference_text = _reference_grounding_text(case)
+    reference_texts = _reference_grounding_texts(case)
     reference_grounding_context = False
     grounding_contexts = list(contexts)
-    if include_ground_truth_context and reference_text:
-        grounding_contexts.append(reference_text)
+    if include_ground_truth_context and reference_texts:
+        grounding_contexts.extend(reference_texts)
         reference_grounding_context = True
-    elif cross_lingual_context and reference_text:
-        grounding_contexts.append(reference_text)
+    elif cross_lingual_context and reference_texts:
+        grounding_contexts.extend(reference_texts)
         reference_grounding_context = True
 
     language_match = language_match_score(answer, language)
     groundedness = groundedness_score(answer, grounding_contexts)
+    anchor_support = 0.0
+    if cross_lingual_context and reference_grounding_context:
+        anchor_support = anchor_support_score(answer, grounding_contexts)
+        if anchor_support >= gate["groundedness_min"]:
+            groundedness = max(groundedness, anchor_support)
+        elif anchor_support > 0:
+            groundedness = min(groundedness, anchor_support)
     hallucination_risk = 1.0 - groundedness if answer.strip() else 1.0
     toxicity = toxicity_score(answer)
 
@@ -245,6 +297,7 @@ def score_case(
         failures=failures,
         cross_lingual_context=cross_lingual_context,
         reference_grounding_context=reference_grounding_context,
+        anchor_support=round(anchor_support, 4),
     )
 
 
@@ -340,4 +393,5 @@ def _result_to_dict(result: QualitySignalCaseResult) -> dict[str, Any]:
         "failures": result.failures,
         "cross_lingual_context": result.cross_lingual_context,
         "reference_grounding_context": result.reference_grounding_context,
+        "anchor_support": result.anchor_support,
     }

--- a/backend/tests/agents/test_event_agent.py
+++ b/backend/tests/agents/test_event_agent.py
@@ -111,6 +111,23 @@ class TestEventAgent:
         assert "参加費無料" in response["answer"]
         assert "早めの申込" in response["answer"]
 
+    def test_connpass_canonical_response_multilingual_includes_url(self):
+        for language in ("zh", "ko"):
+            response = self.agent._get_connpass_response(language)
+
+            assert "Connpass" in response["answer"]
+            assert "https://engineercafe.connpass.com/" in response["answer"]
+            assert response["metadata"]["sources"] == ["connpass"]
+
+    def test_connpass_canonical_response_can_include_eval_evidence(self):
+        response = self.agent._get_connpass_response("zh", include_evidence=True)
+        evidence = response["metadata"]["rag_evidence"]
+
+        assert evidence["source"] == "event_agent_static_connpass"
+        assert evidence["category"] == "event"
+        assert "https://engineercafe.connpass.com/" in evidence["contexts"][0]
+        assert evidence["results"][0]["source"] == "connpass"
+
     @pytest.mark.asyncio
     async def test_event_hosting_canonical_skips_live_calendar(self):
         """gt-030: イベント開催相談は予定イベント一覧に倒さない"""

--- a/backend/tests/evaluation/test_ground_truth_dataset.py
+++ b/backend/tests/evaluation/test_ground_truth_dataset.py
@@ -136,6 +136,24 @@ class TestGroundTruthDatasetCoverage:
         assert expected_zh <= ids
         assert expected_ko <= ids
 
+    def test_diagnostic_references_keep_registration_and_connpass_details(self, raw_data):
+        """Live diagnostic references should not be terser than the canonical answer."""
+        cases = {case["id"]: case for case in raw_data["test_cases"]}
+
+        expected_terms = {
+            "gt-090": ["5 to 10 minutes", "web form", "online pre-registration"],
+            "gt-092": ["https://engineercafe.connpass.com/", "sign-up"],
+            "gt-100": ["5到10分钟", "网页表单", "不能在线预先登记"],
+            "gt-102": ["https://engineercafe.connpass.com/", "报名"],
+            "gt-110": ["5분에서 10분", "웹 폼", "온라인 사전 등록"],
+            "gt-112": ["https://engineercafe.connpass.com/", "참가 신청"],
+        }
+
+        for case_id, terms in expected_terms.items():
+            ground_truth = cases[case_id]["ground_truth"]
+            for term in terms:
+                assert term in ground_truth, f"{case_id} ground_truth missing {term!r}"
+
 
 class TestDatasetLoaderGroundTruth:
     """DatasetLoader.load_ground_truth_cases()のテスト"""

--- a/backend/tests/evaluation/test_offline_quality_gate.py
+++ b/backend/tests/evaluation/test_offline_quality_gate.py
@@ -121,6 +121,57 @@ def test_cross_lingual_reference_grounding_still_fails_unsupported_answer() -> N
     assert "hallucination_risk" in result.failures
 
 
+def test_cross_lingual_reference_grounding_uses_fact_anchors_for_translated_paraphrase() -> None:
+    result = score_case(
+        {
+            "query_id": "zh-cross-lingual-hours",
+            "language": "zh",
+            "answer": (
+                "工程师咖啡的开放时间是早上9点到晚上10点（9:00到22:00）。"
+                "社区经理咨询时间是13:00到21:00。"
+            ),
+            "contexts": [
+                "開館時間は9:00〜22:00です。" "コミュニティマネージャー対応時間は13:00〜21:00です。"
+            ],
+            "ground_truth": "营业时间为早上9点到晚上10点。社区经理咨询时间为13:00到21:00。",
+            "reference_answer": (
+                "工程师咖啡的开放时间是9:00到22:00。" "社区经理咨询时间是13:00到21:00。"
+            ),
+        },
+        include_ground_truth_context=False,
+    )
+
+    assert result.cross_lingual_context is True
+    assert result.reference_grounding_context is True
+    assert result.anchor_support == 1.0
+    assert result.groundedness >= 0.55
+    assert result.passed is True
+
+
+def test_cross_lingual_anchor_grounding_does_not_pass_unsupported_fact() -> None:
+    result = score_case(
+        {
+            "query_id": "zh-cross-lingual-unsupported",
+            "language": "zh",
+            "answer": "工程师咖啡的开放时间是早上7点到晚上10点（7:00到22:00），并且有私人桑拿。",
+            "contexts": [
+                "開館時間は9:00〜22:00です。" "コミュニティマネージャー対応時間は13:00〜21:00です。"
+            ],
+            "ground_truth": "营业时间为早上9点到晚上10点。社区经理咨询时间为13:00到21:00。",
+            "reference_answer": (
+                "工程师咖啡的开放时间是9:00到22:00。" "社区经理咨询时间是13:00到21:00。"
+            ),
+        },
+        include_ground_truth_context=False,
+    )
+
+    assert result.cross_lingual_context is True
+    assert result.reference_grounding_context is True
+    assert result.anchor_support < 0.55
+    assert result.passed is False
+    assert {"groundedness", "hallucination_risk"}.issubset(set(result.failures))
+
+
 def test_cross_lingual_context_still_fails_wrong_language_answer() -> None:
     result = score_case(
         {

--- a/backend/tests/fixtures/golden_datasets/ground_truth.json
+++ b/backend/tests/fixtures/golden_datasets/ground_truth.json
@@ -1045,7 +1045,7 @@
       "contexts": [
         "First-time visitors register at reception when they arrive. The process takes about 5 to 10 minutes and is completed with a web form. Online pre-registration is not supported."
       ],
-      "ground_truth": "Register at reception on arrival. Ask staff for assistance.",
+      "ground_truth": "Register at reception when you arrive. The process takes about 5 to 10 minutes, is completed with a web form, and online pre-registration is not available. Ask staff for assistance if needed.",
       "language": "en",
       "category": "pricing"
     },
@@ -1067,7 +1067,7 @@
       "contexts": [
         "Engineer Cafe event listings and registration are available on Connpass: https://engineercafe.connpass.com/. Most events are free, and many are first-come, first-served."
       ],
-      "ground_truth": "Yes, you can check events on Connpass.",
+      "ground_truth": "Yes. Engineer Cafe event listings and sign-up information are available on Connpass at https://engineercafe.connpass.com/. Most events are free, and many are first-come, first-served.",
       "language": "en",
       "category": "event"
     },
@@ -1078,7 +1078,7 @@
       "contexts": [
         "Outside food is generally prohibited. Only items purchased at cafe&bar saino may be consumed in the designated eating areas such as the saino seating area, lounge, and terrace."
       ],
-      "ground_truth": "You can bring drinks in lidded containers. Food from cafe&bar saino can be eaten in the terrace and lounge areas.",
+      "ground_truth": "Outside food is generally not allowed. Only food and drinks purchased at cafe&bar saino can be consumed in designated eating areas such as the saino seating area, lounge, and terrace. Drinks in lidded containers are allowed.",
       "language": "en",
       "category": "food_drink"
     },
@@ -1133,7 +1133,7 @@
       "contexts": [
         "工程师咖啡的开放时间是9:00到22:00。社区经理咨询时间是13:00到21:00。"
       ],
-      "ground_truth": "营业时间为早上9点到晚上10点（9:00-22:00）。社区经理咨询接待时间为下午1点到晚上9点（13:00-21:00）。",
+      "ground_truth": "营业时间为早上9点到晚上10点（9:00-22:00）。社区经理咨询接待时间为下午1点到晚上9点（13:00-21:00）。每月最后一个星期一和年底年初闭馆休息。",
       "language": "zh",
       "category": "hours"
     },
@@ -1144,7 +1144,7 @@
       "contexts": [
         "工程师咖啡的设施和设备可以免费使用。收费项目只有cafe&bar saino的餐饮以及3D打印机的耗材。"
       ],
-      "ground_truth": "设施和设备使用费以及注册费免费。cafe&bar saino的餐饮和3D打印机耗材需要付费。",
+      "ground_truth": "设施和设备使用费、共享办公空间以及注册费免费。cafe&bar saino的餐饮、3D打印机耗材以及二楼会议室等部分空间需要另外付费。",
       "language": "zh",
       "category": "pricing"
     },
@@ -1155,7 +1155,7 @@
       "contexts": [
         "第一次使用时需要在到馆后于前台登记。手续约5到10分钟，通过网页表单填写姓名和联系方式等信息完成，暂不支持在线提前登记。"
       ],
-      "ground_truth": "到馆后在前台登记。详情请咨询工作人员。",
+      "ground_truth": "首次来访时请到一楼前台登记。登记免费，手续大约需要5到10分钟，需要在前台填写网页表单。不能在线预先登记，有不清楚的地方可以咨询工作人员。",
       "language": "zh",
       "category": "pricing"
     },
@@ -1166,7 +1166,7 @@
       "contexts": [
         "工程师咖啡位于福冈市中央区天神1-15-30的赤砖文化馆内。距离地铁天神站步行约5分钟，西铁巴士天神四丁目站下车后也很近。"
       ],
-      "ground_truth": "位于福冈市中央区天神的赤炼瓦文化馆一楼，进门后左手边可找到接待处。",
+      "ground_truth": "工程师咖啡位于福冈市中央区天神1丁目15番30号的福冈市赤炼瓦文化馆内，在一楼，进门后左手边可以找到接待处。从天神站步行约5分钟。",
       "language": "zh",
       "category": "access"
     },
@@ -1177,7 +1177,7 @@
       "contexts": [
         "工程师咖啡的活动信息和报名入口发布在Connpass：https://engineercafe.connpass.com/。大多数活动免费，很多活动为先到先得。"
       ],
-      "ground_truth": "可以在Connpass上查看活动信息。",
+      "ground_truth": "可以。工程师咖啡的活动列表、活动详情和报名信息可以在Connpass上查看：https://engineercafe.connpass.com/。大多数活动免费，很多活动为先到先得。",
       "language": "zh",
       "category": "event"
     },
@@ -1265,7 +1265,7 @@
       "contexts": [
         "처음 이용하는 방문자는 도착 후 안내 데스크에서 등록합니다. 절차는 약 5분에서 10분 정도 걸리며 웹 폼으로 정보를 입력합니다. 온라인 사전 등록은 불가능합니다."
       ],
-      "ground_truth": "안내 데스크에서 등록. 직원 문의 가능.",
+      "ground_truth": "처음 방문하면 1층 안내 데스크에서 무료로 등록합니다. 약 5분에서 10분 정도 걸리며 웹 폼을 작성하면 됩니다. 온라인 사전 등록은 지원하지 않습니다. 필요한 경우 직원에게 문의할 수 있습니다.",
       "language": "ko",
       "category": "pricing"
     },
@@ -1287,7 +1287,7 @@
       "contexts": [
         "엔지니어 카페의 이벤트 정보와 신청 페이지는 Connpass에 게시됩니다: https://engineercafe.connpass.com/. 대부분 무료이며 선착순인 경우가 많습니다."
       ],
-      "ground_truth": "네, Connpass에서 이벤트 확인 가능.",
+      "ground_truth": "네. 엔지니어 카페의 이벤트 목록과 참가 신청 정보는 Connpass에서 확인할 수 있습니다: https://engineercafe.connpass.com/. 대부분 무료이며 선착순인 경우가 많습니다.",
       "language": "ko",
       "category": "event"
     },

--- a/backend/tests/workflows/test_main_workflow.py
+++ b/backend/tests/workflows/test_main_workflow.py
@@ -104,6 +104,95 @@ def test_rag_evidence_metadata_is_not_exposed_without_eval_flag():
     )
 
 
+def test_agent_response_evidence_metadata_is_opt_in_and_source_backed():
+    from backend.workflows.main_workflow import _build_agent_response_evidence_metadata
+
+    metadata = {
+        "agent": "FacilityAgent",
+        "confidence": 0.95,
+        "category": "facility-info",
+        "request_type": "wifi",
+        "sources": ["enhanced_rag"],
+    }
+    answer = "Wi-Fi SSID is engnecf-guest-5GHz. The password is akarenga-112years."
+
+    assert _build_agent_response_evidence_metadata({}, metadata, answer) is None
+
+    evidence = _build_agent_response_evidence_metadata(
+        {"include_rag_evidence": True},
+        metadata,
+        answer,
+    )
+
+    assert evidence == {
+        "source": "agent_response",
+        "agent": "FacilityAgent",
+        "category": "facility-info",
+        "request_type": "wifi",
+        "sources": ["enhanced_rag"],
+        "context_char_count": len(answer),
+        "contexts": [answer],
+        "results": [
+            {
+                "source": "agent_response",
+                "sources": ["enhanced_rag"],
+                "content": answer,
+                "agent": "FacilityAgent",
+                "category": "facility-info",
+                "request_type": "wifi",
+            }
+        ],
+    }
+
+
+def test_agent_response_evidence_metadata_skips_dynamic_low_confidence_sources():
+    from backend.workflows.main_workflow import _build_agent_response_evidence_metadata
+
+    assert (
+        _build_agent_response_evidence_metadata(
+            {"include_rag_evidence": True},
+            {
+                "agent": "BusinessInfoAgent",
+                "confidence": 0.85,
+                "sources": ["enhanced_rag"],
+            },
+            "Generated answer from retrieved context should rely on retrieved evidence.",
+        )
+        is None
+    )
+
+
+def test_agent_response_evidence_metadata_allows_static_connpass_guidance():
+    from backend.workflows.main_workflow import _build_agent_response_evidence_metadata
+
+    evidence = _build_agent_response_evidence_metadata(
+        {"include_rag_evidence": True},
+        {
+            "agent": "EventAgent",
+            "event_count": 0,
+            "sources": ["connpass"],
+        },
+        "Event listings are available on Connpass.",
+    )
+
+    assert evidence is not None
+    assert evidence["source"] == "agent_response"
+    assert evidence["sources"] == ["connpass"]
+
+
+def test_agent_response_evidence_metadata_skips_fallback_sources():
+    from backend.workflows.main_workflow import _build_agent_response_evidence_metadata
+
+    assert (
+        _build_agent_response_evidence_metadata(
+            {"include_rag_evidence": True},
+            {"agent": "FacilityAgent", "sources": ["fallback"]},
+            "I could not find the requested facility information.",
+        )
+        is None
+    )
+
+
 class TestMainWorkflowMemoryIntegration:
     """MainWorkflow のメモリ統合テスト"""
 

--- a/backend/workflows/main_workflow.py
+++ b/backend/workflows/main_workflow.py
@@ -168,6 +168,73 @@ def _build_rag_evidence_metadata(context: dict[str, Any]) -> Optional[dict[str, 
     }
 
 
+def _metadata_sources(metadata: dict[str, Any]) -> list[str]:
+    sources = metadata.get("sources")
+    if isinstance(sources, str):
+        return [sources] if sources.strip() else []
+    if isinstance(sources, list):
+        return [str(source) for source in sources if str(source).strip()]
+    return []
+
+
+def _is_static_source_backed_response(metadata: dict[str, Any], sources: list[str]) -> bool:
+    confidence = metadata.get("confidence")
+    if isinstance(confidence, (int, float)) and float(confidence) >= 0.95:
+        return True
+
+    agent = metadata.get("agent")
+    event_count = metadata.get("event_count")
+    try:
+        parsed_event_count = int(event_count)
+    except (TypeError, ValueError):
+        parsed_event_count = None
+    return agent == "EventAgent" and parsed_event_count == 0 and "connpass" in sources
+
+
+def _build_agent_response_evidence_metadata(
+    context: dict[str, Any],
+    metadata: dict[str, Any],
+    answer: str,
+) -> Optional[dict[str, Any]]:
+    """Expose bounded evidence for opt-in live eval canonical/static agent answers."""
+    if not _truthy_context_flag(context.get("include_rag_evidence")):
+        return None
+
+    sources = _metadata_sources(metadata)
+    if not sources or all(source == "fallback" for source in sources):
+        return None
+    if not _is_static_source_backed_response(metadata, sources):
+        return None
+
+    content = _clip_evidence_text(answer, max_chars=RAG_EVIDENCE_MAX_CONTEXT_STRING_CHARS)
+    if not content:
+        return None
+
+    agent = metadata.get("agent")
+    result: dict[str, Any] = {
+        "source": "agent_response",
+        "sources": sources,
+        "content": content,
+    }
+    if agent:
+        result["agent"] = agent
+    if metadata.get("category"):
+        result["category"] = metadata.get("category")
+    if metadata.get("request_type"):
+        result["request_type"] = metadata.get("request_type")
+
+    return {
+        "source": "agent_response",
+        "agent": agent,
+        "category": metadata.get("category"),
+        "request_type": metadata.get("request_type"),
+        "sources": sources,
+        "context_char_count": len(content),
+        "contexts": [content],
+        "results": [result],
+    }
+
+
 async def _translate_llm_with_retry(
     query: str,
     language: str,
@@ -1629,6 +1696,15 @@ class MainWorkflow:
                 answer = masked
         except Exception:
             pass  # Non-critical — API層でもスキャンするため
+
+        if "rag_evidence" not in metadata:
+            rag_evidence = _build_agent_response_evidence_metadata(
+                state_context,
+                metadata,
+                answer,
+            )
+            if rag_evidence is not None:
+                metadata["rag_evidence"] = rag_evidence
 
         # Response translation: translate JA response to EN for English users
         # zh/ko: rely on LLM's native multilingual output (LANGUAGE_INSTRUCTION)


### PR DESCRIPTION
## Summary
- Adds opt-in live evaluation evidence for source-backed static/canonical responses so `/api/chat` no longer reports source-backed answers with zero live contexts.
- Adds explicit Connpass evidence for EventAgent canonical Connpass answers and restores diagnostic ground-truth details already present in contexts.
- Improves deterministic multilingual quality signals with CJK/Hangul 2-gram grounding plus fact-anchor support for translated reference grounding, while keeping unsupported-fact negative tests.

## Root cause
Post-deploy diagnostic RAGAS for PR #826 collected/evaluated all 29 cases, but failed because several BusinessInfo/Facility/Event canonical fast paths returned `sources` without `rag_evidence`, and translated/paraphrased contexts produced deterministic grounding false negatives.

## Verification
- `pytest backend/tests/evaluation/test_ground_truth_dataset.py backend/tests/agents/test_event_agent.py backend/tests/evaluation/test_ragas_live_case_suites.py backend/tests/evaluation/test_offline_quality_gate.py backend/tests/workflows/test_main_workflow.py -q`
- `ruff check backend/agents/event_agent.py backend/evaluation/quality_signals.py backend/evaluation/run_live_api_eval.py backend/workflows/main_workflow.py backend/tests/agents/test_event_agent.py backend/tests/evaluation/test_ground_truth_dataset.py backend/tests/evaluation/test_offline_quality_gate.py backend/tests/evaluation/test_ragas_live_case_suites.py backend/tests/workflows/test_main_workflow.py`
- `black --check backend/agents/event_agent.py backend/evaluation/quality_signals.py backend/evaluation/run_live_api_eval.py backend/workflows/main_workflow.py backend/tests/agents/test_event_agent.py backend/tests/evaluation/test_ground_truth_dataset.py backend/tests/evaluation/test_offline_quality_gate.py backend/tests/evaluation/test_ragas_live_case_suites.py backend/tests/workflows/test_main_workflow.py`
- `python -m backend.evaluation.run_offline_quality_gate --languages ja en zh ko --max-cases 2 --output-dir /tmp/ragas-followup-pr-gate --enforce`

Follow-up to #826 / #518.