### PR TITLE
fix: close post-834 critical followups

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -498,6 +498,38 @@ jobs:
           docker push asia-northeast1-docker.pkg.dev/aipartner-426616/cloud-run-source-deploy/engineer-cafe-backend:${{ github.sha }}
           docker push asia-northeast1-docker.pkg.dev/aipartner-426616/cloud-run-source-deploy/engineer-cafe-backend:latest
 
+      - name: Sync optional runtime secrets to Google Secret Manager
+        run: |
+          sync_secret_from_env() {
+            local secret_name="$1"
+            local secret_value="$2"
+            local missing_message="$3"
+
+            if [[ -z "${secret_value}" ]]; then
+              echo "::warning::${missing_message}"
+              return 0
+            fi
+
+            if ! gcloud secrets describe "${secret_name}" >/dev/null 2>&1; then
+              gcloud secrets create "${secret_name}" --replication-policy=automatic
+            fi
+
+            printf '%s' "${secret_value}" \
+              | gcloud secrets versions add "${secret_name}" --data-file=-
+          }
+
+          sync_secret_from_env \
+            "LANGSMITH_API_KEY" \
+            "${LANGSMITH_API_KEY}" \
+            "LANGSMITH_API_KEY GitHub secret is not configured; deploying with LangSmith tracing disabled"
+          sync_secret_from_env \
+            "CONNPASS_API_KEY" \
+            "${CONNPASS_API_KEY}" \
+            "CONNPASS_API_KEY GitHub secret is not configured; relying on existing Google Secret Manager value if present"
+        env:
+          LANGSMITH_API_KEY: ${{ secrets.LANGSMITH_API_KEY }}
+          CONNPASS_API_KEY: ${{ secrets.CONNPASS_API_KEY }}
+
       - name: Deploy to Cloud Run
         run: |
           FRONTEND_PRODUCTION_ORIGIN="${FRONTEND_PRODUCTION_ORIGIN:-$DEFAULT_FRONTEND_PRODUCTION_ORIGIN}"
@@ -506,6 +538,11 @@ jobs:
             BACKEND_SECRET_ARGS="${BACKEND_SECRET_ARGS},LANGSMITH_API_KEY=LANGSMITH_API_KEY:latest"
           else
             echo "::warning::LANGSMITH_API_KEY latest secret version not available; deploying with LangSmith tracing disabled"
+          fi
+          if gcloud secrets versions access latest --secret=CONNPASS_API_KEY >/dev/null 2>&1; then
+            BACKEND_SECRET_ARGS="${BACKEND_SECRET_ARGS},CONNPASS_API_KEY=CONNPASS_API_KEY:latest"
+          else
+            echo "::warning::CONNPASS_API_KEY latest secret version not available; Connpass updates disabled"
           fi
 
           gcloud run deploy engineer-cafe-backend \
@@ -576,6 +613,43 @@ jobs:
 
           print(f"Traffic check passed: 100% on latest ready revision {latest_ready}")
           PY
+
+          check_secret_binding() {
+            local secret_name="$1"
+            local label="$2"
+
+            if gcloud secrets versions access latest --secret="${secret_name}" >/dev/null 2>&1; then
+          python3 - "$SERVICE_JSON" "$secret_name" "$label" <<'PY'
+          import json
+          import sys
+
+          with open(sys.argv[1], encoding="utf-8") as f:
+              service = json.load(f)
+          secret_name = sys.argv[2]
+          label = sys.argv[3]
+
+          env = (
+              service.get("spec", {})
+              .get("template", {})
+              .get("spec", {})
+              .get("containers", [{}])[0]
+              .get("env", [])
+          )
+          entry = next((item for item in env if item.get("name") == secret_name), None)
+          if not entry:
+              raise SystemExit(f"error: {secret_name} secret exists but is not bound to Cloud Run")
+          secret_ref = entry.get("valueFrom", {}).get("secretKeyRef", {})
+          if secret_ref.get("name") != secret_name:
+              raise SystemExit(f"error: unexpected {secret_name} secret binding: {secret_ref}")
+          print(f"{label} secret binding check passed")
+          PY
+            else
+              echo "::warning::${secret_name} unavailable in Google Secret Manager; ${label} binding check skipped"
+            fi
+          }
+
+          check_secret_binding "LANGSMITH_API_KEY" "LangSmith"
+          check_secret_binding "CONNPASS_API_KEY" "Connpass"
 
           SERVICE_URL=$(python3 -c 'import json,sys; print(json.load(open(sys.argv[1]))["status"]["url"])' "$SERVICE_JSON")
           echo "Testing $SERVICE_URL/health ..."

--- a/.github/workflows/frontend-production-smoke.yml
+++ b/.github/workflows/frontend-production-smoke.yml
@@ -54,4 +54,5 @@ jobs:
           FRONTEND_BASE_URL: ${{ steps.target.outputs.target_url }}
           MAX_ATTEMPTS: ${{ env.MAX_ATTEMPTS }}
           SLEEP_SECONDS: ${{ env.SLEEP_SECONDS }}
+          VERCEL_AUTOMATION_BYPASS_SECRET: ${{ secrets.VERCEL_AUTOMATION_BYPASS_SECRET }}
         run: bash scripts/verify-frontend-production.sh

