### PR TITLE
fix: verify vosk model fallback downloads

### DIFF
--- a/backend/scripts/download_vosk_models.sh
+++ b/backend/scripts/download_vosk_models.sh
@@ -13,14 +13,39 @@ mkdir -p "$MODEL_DIR"
 
 JA_MODEL_URL="https://alphacephei.com/vosk/models/vosk-model-small-ja-0.22.zip"
 EN_MODEL_URL="https://alphacephei.com/vosk/models/vosk-model-small-en-us-0.15.zip"
+JA_MODEL_SHA256="efa092d280153a77615e9e0c7d7283e93e600de3d19d3bec686c57ef19d52eac"
+EN_MODEL_SHA256="30f26242c4eb449f948e42cb302dd7a686cb29a3423a8367f99ff41780942498"
 
 JA_TARGET="$MODEL_DIR/vosk-model-ja"
 EN_TARGET="$MODEL_DIR/vosk-model-en-us"
+
+sha256_file() {
+    if command -v sha256sum >/dev/null 2>&1; then
+        sha256sum "$1" | awk '{print $1}'
+    else
+        shasum -a 256 "$1" | awk '{print $1}'
+    fi
+}
+
+download_archive() {
+    local url="$1"
+    local tmpzip="$2"
+    local name="$3"
+
+    if curl -L --fail --retry 3 --retry-delay 2 -o "$tmpzip" "$url"; then
+        return
+    fi
+
+    echo "[warn] TLS-verified download failed for $name; retrying with certificate checks disabled."
+    echo "[warn] Archive integrity is still enforced by pinned SHA-256."
+    curl -k -L --fail --retry 3 --retry-delay 2 -o "$tmpzip" "$url"
+}
 
 download_model() {
     local url="$1"
     local target="$2"
     local name="$3"
+    local expected_sha256="$4"
 
     if [ -d "$target" ]; then
         echo "[skip] $name already exists at $target"
@@ -29,7 +54,16 @@ download_model() {
 
     echo "[download] $name from $url ..."
     tmpzip=$(mktemp /tmp/vosk-XXXXXX.zip)
-    curl -L -o "$tmpzip" "$url"
+    download_archive "$url" "$tmpzip" "$name"
+
+    actual_sha256=$(sha256_file "$tmpzip")
+    if [ "$actual_sha256" != "$expected_sha256" ]; then
+        echo "[error] SHA-256 mismatch for $name" >&2
+        echo "[error] expected: $expected_sha256" >&2
+        echo "[error] actual:   $actual_sha256" >&2
+        rm -f "$tmpzip"
+        exit 1
+    fi
 
     echo "[extract] $name ..."
     tmpdir=$(mktemp -d /tmp/vosk-extract-XXXXXX)
@@ -44,8 +78,8 @@ download_model() {
     echo "[done] $name -> $target"
 }
 
-download_model "$JA_MODEL_URL" "$JA_TARGET" "Japanese (small)"
-download_model "$EN_MODEL_URL" "$EN_TARGET" "English (small)"
+download_model "$JA_MODEL_URL" "$JA_TARGET" "Japanese (small)" "$JA_MODEL_SHA256"
+download_model "$EN_MODEL_URL" "$EN_TARGET" "English (small)" "$EN_MODEL_SHA256"
 
 echo ""
 echo "Vosk models ready:"


### PR DESCRIPTION
## Summary

- fixes the develop deploy blocker from PR #829 where `backend-deploy-staging` failed during Docker build because `alphacephei.com` currently serves an expired TLS certificate for Vosk model downloads
- keeps the normal TLS-verified curl path first
- only falls back to `curl -k` when the verified download fails, then enforces pinned SHA-256 for both Vosk archives before extraction

## Evidence

- develop failure: `backend-deploy-staging` in run `25966343434`, failed at `bash scripts/download_vosk_models.sh models` with `curl: (60) SSL certificate problem: certificate has expired`
- local verification: `tmpdir=$(mktemp -d); cd backend && bash scripts/download_vosk_models.sh "$tmpdir/models" && test -d "$tmpdir/models/vosk-model-ja" && test -d "$tmpdir/models/vosk-model-en-us"` -> pass
- `git diff --check` -> pass
