### PR TITLE
docs(adr): ADR-023 Semantic Router + LangGraph runtime self-evaluation

### DIFF
--- a/docs/adr/023-semantic-router-and-runtime-self-evaluation.md
+++ b/docs/adr/023-semantic-router-and-runtime-self-evaluation.md
@@ -2,7 +2,7 @@
 
 ## Status
 
-Proposed (2026-05-17) — 実装は次セッション以降の別エンジニア担当。本 ADR は設計合意の固定版。
+Accepted (2026-05-17) — 実装は次セッション以降の別エンジニア担当。本 ADR は設計合意の固定版。
 
 ## Context
 
@@ -17,7 +17,7 @@ Engineer Cafe Navigator のルーティング層は ADR-006 (LangGraph workflow 
 | ファイル | 行数 | 制限 | 内容 |
 |---|---|---|---|
 | [`backend/workflows/main_workflow.py`](../../backend/workflows/main_workflow.py) | **2,274** | 800 | 4段ファストパス + reception bypass + clarification handler が同居 |
-| [`backend/config/routing_constants.py`](../../backend/config/routing_constants.py) | **1,147** | 800 | キーワードリスト 30 種以上、`CATEGORY_TO_AGENT_MAP` 23 エントリ |
+| [`backend/config/routing_constants.py`](../../backend/config/routing_constants.py) | **1,147** | 800 | `*_KEYWORDS` 定数 41 個、`CATEGORY_TO_AGENT_MAP` 39 エントリ |
 | [`backend/utils/intent_classifier.py`](../../backend/utils/intent_classifier.py) | **734** | 800 | `classify_fast_intent()` 単一関数に `if match_keywords(...)` 35 連発 |
 | [`backend/utils/query_classifier.py`](../../backend/utils/query_classifier.py) | 508 | 800 | regex + キーワード手書き分類 |
 | [`backend/agents/orchestrator_agent.py`](../../backend/agents/orchestrator_agent.py) | 401 | 800 | LLM ルーティングは "高速パス全部スカった時の最後" |
@@ -220,12 +220,13 @@ async def critic_node(state: WorkflowStateDict) -> dict:
 #### D2c: LangSmith trace 配線（Phase 0 の 5 行）
 
 ```python
-# backend/main.py の startup_event
+# backend/main.py の lifespan(app) startup ブロック内（yield より前）
+# main.py:159 の async def lifespan(app: FastAPI) に追記
 if settings.langsmith_api_key:
     os.environ["LANGSMITH_TRACING"] = "true"
     os.environ["LANGSMITH_API_KEY"] = settings.langsmith_api_key
-    os.environ["LANGSMITH_PROJECT"] = "engineer-cafe-prod"
-    logger.info("LangSmith tracing enabled: project=engineer-cafe-prod")
+    os.environ["LANGSMITH_PROJECT"] = settings.langsmith_project
+    logger.info("LangSmith tracing enabled: project=%s", settings.langsmith_project)
 ```
 
 → これだけで既存 LangGraph ノード全部が **自動 trace される**。critic_node 追加後は `critic_score` カスタム metadata 付きで LangSmith ダッシュボードに並ぶ。
@@ -346,6 +347,6 @@ Latency tail を完全に避けたい場合の保守解。
 
 ## Approvals
 
-- Proposed: Claude Code session (2026-05-17, ツンデレ後輩女子モード) — 設計検討と stack 選定
-- Decided: Terada Kousuke (terisuke) — Router=semantic-router / Eval=LangSmith / Self-repair=1 retry/30s budget
+- Proposed: Claude Code (2026-05-17) — 設計検討と stack 選定
+- Accepted: Terada Kousuke (terisuke, 2026-05-17) — Router=semantic-router / Eval=LangSmith / Self-repair=1 retry/30s budget
 - Pending: 担当エンジニアによる Phase 0 PR 起票、Epic GitHub Issue 起票

--- a/docs/adr/023-semantic-router-and-runtime-self-evaluation.md
+++ b/docs/adr/023-semantic-router-and-runtime-self-evaluation.md
@@ -1,0 +1,351 @@
+# ADR-023: Semantic Router 三段カスケード + LangGraph Runtime Self-Evaluation Loop
+
+## Status
+
+Proposed (2026-05-17) — 実装は次セッション以降の別エンジニア担当。本 ADR は設計合意の固定版。
+
+## Context
+
+### 観測されている構造的問題
+
+Engineer Cafe Navigator のルーティング層は ADR-006 (LangGraph workflow redesign) で導入したキーワード fast-path をベースにしているが、運用 6 ヶ月で以下の悪循環が確立してしまった：
+
+> Q-gate FAIL の発生 → 該当パターンを `*_KEYWORDS` リストに追記 → 新規 if 分岐を `intent_classifier.py` に挿入 → ルーティング表 (`CATEGORY_TO_AGENT_MAP`, `REQUEST_TYPE_TO_AGENT_MAP`) を更新 → 次の Q-gate FAIL で同じことを繰り返す。
+
+#### 現状の規模（2026-05-17 時点）
+
+| ファイル | 行数 | 制限 | 内容 |
+|---|---|---|---|
+| [`backend/workflows/main_workflow.py`](../../backend/workflows/main_workflow.py) | **2,274** | 800 | 4段ファストパス + reception bypass + clarification handler が同居 |
+| [`backend/config/routing_constants.py`](../../backend/config/routing_constants.py) | **1,147** | 800 | キーワードリスト 30 種以上、`CATEGORY_TO_AGENT_MAP` 23 エントリ |
+| [`backend/utils/intent_classifier.py`](../../backend/utils/intent_classifier.py) | **734** | 800 | `classify_fast_intent()` 単一関数に `if match_keywords(...)` 35 連発 |
+| [`backend/utils/query_classifier.py`](../../backend/utils/query_classifier.py) | 508 | 800 | regex + キーワード手書き分類 |
+| [`backend/agents/orchestrator_agent.py`](../../backend/agents/orchestrator_agent.py) | 401 | 800 | LLM ルーティングは "高速パス全部スカった時の最後" |
+
+> 800 行制限（CLAUDE.md `~/.claude/rules/coding-style.md`）を 3 ファイルが超過。
+
+#### 既存ルート判定パイプライン（実態）
+
+```
+START
+  ↓ _input_type_decision
+reception_check
+  ↓ _reception_check_decision
+keyword_router          ← fast-path #1: pre_memory_fast_path（facility/general_knowledge のみ直行）
+  ↓
+memory_loader (RAG pre-fetch)
+  ↓
+orchestrator
+  ├── _is_memory_related_question      ← fast-path #2
+  ├── _try_fast_routing (=classify_fast_intent, 35 連 if)  ← fast-path #3
+  ├── _resolve_cafe_entity_for_turn (saino 強制 business_info) ← fast-path #4
+  ├── LLM 呼び出し（ここでようやく動的判定）
+  ├── _handle_emergency
+  ├── _handle_greeting
+  ├── _handle_clarification
+  ├── _handle_topic_guard
+  ↓
+business_info / facility / event / slide / general_knowledge / farewell
+  ↓
+format_response → END
+```
+
+### 既存の自己評価パイプライン（致命的欠落）
+
+| 項目 | 現状 |
+|---|---|
+| Online (per-turn) eval | **無し**。turn 単位で自分の出力を判定する critic ノードが存在しない |
+| Offline eval | [`backend/evaluation/run_multilingual_eval.py`](../../backend/evaluation/run_multilingual_eval.py)（590 行）+ RAGAS が週1 cron ([`.github/workflows/ragas-evaluation.yml`](../../.github/workflows/ragas-evaluation.yml)) |
+| Trace の入手手段 | DB を SELECT。span/trace の構造化エクスポート無し |
+| LangSmith | API key フィールド (`backend/config/settings.py:81`) は定義済み。**ただし import / instrument は未配線** |
+| Langfuse / OTel | **未配線** |
+| Guardrail への eval feedback | 一方通行（評価結果 → 人が修正 → PR）。runtime には何も戻らない |
+
+### 2026 年業界ベスト・プラクティス（調査結果）
+
+- **Semantic Router (embedding-based 1st stage)**: utterance ベクトル空間で cosine 類似度判定。FastEmbed (ONNX, CPU) で 10–30ms。2026 年時点で数千ルートまで再学習不要、95% 精度・10–20ms latency 達成事例あり。
+  - [aurelio-labs/semantic-router](https://github.com/aurelio-labs/semantic-router)
+  - [Deepchecks: What is Semantic Router? 2026](https://www.deepchecks.com/glossary/semantic-router/)
+  - [vLLM Semantic Router blog (2025/09)](https://blog.vllm.ai/2025/09/11/semantic-router.html)
+- **Cascade routing**: 小モデル → 大モデルへの confidence-aware escalation。
+  - [lm-sys/RouteLLM](https://github.com/lm-sys/RouteLLM)
+  - [IBM Research: LLM routers (2025)](https://research.ibm.com/blog/LLM-routers)
+- **Self-Reflective LangGraph**: generator → critic → revise の閉ループ、`critic_score` を trace span に直接付与。
+  - [langchain-ai/langgraph-reflection](https://github.com/langchain-ai/langgraph-reflection)
+  - [Building Self-Evaluating Systems With LangGraph (2026/02)](https://www.sciencetechniz.com/2026/02/building-self-evaluating-systems-with.html)
+- **Online evaluation as runtime guardrail**: production trace に毎ターン自動 judge スコア付与。eval を dev で定義 → そのまま runtime guardrail。
+  - [Langfuse LLM-as-a-Judge](https://langfuse.com/docs/evaluation/evaluation-methods/llm-as-a-judge)
+  - [LangSmith Evaluation Platform](https://www.langchain.com/langsmith/evaluation)
+  - [Agent Observability 2026 ガイド](https://www.digitalapplied.com/blog/agent-observability-2026-evals-traces-cost-guide)
+- **Voice / kiosk latency 設計**: cascading 構成で intent recognition >95% 精度、Stage 1+2 で 50ms 以内が voice 用途の鉄則。
+  - [Hamming.ai Voice Agent Testing Guide 2026](https://hamming.ai/resources/voice-agent-testing-guide)
+  - [AssemblyAI: AI voice agents 2026](https://www.assemblyai.com/blog/ai-voice-agents)
+
+## Decision
+
+ルーティングを **「三段カスケード Router」** に再設計し、LangGraph に **「critic ノード + 1 回 self-repair + LangSmith trace 配線」** を追加する。"キーワードを 1 つ足す" 運用を "YAML に発話例を 1 行足す" 運用に転換し、本番 100% カバレッジの自己評価ループを runtime に組み込む。
+
+### D1: ルーティング層を三段カスケードに置換
+
+```
+                ┌───────────────────────────────────────────┐
+                │  Stage 1: Deterministic safety regex      │
+User query ────▶│  (emergency / farewell / PII redaction)    │── HIT → 即決
+                │  ~50 行。命に関わる物・自明な hard rule のみ │
+                └────────────────┬──────────────────────────┘
+                                 │ MISS
+                                 ▼
+                ┌───────────────────────────────────────────┐
+                │  Stage 2: Semantic Router                 │
+                │  - aurelio-labs/semantic-router           │
+                │  - FastEmbed (ONNX, CPU) ~10-30ms         │── score ≥ 0.75 → 確定
+                │  - routes.yaml で utterance を管理          │
+                │  - Hybrid mode (BM25 + dense) で OOV吸収   │
+                └────────────────┬──────────────────────────┘
+                                 │ score < 0.75 (曖昧)
+                                 ▼
+                ┌───────────────────────────────────────────┐
+                │  Stage 3: LLM Router (現行 orchestrator)  │
+                │  - Pydantic / JSON schema 構造化出力       │
+                │  - gemini-flash-lite（routing 用）         │
+                └───────────────────────────────────────────┘
+```
+
+#### D1a: 規模目標
+
+| ファイル | Before | After (目標) | 削減手段 |
+|---|---|---|---|
+| `routing_constants.py` | 1,147 | ≤ 300 | キーワード 30 種 → `routes.yaml`（utterance 各 3–5 例）。マッピング表は維持 |
+| `intent_classifier.py` | 734 | ≤ 120 | `classify_fast_intent` 35 連 if → emergency / farewell / assistant_profile / pet_policy など safety hard rule のみ残す |
+| `main_workflow.py` | 2,274 | ≤ 800 (Phase 5 で subgraph 分割) | router / critic / format を subgraph に切り出し |
+
+#### D1b: routes.yaml フォーマット（提案）
+
+```yaml
+# backend/routing/routes.yaml
+version: 1
+encoder: fastembed/Qwen3-Embedding-0.6B  # ONNX, CPU
+threshold: 0.75
+routes:
+  - name: business_hours
+    target_agent: business_info
+    request_type: hours
+    utterances:
+      - "営業時間は何時まで？"
+      - "今日は何時に閉まりますか"
+      - "What time do you close?"
+      - "週末も開いてる？"
+      - "休館日はいつ"
+
+  - name: wifi
+    target_agent: facility
+    request_type: wifi
+    utterances:
+      - "Wi-Fi のパスワード教えて"
+      - "インターネットはありますか"
+      - "What's the Wi-Fi password?"
+      - "无线网密码"
+
+  # ... 約 30 ルート
+```
+
+#### D1c: Voice latency budget 整合
+
+| Stage | 想定 latency | 累積 |
+|---|---|---|
+| Stage 1 (regex) | < 1ms | 1ms |
+| Stage 2 (FastEmbed + 30 routes cosine) | 10–30ms | ~31ms |
+| Stage 3 (LLM router, fallback only) | 150–250ms | ~280ms |
+
+→ Voice 用途の 50ms budget を Stage 1+2 で守る。Stage 3 を踏むのは曖昧クエリのみ。
+
+### D2: LangGraph に Critic ノード + 1 回 self-repair を追加
+
+```
+existing:
+  agent → format_response → END
+
+新:
+  agent → format_response → 🆕 critic_node ───┐
+                                              │
+            ┌──── repair (1 retry only) ◀────┤ verdict.needs_repair=true && retry==0
+            │                                 │
+            └──→ agent (re-execute) ─────────┘
+                                              │
+                                              └─→ END (verdict.passed or retry exhausted)
+                                                  ↓
+                                          🆕 quality_event_emitter
+                                          (LangSmith trace に
+                                           critic_score を非同期 emit)
+```
+
+#### D2a: Critic ノードの責務
+
+```python
+# backend/workflows/critic_node.py (新設, 目標 ≤150 行)
+
+class CriticVerdict(BaseModel):
+    groundedness: float          # RAG context への忠実度 (decision: 0.6 未満で repair)
+    answer_relevancy: float      # 質問への適合度
+    language_match: float        # quality_signals.language_match_score を流用
+    safety: float                # PII / toxicity (既存 pii_scanner + quality_signals 流用)
+    routing_correctness: float   # 選んだ agent が妥当か (LLM judge, 確信度低い時のみ)
+    needs_repair: bool
+    repair_hint: str | None      # "RAG context が空。general_knowledge に re-route 推奨"
+
+async def critic_node(state: WorkflowStateDict) -> dict:
+    # 1. 決定論的シグナル（無料・5ms）: 既存 quality_signals.summarize_quality_signals 流用
+    deterministic = compute_deterministic_signals(state)
+
+    # 2. LLM-as-judge（gemini-flash-lite, ~200ms, 確信度低い時のみ）
+    if deterministic.groundedness < 0.7 or deterministic.language_match < 0.9:
+        judge = await llm_judge.score(query, answer, contexts)
+        verdict = merge(deterministic, judge)
+    else:
+        verdict = CriticVerdict.from_deterministic(deterministic)
+
+    # 3. LangSmith trace に critic_score を非同期 emit (fire-and-forget)
+    emit_trace_score(session_id=state["session_id"], verdict=verdict)
+
+    return {"critic_verdict": verdict.model_dump()}
+```
+
+#### D2b: Self-repair の制約
+
+- **最大 1 回の retry**（無限ループ防止）
+- 既存 [`main_workflow.py:2134`](../../backend/workflows/main_workflow.py:2134) の `asyncio.wait_for(graph.ainvoke, timeout=30)` を尊重。critic + repair の合計でも 30s を超えない
+- `repair_hint` が "re-route" を示す場合のみ別 agent を再呼び出し、それ以外は同 agent の同一実行
+- repair しても improve しなければ retry をやめて元の answer を返す（`fallback_to_original=true` でログ出力）
+
+#### D2c: LangSmith trace 配線（Phase 0 の 5 行）
+
+```python
+# backend/main.py の startup_event
+if settings.langsmith_api_key:
+    os.environ["LANGSMITH_TRACING"] = "true"
+    os.environ["LANGSMITH_API_KEY"] = settings.langsmith_api_key
+    os.environ["LANGSMITH_PROJECT"] = "engineer-cafe-prod"
+    logger.info("LangSmith tracing enabled: project=engineer-cafe-prod")
+```
+
+→ これだけで既存 LangGraph ノード全部が **自動 trace される**。critic_node 追加後は `critic_score` カスタム metadata 付きで LangSmith ダッシュボードに並ぶ。
+
+### D3: 既存決定論評価ロジックの runtime 再利用
+
+`backend/evaluation/quality_signals.py` は **CI/offline で確立された決定論シグナル群** (language_match / groundedness / hallucination_risk / toxicity)。これらを critic ノードに **そのまま import して runtime 評価に流用**する。CI と runtime の評価基準が一致する点が重要。
+
+- CI 側の thresholds（`DEFAULT_THRESHOLDS`）は変更しない
+- critic 側は独自閾値（`groundedness_min=0.6` など）を持つが、CI の thresholds を **上限** として絶対超えない（CI で OK と判定したものを runtime が NG とすると不整合）
+
+### D4: 移行は Shadow Mode を必須にする
+
+Stage 2 (Semantic Router) を **shadow mode** で並走させ、既存 rule との不一致を 1 週間 LangSmith に蓄積してから切替。
+critic ノードも初期は **記録のみ・repair off** で配置し、Phase 4 から self-repair を有効化する。
+
+## Consequences
+
+### Positive
+
+- **キーワード追加運用の終焉**: 新しい言い回しは `routes.yaml` に 1 行追記、関連 PR 規模が激減
+- **多言語の取りこぼし減少**: cosine 類似度で zh/ko の OOV も吸収。Q-gate FAIL の構造的削減
+- **本番 100% カバレッジの quality 可視化**: LangSmith dashboard で `critic_score` を時系列観測
+- **failure mode の自動修復**: groundedness 低下時 1 回 retry で UX 損失を局所化
+- **ファイル規模の coding-style 整合**: 800 行制限超過の 3 ファイルが解消
+- **Codex CLI 経路 C 委任が容易**: utterance 量産は典型的 Codex タスク
+
+### Negative
+
+- **新規依存**: `semantic-router`, `fastembed`（ONNX runtime）の追加 → Cloud Run image size 増加 (~50MB)
+- **LangSmith 課金**: trace 量に応じた cost。Phase 0 で sampling 比率を 100% → 必要なら段階的に 10% へ
+- **Cold start 増加**: FastEmbed model preload で +1–2s。既存 STT preload と同じパターンで吸収
+- **Critic latency tail**: p99 で +200–300ms（LLM judge 経路）。ただし async fire-and-forget で平常 latency には影響しない設計
+- **学習曲線**: チームに Semantic Router / LangSmith の knowledge transfer が必要
+
+### Risk Mitigation
+
+| Risk | Mitigation |
+|---|---|
+| Semantic Router が既存 rule より精度低い | Phase 2 で 1 週間 shadow 計測。不一致率 >5% なら切替延期 |
+| Self-repair で無限ループ | 1 回固定上限・total 30s timeout・`fallback_to_original` の 3 層防御 |
+| LangSmith 障害で本番落ちる | trace は async fire-and-forget。失敗してもユーザー応答は返す |
+| Cloud Run cold start で SLO 違反 | FastEmbed の model warmup を既存 `stt_warmup_service.py` パターンで起動時実行 |
+| 既存 RAGAS との二重計測 | RAGAS は週1 → nightly に降格、runtime critic と分業 |
+
+## Rollout Plan（Phase 別、各 Phase = 1 PR 単位）
+
+| Phase | 内容 | 期間 | 担当候補 | 完了条件 |
+|---|---|---|---|---|
+| **0** | LangSmith tracing 配線（`backend/main.py` startup_event に 5 行追加）+ `settings.langsmith_project` フィールド追加。RAGAS を nightly に降格 | 0.5 日 | backend-developer | 本番 100% の turn が LangSmith dashboard に出る |
+| **1** | `critic_node` 追加（**決定論シグナルのみ、LLM judge off、repair off**）+ trace へ critic_score emit | 2–3 日 | backend-developer + tdd-guide | critic_score が全 turn に付く。groundedness 分布が LangSmith で観測可能 |
+| **2** | `backend/routing/semantic_router.py` 新設、`routes.yaml` 初期版を **shadow mode** で並走。不一致を LangSmith カスタムスコア `routes_mismatch` で記録 | 1 週間（実装3日 + データ収集5日） | backend-developer + Codex CLI 経路 C (utterance 量産) | 1 週間 shadow 計測完了、不一致率 ≤5% |
+| **3** | `routes.yaml` を正系に昇格。`classify_fast_intent` を 35 分岐 → safety hard rule 5 つに減量。`routing_constants.py` を ≤300 行・`intent_classifier.py` を ≤120 行に削減 | 1 週間 | backend-developer | Q-gate 4 FAIL → 0、CI green、ファイル行数達成 |
+| **4** | LLM-as-judge を critic に追加（gemini-flash-lite）。`routing_correctness` を活用し `routes.yaml` 半自動学習データ抽出スクリプト追加。**self-repair (1 retry) を有効化** | 1 週間 | backend-developer + e2e-runner | repair 後 PASS 率 ≥70%、p95 latency 増加 ≤300ms |
+| **5** | `main_workflow.py` を subgraph 分割 (routing_subgraph / critic_subgraph / format_subgraph)。各 ≤800 行 | 1 週間 | architect + backend-developer | 全 ファイル 800 行以下、subgraph 単体テスト追加、E2E green |
+
+### Phase 別 PR 規律
+
+- ブランチ命名: `feat/router-phase{N}-{slug}`
+- 全 PR `--base develop`
+- code-reviewer + Codex CLI 経路 A レビュー必須（CLAUDE.md 規約準拠）
+- Phase 1 / 4 は backend Python なので `cd backend && ruff check . && black --check . && pytest -m "not ragas and not slow"` を CI gate
+- Phase 0 の LangSmith trace 有効化後、各 Phase 完了時に **LangSmith dashboard スクショ** を PR 本文に添付（後工程の証跡）
+
+## Alternatives Considered
+
+### A1: pgvector で自作 Semantic Router
+
+既存 Supabase pgvector を流用、新規依存ゼロ。
+**却下理由**: hybrid (BM25+dense) を自前実装する工数が、`semantic-router` 採用工数を超える。voice latency 用途では FastEmbed の ONNX in-process 推論が pgvector 経由 RPC より明確に速い。pgvector は引き続き knowledge_base 用途で残す。
+
+### A2: RouteLLM (lm-sys) を採用
+
+LLM model selection 寄りの設計で、Engineer Cafe Navigator の "intent → agent 選択" には粒度が合わない。
+**却下理由**: voice kiosk の細粒度 intent 判定には less suited。将来 LLM provider 多重化時に再検討の余地あり。
+
+### A3: Langfuse を採用
+
+OSS, self-host 可、OpenTelemetry ネイティブ。
+**保留**: Phase 0 では LangSmith（既に `langsmith_api_key` フィールド配線済みで即時有効化可能）を採用。Phase 4 完了後にコスト・運用面で Langfuse migration を別 ADR で検討。
+
+### A4: Self-repair なし、critic は guardrail (PII / toxicity / language mismatch) だけ
+
+Latency tail を完全に避けたい場合の保守解。
+**却下理由**: 質問に対する fail recovery を運用 PR で行う現状を維持してしまう。Phase 1 で repair off の critic を入れて十分なデータ取得後に Phase 4 で有効化、というステージングなら risk を抑えられる。
+
+## References
+
+### 本リポジトリ内
+
+- [ADR-006: LangGraph workflow redesign](006-langgraph-workflow-redesign.md) — 現行 keyword fast-path 導入の経緯
+- [ADR-014: Observability phase 1a](014-observability-phase1.md) — 構造化ログ基盤
+- [ADR-017: Observability phase 1b](017-observability-phase1b.md) — Terraform メトリクス・アラート
+- [ADR-018: Alpha fast response and assistant profile routing](018-alpha-fast-response-and-assistant-profile-routing.md) — `is_assistant_profile_question` の経緯
+- [ADR-019: Alpha live RAGAS case accounting](019-alpha-live-ragas-case-accounting.md) — C-127 ケース会計
+- `~/.claude/projects/-Users-teradakousuke-Developer-engineer-cafe-navigator2025/memory/MEMORY.md` — Phase 3.6 残課題（B-1〜B-4）と本 ADR の関連
+
+### 外部
+
+- [aurelio-labs/semantic-router](https://github.com/aurelio-labs/semantic-router)
+- [aurelio-labs/semantic-router — hybrid-router example](https://github.com/aurelio-labs/semantic-router/blob/main/docs/examples/hybrid-router.ipynb)
+- [aurelio-labs/semantic-router — FastEmbed integration](https://github.com/aurelio-labs/semantic-router/blob/main/docs/encoders/fastembed.ipynb)
+- [Deepchecks: What is Semantic Router? (2026)](https://www.deepchecks.com/glossary/semantic-router/)
+- [vLLM Semantic Router blog (2025/09)](https://blog.vllm.ai/2025/09/11/semantic-router.html)
+- [Red Hat Developer: LLM Semantic Router (2025/05)](https://developers.redhat.com/articles/2025/05/20/llm-semantic-router-intelligent-request-routing)
+- [lm-sys/RouteLLM](https://github.com/lm-sys/RouteLLM)
+- [withmartian/routerbench](https://github.com/withmartian/routerbench)
+- [IBM Research: LLM routers](https://research.ibm.com/blog/LLM-routers)
+- [langchain-ai/langgraph-reflection](https://github.com/langchain-ai/langgraph-reflection)
+- [Building Self-Evaluating Systems With LangGraph (Science Techniz, 2026/02)](https://www.sciencetechniz.com/2026/02/building-self-evaluating-systems-with.html)
+- [Next-Generation Agentic RAG with LangGraph (Medium, 2026/03)](https://medium.com/@vinodkrane/next-generation-agentic-rag-with-langgraph-2026-edition-d1c4c068d2b8)
+- [LangSmith Evaluation Platform](https://www.langchain.com/langsmith/evaluation)
+- [Langfuse LLM-as-a-Judge](https://langfuse.com/docs/evaluation/evaluation-methods/llm-as-a-judge)
+- [Agent Observability 2026 ガイド](https://www.digitalapplied.com/blog/agent-observability-2026-evals-traces-cost-guide)
+- [Galileo Runtime Protection (2026)](https://galileo.ai/blog/best-ai-agent-evaluation-platforms)
+- [Hamming.ai Voice Agent Testing Guide 2026](https://hamming.ai/resources/voice-agent-testing-guide)
+- [AssemblyAI: AI voice agents 2026](https://www.assemblyai.com/blog/ai-voice-agents)
+
+## Approvals
+
+- Proposed: Claude Code session (2026-05-17, ツンデレ後輩女子モード) — 設計検討と stack 選定
+- Decided: Terada Kousuke (terisuke) — Router=semantic-router / Eval=LangSmith / Self-repair=1 retry/30s budget
+- Pending: 担当エンジニアによる Phase 0 PR 起票、Epic GitHub Issue 起票

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -28,6 +28,7 @@
 | [009 — Slow 403 / cold-start RCA](009-slow-403-cold-start-rca.md)       | Cloud Run cold-start と 403      |
 | [010 — Qwen ONNX quantization spike](010-qwen-onnx-quantization.md)     | ONNX / INT4 実験                  |
 | [016 — Qwen STT phase 2 profiling](016-qwen-stt-phase2-profiling.md)    | STT プロファイル                      |
+| [023 — Semantic Router + runtime self-evaluation](023-semantic-router-and-runtime-self-evaluation.md) | ルーティング再設計（三段カスケード）と LangGraph critic_node 自己評価 |
 
 
 ## キャラ・長期記憶・インフラ観測
@@ -49,5 +50,5 @@
 
 ## メモ
 
-- ADR 番号は 005 以降を運用しており、**015 は欠番**です（採番のみ存在し、文書化に至らなかったため）。新しい ADR を起票する際は 023 から付番してください。
+- ADR 番号は 005 以降を運用しており、**015 は欠番**です（採番のみ存在し、文書化に至らなかったため）。新しい ADR を起票する際は 024 から付番してください（023 は本リスト追加済）。
 - 001–004 についても、本リポジトリでは初期から ADR 005 以降のみを保守しています。

--- a/docs/plans/semantic-router-self-eval-2026-05-17.md
+++ b/docs/plans/semantic-router-self-eval-2026-05-17.md
@@ -1,0 +1,460 @@
+# Semantic Router + Runtime Self-Evaluation 実装ハンドオフ計画
+
+> **対象 ADR**: [ADR-023](../adr/023-semantic-router-and-runtime-self-evaluation.md)
+> **作成**: 2026-05-17 (Claude Code session — terisuke 承認)
+> **対象**: 次セッション以降の担当エンジニア
+> **前提**: ADR-023 を必読の上、Phase 0 → 5 を順次 PR 化する
+
+本書は ADR-023 の「具体的修正箇所」と「PR ボディ雛形」を提供する**作業手引き**。設計判断の根拠は ADR を参照すること。
+
+---
+
+## 共通ルール（全 Phase 通じて）
+
+### ブランチ・PR
+- ブランチ命名: `feat/router-phase{N}-{slug}` 例: `feat/router-phase0-langsmith-tracing`
+- 全 PR `--base develop`（CLAUDE.md 規約）
+- 1 Phase = 1 PR、複数意図混在禁止
+- PR body 必須項目:
+  - ADR-023 へのリンク
+  - 対象 Phase の "完了条件" を満たした証跡（CI green / ファイル行数 / dashboard スクショ）
+  - `Co-Authored-By:` 行
+
+### CI 必須
+```bash
+cd backend
+ruff check .
+black --check .
+pytest -m "not ragas and not slow" --tb=short -q
+```
+
+### レビューパイプライン
+1. code-reviewer agent (FULL — Python ソース変更を含むため)
+2. Codex CLI 経路 A (`codex exec review`)
+3. 両者 LGTM 後にマージ。CRITICAL/HIGH ゼロ必須
+
+### Memory / docs 同時更新（CLAUDE.md hook 強制）
+- 各 Phase 完了時に `MEMORY.md` の "Session Status" を更新
+- 関連ドキュメント（`docs/architecture/SYSTEM-ARCHITECTURE.md` 等）に router 章を追記
+
+---
+
+## Phase 0: LangSmith Tracing 配線
+
+**期間目安**: 0.5 日
+**ブランチ**: `feat/router-phase0-langsmith-tracing`
+**目的**: 100% の本番 turn を LangSmith に流す。以降の Phase の数値検証基盤を作る。
+
+### 修正対象
+
+| ファイル | 行 | 変更内容 |
+|---|---|---|
+| `backend/main.py` | startup_event 内 | LangSmith 環境変数を 3 つ export、log 1 行追加 |
+| `backend/config/settings.py` | 既存 `langsmith_api_key` フィールド付近 | `langsmith_project: str = "engineer-cafe-prod"` を追加 |
+| `.github/workflows/ragas-evaluation.yml` | cron 行 | `'0 9 * * 1'` → `'0 17 * * *'` (毎日 02:00 JST) に降格 |
+| `MEMORY.md` | Session Status | Phase 0 完了を記録 |
+| `docs/architecture/SYSTEM-ARCHITECTURE.md` | 観測章 | LangSmith 配線を 1 段落追記 |
+
+### 実装スニペット
+
+```python
+# backend/main.py の startup_event 末尾に追加
+if settings.langsmith_api_key:
+    os.environ["LANGSMITH_TRACING"] = "true"
+    os.environ["LANGSMITH_API_KEY"] = settings.langsmith_api_key
+    os.environ["LANGSMITH_PROJECT"] = settings.langsmith_project
+    logger.info(
+        "LangSmith tracing enabled: project=%s",
+        settings.langsmith_project,
+    )
+else:
+    logger.info("LangSmith tracing disabled (no api_key)")
+```
+
+### Secret Manager
+
+```bash
+# GCP Secret Manager に LANGSMITH_API_KEY を追加
+echo -n "lsv2_..." | gcloud secrets create LANGSMITH_API_KEY --data-file=-
+
+# Cloud Run へ反映（--update-secrets で既存上書きしない）
+gcloud run services update engineer-cafe-backend \
+  --region=asia-northeast1 \
+  --update-secrets="LANGSMITH_API_KEY=LANGSMITH_API_KEY:latest"
+```
+
+### 完了条件
+- [ ] Cloud Run revision がデプロイされ、`gcloud run services logs read` で `LangSmith tracing enabled` が確認できる
+- [ ] LangSmith dashboard で `engineer-cafe-prod` プロジェクトに live trace が流れている（本番1ターン後にスクショ）
+- [ ] CI green、code-reviewer + Codex CLI 経路 A LGTM
+- [ ] MEMORY.md に Phase 0 完了記録
+
+### PR ボディ雛形
+
+```markdown
+## Summary
+ADR-023 Phase 0: LangSmith tracing を本番 backend に配線。以降の semantic router / critic node 実装で必要な observability 基盤を立ち上げる。
+
+## Changes
+- `backend/main.py`: startup_event で LangSmith 環境変数を export
+- `backend/config/settings.py`: `langsmith_project` フィールド追加
+- `.github/workflows/ragas-evaluation.yml`: cron 週1 → 日次に降格
+
+## Evidence
+- LangSmith dashboard スクショ (本番 1 turn の trace 表示)
+- Cloud Run logs: `LangSmith tracing enabled` 行
+- CI green: <CI URL>
+
+## ADR
+[ADR-023](docs/adr/023-semantic-router-and-runtime-self-evaluation.md) Phase 0
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+Co-Authored-By: Claude <noreply@anthropic.com>
+```
+
+---
+
+## Phase 1: critic_node 追加（決定論シグナルのみ）
+
+**期間目安**: 2–3 日
+**ブランチ**: `feat/router-phase1-critic-node-deterministic`
+**目的**: 全 turn に `critic_score` を付与し、groundedness 分布を LangSmith で観測可能にする。**LLM judge は使わず、self-repair も off**。
+
+### 修正対象
+
+| ファイル | 変更内容 |
+|---|---|
+| `backend/workflows/critic_node.py` (新設, ≤150行) | `CriticVerdict` Pydantic + `critic_node()` 関数 |
+| `backend/workflows/main_workflow.py` | `_build_graph` に critic_node を追加、format_response → critic → END に変更 |
+| `backend/workflows/critic_metrics.py` (新設, ≤80行) | LangSmith trace に `critic_score` を非同期 emit するヘルパー |
+| `backend/tests/workflows/test_critic_node.py` (新設) | tdd-guide で先に書く。groundedness 0.6/0.8/1.0 の境界テスト |
+
+### 実装スケルトン
+
+```python
+# backend/workflows/critic_node.py
+from pydantic import BaseModel, Field
+from backend.evaluation.quality_signals import (
+    language_match_score,
+    groundedness_score,  # quality_signals から流用
+)
+from backend.workflows.critic_metrics import emit_critic_score
+
+class CriticVerdict(BaseModel):
+    groundedness: float = Field(ge=0, le=1)
+    answer_relevancy: float = Field(ge=0, le=1)
+    language_match: float = Field(ge=0, le=1)
+    safety: float = Field(ge=0, le=1)
+    routing_correctness: float = Field(ge=0, le=1, default=1.0)  # Phase 4 まで 1.0
+    needs_repair: bool = False
+    repair_hint: str | None = None
+
+async def critic_node(state: dict) -> dict:
+    query = state.get("query", "")
+    answer = state.get("answer", "")
+    language = state.get("language", "ja")
+    contexts = state.get("context", {}).get("knowledge_results", {}).get("results", [])
+
+    verdict = CriticVerdict(
+        groundedness=groundedness_score(answer, contexts),
+        answer_relevancy=1.0,  # Phase 4 で LLM judge 実装
+        language_match=language_match_score(answer, language),
+        safety=1.0,  # 既存 PII scanner が format_response で処理済み
+        needs_repair=False,  # Phase 4 まで always False
+    )
+
+    # 非同期 fire-and-forget で trace に emit（応答 latency に影響させない）
+    asyncio.create_task(emit_critic_score(state["session_id"], verdict))
+
+    return {"critic_verdict": verdict.model_dump()}
+```
+
+```python
+# backend/workflows/critic_metrics.py
+from langsmith import Client
+
+_client = Client()
+
+async def emit_critic_score(session_id: str, verdict: CriticVerdict) -> None:
+    """LangSmith trace に critic_score を non-blocking で emit."""
+    try:
+        # 既存 trace に metadata 追加
+        _client.update_run(
+            run_id=...,  # 現在の run_id を thread-local から取得
+            extra={"metadata": {"critic": verdict.model_dump()}},
+        )
+    except Exception as exc:
+        logger.warning("critic_score emit failed: %s", exc)
+```
+
+### 完了条件
+- [ ] tdd-guide で書いた critic_node のテスト 80% カバレッジ達成
+- [ ] LangSmith dashboard で全 turn に `critic.groundedness` が表示される
+- [ ] 本番 100 turn で `critic.groundedness` 平均値・分布を PR body に記載
+- [ ] p95 latency 増加 < 50ms（fire-and-forget なので原則ゼロ）
+- [ ] CI green、code-reviewer + Codex CLI 経路 A LGTM
+
+### 注意点
+- `groundedness_score` は `quality_signals.py` に既に類似ロジックあり。**新規に書かず、流用する**こと
+- `critic_node` 内で例外が起きてもグラフ全体を止めない（try/except で握って WARN log）
+- `asyncio.create_task` で fire-and-forget するが、unhandled exception を握り潰さないよう `_log_task_exception` ヘルパー追加
+
+---
+
+## Phase 2: Semantic Router shadow mode
+
+**期間目安**: 1 週間（実装3日 + データ収集5日）
+**ブランチ**: `feat/router-phase2-semantic-router-shadow`
+**目的**: `aurelio-labs/semantic-router` を導入し、既存 rule と並走させ不一致を計測。
+
+### 修正対象
+
+| ファイル | 変更内容 |
+|---|---|
+| `backend/pyproject.toml` | `semantic-router[fastembed]>=0.1.x` を追加 |
+| `backend/routing/__init__.py` (新設) | パッケージ初期化 |
+| `backend/routing/semantic_router.py` (新設, ≤200行) | RouteLayer 初期化、`classify_intent(query) -> RouteHit` |
+| `backend/routing/routes.yaml` (新設) | 約 30 ルート、各 utterance 3–5 例 |
+| `backend/workflows/main_workflow.py` | `_keyword_router_node` 内で shadow 呼び出し、不一致を `critic_metrics.emit_routes_mismatch` で記録 |
+| `backend/services/stt_warmup_service.py` 参考 | FastEmbed model warmup を起動時実行する pattern を流用 |
+| `backend/tests/routing/test_semantic_router.py` (新設) | 30 ルート全てに対する正例 + 反例テスト |
+
+### routes.yaml 初期データ作成
+
+**Codex CLI 経路 C 委任候補**: routing_constants.py の各 `*_KEYWORDS` リストから 30 ルート分の代表発話 3–5 例を抽出する単純作業。
+
+```bash
+# 経路 C 委任スニペット例（次セッションで担当が実行）
+codex orchestrate \
+  --task "backend/routing/routes.yaml を作成。backend/config/routing_constants.py の WIFI_KEYWORDS, BUSINESS_HOURS_KEYWORDS, ... 各リストを参照し、ルート名 / target_agent / request_type / utterances (各 3-5 例, ja/en/zh/ko 混在 OK) を yaml で記述"
+```
+
+### Shadow mode 実装パターン
+
+```python
+# backend/workflows/main_workflow.py の _keyword_router_node 内
+fast_route = RoutingLogicAgent._try_fast_routing(self, query)
+
+# Shadow: Semantic Router も呼び出して不一致を記録
+try:
+    shadow_hit = await semantic_router_classifier.classify_intent(query)
+    if fast_route and shadow_hit and fast_route.get("agent") != shadow_hit.target_agent:
+        await emit_routes_mismatch(
+            session_id=session_id,
+            query=query,
+            rule_agent=fast_route.get("agent"),
+            semantic_agent=shadow_hit.target_agent,
+            semantic_score=shadow_hit.score,
+        )
+except Exception as exc:
+    logger.warning("Semantic router shadow failed: %s", exc)
+
+# 既存 rule の結果をそのまま使う（shadow なので動作変更なし）
+```
+
+### 完了条件
+- [ ] `routes.yaml` に 30 ルート以上、ja/en/zh/ko すべての utterance を含む
+- [ ] FastEmbed model が Cloud Run 起動時に preload される（cold start +2s 程度想定）
+- [ ] 1 週間 shadow 計測結果を PR body に記載: **不一致率 ≤ 5%** が目標
+- [ ] 不一致 case を analytical に grouping し、`routes.yaml` 改善案 issue を起票
+- [ ] CI green、code-reviewer + Codex CLI 経路 A LGTM
+
+---
+
+## Phase 3: routes.yaml 正系昇格 + intent_classifier 減量
+
+**期間目安**: 1 週間
+**ブランチ**: `feat/router-phase3-cutover-and-shrink`
+**目的**: Semantic Router を正系にし、`intent_classifier.py` を 734 → ≤120 行・`routing_constants.py` を 1147 → ≤300 行に削減。
+
+### 修正対象
+
+| ファイル | Before | After | 変更内容 |
+|---|---|---|---|
+| `backend/utils/intent_classifier.py` | 734 | ≤120 | `classify_fast_intent` を safety hard rule 5 つに減量 (emergency / farewell / assistant_profile / pet_policy / lost_found) |
+| `backend/config/routing_constants.py` | 1147 | ≤300 | キーワードリストを削除、`CATEGORY_TO_AGENT_MAP` と `REQUEST_TYPE_TO_AGENT_MAP` のみ維持 |
+| `backend/workflows/main_workflow.py` | 2274 | (Phase 5 で対応) | `_keyword_router_node` を Stage 1+2 (regex → semantic_router) 呼び出しに置換 |
+| `backend/agents/orchestrator_agent.py` | 401 | 同等 | `_try_fast_routing` を Stage 2 (semantic_router) に置換、`_is_memory_related_question` も semantic で吸収可能か検証 |
+| `backend/tests/utils/test_intent_classifier.py` | 既存 | 該当 hard rule のみ残す | 削除した 30 ルートのテストは Phase 2 で routes.yaml 側に移譲済み |
+
+### 安全策
+
+- 1 PR の中で **rule 削除と semantic_router 昇格を同時に行う**（並走を絶つ）
+- shadow 期間で確認した不一致 ≤ 5% を超えていたら Phase 3 を延期
+- Phase 4 で routing_correctness を計測予定なので、Phase 3 完了直後に Q-gate を手動 1 回回し FAIL ≤ 1 を確認
+
+### 完了条件
+- [ ] `intent_classifier.py` ≤120 行、`routing_constants.py` ≤300 行
+- [ ] Q-gate（BIZ-JA-002 / RECV-JA-002 / SAFE-JA-001 / SAFE-EN-001 含む）すべて PASS
+- [ ] LangSmith dashboard で routing 経路（regex / semantic / llm fallback）の割合を可視化、LLM fallback 比率 ≤ 10% 目標
+- [ ] CI green、code-reviewer + Codex CLI 経路 A LGTM
+
+---
+
+## Phase 4: LLM-as-judge + self-repair 有効化 + routes 半自動学習
+
+**期間目安**: 1 週間
+**ブランチ**: `feat/router-phase4-llm-judge-and-repair`
+**目的**: critic に LLM judge を追加し、`needs_repair=true` 時に 1 回 retry。`routes.yaml` の改善 PR を半自動生成。
+
+### 修正対象
+
+| ファイル | 変更内容 |
+|---|---|
+| `backend/workflows/critic_node.py` | gemini-flash-lite で answer_relevancy + routing_correctness を判定 |
+| `backend/workflows/main_workflow.py` | critic → conditional_edge → (repair branch | END)、retry counter を state に追加 |
+| `backend/workflows/repair_branch.py` (新設) | `repair_hint` に応じて agent 再選択 or context 拡張 |
+| `scripts/extract_route_improvements.py` (新設) | LangSmith trace から `routing_correctness < 0.7` の case を抽出し routes.yaml 追加候補を生成 |
+| `.github/workflows/route-improvement-pr.yml` (新設) | 週1 cron で上記スクリプト実行 → PR 自動起票 |
+
+### 完了条件
+- [ ] Self-repair 後 PASS 率 ≥ 70%（Phase 1 で計測した baseline と比較）
+- [ ] p95 latency 増加 ≤ 300ms（repair branch 経路）
+- [ ] `total_timeout=30s` を 1 turn でも破らない（既存 `asyncio.wait_for` で担保）
+- [ ] 週1 で route_improvement PR が自動起票され、人がレビュー・マージ
+- [ ] CI green、code-reviewer + Codex CLI 経路 A LGTM
+
+---
+
+## Phase 5: main_workflow.py を subgraph 分割
+
+**期間目安**: 1 週間
+**ブランチ**: `feat/router-phase5-subgraph-split`
+**目的**: 800 行制限超過の解消。テスト性回復。
+
+### 修正対象
+
+| ファイル | Before | After |
+|---|---|---|
+| `backend/workflows/main_workflow.py` | 2274+ (Phase 4 で 100行程度増加見込み) | ≤ 800 |
+| `backend/workflows/subgraphs/routing_subgraph.py` (新設) | — | ≤ 400 |
+| `backend/workflows/subgraphs/critic_subgraph.py` (新設) | — | ≤ 300 |
+| `backend/workflows/subgraphs/format_subgraph.py` (新設) | — | ≤ 400 |
+| `backend/tests/workflows/subgraphs/*` (新設) | — | 各 subgraph 単体テスト |
+
+### 完了条件
+- [ ] 全ファイル 800 行以下
+- [ ] 各 subgraph の単体テスト追加、カバレッジ 80% 以上
+- [ ] E2E (Playwright `voice-e2e-nightly.yml`) green
+- [ ] CI green、code-reviewer + Codex CLI 経路 A LGTM
+
+---
+
+## GitHub Epic & Sub-Issue 起票案
+
+Epic 1 件 + Phase ごとの sub-issue 6 件を起票する。雛形：
+
+### Epic タイトル
+> `[Epic] Routing modernization & runtime self-evaluation (ADR-023)`
+
+### Epic 本文（雛形）
+```markdown
+ADR-023 に基づき、キーワード爆発状態のルーティング層を Semantic Router 三段カスケードに置換し、LangGraph に runtime self-evaluation ループ (critic_node + 1 回 self-repair + LangSmith trace) を追加する。
+
+## なぜ今やるか
+- routing_constants.py 1147 行、intent_classifier.py 734 行、main_workflow.py 2274 行 (800 行制限の 2.8 倍)
+- Q-gate FAIL が出るたびにキーワード追加 → 永久肥大化
+- LLM オーケストレーターがあるのに自己評価ループが無く、評価は DB SELECT + 週1 RAGAS のみ
+
+## 設計判断
+- ADR-023 (docs/adr/023-semantic-router-and-runtime-self-evaluation.md) — Accepted
+- Router lib: aurelio-labs/semantic-router + FastEmbed
+- Eval backend: LangSmith (Phase 0 即時有効化)
+- Self-repair: 1 retry, 30s total budget
+
+## Phase 別 sub-issue
+- [ ] #NN Phase 0: LangSmith tracing 配線
+- [ ] #NN Phase 1: critic_node 追加（決定論シグナルのみ）
+- [ ] #NN Phase 2: Semantic Router shadow mode
+- [ ] #NN Phase 3: routes.yaml 正系昇格 + intent_classifier 減量
+- [ ] #NN Phase 4: LLM-as-judge + self-repair 有効化
+- [ ] #NN Phase 5: main_workflow.py subgraph 分割
+
+## 関連
+- docs/plans/semantic-router-self-eval-2026-05-17.md (実装ハンドオフ計画)
+- 関連 ADR: 006, 014, 017, 018
+- MEMORY.md Phase 3.6 残課題 (B-1〜B-4) と本 Epic で並行解消可能
+```
+
+### Sub-issue 雛形（Phase N 用）
+```markdown
+## Epic
+#<Epic 番号>
+
+## ADR
+docs/adr/023-semantic-router-and-runtime-self-evaluation.md — Phase N
+
+## 詳細
+docs/plans/semantic-router-self-eval-2026-05-17.md の "Phase N" セクション参照。
+
+## 完了条件
+- (ハンドオフ計画書の Phase N "完了条件" 全てを転記)
+
+## 推定工数
+N 日
+
+## 担当ロール
+backend-developer (+ tdd-guide / Codex CLI 経路 C を使う場合は明記)
+```
+
+### 起票コマンド例
+```bash
+# Epic
+gh issue create \
+  --repo EngineerCafeJP/engineer-cafe-navigator2025 \
+  --title "[Epic] Routing modernization & runtime self-evaluation (ADR-023)" \
+  --body-file <(cat <<'EOF'
+...Epic 本文...
+EOF
+) \
+  --label "epic,architecture,routing"
+
+# Phase 0 sub-issue
+gh issue create \
+  --repo EngineerCafeJP/engineer-cafe-navigator2025 \
+  --title "[Phase 0] LangSmith tracing 配線 (ADR-023)" \
+  --body-file <(cat <<'EOF'
+## Epic
+#<Epic 番号>
+...
+EOF
+) \
+  --label "phase-0,observability,routing"
+
+# Phase 1〜5 も同パターン
+```
+
+---
+
+## 引き継ぎチェックリスト（担当エンジニア向け）
+
+着手前に以下を完了：
+
+- [ ] ADR-023 を通読
+- [ ] 本ハンドオフ計画書を通読
+- [ ] `git pull origin develop` 最新化
+- [ ] 該当 Phase のブランチを切る (`git checkout -b feat/router-phaseN-...`)
+- [ ] `cd backend && pytest -m "not ragas and not slow" --tb=short -q` が手元で green
+- [ ] LangSmith アカウント作成（Phase 0 担当者のみ）
+- [ ] GCP `LANGSMITH_API_KEY` シークレット権限確認（Phase 0 担当者のみ）
+- [ ] Codex CLI 経路 C の utterance 量産依頼を準備（Phase 2 担当者のみ）
+
+着手後：
+
+- [ ] tdd-guide で先にテストを書く（Phase 1, 4, 5）
+- [ ] 各 Phase 完了時に MEMORY.md の "Session Status" を更新
+- [ ] PR body にハンドオフ計画書の "完了条件" チェックを転記し、すべて埋める
+- [ ] code-reviewer + Codex CLI 経路 A の両 LGTM を得る
+- [ ] 次 Phase の sub-issue へ進捗を引き継ぐ
+
+---
+
+## 関連ドキュメント
+
+- [ADR-023](../adr/023-semantic-router-and-runtime-self-evaluation.md) — 本計画の設計判断記録
+- [ADR-006](../adr/006-langgraph-workflow-redesign.md) — 現行 keyword fast-path 導入経緯
+- [ADR-014](../adr/014-observability-phase1.md) — 構造化ログ
+- [ADR-017](../adr/017-observability-phase1b.md) — Terraform メトリクス
+- [`CLAUDE.md`](../../CLAUDE.md) — リポジトリ全体規約
+- [`.claude/rules/workflow.md`](../../.claude/rules/workflow.md) — 2-Agent ワークフロー
+- `MEMORY.md` (project root) — セッション継続情報

--- a/docs/plans/semantic-router-self-eval-2026-05-17.md
+++ b/docs/plans/semantic-router-self-eval-2026-05-17.md
@@ -49,7 +49,7 @@ pytest -m "not ragas and not slow" --tb=short -q
 
 | ファイル | 行 | 変更内容 |
 |---|---|---|
-| `backend/main.py` | startup_event 内 | LangSmith 環境変数を 3 つ export、log 1 行追加 |
+| `backend/main.py` | `async def lifespan(app)` の startup ブロック内（yield より前、main.py:159 付近） | LangSmith 環境変数を 3 つ export、log 1 行追加 |
 | `backend/config/settings.py` | 既存 `langsmith_api_key` フィールド付近 | `langsmith_project: str = "engineer-cafe-prod"` を追加 |
 | `.github/workflows/ragas-evaluation.yml` | cron 行 | `'0 9 * * 1'` → `'0 17 * * *'` (毎日 02:00 JST) に降格 |
 | `MEMORY.md` | Session Status | Phase 0 完了を記録 |
@@ -58,7 +58,8 @@ pytest -m "not ragas and not slow" --tb=short -q
 ### 実装スニペット
 
 ```python
-# backend/main.py の startup_event 末尾に追加
+# backend/main.py の async def lifespan(app) startup ブロック内に追加
+# (main.py:159 の lifespan 関数、yield より前)
 if settings.langsmith_api_key:
     os.environ["LANGSMITH_TRACING"] = "true"
     os.environ["LANGSMITH_API_KEY"] = settings.langsmith_api_key
@@ -96,7 +97,7 @@ gcloud run services update engineer-cafe-backend \
 ADR-023 Phase 0: LangSmith tracing を本番 backend に配線。以降の semantic router / critic node 実装で必要な observability 基盤を立ち上げる。
 
 ## Changes
-- `backend/main.py`: startup_event で LangSmith 環境変数を export
+- `backend/main.py`: `lifespan(app)` startup ブロックで LangSmith 環境変数を export
 - `backend/config/settings.py`: `langsmith_project` フィールド追加
 - `.github/workflows/ragas-evaluation.yml`: cron 週1 → 日次に降格
 
@@ -401,7 +402,7 @@ backend-developer (+ tdd-guide / Codex CLI 経路 C を使う場合は明記)
 ```bash
 # Epic
 gh issue create \
-  --repo EngineerCafeJP/engineer-cafe-navigator2025 \
+  --repo EngineerCafeJP/engineercafe-navigator \
   --title "[Epic] Routing modernization & runtime self-evaluation (ADR-023)" \
   --body-file <(cat <<'EOF'
 ...Epic 本文...
@@ -411,7 +412,7 @@ EOF
 
 # Phase 0 sub-issue
 gh issue create \
-  --repo EngineerCafeJP/engineer-cafe-navigator2025 \
+  --repo EngineerCafeJP/engineercafe-navigator \
   --title "[Phase 0] LangSmith tracing 配線 (ADR-023)" \
   --body-file <(cat <<'EOF'
 ## Epic


### PR DESCRIPTION
## Summary

Records the 2026-05-17 design decision (Terada-san approved) to address the keyword-explosion routing layer and the missing online self-evaluation loop.

### Why now
- `backend/config/routing_constants.py` 1,147 lines / `backend/utils/intent_classifier.py` 734 lines / `backend/workflows/main_workflow.py` 2,274 lines — three files exceed the 800-line coding-style limit
- Every Q-gate FAIL triggers a new keyword/if branch (`Q-RECV-JA-002`, `Q-FAREWELL-JA-001`, `#615` follow-up, etc.) — permanent bloat
- LangGraph has no critic/judge node; quality evaluation is weekly RAGAS cron + DB SELECT only
- `settings.langsmith_api_key` field exists but is never instrumented

### What this PR adds
- `docs/adr/023-semantic-router-and-runtime-self-evaluation.md` — Accepted ADR documenting the three-stage cascade router (regex safety → `aurelio-labs/semantic-router` + FastEmbed → LLM router) and the LangGraph `critic_node` + 1-retry self-repair + LangSmith trace wiring
- `docs/plans/semantic-router-self-eval-2026-05-17.md` — Phase 0–5 handoff plan with file-by-file scope, completion criteria, PR body templates, and Codex CLI route C delegation hints

### Selected stack (per design Q&A)
- **Router**: aurelio-labs/semantic-router + FastEmbed (ONNX/CPU, 10–30ms)
- **Eval backend**: LangSmith (Phase 0 enables in 5 lines)
- **Self-repair**: 1 retry max, kept within the existing 30s `asyncio.wait_for` budget

### Out of scope
No code changes. This PR is documentation only — the actual implementation is split across Phase 0–5 sub-issues that will be opened against a separate Epic once this ADR is merged.

### Research basis (2026-05 state of the art)
- [aurelio-labs/semantic-router](https://github.com/aurelio-labs/semantic-router)
- [langchain-ai/langgraph-reflection](https://github.com/langchain-ai/langgraph-reflection)
- [Building Self-Evaluating Systems With LangGraph (2026/02)](https://www.sciencetechniz.com/2026/02/building-self-evaluating-systems-with.html)
- [Agent Observability 2026 guide](https://www.digitalapplied.com/blog/agent-observability-2026-evals-traces-cost-guide)
- Full citation list in the ADR References section

## Reviewer focus
1. Are the Phase boundaries / completion criteria implementable as 1-PR-per-phase?
2. Does the handoff plan give enough file:line specificity for a different engineer to pick it up cold?
3. Risk mitigations sufficient (shadow mode, fallback_to_original, async fire-and-forget)?

## Follow-up after merge
1. Open Epic + 6 sub-issues (Phase 0–5) referencing this ADR
2. Start Phase 0 (LangSmith trace wiring) — smallest, unblocks every later phase

## Related
- ADR-006 (current keyword fast-path), ADR-014/017 (observability), ADR-018 (assistant_profile routing)
- MEMORY Phase 3.6 remaining items (B-1 ~ B-4) can run in parallel with Phase 0–1

🤖 Generated with [Claude Code](https://claude.com/claude-code)