--- a/backend/tests/utils/test_memory_helper_unit.py
+++ b/backend/tests/utils/test_memory_helper_unit.py
@@ -18,7 +18,11 @@ from datetime import datetime
 from unittest.mock import Mock, AsyncMock, patch, MagicMock
 
 import backend.utils.memory_helper as memory_helper_module
-from backend.utils.memory_helper import SimplifiedMemoryHelper, get_memory_helper
+from backend.utils.memory_helper import (
+    SimplifiedMemoryHelper,
+    get_memory_helper,
+    infer_previous_request_type_from_messages,
+)
 
 _ACTIVE_SESSION_ID = "11111111-1111-1111-1111-111111111111"
 _ENDED_SESSION_ID = "22222222-2222-2222-2222-222222222222"
@@ -85,6 +89,33 @@ def _build_chain_mock(execute_return):
     ):
         getattr(chain, method_name).return_value = chain
     return chain
+
+
+def test_infer_previous_request_type_from_messages_prefers_latest_user_intent():
+    messages = [
+        {
+            "role": "user",
+            "content": "エンジニアカフェの営業時間を教えて",
+            "metadata": {"request_type": "hours"},
+        },
+        {"role": "assistant", "content": "9時から22時です。", "metadata": {}},
+        {"role": "user", "content": "料金はいくら？", "metadata": {}},
+    ]
+
+    assert infer_previous_request_type_from_messages(messages) == "price"
+
+
+def test_infer_previous_request_type_from_messages_ignores_assistant_rows():
+    messages = [
+        {
+            "role": "assistant",
+            "content": "営業時間の話です。",
+            "metadata": {"request_type": "hours"},
+        },
+        {"role": "user", "content": "こんにちは", "metadata": {}},
+    ]
+
+    assert infer_previous_request_type_from_messages(messages) is None
 
 
 # =============================================================================

--- a/backend/tests/workflows/test_main_workflow.py
+++ b/backend/tests/workflows/test_main_workflow.py
@@ -10,6 +10,7 @@ from types import SimpleNamespace
 
 import pytest
 from backend.agents.orchestrator_agent import OrchestratorAgent
+from langchain_core.messages import AIMessage, HumanMessage
 from unittest.mock import MagicMock, Mock, AsyncMock, patch
 
 
@@ -372,6 +373,67 @@ class TestMainWorkflowMemoryIntegration:
             assert "context" in result
             assert "memory" in result["context"]
             mock_helper.get_context.assert_called_once()
+
+    @pytest.mark.asyncio
+    @patch("backend.workflows.main_workflow.OrchestratorAgent")
+    async def test_memory_loader_node_infers_request_type_from_checkpoint_when_stm_writes_disabled(
+        self, mock_orchestrator_class
+    ):
+        """STM writes off でも LangGraph 履歴から前ターン意図を復元する。"""
+        from backend.workflows.main_workflow import MainWorkflow
+
+        mock_orchestrator_class.return_value = AsyncMock()
+        mock_helper = AsyncMock()
+        mock_helper.get_context = AsyncMock(
+            return_value={
+                "recent_messages": [],
+                "context_string": "",
+                "knowledge_results": [],
+                "inherited_request_type": None,
+            }
+        )
+        mock_helper._rank_messages = Mock(side_effect=lambda messages, _query: messages)
+        mock_helper._build_comprehensive_context = Mock(return_value="checkpoint context")
+        mock_helper.store_message = AsyncMock()
+        classifier = MagicMock()
+        classifier.classify_with_details = AsyncMock(return_value=MagicMock(category="general"))
+        rag = MagicMock()
+        rag.search = AsyncMock(
+            return_value={
+                "success": True,
+                "data": {"results": [], "context": ""},
+            }
+        )
+
+        with (
+            patch("backend.utils.memory_helper.get_memory_helper", return_value=mock_helper),
+            patch(
+                "backend.utils.memory_feature_flags.get_memory_feature_flags",
+                return_value=SimpleNamespace(enable_agent_memory_stm_writes=False),
+            ),
+            patch("backend.utils.query_classifier.QueryClassifier", return_value=classifier),
+            patch("backend.tools.enhanced_rag.EnhancedRAGSearch", return_value=rag),
+        ):
+            workflow = MainWorkflow()
+            result = await workflow._memory_loader_node(
+                {
+                    "query": "隣のカフェは？",
+                    "session_id": "test-session",
+                    "language": "ja",
+                    "context": {},
+                    "messages": [
+                        HumanMessage(content="エンジニアカフェの営業時間を教えて"),
+                        AIMessage(content="9時から22時です。"),
+                    ],
+                },
+                _mock_runtime(),
+            )
+
+        memory = result["context"]["memory"]
+        assert memory["stm_source"] == "langgraph_checkpointer"
+        assert memory["inherited_request_type"] == "hours"
+        assert memory["recent_messages"][0]["metadata"]["request_type"] == "hours"
+        mock_helper._build_comprehensive_context.assert_called_once()
 
     @pytest.mark.asyncio
     @patch("backend.workflows.main_workflow.OrchestratorAgent")

--- a/backend/tests/workflows/test_trag_translation.py
+++ b/backend/tests/workflows/test_trag_translation.py
@@ -15,6 +15,7 @@ from backend.workflows.main_workflow import (
     _TRAG_PREAMBLE_RE,
     _clean_trag_translation,
     _get_trag_client,
+    _is_acceptable_trag_japanese,
     _is_pathological_translation,
 )
 
@@ -87,6 +88,29 @@ class TestJaRegex:
 
     def test_rejects_chinese_only(self):
         assert not _JA_RE.search("营业时间")
+
+
+class TestTragJapaneseAcceptance:
+    """tRAG 日本語翻訳受け入れ判定テスト"""
+
+    @pytest.mark.parametrize("text", ["営業時間", "会員登録", "駐車場"])
+    def test_accepts_japanese_kanji_only_domain_translations(self, text):
+        assert _is_acceptable_trag_japanese(text) is True
+
+    @pytest.mark.parametrize(
+        "text",
+        [
+            "营业时间",
+            "会员注册",
+            "停车场",
+            "영업시간",
+            "abc123",
+            "亜亜亜亜",
+            "営業時間営業時間営業時間",
+        ],
+    )
+    def test_rejects_non_japanese_or_low_information_output(self, text):
+        assert _is_acceptable_trag_japanese(text) is False
 
 
 class TestGetTragClient:
@@ -200,6 +224,51 @@ class TestTragTranslationIntegration:
         assert rag.search.await_args.kwargs["query"] == "営業時間は何時までですか？"
         knowledge_results = result["context"]["knowledge_results"]
         assert knowledge_results["translated_query"] == "営業時間は何時までですか？"
+
+    @pytest.mark.asyncio
+    @patch("backend.workflows.main_workflow.OrchestratorAgent")
+    async def test_kanji_only_translation_is_used_for_rag(
+        self,
+        mock_orch_class,
+        english_state,
+    ):
+        """Kanji-only Japanese translations must not be rejected by tRAG."""
+        from backend.workflows.main_workflow import MainWorkflow
+
+        mock_orch_class.return_value = AsyncMock()
+        classifier = MagicMock()
+        classifier.classify_with_details = AsyncMock(
+            return_value=MagicMock(category="business-hours")
+        )
+        rag = MagicMock()
+        rag.search = AsyncMock(
+            return_value={
+                "success": True,
+                "data": {"results": [{"id": "hours"}], "context": "営業時間 context"},
+            }
+        )
+
+        with (
+            patch("backend.utils.memory_helper.get_memory_helper") as mock_mh,
+            patch(
+                "backend.workflows.main_workflow._translate_llm_with_retry",
+                new_callable=AsyncMock,
+                return_value="営業時間",
+            ) as translate_mock,
+            patch("backend.utils.query_classifier.QueryClassifier", return_value=classifier),
+            patch("backend.tools.enhanced_rag.EnhancedRAGSearch", return_value=rag),
+        ):
+            mock_mh.return_value = _mock_memory_helper()
+
+            wf = MainWorkflow()
+            runtime = _mock_runtime()
+            result = await wf._memory_loader_node(english_state, runtime)
+
+        translate_mock.assert_awaited_once_with("What are the opening hours?", "en")
+        rag.search.assert_awaited_once()
+        assert rag.search.await_args.kwargs["query"] == "営業時間"
+        knowledge_results = result["context"]["knowledge_results"]
+        assert knowledge_results["translated_query"] == "営業時間"
 
     @pytest.mark.asyncio
     @patch("backend.workflows.main_workflow.OrchestratorAgent")

--- a/backend/utils/memory_helper.py
+++ b/backend/utils/memory_helper.py
@@ -28,6 +28,25 @@ logger = logging.getLogger(__name__)
 _AGENT_MEMORY_SESSION_COLUMN = "value->>sessionId"
 
 
+def infer_previous_request_type_from_messages(messages: List[Dict[str, Any]]) -> Optional[str]:
+    """Infer the latest user request_type from memory-style message rows."""
+    for message in reversed(messages):
+        if not isinstance(message, dict) or message.get("role") != "user":
+            continue
+
+        metadata = message.get("metadata")
+        request_type = metadata.get("request_type") if isinstance(metadata, dict) else None
+        if isinstance(request_type, str) and request_type.strip():
+            return request_type.strip()
+
+        content = str(message.get("content") or "")
+        request_type = extract_request_type(content)
+        if request_type:
+            return request_type
+
+    return None
+
+
 def _log_memory_event_safely(event: str, **fields: Any) -> None:
     try:
         from backend.observability.structured_logger import log_memory_event

--- a/backend/workflows/main_workflow.py
+++ b/backend/workflows/main_workflow.py
@@ -64,13 +64,59 @@ _workflow_lock = asyncio.Lock()
 # tRAG: Reusable httpx client for KO/ZH translation
 _trag_http_client: Optional["_httpx.AsyncClient"] = None
 
-# tRAG: Japanese kana detection for translation validation
-# NOTE: Intentionally kana-only (no CJK U+4E00-9FFF). Kanji-only
-# translations like "営業時間" are false-negatives, but including
-# CJK would also accept untranslated Chinese input. This trade-off
-# is documented in commit 72e42c974. Most natural Japanese sentences
-# contain at least one kana character.
+# tRAG: Japanese kana detection for translation validation.
+# Keep this regex kana-only. Kanji acceptance is handled by the narrower
+# _is_acceptable_trag_japanese helper so untranslated Chinese is not broadly
+# accepted just because it contains CJK characters.
 _JA_RE = re.compile(r"[\u3040-\u309f\u30a0-\u30ff]")
+_TRAG_CJK_RE = re.compile(r"[\u3400-\u9fff]")
+_TRAG_DISALLOWED_SCRIPT_RE = re.compile(r"[\uac00-\ud7af\u1100-\u11ff\u3130-\u318fA-Za-z]")
+_TRAG_JA_KANJI_TERMS = frozenset(
+    {
+        "営業時間",
+        "営業",
+        "開館",
+        "閉館",
+        "休館",
+        "会員登録",
+        "会員",
+        "登録",
+        "駐車場",
+        "駐車",
+        "駐輪場",
+        "駐輪",
+        "会議室",
+        "貸切",
+        "利用",
+        "予約",
+        "料金",
+        "無料",
+        "有料",
+        "設備",
+        "施設",
+        "電源",
+        "住所",
+        "受付",
+        "場所",
+        "写真",
+        "飲食",
+        "持込",
+        "喫煙",
+        "禁煙",
+        "建物",
+        "歴史",
+        "最寄",
+        "相談",
+        "転職",
+        "勉強会",
+        "交流会",
+        "参加",
+        "車椅子",
+        "子供",
+        "可能",
+        "必要",
+    }
+)
 
 # tRAG: Preamble pattern to strip from LLM translation output
 # Require delimiter (colon/space) after keyword to avoid stripping
@@ -126,7 +172,7 @@ def _is_pathological_translation(text: str) -> bool:
     if len(set(compact)) == 1:
         return True
 
-    for unit_len in (1, 2, 3):
+    for unit_len in range(1, min(8, len(compact) // 3) + 1):
         if len(compact) < unit_len * 3 or len(compact) % unit_len:
             continue
         unit = compact[:unit_len]
@@ -148,6 +194,22 @@ def _clean_trag_translation(text: str) -> str:
         logger.warning("tRAG low-information translation rejected: '%s'", translated[:60])
         return ""
     return translated
+
+
+def _is_acceptable_trag_japanese(text: str) -> bool:
+    """Return True when a tRAG translation looks usable as Japanese."""
+    if _JA_RE.search(text or ""):
+        return True
+
+    compact = _TRAG_REPEAT_PUNCT_RE.sub("", text or "")
+    if not compact or not _TRAG_CJK_RE.search(compact):
+        return False
+    if _TRAG_DISALLOWED_SCRIPT_RE.search(compact):
+        return False
+    if _is_pathological_translation(compact):
+        return False
+
+    return any(term in compact for term in _TRAG_JA_KANJI_TERMS)
 
 
 def _truthy_context_flag(value: Any) -> bool:
@@ -985,13 +1047,16 @@ class MainWorkflow:
             content = str(content or "").strip()
             if not content:
                 continue
+            metadata = {"canonical_content_key": canonicalize_facility_memory_key_text(content)}
+            if role == "user":
+                request_type = extract_request_type(content)
+                if request_type:
+                    metadata["request_type"] = request_type
             recent.append(
                 {
                     "role": role,
                     "content": content,
-                    "metadata": {
-                        "canonical_content_key": canonicalize_facility_memory_key_text(content)
-                    },
+                    "metadata": metadata,
                 }
             )
         return recent[-20:]
@@ -1128,7 +1193,10 @@ class MainWorkflow:
         全クエリの前処理として、SimplifiedMemoryHelperから会話履歴を取得し、
         stateのcontextに追加する。
         """
-        from backend.utils.memory_helper import get_memory_helper
+        from backend.utils.memory_helper import (
+            get_memory_helper,
+            infer_previous_request_type_from_messages,
+        )
 
         memory_helper = get_memory_helper()
         session_id = state.get("session_id", "")
@@ -1153,13 +1221,17 @@ class MainWorkflow:
                     checkpoint_messages = self._checkpoint_messages_to_recent_memory(
                         state.get("messages", [])
                     )
+                    checkpoint_inherited_request_type = None
                     if checkpoint_messages:
                         checkpoint_messages = memory_helper._rank_messages(
                             checkpoint_messages,
                             query,
                         )
-                    memory_context = {
-                        **memory_context,
+                        if not extract_request_type(query):
+                            checkpoint_inherited_request_type = (
+                                infer_previous_request_type_from_messages(checkpoint_messages)
+                            )
+                    checkpoint_overlay = {
                         "recent_messages": checkpoint_messages,
                         "context_string": memory_helper._build_comprehensive_context(
                             checkpoint_messages,
@@ -1167,6 +1239,16 @@ class MainWorkflow:
                             language,
                         ),
                         "stm_source": "langgraph_checkpointer",
+                    }
+                    if checkpoint_inherited_request_type and not memory_context.get(
+                        "inherited_request_type"
+                    ):
+                        checkpoint_overlay["inherited_request_type"] = (
+                            checkpoint_inherited_request_type
+                        )
+                    memory_context = {
+                        **memory_context,
+                        **checkpoint_overlay,
                     }
             except Exception as checkpoint_context_error:
                 logger.debug(
@@ -1198,7 +1280,7 @@ class MainWorkflow:
                 if language in ("en", "ko", "zh"):
                     try:
                         translated = await _translate_llm_with_retry(query, language)
-                        if translated and _JA_RE.search(translated):
+                        if translated and _is_acceptable_trag_japanese(translated):
                             rag_query = translated
                             logger.info(
                                 "tRAG %s->ja: '%s' -> '%s'",

--- a/frontend/e2e/helpers/mocks.ts
+++ b/frontend/e2e/helpers/mocks.ts
@@ -44,6 +44,13 @@ export const MOCK_EDITOR_CONFIG = {
   },
 };
 
+export const MOCK_METADATA_TEMPLATES = {
+  templates: MOCK_EDITOR_CONFIG.templates,
+  availableCategories: Object.keys(MOCK_EDITOR_CONFIG.templates).filter(
+    (category) => category !== 'default',
+  ),
+};
+
 /**
  * 音声レスポンスのモックデータ
  * 最小の有効な MP3: ID3 ヘッダ + 1フレーム（無音）
@@ -61,6 +68,10 @@ export async function setupKnowledgeMocks(page: Page) {
   // editor-config エンドポイント
   await page.route('/api/admin/knowledge/editor-config', (route) =>
     route.fulfill({ json: MOCK_EDITOR_CONFIG }),
+  );
+
+  await page.route('/api/admin/knowledge/metadata-templates', (route) =>
+    route.fulfill({ json: MOCK_METADATA_TEMPLATES }),
   );
 
   // 個別エントリ取得・更新・削除

--- a/frontend/e2e/knowledge.spec.ts
+++ b/frontend/e2e/knowledge.spec.ts
@@ -3,6 +3,7 @@ import {
   MOCK_EDITOR_CONFIG,
   MOCK_KNOWLEDGE_ENTRY,
   MOCK_KNOWLEDGE_LIST,
+  MOCK_METADATA_TEMPLATES,
 } from './helpers/mocks';
 import {
   acceptDialog,
@@ -34,6 +35,12 @@ function buildChunkTitles(baseTitle: string, chunkCount: number): string[] {
     ...Array.from({ length: chunkCount - 1 }, (_, index) => `${baseTitle} [chunk ${index + 1}]`),
   ];
 }
+
+test.beforeEach(async ({ page }) => {
+  await page.route('/api/admin/knowledge/metadata-templates', async (route) => {
+    return route.fulfill({ json: MOCK_METADATA_TEMPLATES });
+  });
+});
 
 test.describe('Knowledge 一覧ページ', () => {
   test.beforeEach(async ({ page }) => {

--- a/frontend/scripts/check-vercel-production-env.ts
+++ b/frontend/scripts/check-vercel-production-env.ts
@@ -8,19 +8,21 @@ import {
 
 const args = new Set(process.argv.slice(2));
 const shouldForce = args.has("--force") || args.has("--production");
-const shouldCheck = shouldForce || process.env.VERCEL_ENV === "production";
+const requiredVercelEnvironments = new Set(["production", "preview"]);
+const shouldCheck =
+  shouldForce || requiredVercelEnvironments.has(process.env.VERCEL_ENV ?? "");
 
 if (args.has("--help") || args.has("-h")) {
   console.log(`Usage: pnpm env:check:production [--force]
 
-Checks Vercel production-required frontend env vars without printing values.
-By default this runs only when VERCEL_ENV=production. Use --force in CI or local smoke checks.`);
+Checks Vercel production/preview-required frontend env vars without printing values.
+By default this runs only when VERCEL_ENV=production or VERCEL_ENV=preview. Use --force in CI or local smoke checks.`);
   process.exit(0);
 }
 
 if (!shouldCheck) {
   console.log(
-    `[env-check] skipped: VERCEL_ENV=${process.env.VERCEL_ENV ?? "(unset)"} is not production.`
+    `[env-check] skipped: VERCEL_ENV=${process.env.VERCEL_ENV ?? "(unset)"} is not production or preview.`
   );
   process.exit(0);
 }

--- a/frontend/src/__tests__/api-proxy-contract.test.ts
+++ b/frontend/src/__tests__/api-proxy-contract.test.ts
@@ -27,6 +27,11 @@ function mockBackendJsonResponse(body: unknown, status: number) {
     })) as typeof fetch;
 }
 
+function setBackendProxyEnv() {
+  process.env.BACKEND_API_URL = 'https://backend.example.com';
+  process.env.BACKEND_API_KEY = 'test-backend-key';
+}
+
 test(
   'createBackendErrorResponse maps backend detail to the standard error payload',
   { concurrency: false },
@@ -60,7 +65,7 @@ test(
   'qa POST preserves backend status codes and error payloads',
   { concurrency: false },
   async () => {
-    process.env.BACKEND_API_URL = 'https://backend.example.com';
+    setBackendProxyEnv();
     (process.env as Record<string, string | undefined>).NODE_ENV = 'test';
     mockBackendJsonResponse({ detail: 'validation failed' }, 422);
 
@@ -82,7 +87,7 @@ test(
   'voice GET preserves backend 4xx responses',
   { concurrency: false },
   async () => {
-    process.env.BACKEND_API_URL = 'https://backend.example.com';
+    setBackendProxyEnv();
     (process.env as Record<string, string | undefined>).NODE_ENV = 'test';
     mockBackendJsonResponse({ error: 'Unsupported action' }, 400);
 
@@ -100,7 +105,7 @@ test(
   'reception sensor-status GET forwards query params and backend payloads',
   { concurrency: false },
   async () => {
-    process.env.BACKEND_API_URL = 'https://backend.example.com';
+    setBackendProxyEnv();
     (process.env as Record<string, string | undefined>).NODE_ENV = 'test';
     mockBackendJsonResponse({ triggered: true, device_id: 'm5stack-001' }, 200);
 
@@ -120,6 +125,31 @@ test(
 );
 
 test(
+  'backend proxy refuses to send requests without BACKEND_API_KEY',
+  { concurrency: false },
+  async () => {
+    process.env.BACKEND_API_URL = 'https://backend.example.com';
+    delete process.env.BACKEND_API_KEY;
+    (process.env as Record<string, string | undefined>).NODE_ENV = 'test';
+    let fetchCalled = false;
+    global.fetch = (async () => {
+      fetchCalled = true;
+      throw new Error('fetch must not be called without BACKEND_API_KEY');
+    }) as typeof fetch;
+
+    const { backendFetch } = await import('../lib/api/backend-proxy');
+
+    await assert.rejects(
+      backendFetch('/api/chat', {
+        body: { query: 'hello' },
+      }),
+      /BACKEND_API_KEY environment variable is not set/,
+    );
+    assert.equal(fetchCalled, false);
+  }
+);
+
+test(
   'slides route no longer exports a GET handler',
   { concurrency: false },
   async () => {
@@ -133,7 +163,7 @@ test(
   'voice POST forwards warmup action to backend',
   { concurrency: false },
   async () => {
-    process.env.BACKEND_API_URL = 'https://backend.example.com';
+    setBackendProxyEnv();
     (process.env as Record<string, string | undefined>).NODE_ENV = 'test';
     let capturedBody: Record<string, unknown> | null = null;
     global.fetch = (async (_input, init) => {
@@ -177,7 +207,7 @@ test(
   'voice POST maps backend proxy timeout to a controlled 504 payload',
   { concurrency: false },
   async () => {
-    process.env.BACKEND_API_URL = 'https://backend.example.com';
+    setBackendProxyEnv();
     (process.env as Record<string, string | undefined>).NODE_ENV = 'test';
     global.fetch = (async () => {
       throw new DOMException('The operation was aborted due to timeout', 'TimeoutError');
@@ -201,7 +231,7 @@ test(
   'voice filler POST maps backend proxy timeout to a controlled 504 payload',
   { concurrency: false },
   async () => {
-    process.env.BACKEND_API_URL = 'https://backend.example.com';
+    setBackendProxyEnv();
     (process.env as Record<string, string | undefined>).NODE_ENV = 'test';
     global.fetch = (async () => {
       throw new DOMException('The operation was aborted due to timeout', 'TimeoutError');

--- a/frontend/src/__tests__/middleware.test.ts
+++ b/frontend/src/__tests__/middleware.test.ts
@@ -8,11 +8,19 @@ const env = process.env as Record<string, string | undefined>;
 const originalAdminApiSecret = process.env.ADMIN_API_SECRET;
 const originalNodeEnv = process.env.NODE_ENV;
 
-function createRequest(pathname: string, authorization?: string): NextRequest {
+function createRequest(
+  pathname: string,
+  authorization?: string,
+  extraHeaders: Record<string, string> = {},
+): NextRequest {
   const headers = new Headers();
 
   if (authorization) {
     headers.set('authorization', authorization);
+  }
+
+  for (const [key, value] of Object.entries(extraHeaders)) {
+    headers.set(key, value);
   }
 
   return new NextRequest(`https://example.com${pathname}`, { headers });
@@ -37,6 +45,19 @@ test('returns 401 when authorization header is missing', async () => {
   process.env.ADMIN_API_SECRET = 'test-secret';
 
   const response = await middleware(createRequest('/api/admin/knowledge'));
+
+  assert.equal(response.status, 401);
+  assert.deepEqual(await response.json(), { error: 'Unauthorized' });
+});
+
+test('returns 401 for same-origin admin browser requests without bearer token', async () => {
+  process.env.ADMIN_API_SECRET = 'test-secret';
+
+  const response = await middleware(
+    createRequest('/api/admin/knowledge', undefined, {
+      'sec-fetch-site': 'same-origin',
+    }),
+  );
 
   assert.equal(response.status, 401);
   assert.deepEqual(await response.json(), { error: 'Unauthorized' });
@@ -93,11 +114,21 @@ test('fails closed in production when ADMIN_API_SECRET is only whitespace', asyn
   assert.deepEqual(await response.json(), { error: 'Unauthorized' });
 });
 
-test('allows requests in development when ADMIN_API_SECRET is not set', async () => {
+test('fails closed for admin routes in development when ADMIN_API_SECRET is not set', async () => {
   delete env.ADMIN_API_SECRET;
   env.NODE_ENV = 'development';
 
   const response = await middleware(createRequest('/api/admin/knowledge'));
+
+  assert.equal(response.status, 401);
+  assert.deepEqual(await response.json(), { error: 'Unauthorized' });
+});
+
+test('allows non-admin operational routes in development when ADMIN_API_SECRET is not set', async () => {
+  delete env.ADMIN_API_SECRET;
+  env.NODE_ENV = 'development';
+
+  const response = await middleware(createRequest('/api/monitoring/dashboard'));
 
   assert.equal(response.status, 200);
   assert.equal(response.headers.get('x-middleware-next'), '1');

--- a/frontend/src/lib/api/backend-proxy.ts
+++ b/frontend/src/lib/api/backend-proxy.ts
@@ -5,13 +5,12 @@
  * and attaches the X-API-Key header to every outgoing request.
  */
 
-const BACKEND_API_URL = process.env.BACKEND_API_URL;
 export const BACKEND_PROXY_TIMEOUT_MS = 110_000;
 export const VERCEL_VOICE_MAX_DURATION_MS = 120_000;
 export const CLOUD_RUN_TIMEOUT_MS = 300_000;
 export const ISSUE_696_WORST_OBSERVED_LATENCY_MS = 97_630;
 
-if (!BACKEND_API_URL) {
+if (!process.env.BACKEND_API_URL) {
   console.warn(
     "BACKEND_API_URL is not set. Backend proxy requests will fail.",
   );
@@ -61,7 +60,13 @@ export async function backendFetch<T = unknown>(
   opts: BackendProxyOptions = {},
 ): Promise<BackendProxyResult<T>> {
   const { method = "POST", body, headers = {}, params, signal, timeoutMs } = opts;
-  const apiKey = process.env.BACKEND_API_KEY || "";
+  const apiKey = process.env.BACKEND_API_KEY?.trim();
+
+  if (!apiKey) {
+    throw new Error(
+      "BACKEND_API_KEY environment variable is not set. Refusing to proxy to backend.",
+    );
+  }
 
   const url = buildUrl(path, params);
 
@@ -71,9 +76,7 @@ export async function backendFetch<T = unknown>(
     mergedHeaders["Content-Type"] ??= "application/json";
   }
 
-  if (apiKey) {
-    mergedHeaders["X-API-Key"] = apiKey;
-  }
+  mergedHeaders["X-API-Key"] = apiKey;
 
   // Keep the default proxy timeout below Vercel's 120s route maxDuration and
   // above the Issue #696 observed 60-97s cold-start range. This lets the client
@@ -123,12 +126,14 @@ function buildUrl(
   path: string,
   params?: Readonly<Record<string, string>>,
 ): string {
-  if (!BACKEND_API_URL) {
+  const backendApiUrl = process.env.BACKEND_API_URL?.trim();
+
+  if (!backendApiUrl) {
     throw new Error(
       "BACKEND_API_URL environment variable is not set. Cannot proxy to backend.",
     );
   }
-  const base = BACKEND_API_URL.replace(/\/+$/, "");
+  const base = backendApiUrl.replace(/\/+$/, "");
   const normalizedPath = path.startsWith("/") ? path : `/${path}`;
   const url = new URL(`${base}${normalizedPath}`);
 

--- a/frontend/src/middleware.ts
+++ b/frontend/src/middleware.ts
@@ -54,15 +54,6 @@ function traceUserAgent(request: NextRequest): void {
   );
 }
 
-/**
- * Detect same-origin browser requests via the Sec-Fetch-Site header.
- * Modern browsers set this automatically; non-browser clients (curl, etc.)
- * do not send it. This header cannot be spoofed by browser-side JavaScript.
- */
-function isSameOriginBrowserRequest(request: NextRequest): boolean {
-  return request.headers.get('sec-fetch-site') === 'same-origin';
-}
-
 export async function middleware(request: NextRequest): Promise<NextResponse> {
   traceUserAgent(request);
 
@@ -70,16 +61,10 @@ export async function middleware(request: NextRequest): Promise<NextResponse> {
     return NextResponse.next();
   }
 
-  // Allow same-origin browser requests to admin routes without Bearer token.
-  // The underlying API routes still enforce backend auth via X-API-Key.
-  if (isAdminRoute(request.nextUrl.pathname) && isSameOriginBrowserRequest(request)) {
-    return NextResponse.next();
-  }
-
   const adminApiSecret = process.env.ADMIN_API_SECRET?.trim();
 
   if (!adminApiSecret) {
-    if (process.env.NODE_ENV === 'production') {
+    if (isAdminRoute(request.nextUrl.pathname) || process.env.NODE_ENV === 'production') {
       return unauthorizedResponse();
     }
 

--- a/scripts/verify-frontend-production.sh
+++ b/scripts/verify-frontend-production.sh
@@ -9,10 +9,14 @@ set -euo pipefail
 # Usage:
 #   ./scripts/verify-frontend-production.sh <frontend_base_url>
 #   FRONTEND_BASE_URL=https://example.vercel.app ./scripts/verify-frontend-production.sh
+#
+# For protected Vercel preview deployments, set VERCEL_AUTOMATION_BYPASS_SECRET.
+# The value is sent as a request header and is never logged.
 
 FRONTEND_BASE_URL="${1:-${FRONTEND_BASE_URL:-${FRONTEND_PRODUCTION_ORIGIN:-}}}"
 MAX_ATTEMPTS="${MAX_ATTEMPTS:-12}"
 SLEEP_SECONDS="${SLEEP_SECONDS:-15}"
+VERCEL_AUTOMATION_BYPASS_SECRET="${VERCEL_AUTOMATION_BYPASS_SECRET:-}"
 
 if [[ -z "$FRONTEND_BASE_URL" ]]; then
   echo "error: frontend base URL is required." >&2
@@ -60,13 +64,28 @@ request_with_retries() {
     : > "$body_file"
 
     if [[ "$method" == "GET" ]]; then
-      code="$(curl -sS -o "$body_file" -w "%{http_code}" "$BASE_URL$path" || true)"
+      if [[ -n "$VERCEL_AUTOMATION_BYPASS_SECRET" ]]; then
+        code="$(curl -sS -o "$body_file" -w "%{http_code}" \
+          -H "x-vercel-protection-bypass: $VERCEL_AUTOMATION_BYPASS_SECRET" \
+          "$BASE_URL$path" || true)"
+      else
+        code="$(curl -sS -o "$body_file" -w "%{http_code}" "$BASE_URL$path" || true)"
+      fi
     else
-      code="$(curl -sS -o "$body_file" -w "%{http_code}" \
-        -X "$method" \
-        -H "Content-Type: application/json" \
-        -d "$body" \
-        "$BASE_URL$path" || true)"
+      if [[ -n "$VERCEL_AUTOMATION_BYPASS_SECRET" ]]; then
+        code="$(curl -sS -o "$body_file" -w "%{http_code}" \
+          -X "$method" \
+          -H "x-vercel-protection-bypass: $VERCEL_AUTOMATION_BYPASS_SECRET" \
+          -H "Content-Type: application/json" \
+          -d "$body" \
+          "$BASE_URL$path" || true)"
+      else
+        code="$(curl -sS -o "$body_file" -w "%{http_code}" \
+          -X "$method" \
+          -H "Content-Type: application/json" \
+          -d "$body" \
+          "$BASE_URL$path" || true)"
+      fi
     fi
 
     if [[ "$code" == "$expected" ]]; then
@@ -93,6 +112,11 @@ echo "Frontend Production Smoke Verification"
 echo "URL: $BASE_URL"
 echo "Attempts: $MAX_ATTEMPTS"
 echo "Sleep seconds: $SLEEP_SECONDS"
+if [[ -n "$VERCEL_AUTOMATION_BYPASS_SECRET" ]]; then
+  echo "Vercel deployment protection bypass: enabled"
+else
+  echo "Vercel deployment protection bypass: disabled"
+fi
 echo "============================================"
 echo
 


### PR DESCRIPTION
## Summary

Closes #836
Closes #837
Closes #838
Closes #839
Closes #840

- Fail closed for frontend admin/API proxy auth: no same-origin admin bypass, backend proxy refuses requests without `BACKEND_API_KEY`, and Vercel preview env checks now run.
- Fix tRAG English/Korean/Chinese translation validation so valid Japanese kanji-only domain translations such as `営業時間` are accepted while repeated/foreign-script output is rejected.
- Restore STM request-type inheritance when `ENABLE_AGENT_MEMORY_STM_WRITES=false` by deriving prior request type from LangGraph checkpoint messages.
- Sync/bind optional runtime secrets for LangSmith and Connpass in backend deploy; manually promoted the existing local `CONNPASS_API_KEY` to Google Secret Manager without printing the value.
- Add Vercel deployment-protection bypass support to frontend smoke verification without logging the secret.

## Local Verification

- `pnpm --dir frontend exec tsx --test --import ./src/__tests__/node-test-setup.ts src/__tests__/api-proxy-contract.test.ts src/__tests__/middleware.test.ts src/__tests__/env-validation.test.ts`
- `pnpm --dir frontend test:node` (142 passed)
- `pnpm --dir frontend typecheck`
- `pnpm --dir frontend lint` (existing VoiceInterface hook warnings only)
- `NEXT_PUBLIC_SUPABASE_URL=https://example.supabase.co NEXT_PUBLIC_SUPABASE_ANON_KEY=test-anon BACKEND_API_URL=https://backend.example.com BACKEND_API_KEY=test-key VERCEL_ENV=preview pnpm --dir frontend env:check:production`
- `FRONTEND_BASE_URL=https://frontend-delta-six-20.vercel.app MAX_ATTEMPTS=1 SLEEP_SECONDS=1 bash scripts/verify-frontend-production.sh`
- `uv run pytest backend/tests/workflows/test_main_workflow.py backend/tests/workflows/test_trag_translation.py backend/tests/utils/test_memory_helper_unit.py -q` (178 passed)
- `uv run ruff check backend/workflows/main_workflow.py backend/utils/memory_helper.py backend/tests/workflows/test_trag_translation.py backend/tests/workflows/test_main_workflow.py backend/tests/utils/test_memory_helper_unit.py`
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/ci.yml"); YAML.load_file(".github/workflows/frontend-production-smoke.yml")'`\n- `bash -n scripts/verify-frontend-production.sh`\n- `git diff --check`\n\n## Secret Evidence\n\n- `LANGSMITH_API_KEY` exists in GitHub Actions secrets only; absent from local shell/env files and GCP Secret Manager before this PR. The deploy workflow now syncs it to GCP Secret Manager from GitHub secrets before deploy.\n- `CONNPASS_API_KEY` existed in `backend/.env`; it has been added to GCP Secret Manager as `CONNPASS_API_KEY` without printing the value.\n\n## Post-Merge Verification Plan\n\n- Confirm develop CI deploy succeeds and routes 100% traffic to the new Cloud Run revision.\n- Confirm latest Cloud Run revision binds `LANGSMITH_API_KEY` and `CONNPASS_API_KEY` when present.\n- Confirm backend `/health`, frontend smoke, tRAG English-hours query, same-origin admin 401, STM cafe follow-up, and absence of latest-revision LangSmith/Connpass disabled warnings in Cloud Logging.\n