### PR TITLE
fix: close Phase 2 alpha readiness blockers

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,6 +39,10 @@ jobs:
               - '.github/workflows/voice-e2e-nightly.yml'
             backend:
               - 'backend/**'
+              - 'infra/**'
+              - 'scripts/**'
+              - '.github/workflows/ci.yml'
+              - '.github/workflows/alpha-live-verification.yml'
 
   # Frontend: Lint
   frontend-lint:
@@ -526,9 +530,14 @@ jobs:
             "CONNPASS_API_KEY" \
             "${CONNPASS_API_KEY}" \
             "CONNPASS_API_KEY GitHub secret is not configured; relying on existing Google Secret Manager value if present"
+          sync_secret_from_env \
+            "GOOGLE_CALENDAR_ICAL_URL" \
+            "${GOOGLE_CALENDAR_ICAL_URL}" \
+            "GOOGLE_CALENDAR_ICAL_URL GitHub secret is not configured; relying on existing Google Secret Manager value if present"
         env:
           LANGSMITH_API_KEY: ${{ secrets.LANGSMITH_API_KEY }}
           CONNPASS_API_KEY: ${{ secrets.CONNPASS_API_KEY }}
+          GOOGLE_CALENDAR_ICAL_URL: ${{ secrets.GOOGLE_CALENDAR_ICAL_URL }}
 
       - name: Deploy to Cloud Run
         run: |
@@ -544,6 +553,11 @@ jobs:
           else
             echo "::warning::CONNPASS_API_KEY latest secret version not available; Connpass updates disabled"
           fi
+          if gcloud secrets versions access latest --secret=GOOGLE_CALENDAR_ICAL_URL >/dev/null 2>&1; then
+            BACKEND_SECRET_ARGS="${BACKEND_SECRET_ARGS},GOOGLE_CALENDAR_ICAL_URL=GOOGLE_CALENDAR_ICAL_URL:latest"
+          else
+            echo "::warning::GOOGLE_CALENDAR_ICAL_URL latest secret version not available; Google Calendar event sync disabled"
+          fi
 
           gcloud run deploy engineer-cafe-backend \
             --image asia-northeast1-docker.pkg.dev/aipartner-426616/cloud-run-source-deploy/engineer-cafe-backend:${{ github.sha }} \
@@ -558,7 +572,7 @@ jobs:
             --max-instances 15 \
             --cpu-boost \
             --no-cpu-throttling \
-            --update-env-vars "ENVIRONMENT=production,TTS_PROVIDER=piper,TTS_REQUIRE_PRIMARY_PROVIDER=true,PIPER_PLUS_API_URL=https://piper-plus-639959525777.asia-northeast1.run.app,VOICEVOX_API_URL=https://voicevox-proto-639959525777.asia-northeast2.run.app,STT_PROVIDER=qwen-primary,STT_QWEN_RUNTIME=torch,STT_LLM_POSTPROCESS=false,VOICE_STT_REQUEST_TIMEOUT_SECONDS=15,QWEN_STT_TIMEOUT=15,QWEN_STT_HEDGE_DELAY_SECONDS=1.5,QWEN_STT_HEDGE_GRACE_SECONDS=4,QWEN_STT_LATENCY_BUDGET_SECONDS=11.5,STT_PRELOAD_QWEN_PRIMARY=true,STT_PRELOAD_VOSK_FALLBACK=true,ENABLE_AGENT_MEMORY_STM_WRITES=false,ALLOW_AGENT_MEMORY_STM_WRITE_DISABLE=true,HF_HOME=/app/.hf_cache,FRONTEND_PRODUCTION_ORIGIN=${FRONTEND_PRODUCTION_ORIGIN},ALLOWED_ORIGINS=${FRONTEND_PRODUCTION_ORIGIN},FAST_LLM_ENABLED=true,FAST_LLM_PRIMARY_PROVIDER=cerebras,FAST_LLM_PRIMARY_MODEL=google/gemini-3.1-flash-lite-preview,FAST_LLM_FALLBACK_PROVIDER=gemini,FAST_LLM_FALLBACK_MODEL=google/gemini-2.5-flash-lite,FAST_LLM_TERTIARY_PROVIDER=cerebras,CEREBRAS_ENABLED=true,CEREBRAS_FAST_MODEL=gpt-oss-120b,CEREBRAS_REASONING_EFFORT=low,DEEP_REASONING_MODEL=google/gemini-3.1-pro-preview,DEEP_REASONING_FALLBACK_MODEL=google/gemini-2.5-pro,LANGSMITH_PROJECT=engineer-cafe-navigator-production,LANGCHAIN_PROJECT=engineer-cafe-navigator-production" \
+            --update-env-vars "ENVIRONMENT=production,TTS_PROVIDER=piper,TTS_REQUIRE_PRIMARY_PROVIDER=true,PIPER_PLUS_API_URL=https://piper-plus-639959525777.asia-northeast1.run.app,VOICEVOX_API_URL=https://voicevox-proto-639959525777.asia-northeast2.run.app,STT_PROVIDER=qwen-primary,STT_QWEN_RUNTIME=torch,STT_LLM_POSTPROCESS=false,VOICE_STT_REQUEST_TIMEOUT_SECONDS=15,QWEN_STT_TIMEOUT=15,QWEN_STT_HEDGE_DELAY_SECONDS=1.5,QWEN_STT_HEDGE_GRACE_SECONDS=4,QWEN_STT_LATENCY_BUDGET_SECONDS=11.5,STT_PRELOAD_QWEN_PRIMARY=true,STT_PRELOAD_VOSK_FALLBACK=true,ENABLE_AGENT_MEMORY_STM_WRITES=false,ALLOW_AGENT_MEMORY_STM_WRITE_DISABLE=true,ENABLE_MEMORY_CANDIDATES=true,ENABLE_MEMORY_PROMOTION=true,ENABLE_LONG_TERM_MEMORY_RERANK=true,HF_HOME=/app/.hf_cache,FRONTEND_PRODUCTION_ORIGIN=${FRONTEND_PRODUCTION_ORIGIN},ALLOWED_ORIGINS=${FRONTEND_PRODUCTION_ORIGIN},FAST_LLM_ENABLED=true,FAST_LLM_PRIMARY_PROVIDER=cerebras,FAST_LLM_PRIMARY_MODEL=google/gemini-3.1-flash-lite-preview,FAST_LLM_FALLBACK_PROVIDER=gemini,FAST_LLM_FALLBACK_MODEL=google/gemini-2.5-flash-lite,FAST_LLM_TERTIARY_PROVIDER=cerebras,CEREBRAS_ENABLED=true,CEREBRAS_FAST_MODEL=gpt-oss-120b,CEREBRAS_REASONING_EFFORT=low,DEEP_REASONING_MODEL=google/gemini-3.1-pro-preview,DEEP_REASONING_FALLBACK_MODEL=google/gemini-2.5-pro,LANGSMITH_PROJECT=engineer-cafe-navigator-production,LANGCHAIN_PROJECT=engineer-cafe-navigator-production" \
             --update-secrets "${BACKEND_SECRET_ARGS}"
 
           LATEST_READY_REVISION=$(gcloud run services describe engineer-cafe-backend \
@@ -574,6 +588,82 @@ jobs:
             --to-latest
         env:
           FRONTEND_PRODUCTION_ORIGIN: ${{ vars.FRONTEND_PRODUCTION_ORIGIN }}
+
+      - name: Deploy Event KB sync job and scheduler
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          PROJECT_ID="aipartner-426616"
+          REGION="asia-northeast1"
+          JOB_NAME="event-kb-sync"
+          SCHEDULER_JOB_NAME="event-kb-sync-daily"
+          JOB_SERVICE_ACCOUNT="engineer-cafe-navigator@${PROJECT_ID}.iam.gserviceaccount.com"
+          IMAGE="asia-northeast1-docker.pkg.dev/${PROJECT_ID}/cloud-run-source-deploy/engineer-cafe-backend:${{ github.sha }}"
+
+          gcloud services enable cloudscheduler.googleapis.com run.googleapis.com \
+            --project="${PROJECT_ID}" \
+            --quiet
+
+          for secret_name in OPENROUTER_API_KEY SUPABASE_URL SUPABASE_KEY GOOGLE_CALENDAR_ICAL_URL; do
+            if ! gcloud secrets versions access latest --secret="${secret_name}" >/dev/null 2>&1; then
+              echo "error: required secret ${secret_name} is missing or has no enabled version" >&2
+              exit 1
+            fi
+          done
+
+          gcloud run jobs deploy "${JOB_NAME}" \
+            --project="${PROJECT_ID}" \
+            --region="${REGION}" \
+            --image="${IMAGE}" \
+            --service-account="${JOB_SERVICE_ACCOUNT}" \
+            --command=python \
+            --args=-m,backend.scripts.sync_event_kb \
+            --tasks=1 \
+            --max-retries=1 \
+            --task-timeout=3600s \
+            --cpu=1 \
+            --memory=1Gi \
+            --set-env-vars="ENVIRONMENT=production,GOOGLE_CLOUD_PROJECT=${PROJECT_ID}" \
+            --set-secrets="OPENROUTER_API_KEY=OPENROUTER_API_KEY:latest,SUPABASE_URL=SUPABASE_URL:latest,SUPABASE_KEY=SUPABASE_KEY:latest,GOOGLE_CALENDAR_ICAL_URL=GOOGLE_CALENDAR_ICAL_URL:latest"
+
+          JOB_RUN_URI="https://run.googleapis.com/v2/projects/${PROJECT_ID}/locations/${REGION}/jobs/${JOB_NAME}:run"
+          if gcloud scheduler jobs describe "${SCHEDULER_JOB_NAME}" \
+            --project="${PROJECT_ID}" \
+            --location="${REGION}" >/dev/null 2>&1; then
+            gcloud scheduler jobs update http "${SCHEDULER_JOB_NAME}" \
+              --project="${PROJECT_ID}" \
+              --location="${REGION}" \
+              --schedule="0 9 * * *" \
+              --time-zone="Asia/Tokyo" \
+              --uri="${JOB_RUN_URI}" \
+              --http-method=POST \
+              --update-headers="Content-Type=application/json" \
+              --message-body="{}" \
+              --oauth-service-account-email="${JOB_SERVICE_ACCOUNT}" \
+              --oauth-token-scope="https://www.googleapis.com/auth/cloud-platform" \
+              --attempt-deadline=30s \
+              --max-retry-attempts=1
+          else
+            gcloud scheduler jobs create http "${SCHEDULER_JOB_NAME}" \
+              --project="${PROJECT_ID}" \
+              --location="${REGION}" \
+              --schedule="0 9 * * *" \
+              --time-zone="Asia/Tokyo" \
+              --uri="${JOB_RUN_URI}" \
+              --http-method=POST \
+              --headers="Content-Type=application/json" \
+              --message-body="{}" \
+              --oauth-service-account-email="${JOB_SERVICE_ACCOUNT}" \
+              --oauth-token-scope="https://www.googleapis.com/auth/cloud-platform" \
+              --attempt-deadline=30s \
+              --max-retry-attempts=1
+          fi
+
+          gcloud run jobs execute "${JOB_NAME}" \
+            --project="${PROJECT_ID}" \
+            --region="${REGION}" \
+            --wait
 
       - name: Smoke test deployed service
         run: |
@@ -650,8 +740,10 @@ jobs:
 
           check_secret_binding "LANGSMITH_API_KEY" "LangSmith"
           check_secret_binding "CONNPASS_API_KEY" "Connpass"
+          check_secret_binding "GOOGLE_CALENDAR_ICAL_URL" "Google Calendar ICS"
 
           SERVICE_URL=$(python3 -c 'import json,sys; print(json.load(open(sys.argv[1]))["status"]["url"])' "$SERVICE_JSON")
+          LATEST_READY_REVISION=$(python3 -c 'import json,sys; print(json.load(open(sys.argv[1]))["status"]["latestReadyRevisionName"])' "$SERVICE_JSON")
           echo "Testing $SERVICE_URL/health ..."
           for i in 1 2 3; do
             HEALTH=$(curl -sf --max-time 30 "$SERVICE_URL/health") && break
@@ -660,6 +752,95 @@ jobs:
           done
           echo "$HEALTH"
           echo "$HEALTH" | python3 -c "import sys,json; d=json.load(sys.stdin); assert d['status']=='ok', f'Health check failed: {d}'"
+
+          REQUEST_ID="ci-llm-observability-${GITHUB_SHA:0:12}-$(date +%s)"
+          SESSION_ID="${REQUEST_ID}"
+          API_KEY="$(gcloud secrets versions access latest --secret=API_SECRET_KEY)"
+          CHAT_BODY=$(mktemp)
+          cat > "$CHAT_BODY" <<JSON
+          {
+            "query": "量子コンピュータを初心者向けに一文で説明してください",
+            "session_id": "${SESSION_ID}",
+            "language": "ja"
+          }
+          JSON
+
+          echo "Testing $SERVICE_URL/api/chat LLM observability with request_id=$REQUEST_ID ..."
+          CHAT_RESPONSE=$(curl -sf --max-time 120 \
+            -X POST "$SERVICE_URL/api/chat" \
+            -H "Content-Type: application/json" \
+            -H "X-API-Key: ${API_KEY}" \
+            -H "X-Request-ID: ${REQUEST_ID}" \
+            --data-binary @"$CHAT_BODY")
+
+          python3 - "$CHAT_RESPONSE" <<'PY'
+          import json
+          import sys
+
+          response = json.loads(sys.argv[1])
+          metadata = response.get("metadata") or {}
+          provider = metadata.get("provider") or metadata.get("llm_provider")
+          model = metadata.get("model") or metadata.get("llm_model")
+          route = metadata.get("route") or metadata.get("category") or metadata.get("request_type")
+          latency = metadata.get("llm_latency_ms")
+          missing = [
+              name
+              for name, value in {
+                  "provider": provider,
+                  "model": model,
+                  "route": route,
+                  "llm_latency_ms": latency,
+              }.items()
+              if value in (None, "", "unknown")
+          ]
+          if missing:
+              raise SystemExit(f"error: /api/chat metadata missing LLM observability fields: {missing}")
+          print(
+              "Chat response metadata check passed: "
+              f"provider={provider} model={model} route={route} llm_latency_ms={latency}"
+          )
+          PY
+
+          for attempt in 1 2 3 4 5 6 7 8 9 10; do
+            LOG_JSON=$(gcloud logging read \
+              "resource.type=\"cloud_run_revision\" AND resource.labels.service_name=\"engineer-cafe-backend\" AND resource.labels.revision_name=\"${LATEST_READY_REVISION}\" AND jsonPayload.event=\"chat_response\" AND jsonPayload.request_id=\"${REQUEST_ID}\"" \
+              --project=aipartner-426616 \
+              --limit=1 \
+              --format=json)
+            if python3 - "$LOG_JSON" <<'PY'
+          import json
+          import sys
+
+          rows = json.loads(sys.argv[1])
+          if not rows:
+              raise SystemExit(1)
+          payload = rows[0].get("jsonPayload") or {}
+          failures = []
+          if payload.get("provider") in (None, "", "unknown"):
+              failures.append("provider")
+          if payload.get("model") in (None, "", "unknown"):
+              failures.append("model")
+          if payload.get("route") in (None, "", "unknown"):
+              failures.append("route")
+          if payload.get("llm_latency_ms") is None:
+              failures.append("llm_latency_ms")
+          if failures:
+              raise SystemExit(f"error: Cloud Logging chat_response missing fields: {failures}")
+          print(
+              "Cloud Logging observability check passed: "
+              f"provider={payload.get('provider')} model={payload.get('model')} "
+              f"route={payload.get('route')} llm_latency_ms={payload.get('llm_latency_ms')}"
+          )
+          PY
+            then
+              exit 0
+            fi
+            echo "Waiting for chat_response log row (attempt $attempt/10)..."
+            sleep 10
+          done
+
+          echo "error: chat_response log row with request_id=${REQUEST_ID} did not arrive" >&2
+          exit 1
 
   # Frontend: Vercel deploy is handled by Vercel Deploy Hook (auto-deploy on push).
   # The former CI-based `frontend-deploy-production` job was removed 2026-03-18

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -759,9 +759,10 @@ jobs:
           CHAT_BODY=$(mktemp)
           cat > "$CHAT_BODY" <<JSON
           {
-            "query": "量子コンピュータを初心者向けに一文で説明してください",
+            "query": "覚えて、私はCIテストユーザーです。量子コンピュータを初心者向けに一文で説明してください",
             "session_id": "${SESSION_ID}",
-            "language": "ja"
+            "language": "ja",
+            "visitor_id": "${SESSION_ID}"
           }
           JSON
 
@@ -795,12 +796,18 @@ jobs:
           ]
           if missing:
               raise SystemExit(f"error: /api/chat metadata missing LLM observability fields: {missing}")
+          if provider != "cerebras" or model != "gpt-oss-120b":
+              raise SystemExit(
+                  "error: /api/chat did not complete through Cerebras direct hop: "
+                  f"provider={provider} model={model}"
+              )
           print(
               "Chat response metadata check passed: "
               f"provider={provider} model={model} route={route} llm_latency_ms={latency}"
           )
           PY
 
+          CHAT_LOG_OK=false
           for attempt in 1 2 3 4 5 6 7 8 9 10; do
             LOG_JSON=$(gcloud logging read \
               "resource.type=\"cloud_run_revision\" AND resource.labels.service_name=\"engineer-cafe-backend\" AND resource.labels.revision_name=\"${LATEST_READY_REVISION}\" AND jsonPayload.event=\"chat_response\" AND jsonPayload.request_id=\"${REQUEST_ID}\"" \
@@ -826,6 +833,11 @@ jobs:
               failures.append("llm_latency_ms")
           if failures:
               raise SystemExit(f"error: Cloud Logging chat_response missing fields: {failures}")
+          if payload.get("provider") != "cerebras" or payload.get("model") != "gpt-oss-120b":
+              raise SystemExit(
+                  "error: Cloud Logging chat_response did not record Cerebras direct hop: "
+                  f"provider={payload.get('provider')} model={payload.get('model')}"
+              )
           print(
               "Cloud Logging observability check passed: "
               f"provider={payload.get('provider')} model={payload.get('model')} "
@@ -833,14 +845,55 @@ jobs:
           )
           PY
             then
-              exit 0
+              CHAT_LOG_OK=true
+              break
             fi
             echo "Waiting for chat_response log row (attempt $attempt/10)..."
             sleep 10
           done
 
-          echo "error: chat_response log row with request_id=${REQUEST_ID} did not arrive" >&2
-          exit 1
+          if [[ "$CHAT_LOG_OK" != "true" ]]; then
+            echo "error: chat_response log row with request_id=${REQUEST_ID} did not arrive" >&2
+            exit 1
+          fi
+
+          for event_name in \
+            memory_loader_get_recent_messages_duration_ms \
+            memory_extractor_run \
+            memory_promote_run \
+            memory_candidate_aggregate; do
+            EVENT_OK=false
+            for attempt in 1 2 3 4 5 6 7 8 9 10; do
+              EVENT_JSON=$(gcloud logging read \
+                "resource.type=\"cloud_run_revision\" AND resource.labels.service_name=\"engineer-cafe-backend\" AND resource.labels.revision_name=\"${LATEST_READY_REVISION}\" AND jsonPayload.event=\"${event_name}\" AND jsonPayload.request_id=\"${REQUEST_ID}\"" \
+                --project=aipartner-426616 \
+                --limit=1 \
+                --format=json)
+              if python3 - "$EVENT_JSON" "$event_name" <<'PY'
+          import json
+          import sys
+
+          rows = json.loads(sys.argv[1])
+          event_name = sys.argv[2]
+          if not rows:
+              raise SystemExit(1)
+          payload = rows[0].get("jsonPayload") or {}
+          if payload.get("event") != event_name:
+              raise SystemExit(f"error: unexpected memory event payload: {payload}")
+          print(f"Cloud Logging memory event check passed: {event_name}")
+          PY
+              then
+                EVENT_OK=true
+                break
+              fi
+              echo "Waiting for ${event_name} log row (attempt $attempt/10)..."
+              sleep 10
+            done
+            if [[ "$EVENT_OK" != "true" ]]; then
+              echo "error: ${event_name} log row with request_id=${REQUEST_ID} did not arrive" >&2
+              exit 1
+            fi
+          done
 
   # Frontend: Vercel deploy is handled by Vercel Deploy Hook (auto-deploy on push).
   # The former CI-based `frontend-deploy-production` job was removed 2026-03-18

--- a/backend/agents/business_info_agent.py
+++ b/backend/agents/business_info_agent.py
@@ -8,6 +8,7 @@ from typing import Dict, Optional
 
 from langchain_core.messages import HumanMessage
 
+from backend.agents.llm_metadata import merge_llm_metadata
 from backend.llm import get_llm_provider, get_model_config
 from backend.tools.enhanced_rag import EnhancedRAGSearch
 from backend.utils.cafe_entity import (
@@ -176,16 +177,22 @@ class BusinessInfoAgent:
             # 感情タグを決定
             emotion = self._determine_emotion(request_type, response_text)
 
-            return {
-                "answer": response_text,
-                "emotion": emotion,
-                "metadata": {
+            metadata = merge_llm_metadata(
+                {
                     "agent": "BusinessInfoAgent",
                     "confidence": 0.85,
                     "category": category,
                     "request_type": request_type,
+                    "route": category,
                     "sources": ["enhanced_rag"],
                 },
+                response_text,
+            )
+
+            return {
+                "answer": str(response_text),
+                "emotion": emotion,
+                "metadata": metadata,
             }
 
         except Exception as e:
@@ -1145,6 +1152,7 @@ Information: {context}
             "agent": "BusinessInfoAgent",
             "confidence": 0.95,
             "request_type": request_type,
+            "route": category or request_type or "business_info",
             "sources": ["enhanced_rag"],
         }
         if category:

--- a/backend/agents/event_agent.py
+++ b/backend/agents/event_agent.py
@@ -11,6 +11,7 @@ from typing import Dict, List, Optional
 
 from langchain_core.messages import HumanMessage
 
+from backend.agents.llm_metadata import merge_llm_metadata
 from backend.config.prompts.event_prompts import build_event_prompt, get_time_range_label
 from backend.llm import get_llm_provider, get_model_config
 from backend.tools.calendar_service import CalendarService
@@ -204,10 +205,14 @@ class EventAgent:
             ] or ["google_calendar", "connpass"]
             metadata = {
                 "agent": "EventAgent",
+                "category": "event",
+                "request_type": "event",
+                "route": "event",
                 "time_range": time_range,
                 "event_count": event_count,
                 "sources": sources,
             }
+            merge_llm_metadata(metadata, response_text)
             if include_evidence:
                 metadata["rag_evidence"] = {
                     "source": "event_agent",
@@ -226,7 +231,7 @@ class EventAgent:
                 }
 
             return {
-                "answer": response_text,
+                "answer": str(response_text),
                 "emotion": emotion,
                 "metadata": metadata,
             }
@@ -435,6 +440,9 @@ class EventAgent:
         context = answer.split("]", 1)[1] if answer.startswith("[") and "]" in answer else answer
         metadata = {
             "agent": "EventAgent",
+            "category": "event",
+            "request_type": "event",
+            "route": "event",
             "time_range": "thisWeek",
             "event_count": 0,
             "sources": ["connpass"],

--- a/backend/agents/facility_agent.py
+++ b/backend/agents/facility_agent.py
@@ -12,6 +12,7 @@ from backend.config.prompts.facility_prompts import (
     FACILITY_ENHANCEMENT_KEYWORDS,
     build_facility_prompt,
 )
+from backend.agents.llm_metadata import merge_llm_metadata
 from backend.config.routing_constants import match_pet_policy_keywords
 from backend.llm import get_llm_provider, get_model_config
 from backend.tools.enhanced_rag import EnhancedRAGSearch
@@ -185,16 +186,22 @@ class FacilityAgent:
             # 感情タグを決定
             emotion = self._determine_emotion(request_type, response_text)
 
-            return {
-                "answer": response_text,
-                "emotion": emotion,
-                "metadata": {
+            metadata = merge_llm_metadata(
+                {
                     "agent": "FacilityAgent",
                     "confidence": 0.85,
                     "category": rag_category,
                     "request_type": request_type,
+                    "route": rag_category,
                     "sources": ["enhanced_rag"],
                 },
+                response_text,
+            )
+
+            return {
+                "answer": str(response_text),
+                "emotion": emotion,
+                "metadata": metadata,
             }
 
         except Exception as e:
@@ -1194,6 +1201,7 @@ class FacilityAgent:
                 "confidence": 0.95,
                 "category": "facility-info",
                 "request_type": request_type,
+                "route": "facility-info",
                 "sources": ["enhanced_rag"],
             },
         }
@@ -1970,6 +1978,7 @@ class FacilityAgent:
                 "agent": "FacilityAgent",
                 "confidence": 0.3,
                 "request_type": request_type,
+                "route": request_type or "facility-info",
                 "sources": ["fallback"],
             },
         }

--- a/backend/agents/farewell_agent.py
+++ b/backend/agents/farewell_agent.py
@@ -8,6 +8,7 @@ from typing import Dict, Optional
 
 from langchain_core.messages import HumanMessage
 
+from backend.agents.llm_metadata import merge_llm_metadata
 from backend.llm import get_llm_provider, get_model_config
 from backend.tools.enhanced_rag import EnhancedRAGSearch
 
@@ -122,14 +123,22 @@ class FarewellAgent:
                 config=get_model_config("facility_info"),
             )
 
-            return {
-                "answer": response_text,
-                "emotion": "happy",
-                "metadata": {
+            metadata = merge_llm_metadata(
+                {
                     "agent": "FarewellAgent",
                     "confidence": 0.85,
+                    "category": "farewell",
+                    "request_type": "farewell",
+                    "route": "farewell",
                     "sources": ["enhanced_rag"],
                 },
+                response_text,
+            )
+
+            return {
+                "answer": str(response_text),
+                "emotion": "happy",
+                "metadata": metadata,
             }
 
         except Exception as e:
@@ -231,6 +240,9 @@ class FarewellAgent:
             "metadata": {
                 "agent": "FarewellAgent",
                 "confidence": 0.3,
+                "category": "farewell",
+                "request_type": "farewell",
+                "route": "farewell",
                 "sources": ["fallback"],
             },
         }

--- a/backend/agents/general_knowledge_agent.py
+++ b/backend/agents/general_knowledge_agent.py
@@ -24,6 +24,7 @@ import logging
 from typing import Dict, Any, List, Optional, Literal
 
 from backend.config.prompts.memory_prompts import build_memory_prompt
+from backend.agents.llm_metadata import merge_llm_metadata
 from backend.llm.openrouter import OpenRouterProvider
 from backend.llm.models import get_model_config
 from backend.tools.enhanced_rag import EnhancedRAGSearch
@@ -225,14 +226,14 @@ class GeneralKnowledgeAgent:
 
             logger.info("回答生成完了: emotion=%s, confidence=%s", emotion, confidence)
 
-            return {
-                "answer": response_text,
-                "emotion": emotion,
-                "metadata": {
+            metadata = merge_llm_metadata(
+                {
                     "agent": self.name,
                     "status": "success",
                     "confidence": confidence,
                     "category": "general_knowledge",
+                    "request_type": mode,
+                    "route": "general_knowledge",
                     "query_type": mode,
                     "model_use_case": (
                         "deep_reasoning" if mode == "deep_reasoning" else "general_knowledge"
@@ -241,6 +242,13 @@ class GeneralKnowledgeAgent:
                     "web_search_used": "web_search" in sources,
                     "rag_used": any(source.startswith("knowledge_base") for source in sources),
                 },
+                response_text,
+            )
+
+            return {
+                "answer": str(response_text),
+                "emotion": emotion,
+                "metadata": metadata,
             }
 
         except Exception as e:
@@ -296,17 +304,25 @@ class GeneralKnowledgeAgent:
 
             emotion = self._determine_memory_emotion(context, query_type)
 
-            return {
-                "answer": answer,
-                "emotion": emotion,
-                "metadata": {
+            metadata = merge_llm_metadata(
+                {
                     "agent": self.name,
                     "status": "success",
+                    "category": "general_knowledge",
+                    "request_type": query_type,
+                    "route": "general_knowledge",
                     "query_type": query_type,
                     "message_count": len(context.get("recent_messages", [])),
                     "inherited_request_type": context.get("inherited_request_type"),
                     "long_term_memory_count": len(context.get("long_term_memory", [])),
                 },
+                answer,
+            )
+
+            return {
+                "answer": str(answer),
+                "emotion": emotion,
+                "metadata": metadata,
             }
         except Exception as e:
             logger.exception("Memory query error: %s", e)
@@ -707,6 +723,8 @@ class GeneralKnowledgeAgent:
                 "agent": self.name,
                 "status": "success",
                 "category": "general_knowledge",
+                "request_type": "assistant_profile",
+                "route": "general_knowledge",
                 "query_type": "assistant_profile",
                 "sources": [],
                 "web_search_used": False,
@@ -755,6 +773,8 @@ class GeneralKnowledgeAgent:
                 "agent": self.name,
                 "status": "success",
                 "category": "general_knowledge",
+                "request_type": "daily_conversation",
+                "route": "general_knowledge",
                 "query_type": "daily_conversation",
                 "sources": [],
                 "web_search_used": False,
@@ -779,6 +799,8 @@ class GeneralKnowledgeAgent:
                 "agent": self.name,
                 "status": "current_info_unavailable",
                 "category": "general_knowledge",
+                "request_type": "current_info",
+                "route": "general_knowledge",
                 "query_type": "current_info",
                 "sources": [],
                 "web_search_used": False,

--- a/backend/agents/llm_metadata.py
+++ b/backend/agents/llm_metadata.py
@@ -1,0 +1,24 @@
+"""Helpers for propagating LLM observability metadata from provider returns."""
+
+from typing import Any
+
+LLM_METADATA_KEYS = ("provider", "model", "llm_latency_ms")
+
+
+def extract_llm_metadata(response: Any) -> dict[str, Any]:
+    """Extract provider/model/latency metadata carried by an LLM response object."""
+
+    raw_metadata = getattr(response, "llm_metadata", None)
+    if not isinstance(raw_metadata, dict):
+        return {}
+    return {
+        key: raw_metadata[key] for key in LLM_METADATA_KEYS if raw_metadata.get(key) is not None
+    }
+
+
+def merge_llm_metadata(metadata: dict[str, Any], response: Any) -> dict[str, Any]:
+    """Merge explicit LLM metadata into agent metadata without overwriting callers."""
+
+    for key, value in extract_llm_metadata(response).items():
+        metadata.setdefault(key, value)
+    return metadata

--- a/backend/agents/slide_agent.py
+++ b/backend/agents/slide_agent.py
@@ -10,6 +10,7 @@ from typing import Dict, Optional, Literal
 
 from langchain_core.messages import HumanMessage
 
+from backend.agents.llm_metadata import merge_llm_metadata
 from backend.llm import get_llm_provider, get_model_config
 
 logger = logging.getLogger(__name__)
@@ -151,6 +152,9 @@ class SlideAgent:
                 "emotion": "neutral",
                 "metadata": {
                     "agent": "SlideAgent",
+                    "category": "slide",
+                    "request_type": "slide_next",
+                    "route": "slide",
                     "action": "next",
                     "slideNumber": current,
                 },
@@ -171,6 +175,9 @@ class SlideAgent:
                 "emotion": "neutral",
                 "metadata": {
                     "agent": "SlideAgent",
+                    "category": "slide",
+                    "request_type": "slide_previous",
+                    "route": "slide",
                     "action": "previous",
                     "slideNumber": current,
                 },
@@ -196,6 +203,9 @@ class SlideAgent:
                 "emotion": "neutral",
                 "metadata": {
                     "agent": "SlideAgent",
+                    "category": "slide",
+                    "request_type": "slide_goto",
+                    "route": "slide",
                     "action": "goto",
                     "slideNumber": current,
                 },
@@ -218,6 +228,9 @@ class SlideAgent:
                 "emotion": "neutral",
                 "metadata": {
                     "agent": "SlideAgent",
+                    "category": "slide",
+                    "request_type": "slide_narrate",
+                    "route": "slide",
                     "action": "narrate",
                     "slideNumber": slide_number,
                 },
@@ -238,6 +251,9 @@ class SlideAgent:
             "emotion": emotion,
             "metadata": {
                 "agent": "SlideAgent",
+                "category": "slide",
+                "request_type": "slide_narrate",
+                "route": "slide",
                 "action": "narrate",
                 "slideNumber": slide_number,
                 "characterAction": character_action,
@@ -263,6 +279,9 @@ class SlideAgent:
                 "emotion": "neutral",
                 "metadata": {
                     "agent": "SlideAgent",
+                    "category": "slide",
+                    "request_type": "slide_question",
+                    "route": "slide",
                     "action": "question",
                     "slideNumber": current,
                 },
@@ -282,6 +301,9 @@ class SlideAgent:
                     "emotion": "helpful",
                     "metadata": {
                         "agent": "SlideAgent",
+                        "category": "slide",
+                        "request_type": "slide_question",
+                        "route": "slide",
                         "action": "question",
                         "slideNumber": current,
                     },
@@ -298,14 +320,22 @@ class SlideAgent:
                 config=get_model_config("qa_response"),
             )
 
-            return {
-                "answer": response_text,
-                "emotion": "helpful",
-                "metadata": {
+            metadata = merge_llm_metadata(
+                {
                     "agent": "SlideAgent",
+                    "category": "slide",
+                    "request_type": "slide_question",
+                    "route": "slide",
                     "action": "question",
                     "slideNumber": current,
                 },
+                response_text,
+            )
+
+            return {
+                "answer": str(response_text),
+                "emotion": "helpful",
+                "metadata": metadata,
                 "slideNumber": current,
             }
 
@@ -321,6 +351,9 @@ class SlideAgent:
                 "emotion": "apologetic",
                 "metadata": {
                     "agent": "SlideAgent",
+                    "category": "slide",
+                    "request_type": "slide_question",
+                    "route": "slide",
                     "action": "question",
                     "slideNumber": current,
                 },

--- a/backend/llm/openrouter.py
+++ b/backend/llm/openrouter.py
@@ -14,7 +14,7 @@ import json
 import logging
 import os
 import time
-from typing import AsyncGenerator, Dict, List, Optional
+from typing import Any, AsyncGenerator, Dict, List, Mapping, Optional
 
 import httpx
 from langchain_core.messages import (
@@ -54,6 +54,25 @@ class OpenRouterError(Exception):
         self.status_code = status_code
         self.response = response
         super().__init__(self.message)
+
+
+class LLMResponseText(str):
+    """Generated text plus explicit LLM observability metadata.
+
+    This is intentionally a ``str`` subclass so existing callers keep working
+    while agents can propagate provider/model/latency without ContextVar state.
+    """
+
+    llm_metadata: dict[str, Any]
+
+    def __new__(
+        cls,
+        value: str,
+        metadata: Mapping[str, Any] | None = None,
+    ) -> "LLMResponseText":
+        obj = str.__new__(cls, value)
+        obj.llm_metadata = dict(metadata or {})
+        return obj
 
 
 class OpenRouterProvider(LLMProvider):
@@ -127,10 +146,17 @@ class OpenRouterProvider(LLMProvider):
         await self._http_client.aclose()
 
     @staticmethod
-    def _record_successful_llm_call(*, provider: str, model: str, started_at: float) -> None:
-        """Record request-scoped provider/model metadata without shared instance state."""
+    def _record_successful_llm_call(
+        *, provider: str, model: str, started_at: float
+    ) -> dict[str, Any]:
+        """Return explicit provider/model metadata and mirror it to token tracking."""
 
         latency_ms = int((time.perf_counter() - started_at) * 1000)
+        metadata = {
+            "provider": provider,
+            "model": model,
+            "llm_latency_ms": max(0, latency_ms),
+        }
         try:
             record_llm_call_metadata(
                 provider=provider,
@@ -139,6 +165,7 @@ class OpenRouterProvider(LLMProvider):
             )
         except Exception as e:
             logger.debug("LLM metadata tracking failed (non-critical): %s", e)
+        return metadata
 
     def _convert_messages(self, messages: List[BaseMessage]) -> List[Dict[str, str]]:
         """
@@ -259,12 +286,12 @@ class OpenRouterProvider(LLMProvider):
             try:
                 started_at = time.perf_counter()
                 response_text = await self._cerebras_generate(messages, root_cfg)
-                self._record_successful_llm_call(
+                metadata = self._record_successful_llm_call(
                     provider="cerebras",
                     model=cerebras_model_slug(),
                     started_at=started_at,
                 )
-                return response_text
+                return LLMResponseText(response_text, metadata)
             except Exception as ce:
                 _cerebras_tried = True
                 logger.warning("Cerebras primary failed; falling back to OpenRouter: %s", ce)
@@ -297,12 +324,12 @@ class OpenRouterProvider(LLMProvider):
                     logger.debug("Token tracking failed (non-critical): %s", e)
 
             response_text = data["choices"][0]["message"]["content"]
-            self._record_successful_llm_call(
+            metadata = self._record_successful_llm_call(
                 provider="openrouter",
                 model=primary_slug,
                 started_at=started_at,
             )
-            return response_text
+            return LLMResponseText(response_text, metadata)
 
         except httpx.HTTPStatusError as e:
             if config.fallback_model and _fallback_count < 1:
@@ -330,12 +357,12 @@ class OpenRouterProvider(LLMProvider):
                 try:
                     started_at = time.perf_counter()
                     response_text = await self._cerebras_generate(messages, root_cfg)
-                    self._record_successful_llm_call(
+                    metadata = self._record_successful_llm_call(
                         provider="cerebras",
                         model=cerebras_model_slug(),
                         started_at=started_at,
                     )
-                    return response_text
+                    return LLMResponseText(response_text, metadata)
                 except Exception as ce:
                     logger.warning("Cerebras fallback failed: %s", ce, exc_info=True)
 
@@ -364,12 +391,12 @@ class OpenRouterProvider(LLMProvider):
                 try:
                     started_at = time.perf_counter()
                     response_text = await self._cerebras_generate(messages, root_cfg)
-                    self._record_successful_llm_call(
+                    metadata = self._record_successful_llm_call(
                         provider="cerebras",
                         model=cerebras_model_slug(),
                         started_at=started_at,
                     )
-                    return response_text
+                    return LLMResponseText(response_text, metadata)
                 except Exception as ce:
                     logger.warning("Cerebras fallback failed: %s", ce, exc_info=True)
 

--- a/backend/scripts/bench_memory_loader.py
+++ b/backend/scripts/bench_memory_loader.py
@@ -1,0 +1,61 @@
+"""Benchmark SimplifiedMemoryHelper recent-message loading latency.
+
+This script is intentionally read-only. It measures the current live or local
+Supabase-backed `agent_memory` query path for an existing session.
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+import statistics
+import time
+
+from backend.utils.memory_helper import SimplifiedMemoryHelper
+
+
+def _parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Benchmark memory loader p95 latency.")
+    parser.add_argument("--session-id", required=True, help="Existing session_id to read.")
+    parser.add_argument("--iterations", type=int, default=50, help="Number of read iterations.")
+    return parser.parse_args()
+
+
+def _percentile(values: list[float], percentile: float) -> float:
+    if not values:
+        return 0.0
+    ordered = sorted(values)
+    index = min(len(ordered) - 1, max(0, int(round((percentile / 100) * (len(ordered) - 1)))))
+    return ordered[index]
+
+
+async def _run() -> None:
+    args = _parse_args()
+    helper = SimplifiedMemoryHelper()
+    if helper.supabase is None:
+        raise SystemExit("SUPABASE_URL and SUPABASE_KEY are required")
+
+    timings_ms: list[float] = []
+    row_counts: list[int] = []
+    for _ in range(max(1, args.iterations)):
+        started_at = time.perf_counter()
+        messages = await helper._get_recent_messages(args.session_id)
+        timings_ms.append((time.perf_counter() - started_at) * 1000)
+        row_counts.append(len(messages))
+
+    result = {
+        "session_id": args.session_id,
+        "iterations": len(timings_ms),
+        "row_count_min": min(row_counts) if row_counts else 0,
+        "row_count_max": max(row_counts) if row_counts else 0,
+        "latency_ms_min": round(min(timings_ms), 2),
+        "latency_ms_p50": round(statistics.median(timings_ms), 2),
+        "latency_ms_p95": round(_percentile(timings_ms, 95), 2),
+        "latency_ms_max": round(max(timings_ms), 2),
+    }
+    print(json.dumps(result, ensure_ascii=False, indent=2))
+
+
+if __name__ == "__main__":
+    asyncio.run(_run())

--- a/backend/services/memory_promoter.py
+++ b/backend/services/memory_promoter.py
@@ -13,7 +13,7 @@ import uuid
 from dataclasses import dataclass
 from typing import Any, Dict, Iterable
 
-from backend.observability.structured_logger import log_ltm_promote
+from backend.observability.structured_logger import log_ltm_promote, log_memory_event
 from backend.utils.cafe_entity import canonicalize_facility_memory_key_text
 
 
@@ -21,6 +21,17 @@ from backend.utils.cafe_entity import canonicalize_facility_memory_key_text
 class PromotionDecision:
     promote: bool
     reason: str
+
+
+def _duration_ms(started_at: float) -> int:
+    return max(0, int((time.perf_counter() - started_at) * 1000))
+
+
+def _log_memory_event_safely(event: str, **fields: Any) -> None:
+    try:
+        log_memory_event(event=event, **fields)
+    except Exception:
+        pass
 
 
 class MemoryPromoter:
@@ -48,90 +59,126 @@ class MemoryPromoter:
         Returns:
             集計統計 {"candidates", "aggregated", "promoted", "duplicates_skipped", ...}
         """
+        started_at = time.perf_counter()
         candidate_ns = (self.candidate_namespace_root, user_id)
         long_term_ns = (self.long_term_namespace_root, user_id)
         try:
             log_ltm_promote(status="started", user_id=user_id)
         except Exception:
             pass
+        _log_memory_event_safely(
+            "memory_promote_run",
+            status="started",
+            user_id=user_id,
+            max_candidates=max_candidates,
+            max_existing=max_existing,
+            delete_promoted_candidates=delete_promoted_candidates,
+        )
 
-        candidate_items = await store.asearch(candidate_ns, query="", limit=max_candidates)
-        if not candidate_items:
+        try:
+            candidate_items = await store.asearch(candidate_ns, query="", limit=max_candidates)
+            if not candidate_items:
+                stats = {
+                    "candidates": 0,
+                    "aggregated": 0,
+                    "promoted": 0,
+                    "duplicates_skipped": 0,
+                    "rule_rejected": 0,
+                }
+                try:
+                    log_ltm_promote(status="skipped", user_id=user_id, **stats)
+                except Exception:
+                    pass
+                _log_memory_event_safely(
+                    "memory_promote_run",
+                    status="skipped",
+                    user_id=user_id,
+                    duration_ms=_duration_ms(started_at),
+                    **stats,
+                )
+                return stats
+
+            aggregated = self.aggregate_candidates(candidate_items)
+            existing_items = await store.asearch(long_term_ns, query="", limit=max_existing)
+            existing_keys = self.build_existing_index(existing_items)
+
+            promoted = 0
+            duplicates_skipped = 0
+            rule_rejected = 0
+            promoted_candidate_keys: list[str] = []
+
+            for agg_key, aggregate in aggregated.items():
+                decision = self.should_promote(aggregate)
+                if not decision.promote:
+                    rule_rejected += 1
+                    continue
+
+                if agg_key in existing_keys:
+                    duplicates_skipped += 1
+                    continue
+
+                payload = self.to_long_term_record(aggregate)
+                try:
+                    await store.aput(long_term_ns, str(uuid.uuid4()), payload)
+                except Exception as exc:
+                    try:
+                        log_ltm_promote(
+                            status="failed",
+                            user_id=user_id,
+                            error_type=type(exc).__name__,
+                            promoted=promoted,
+                        )
+                    except Exception:
+                        pass
+                    raise
+                promoted += 1
+                promoted_candidate_keys.extend(aggregate["candidate_keys"])
+
+            if delete_promoted_candidates and hasattr(store, "adelete"):
+                for key in promoted_candidate_keys:
+                    try:
+                        await store.adelete(candidate_ns, key)
+                    except Exception:
+                        # cleanup failure is non-fatal
+                        pass
+
             stats = {
-                "candidates": 0,
-                "aggregated": 0,
-                "promoted": 0,
-                "duplicates_skipped": 0,
-                "rule_rejected": 0,
+                "candidates": len(candidate_items),
+                "aggregated": len(aggregated),
+                "promoted": promoted,
+                "duplicates_skipped": duplicates_skipped,
+                "rule_rejected": rule_rejected,
             }
             try:
-                log_ltm_promote(status="skipped", user_id=user_id, **stats)
+                log_ltm_promote(status="success", user_id=user_id, **stats)
             except Exception:
                 pass
+            _log_memory_event_safely(
+                "memory_promote_run",
+                status="success",
+                user_id=user_id,
+                duration_ms=_duration_ms(started_at),
+                **stats,
+            )
             return stats
-
-        aggregated = self.aggregate_candidates(candidate_items)
-        existing_items = await store.asearch(long_term_ns, query="", limit=max_existing)
-        existing_keys = self.build_existing_index(existing_items)
-
-        promoted = 0
-        duplicates_skipped = 0
-        rule_rejected = 0
-        promoted_candidate_keys: list[str] = []
-
-        for agg_key, aggregate in aggregated.items():
-            decision = self.should_promote(aggregate)
-            if not decision.promote:
-                rule_rejected += 1
-                continue
-
-            if agg_key in existing_keys:
-                duplicates_skipped += 1
-                continue
-
-            payload = self.to_long_term_record(aggregate)
-            try:
-                await store.aput(long_term_ns, str(uuid.uuid4()), payload)
-            except Exception as exc:
-                try:
-                    log_ltm_promote(
-                        status="failed",
-                        user_id=user_id,
-                        error_type=type(exc).__name__,
-                        promoted=promoted,
-                    )
-                except Exception:
-                    pass
-                raise
-            promoted += 1
-            promoted_candidate_keys.extend(aggregate["candidate_keys"])
-
-        if delete_promoted_candidates and hasattr(store, "adelete"):
-            for key in promoted_candidate_keys:
-                try:
-                    await store.adelete(candidate_ns, key)
-                except Exception:
-                    # cleanup failure is non-fatal
-                    pass
-
-        stats = {
-            "candidates": len(candidate_items),
-            "aggregated": len(aggregated),
-            "promoted": promoted,
-            "duplicates_skipped": duplicates_skipped,
-            "rule_rejected": rule_rejected,
-        }
-        try:
-            log_ltm_promote(status="success", user_id=user_id, **stats)
-        except Exception:
-            pass
-        return stats
+        except Exception as exc:
+            _log_memory_event_safely(
+                "memory_promote_run",
+                status="failed",
+                user_id=user_id,
+                duration_ms=_duration_ms(started_at),
+                error_type=type(exc).__name__,
+            )
+            raise
 
     @staticmethod
     def aggregate_candidates(items: Iterable[Any]) -> Dict[str, Dict[str, Any]]:
         """候補メモリを type+content 単位で集約する。"""
+        started_at = time.perf_counter()
         grouped: Dict[str, Dict[str, Any]] = {}
+        candidate_count = 0
         for item in items:
+            candidate_count += 1
             value = getattr(item, "value", None) or {}
             ctype = value.get("candidate_type") or value.get("type") or "unknown"
             content = str(value.get("content", "")).strip()
@@ -184,6 +231,14 @@ class MemoryPromoter:
             g["languages"] = sorted(g["languages"])
             g["sources"] = sorted(g["sources"])
             g["evidence_queries"] = sorted(g["evidence_queries"])
+        _log_memory_event_safely(
+            "memory_candidate_aggregate",
+            success=True,
+            duration_ms=_duration_ms(started_at),
+            candidate_count=candidate_count,
+            aggregated_count=len(grouped),
+            candidate_types=sorted({str(g["candidate_type"]) for g in grouped.values()}),
+        )
         return grouped
 
     @staticmethod

--- a/backend/tests/agents/test_facility_agent.py
+++ b/backend/tests/agents/test_facility_agent.py
@@ -6,6 +6,7 @@ FacilityAgent テストスイート
 import pytest
 from unittest.mock import AsyncMock, patch
 from backend.agents.facility_agent import FacilityAgent
+from backend.llm.openrouter import LLMResponseText
 
 
 class TestFacilityAgent:
@@ -46,8 +47,13 @@ class TestFacilityAgent:
                 },
             }
 
-            mock_llm.return_value = (
-                "[relaxed]Wi-Fiは無料で利用可能です。接続方法はスタッフにお尋ねください。"
+            mock_llm.return_value = LLMResponseText(
+                "[relaxed]Wi-Fiは無料で利用可能です。接続方法はスタッフにお尋ねください。",
+                {
+                    "provider": "cerebras",
+                    "model": "gpt-oss-120b",
+                    "llm_latency_ms": 23,
+                },
             )
 
             result = await agent.answer_facility_query(
@@ -63,6 +69,9 @@ class TestFacilityAgent:
             assert result["emotion"] in ["relaxed", "informative", "helpful"]
             assert result["metadata"]["agent"] == "FacilityAgent"
             assert result["metadata"]["request_type"] == "wifi"
+            assert result["metadata"]["provider"] == "cerebras"
+            assert result["metadata"]["model"] == "gpt-oss-120b"
+            assert result["metadata"]["llm_latency_ms"] == 23
 
     # ==========================================================================
     # 基本機能テスト - 設備

--- a/backend/tests/agents/test_general_knowledge_agent.py
+++ b/backend/tests/agents/test_general_knowledge_agent.py
@@ -7,6 +7,7 @@ import time
 import pytest
 from unittest.mock import patch, MagicMock, AsyncMock
 from backend.agents.general_knowledge_agent import GeneralKnowledgeAgent
+from backend.llm.openrouter import LLMResponseText
 
 
 class TestGeneralKnowledgeAgent:
@@ -176,8 +177,13 @@ class TestGeneralKnowledgeAgentIntegration:
         # OpenRouterProviderのモック
         self.mock_provider = MagicMock()
         self.mock_provider.generate = AsyncMock(
-            return_value=(
-                "[helpful]これはテスト回答です。" "Engineer Cafeについての情報をお伝えします。"
+            return_value=LLMResponseText(
+                "[helpful]これはテスト回答です。Engineer Cafeについての情報をお伝えします。",
+                {
+                    "provider": "openrouter",
+                    "model": "google/gemini-3.1-flash-lite-preview",
+                    "llm_latency_ms": 45,
+                },
             )
         )
 
@@ -225,6 +231,9 @@ class TestGeneralKnowledgeAgentIntegration:
         assert result["metadata"]["agent"] == "GeneralKnowledgeAgent"
         assert "confidence" in result["metadata"]
         assert 0 <= result["metadata"]["confidence"] <= 1
+        assert result["metadata"]["provider"] == "openrouter"
+        assert result["metadata"]["model"] == "google/gemini-3.1-flash-lite-preview"
+        assert result["metadata"]["llm_latency_ms"] == 45
 
     @pytest.mark.asyncio
     async def test_answer_general_query_english(self):

--- a/backend/tests/llm/test_openrouter.py
+++ b/backend/tests/llm/test_openrouter.py
@@ -8,7 +8,7 @@ from unittest.mock import ANY, AsyncMock, MagicMock, patch
 import httpx
 from langchain_core.messages import HumanMessage
 
-from backend.llm.openrouter import OpenRouterProvider, OpenRouterError
+from backend.llm.openrouter import LLMResponseText, OpenRouterProvider, OpenRouterError
 from backend.llm.models import ModelConfig, SupportedModel
 
 
@@ -166,6 +166,10 @@ class TestOpenRouterProvider:
 
             # プライマリモデルが成功し、レスポンスが返る
             assert response == "Primary model response"
+            assert isinstance(response, LLMResponseText)
+            assert response.llm_metadata["provider"] == "openrouter"
+            assert response.llm_metadata["model"] == "google/gemini-3.1-flash-lite-preview"
+            assert isinstance(response.llm_metadata["llm_latency_ms"], int)
             # 1回だけ呼び出されることを確認（フォールバック不要）
             assert mock.call_count == 1
             metadata_mock.assert_called_once_with(
@@ -173,6 +177,37 @@ class TestOpenRouterProvider:
                 model="google/gemini-3.1-flash-lite-preview",
                 llm_latency_ms=ANY,
             )
+
+    @pytest.mark.asyncio
+    async def test_generate_returns_metadata_when_context_tracker_fails(self):
+        """Provider/model metadata is carried on the return value, not only ContextVar."""
+        messages = [HumanMessage(content="Test message")]
+        config = ModelConfig(
+            model_id=SupportedModel.GEMINI_3_1_FLASH_LITE,
+            fallback_model=None,
+        )
+
+        mock_response = MagicMock()
+        mock_response.json.return_value = {
+            "choices": [{"message": {"content": "Context-free metadata response"}}]
+        }
+
+        async def mock_post(*args, **kwargs):
+            return mock_response
+
+        with (
+            patch.object(self.provider._http_client, "post", side_effect=mock_post),
+            patch(
+                "backend.llm.openrouter.record_llm_call_metadata",
+                side_effect=RuntimeError("context unavailable"),
+            ),
+        ):
+            response = await self.provider.generate(messages, config)
+
+        assert response == "Context-free metadata response"
+        assert response.llm_metadata["provider"] == "openrouter"
+        assert response.llm_metadata["model"] == "google/gemini-3.1-flash-lite-preview"
+        assert isinstance(response.llm_metadata["llm_latency_ms"], int)
 
     @pytest.mark.asyncio
     async def test_cerebras_fast_primary_before_openrouter(self):
@@ -206,6 +241,10 @@ class TestOpenRouterProvider:
             response = await self.provider.generate(messages, config)
 
         assert response == "Cerebras fast response"
+        assert isinstance(response, LLMResponseText)
+        assert response.llm_metadata["provider"] == "cerebras"
+        assert response.llm_metadata["model"] == "gpt-oss-120b"
+        assert isinstance(response.llm_metadata["llm_latency_ms"], int)
         cerebras_mock.assert_awaited_once()
         openrouter_mock.assert_not_called()
         metadata_mock.assert_called_once_with(

--- a/backend/tests/services/test_memory_promoter.py
+++ b/backend/tests/services/test_memory_promoter.py
@@ -1,7 +1,7 @@
 """Tests for backend.services.memory_promoter."""
 
 from types import SimpleNamespace
-from unittest.mock import AsyncMock
+from unittest.mock import AsyncMock, patch
 
 import pytest
 
@@ -28,6 +28,26 @@ class TestMemoryPromoterAggregation:
         assert aggregate["candidate_count"] == 2
         assert aggregate["confidence_max"] == 0.9
         assert aggregate["confidence_avg"] == pytest.approx(0.85)
+
+    def test_aggregate_candidates_emits_memory_candidate_aggregate_event(self):
+        items = [
+            _item("k1", {"candidate_type": "visitor_name", "content": "田中", "confidence": 0.9}),
+            _item("k2", {"candidate_type": "visitor_name", "content": "田中", "confidence": 0.8}),
+        ]
+
+        with patch("backend.services.memory_promoter.log_memory_event") as mock_log:
+            grouped = MemoryPromoter.aggregate_candidates(items)
+
+        assert len(grouped) == 1
+        payloads = [call.kwargs for call in mock_log.call_args_list]
+        aggregate_event = next(
+            payload for payload in payloads if payload["event"] == "memory_candidate_aggregate"
+        )
+        assert aggregate_event["success"] is True
+        assert aggregate_event["candidate_count"] == 2
+        assert aggregate_event["aggregated_count"] == 1
+        assert aggregate_event["candidate_types"] == ["visitor_name"]
+        assert isinstance(aggregate_event["duration_ms"], int)
 
     def test_should_promote_explicit_remember(self):
         decision = MemoryPromoter.should_promote(
@@ -109,6 +129,37 @@ class TestMemoryPromoterService:
         assert payload["data"] == "田中"
         assert payload["source"] == "promoter"
         assert payload["promotion"]["candidate_count"] == 2
+
+    @pytest.mark.asyncio
+    async def test_promote_for_user_emits_memory_promote_run_event(self):
+        promoter = MemoryPromoter()
+        store = AsyncMock()
+
+        candidate_items = [
+            _item("c1", {"candidate_type": "visitor_name", "content": "田中", "confidence": 0.9}),
+            _item("c2", {"candidate_type": "visitor_name", "content": "田中", "confidence": 0.92}),
+        ]
+        store.asearch = AsyncMock(side_effect=[candidate_items, []])
+        store.aput = AsyncMock()
+
+        with (
+            patch("backend.services.memory_promoter.log_ltm_promote"),
+            patch("backend.services.memory_promoter.log_memory_event") as mock_log,
+        ):
+            stats = await promoter.promote_for_user(store, "u1")
+
+        assert stats["promoted"] == 1
+        payloads = [call.kwargs for call in mock_log.call_args_list]
+        promote_events = [
+            payload for payload in payloads if payload["event"] == "memory_promote_run"
+        ]
+        assert [payload["status"] for payload in promote_events] == ["started", "success"]
+        success_event = promote_events[-1]
+        assert success_event["user_id"] == "u1"
+        assert success_event["candidates"] == 2
+        assert success_event["aggregated"] == 1
+        assert success_event["promoted"] == 1
+        assert isinstance(success_event["duration_ms"], int)
 
     @pytest.mark.asyncio
     async def test_promote_for_user_skips_duplicate_existing(self):

--- a/backend/tests/utils/test_checkpointer.py
+++ b/backend/tests/utils/test_checkpointer.py
@@ -7,6 +7,7 @@ from psycopg import OperationalError
 from psycopg_pool import PoolClosed
 
 from backend.utils import checkpointer
+from backend.utils.context_priority import ContextSignals
 
 
 class TestMaskConnectionString:
@@ -90,7 +91,59 @@ class TestCheckpointerFactory:
         assert "Failed to connect to Supabase PostgreSQL" in str(exc_info.value)
 
 
+class TestCheckpointerSerde:
+    def test_context_signals_round_trips_through_msgpack(self):
+        signals = ContextSignals(
+            memory_topics=("event", "facility"),
+            rag_cache_top_score=0.91,
+            request_specificity=0.82,
+            conversation_depth=4,
+            previous_categories=("facility",),
+        )
+        serde = checkpointer.create_checkpointer_serde()
+
+        loaded = serde.loads_typed(serde.dumps_typed({"signals": signals}))
+
+        assert loaded == {"signals": signals}
+
+    def test_future_langgraph_serializer_gets_msgpack_allowlist(self):
+        class FutureJsonPlusSerializer:
+            def __init__(
+                self,
+                *,
+                allowed_json_modules=None,
+                allowed_msgpack_modules=None,
+                __unpack_ext_hook__=None,
+            ):
+                self.allowed_json_modules = allowed_json_modules
+                self.allowed_msgpack_modules = allowed_msgpack_modules
+                self.unpack_ext_hook = __unpack_ext_hook__
+
+        with patch.object(checkpointer, "JsonPlusSerializer", FutureJsonPlusSerializer):
+            serde = checkpointer.create_checkpointer_serde()
+
+        assert serde.allowed_json_modules == [
+            ("backend", "utils", "context_priority", "ContextSignals")
+        ]
+        assert serde.allowed_msgpack_modules == [
+            ("backend.utils.context_priority", "ContextSignals")
+        ]
+        assert serde.unpack_ext_hook is None
+
+
 class TestResilientAsyncPostgresSaver:
+    @pytest.mark.asyncio
+    async def test_uses_context_signals_aware_serde(self):
+        saver = checkpointer.ResilientAsyncPostgresSaver(
+            factory=MagicMock(),
+            pool=MagicMock(),
+        )
+        signals = ContextSignals(previous_categories=("facility",))
+
+        loaded = saver.serde.loads_typed(saver.serde.dumps_typed(signals))
+
+        assert loaded == signals
+
     @pytest.mark.asyncio
     async def test_aget_tuple_strips_postgres_nul_chars_before_read(self):
         saver = checkpointer.ResilientAsyncPostgresSaver(

--- a/backend/tests/utils/test_memory_extractor.py
+++ b/backend/tests/utils/test_memory_extractor.py
@@ -1,5 +1,7 @@
 """Tests for backend.utils.memory_extractor — memory extraction from conversations."""
 
+from unittest.mock import patch
+
 from backend.utils.memory_extractor import (
     extract_memories,
     extract_memory_candidates,
@@ -92,6 +94,23 @@ class TestExtractMemories:
         lang_prefs = [m for m in result if m["type"] == "language_preference"]
         assert len(lang_prefs) == 1
 
+    def test_extract_memories_emits_memory_extractor_run_event(self):
+        with patch("backend.observability.structured_logger.log_memory_event") as mock_log:
+            result = extract_memories("私は田中です", "こんにちは田中さん", "ja")
+
+        assert any(memory["type"] == "visitor_name" for memory in result)
+        payloads = [call.kwargs for call in mock_log.call_args_list]
+        extractor_event = next(
+            payload
+            for payload in payloads
+            if payload["event"] == "memory_extractor_run" and payload["extractor_type"] == "direct"
+        )
+        assert extractor_event["success"] is True
+        assert extractor_event["language"] == "ja"
+        assert extractor_event["extracted_count"] >= 1
+        assert "visitor_name" in extractor_event["memory_types"]
+        assert isinstance(extractor_event["duration_ms"], int)
+
 
 class TestExtractMemoryCandidates:
     """extract_memory_candidates() のテスト"""
@@ -146,6 +165,29 @@ class TestExtractMemoryCandidates:
         assert len(loc) == 1
         assert loc[0]["sensitivity"] == "non_pii"
         assert loc[0]["volatility"] == "medium"
+
+    def test_extract_memory_candidates_emits_candidate_extractor_event(self):
+        with patch("backend.observability.structured_logger.log_memory_event") as mock_log:
+            result = extract_memory_candidates(
+                "私は田中です",
+                "こんにちは田中さん",
+                "ja",
+                extracted_at=1700000000.0,
+            )
+
+        assert any(candidate["candidate_type"] == "visitor_name" for candidate in result)
+        payloads = [call.kwargs for call in mock_log.call_args_list]
+        candidate_event = next(
+            payload
+            for payload in payloads
+            if payload["event"] == "memory_extractor_run"
+            and payload["extractor_type"] == "candidate"
+        )
+        assert candidate_event["success"] is True
+        assert candidate_event["language"] == "ja"
+        assert candidate_event["extracted_count"] >= 1
+        assert "visitor_name" in candidate_event["candidate_types"]
+        assert isinstance(candidate_event["duration_ms"], int)
 
 
 class TestExtractName:

--- a/backend/tests/utils/test_memory_helper_unit.py
+++ b/backend/tests/utils/test_memory_helper_unit.py
@@ -307,6 +307,45 @@ class TestGetPreviousRequestType:
         assert result == "hours"
 
     @pytest.mark.asyncio
+    async def test_emits_previous_request_type_duration_probe(self, helper_with_client):
+        helper, client = helper_with_client
+        chain = _build_chain_mock(
+            Mock(
+                data=[
+                    {
+                        "value": {
+                            "role": "user",
+                            "sessionId": "sess-1",
+                            "request_type": "hours",
+                        }
+                    },
+                ]
+            )
+        )
+        client.table.return_value = chain
+
+        with patch("backend.observability.structured_logger.log_memory_event") as mock_log:
+            result = await helper.get_previous_request_type("sess-1")
+
+        assert result == "hours"
+        payloads = [call.kwargs for call in mock_log.call_args_list]
+        probe = next(
+            payload
+            for payload in payloads
+            if payload["event"] == "memory_loader_get_previous_request_type"
+        )
+        compatibility_probe = next(
+            payload
+            for payload in payloads
+            if payload["event"] == "memory_loader_get_previous_request_type_duration_ms"
+        )
+        assert probe["success"] is True
+        assert probe["row_count"] == 1
+        assert probe["request_type"] == "hours"
+        assert isinstance(probe["memory_loader_get_previous_request_type_duration_ms"], int)
+        assert compatibility_probe["request_type"] == "hours"
+
+    @pytest.mark.asyncio
     async def test_returns_none_when_no_messages(self, helper_with_client):
         """メッセージが存在しない場合 None を返す"""
         helper, client = helper_with_client
@@ -451,6 +490,46 @@ class TestGetRecentMessages:
         memory_chain.filter.assert_called_once_with("value->>sessionId", "eq", "sess-1")
 
     @pytest.mark.asyncio
+    async def test_emits_recent_messages_duration_probe(self, helper_with_client):
+        helper, client = helper_with_client
+        memory_chain = _build_chain_mock(
+            Mock(
+                data=[
+                    {
+                        "value": {
+                            "role": "user",
+                            "content": "Hello",
+                            "sessionId": "sess-1",
+                            "timestamp": 1000,
+                        }
+                    },
+                ]
+            )
+        )
+        client.table.return_value = memory_chain
+
+        with patch("backend.observability.structured_logger.log_memory_event") as mock_log:
+            messages = await helper._get_recent_messages("sess-1")
+
+        assert len(messages) == 1
+        payloads = [call.kwargs for call in mock_log.call_args_list]
+        probe = next(
+            payload
+            for payload in payloads
+            if payload["event"] == "memory_loader_get_recent_messages"
+        )
+        compatibility_probe = next(
+            payload
+            for payload in payloads
+            if payload["event"] == "memory_loader_get_recent_messages_duration_ms"
+        )
+        assert probe["success"] is True
+        assert probe["row_count"] == 1
+        assert probe["message_count"] == 1
+        assert isinstance(probe["memory_loader_get_recent_messages_duration_ms"], int)
+        assert compatibility_probe["message_count"] == 1
+
+    @pytest.mark.asyncio
     async def test_returns_empty_list_when_session_inactive(self, helper_with_client):
         """非アクティブセッションでは空リストを返す"""
         helper, client = helper_with_client
@@ -466,9 +545,20 @@ class TestGetRecentMessages:
     @pytest.mark.asyncio
     async def test_returns_empty_list_when_supabase_is_none(self, helper_without_client):
         """supabase が None の場合は空リストを返す"""
-        messages = await helper_without_client._get_recent_messages("sess-1")
+        with patch("backend.observability.structured_logger.log_memory_event") as mock_log:
+            messages = await helper_without_client._get_recent_messages("sess-1")
 
         assert messages == []
+        payloads = [call.kwargs for call in mock_log.call_args_list]
+        probe = next(
+            payload
+            for payload in payloads
+            if payload["event"] == "memory_loader_get_recent_messages"
+        )
+        assert probe["success"] is True
+        assert probe["skipped"] is True
+        assert probe["reason"] == "supabase_unavailable"
+        assert probe["row_count"] == 0
 
     @pytest.mark.asyncio
     async def test_returns_empty_list_when_no_data(self, helper_with_client):
@@ -509,9 +599,19 @@ class TestGetRecentMessages:
 
         client.table.side_effect = table_side_effect
 
-        messages = await helper._get_recent_messages(_ACTIVE_SESSION_ID)
+        with patch("backend.observability.structured_logger.log_memory_event") as mock_log:
+            messages = await helper._get_recent_messages(_ACTIVE_SESSION_ID)
 
         assert messages == []
+        payloads = [call.kwargs for call in mock_log.call_args_list]
+        probe = next(
+            payload
+            for payload in payloads
+            if payload["event"] == "memory_loader_get_recent_messages"
+        )
+        assert probe["success"] is False
+        assert probe["error_type"] == "Exception"
+        assert isinstance(probe["memory_loader_get_recent_messages_duration_ms"], int)
 
 
 # =============================================================================
@@ -1422,6 +1522,48 @@ class TestGetContext:
 
             mock_rag_class.assert_not_called()
             assert result["knowledge_results"] == []
+
+    @pytest.mark.asyncio
+    async def test_get_context_emits_recent_messages_probe_when_stm_writes_disabled(self):
+        with patch.dict(
+            os.environ,
+            {
+                "SUPABASE_URL": "",
+                "SUPABASE_KEY": "",
+                "ENABLE_AGENT_MEMORY_STM_WRITES": "false",
+                "ENVIRONMENT": "development",
+            },
+        ):
+            helper = SimplifiedMemoryHelper()
+            with (
+                patch("backend.observability.structured_logger.log_memory_event") as mock_log,
+                patch("backend.tools.enhanced_rag.EnhancedRAGSearch") as mock_rag_class,
+            ):
+                result = await helper.get_context(
+                    "営業時間は？",
+                    "sess-1",
+                    {"include_knowledge_base": False},
+                )
+
+            mock_rag_class.assert_not_called()
+            assert result["recent_messages"] == []
+            payloads = [call.kwargs for call in mock_log.call_args_list]
+            probe = next(
+                payload
+                for payload in payloads
+                if payload["event"] == "memory_loader_get_recent_messages"
+            )
+            compatibility_probe = next(
+                payload
+                for payload in payloads
+                if payload["event"] == "memory_loader_get_recent_messages_duration_ms"
+            )
+            assert probe["success"] is True
+            assert probe["skipped"] is True
+            assert probe["reason"] == "agent_memory_stm_writes_disabled"
+            assert probe["row_count"] == 0
+            assert probe["memory_loader_get_recent_messages_duration_ms"] == 0
+            assert compatibility_probe["reason"] == "agent_memory_stm_writes_disabled"
 
     @pytest.mark.asyncio
     async def test_handles_rag_failure_gracefully(self):

--- a/backend/tests/utils/test_token_tracker.py
+++ b/backend/tests/utils/test_token_tracker.py
@@ -5,6 +5,7 @@ record()、total_tokens、total_cost_usd、summary、reset、
 ContextVar ヘルパー（get_token_tracker / reset_token_tracker）を検証する。
 """
 
+import logging
 from unittest.mock import patch
 
 import pytest
@@ -56,6 +57,28 @@ def test_record_negative_tokens():
     assert usage.prompt_tokens == 0
     assert usage.completion_tokens == 0
     assert usage.total_tokens == 0
+
+
+def test_cerebras_fast_model_cost_is_env_configurable_without_unknown_warning(
+    monkeypatch,
+    caplog,
+):
+    """Cerebras direct-hop models should not pollute production logs as unknown."""
+
+    monkeypatch.setenv("CEREBRAS_FAST_MODEL", "gpt-oss-120b")
+    monkeypatch.setenv("CEREBRAS_INPUT_COST_PER_1K", "0.25")
+    monkeypatch.setenv("CEREBRAS_OUTPUT_COST_PER_1K", "0.75")
+    tracker = TokenTracker()
+
+    with caplog.at_level(logging.WARNING):
+        usage = tracker.record(
+            model="gpt-oss-120b",
+            prompt_tokens=1000,
+            completion_tokens=2000,
+        )
+
+    assert usage.estimated_cost_usd == 1.75
+    assert "No cost data for model" not in caplog.text
 
 
 # ============================================

--- a/backend/utils/checkpointer.py
+++ b/backend/utils/checkpointer.py
@@ -6,6 +6,7 @@ through stale PostgreSQL connections after idle scale-to-zero periods.
 """
 
 import asyncio
+import inspect
 import logging
 import os
 import re
@@ -19,11 +20,18 @@ from langgraph.checkpoint.base import (
     CheckpointMetadata,
     RunnableConfig,
 )
+from langgraph.checkpoint.serde.jsonplus import (
+    EXT_CONSTRUCTOR_KW_ARGS,
+    JsonPlusSerializer,
+    _msgpack_ext_hook,
+)
 from langgraph.checkpoint.postgres.aio import AsyncPostgresSaver
+import ormsgpack
 from psycopg import AsyncConnection, InterfaceError, OperationalError
 from psycopg.rows import dict_row
 from psycopg_pool import AsyncConnectionPool, PoolClosed
 
+from backend.utils.context_priority import ContextSignals
 from backend.utils.postgres_sanitizer import sanitize_for_postgres
 
 logger = logging.getLogger(__name__)
@@ -51,6 +59,62 @@ _CONNECTION_ERROR_MESSAGES = (
 _checkpointer_lock = asyncio.Lock()
 _checkpointer_cm = None
 _checkpointer_instance: Optional[AsyncPostgresSaver] = None
+
+_CONTEXT_SIGNALS_MSGPACK_MODULE = (
+    "backend.utils.context_priority",
+    "ContextSignals",
+)
+_CONTEXT_SIGNALS_JSON_MODULE = (
+    "backend",
+    "utils",
+    "context_priority",
+    "ContextSignals",
+)
+
+
+def _revive_context_signals(kwargs: dict[str, Any]) -> ContextSignals:
+    normalized = dict(kwargs)
+    for tuple_field in ("memory_topics", "previous_categories"):
+        value = normalized.get(tuple_field)
+        if isinstance(value, list):
+            normalized[tuple_field] = tuple(value)
+    return ContextSignals(**normalized)
+
+
+def _context_signals_msgpack_ext_hook(code: int, data: bytes) -> Any:
+    """Revive ContextSignals explicitly while delegating other LangGraph types."""
+    if code == EXT_CONSTRUCTOR_KW_ARGS:
+        try:
+            module_name, class_name, kwargs = ormsgpack.unpackb(
+                data,
+                ext_hook=_context_signals_msgpack_ext_hook,
+                option=ormsgpack.OPT_NON_STR_KEYS,
+            )
+        except Exception:
+            return _msgpack_ext_hook(code, data)
+
+        if (module_name, class_name) == _CONTEXT_SIGNALS_MSGPACK_MODULE and isinstance(
+            kwargs, dict
+        ):
+            return _revive_context_signals(kwargs)
+
+    return _msgpack_ext_hook(code, data)
+
+
+def create_checkpointer_serde() -> JsonPlusSerializer:
+    """Create LangGraph serde with ContextSignals allowlisted for checkpoints."""
+    serializer_params = inspect.signature(JsonPlusSerializer).parameters
+    kwargs: dict[str, Any] = {}
+
+    if "allowed_json_modules" in serializer_params:
+        kwargs["allowed_json_modules"] = [_CONTEXT_SIGNALS_JSON_MODULE]
+
+    if "allowed_msgpack_modules" in serializer_params:
+        kwargs["allowed_msgpack_modules"] = [_CONTEXT_SIGNALS_MSGPACK_MODULE]
+    elif "__unpack_ext_hook__" in serializer_params:
+        kwargs["__unpack_ext_hook__"] = _context_signals_msgpack_ext_hook
+
+    return JsonPlusSerializer(**kwargs)
 
 
 def _mask_connection_string(db_uri: str) -> str:
@@ -134,7 +198,7 @@ class ResilientAsyncPostgresSaver(AsyncPostgresSaver):
     """AsyncPostgresSaver that can replace its own pool after connection loss."""
 
     def __init__(self, factory: _CheckpointerFactory, pool: AsyncConnectionPool) -> None:
-        super().__init__(conn=pool)
+        super().__init__(conn=pool, serde=create_checkpointer_serde())
         self._factory = factory
         self._pool_refresh_lock = asyncio.Lock()
 

--- a/backend/utils/context_priority.py
+++ b/backend/utils/context_priority.py
@@ -24,6 +24,10 @@ class ContextSignals:
     conversation_depth: int = 0
     previous_categories: tuple = ()
 
+    def __post_init__(self) -> None:
+        object.__setattr__(self, "memory_topics", tuple(self.memory_topics or ()))
+        object.__setattr__(self, "previous_categories", tuple(self.previous_categories or ()))
+
 
 class ContextPriorityEngine:
     """コンテキスト駆動の優先度エンジン"""

--- a/backend/utils/memory_extractor.py
+++ b/backend/utils/memory_extractor.py
@@ -18,6 +18,19 @@ from typing import Any, Dict, List
 logger = logging.getLogger(__name__)
 
 
+def _duration_ms(started_at: float) -> int:
+    return max(0, int((time.perf_counter() - started_at) * 1000))
+
+
+def _log_memory_event_safely(event: str, **fields: Any) -> None:
+    try:
+        from backend.observability.structured_logger import log_memory_event
+
+        log_memory_event(event=event, **fields)
+    except Exception:
+        pass
+
+
 def extract_memories(
     query: str,
     answer: str,
@@ -35,6 +48,7 @@ def extract_memories(
         抽出されたメモリのリスト。各メモリは以下の形式:
         {"type": str, "content": str, "confidence": float}
     """
+    started_at = time.perf_counter()
     memories: List[Dict[str, Any]] = []
 
     # 1. 名前の抽出
@@ -102,6 +116,15 @@ def extract_memories(
             }
         )
 
+    _log_memory_event_safely(
+        "memory_extractor_run",
+        extractor_type="direct",
+        language=language,
+        success=True,
+        duration_ms=_duration_ms(started_at),
+        extracted_count=len(memories),
+        memory_types=sorted({str(memory.get("type", "unknown")) for memory in memories}),
+    )
     return memories
 
 
@@ -118,8 +141,18 @@ def extract_memory_candidates(
 
     既存 extract_memories() の互換性を保ちながら、段階昇格に必要なメタデータを付与する。
     """
+    started_at = time.perf_counter()
     base_memories = extract_memories(query=query, answer=answer, language=language)
     if not base_memories:
+        _log_memory_event_safely(
+            "memory_extractor_run",
+            extractor_type="candidate",
+            language=language,
+            success=True,
+            duration_ms=_duration_ms(started_at),
+            extracted_count=0,
+            candidate_types=[],
+        )
         return []
 
     ts = extracted_at if extracted_at is not None else time.time()
@@ -147,6 +180,17 @@ def extract_memory_candidates(
                 },
             }
         )
+    _log_memory_event_safely(
+        "memory_extractor_run",
+        extractor_type="candidate",
+        language=language,
+        success=True,
+        duration_ms=_duration_ms(started_at),
+        extracted_count=len(candidates),
+        candidate_types=sorted(
+            {str(candidate.get("candidate_type", "unknown")) for candidate in candidates}
+        ),
+    )
     return candidates
 
 

--- a/backend/utils/memory_helper.py
+++ b/backend/utils/memory_helper.py
@@ -9,6 +9,7 @@ conversation_sessionsテーブルでセッション境界を判定し、
 """
 
 import os
+import time
 import uuid
 from typing import Optional, Dict, Any, List
 from datetime import datetime
@@ -26,6 +27,20 @@ from backend.utils.postgres_sanitizer import sanitize_for_postgres
 logger = logging.getLogger(__name__)
 
 _AGENT_MEMORY_SESSION_COLUMN = "value->>sessionId"
+_DURATION_EVENT_ALIASES = {
+    "memory_loader_get_recent_messages_duration_ms": (
+        "memory_loader_get_recent_messages",
+        "memory_loader_get_recent_messages_duration_ms",
+    ),
+    "memory_loader_get_previous_request_type_duration_ms": (
+        "memory_loader_get_previous_request_type",
+        "memory_loader_get_previous_request_type_duration_ms",
+    ),
+    "memory_cleanup_session_duration_ms": (
+        "memory_cleanup_session",
+        "memory_cleanup_session_duration_ms",
+    ),
+}
 
 
 def infer_previous_request_type_from_messages(messages: List[Dict[str, Any]]) -> Optional[str]:
@@ -51,9 +66,22 @@ def _log_memory_event_safely(event: str, **fields: Any) -> None:
     try:
         from backend.observability.structured_logger import log_memory_event
 
+        alias = _DURATION_EVENT_ALIASES.get(event)
+        if alias:
+            alias_event, duration_field = alias
+            if "duration_ms" in fields:
+                fields.setdefault(duration_field, fields["duration_ms"])
+            log_memory_event(event=alias_event, **fields)
+            log_memory_event(event=event, **fields)
+            return
+
         log_memory_event(event=event, **fields)
     except Exception:
         pass
+
+
+def _duration_ms(started_at: float) -> int:
+    return max(0, int((time.perf_counter() - started_at) * 1000))
 
 
 class SimplifiedMemoryHelper:
@@ -141,9 +169,20 @@ class SimplifiedMemoryHelper:
             存在しない場合は None
         """
         logger.info("Getting previous request type for session: %s", session_id)
+        started_at = time.perf_counter()
 
         if not self.supabase:
             logger.warning("Supabase not available")
+            _log_memory_event_safely(
+                "memory_loader_get_previous_request_type_duration_ms",
+                session_id=session_id,
+                success=True,
+                skipped=True,
+                reason="supabase_unavailable",
+                duration_ms=_duration_ms(started_at),
+                row_count=0,
+                request_type=None,
+            )
             return None
 
         try:
@@ -161,6 +200,14 @@ class SimplifiedMemoryHelper:
             )
 
             if not response.data:
+                _log_memory_event_safely(
+                    "memory_loader_get_previous_request_type_duration_ms",
+                    session_id=session_id,
+                    success=True,
+                    duration_ms=_duration_ms(started_at),
+                    row_count=0,
+                    request_type=None,
+                )
                 return None
 
             # 最新のuser messageを探す。session_id/role は SQL 側で絞り込み済み。
@@ -170,28 +217,58 @@ class SimplifiedMemoryHelper:
                 if request_type:
                     logger.info("Found previous request type: %s", request_type)
                     _log_memory_event_safely(
+                        "memory_loader_get_previous_request_type_duration_ms",
+                        session_id=session_id,
+                        success=True,
+                        duration_ms=_duration_ms(started_at),
+                        row_count=len(response.data),
+                        request_type=request_type,
+                    )
+                    _log_memory_event_safely(
                         "memory_previous_request_type_load",
                         session_id=session_id,
                         success=True,
                         request_type=request_type,
+                        duration_ms=_duration_ms(started_at),
+                        row_count=len(response.data),
                     )
                     return request_type
 
+            _log_memory_event_safely(
+                "memory_loader_get_previous_request_type_duration_ms",
+                session_id=session_id,
+                success=True,
+                duration_ms=_duration_ms(started_at),
+                row_count=len(response.data),
+                request_type=None,
+            )
             _log_memory_event_safely(
                 "memory_previous_request_type_load",
                 session_id=session_id,
                 success=True,
                 request_type=None,
+                duration_ms=_duration_ms(started_at),
+                row_count=len(response.data),
             )
             return None
 
         except Exception as e:
             logger.error("Error getting previous request type: %s", e)
             _log_memory_event_safely(
+                "memory_loader_get_previous_request_type_duration_ms",
+                session_id=session_id,
+                success=False,
+                duration_ms=_duration_ms(started_at),
+                row_count=0,
+                error_type=type(e).__name__,
+            )
+            _log_memory_event_safely(
                 "memory_previous_request_type_load",
                 session_id=session_id,
                 success=False,
                 error_type=type(e).__name__,
+                duration_ms=_duration_ms(started_at),
+                row_count=0,
             )
             return None
 
@@ -236,11 +313,22 @@ class SimplifiedMemoryHelper:
         if memory_flags and not memory_flags.enable_agent_memory_stm_writes:
             recent_messages = []
             _log_memory_event_safely(
+                "memory_loader_get_recent_messages_duration_ms",
+                session_id=session_id,
+                success=True,
+                skipped=True,
+                reason="agent_memory_stm_writes_disabled",
+                duration_ms=0,
+                row_count=0,
+            )
+            _log_memory_event_safely(
                 "memory_recent_messages_load",
                 session_id=session_id,
                 success=True,
                 skipped=True,
                 reason="agent_memory_stm_writes_disabled",
+                duration_ms=0,
+                row_count=0,
             )
         else:
             recent_messages = await self._get_recent_messages(session_id)
@@ -331,7 +419,17 @@ class SimplifiedMemoryHelper:
         Returns:
             セッション内のメッセージリスト
         """
+        started_at = time.perf_counter()
         if not self.supabase:
+            _log_memory_event_safely(
+                "memory_loader_get_recent_messages_duration_ms",
+                session_id=session_id,
+                success=True,
+                skipped=True,
+                reason="supabase_unavailable",
+                duration_ms=_duration_ms(started_at),
+                row_count=0,
+            )
             return []
 
         try:
@@ -339,6 +437,26 @@ class SimplifiedMemoryHelper:
             session_active = await self._is_session_active(session_id)
             if not session_active:
                 logger.info("Session %s is not active, returning empty messages", session_id)
+                duration_ms = _duration_ms(started_at)
+                _log_memory_event_safely(
+                    "memory_loader_get_recent_messages_duration_ms",
+                    session_id=session_id,
+                    success=True,
+                    skipped=True,
+                    reason="session_inactive",
+                    duration_ms=duration_ms,
+                    row_count=0,
+                )
+                _log_memory_event_safely(
+                    "memory_recent_messages_load",
+                    session_id=session_id,
+                    success=True,
+                    skipped=True,
+                    reason="session_inactive",
+                    duration_ms=duration_ms,
+                    row_count=0,
+                    message_count=0,
+                )
                 return []
 
             response = (
@@ -353,6 +471,22 @@ class SimplifiedMemoryHelper:
             )
 
             if not response.data:
+                duration_ms = _duration_ms(started_at)
+                _log_memory_event_safely(
+                    "memory_loader_get_recent_messages_duration_ms",
+                    session_id=session_id,
+                    success=True,
+                    duration_ms=duration_ms,
+                    row_count=0,
+                )
+                _log_memory_event_safely(
+                    "memory_recent_messages_load",
+                    session_id=session_id,
+                    success=True,
+                    duration_ms=duration_ms,
+                    row_count=0,
+                    message_count=0,
+                )
                 return []
 
             # メッセージを整形。session_id は SQL 側で絞り込み済み。
@@ -378,20 +512,42 @@ class SimplifiedMemoryHelper:
             # DESC順で取得しているので時系列順に戻し、max_entriesで制限
             messages = messages[::-1]
             result = messages[-self.max_entries :] if len(messages) > self.max_entries else messages
+            duration_ms = _duration_ms(started_at)
+            _log_memory_event_safely(
+                "memory_loader_get_recent_messages_duration_ms",
+                session_id=session_id,
+                success=True,
+                duration_ms=duration_ms,
+                row_count=len(response.data),
+                message_count=len(result),
+            )
             _log_memory_event_safely(
                 "memory_recent_messages_load",
                 session_id=session_id,
                 success=True,
+                duration_ms=duration_ms,
+                row_count=len(response.data),
                 message_count=len(result),
             )
             return result
 
         except Exception as e:
             logger.error("Error getting recent messages: %s", e)
+            duration_ms = _duration_ms(started_at)
+            _log_memory_event_safely(
+                "memory_loader_get_recent_messages_duration_ms",
+                session_id=session_id,
+                success=False,
+                duration_ms=duration_ms,
+                row_count=0,
+                error_type=type(e).__name__,
+            )
             _log_memory_event_safely(
                 "memory_recent_messages_load",
                 session_id=session_id,
                 success=False,
+                duration_ms=duration_ms,
+                row_count=0,
                 error_type=type(e).__name__,
             )
             return []
@@ -690,8 +846,18 @@ class SimplifiedMemoryHelper:
             session_id: セッションID
         """
         logger.info("Cleaning up messages for session: %s", session_id)
+        started_at = time.perf_counter()
 
         if not self.supabase:
+            _log_memory_event_safely(
+                "memory_cleanup_session_duration_ms",
+                session_id=session_id,
+                success=True,
+                skipped=True,
+                reason="supabase_unavailable",
+                duration_ms=_duration_ms(started_at),
+                deleted_count=0,
+            )
             return
 
         try:
@@ -706,19 +872,38 @@ class SimplifiedMemoryHelper:
 
             deleted_count = len(response.data or [])
             logger.info("Cleaned up %d messages for session: %s", deleted_count, session_id)
+            duration_ms = _duration_ms(started_at)
+            _log_memory_event_safely(
+                "memory_cleanup_session_duration_ms",
+                session_id=session_id,
+                success=True,
+                duration_ms=duration_ms,
+                deleted_count=deleted_count,
+            )
             _log_memory_event_safely(
                 "memory_cleanup_session",
                 session_id=session_id,
                 success=True,
+                duration_ms=duration_ms,
                 deleted_count=deleted_count,
             )
 
         except Exception as e:
             logger.error("Error during session cleanup: %s", e)
+            duration_ms = _duration_ms(started_at)
+            _log_memory_event_safely(
+                "memory_cleanup_session_duration_ms",
+                session_id=session_id,
+                success=False,
+                duration_ms=duration_ms,
+                deleted_count=0,
+                error_type=type(e).__name__,
+            )
             _log_memory_event_safely(
                 "memory_cleanup_session",
                 session_id=session_id,
                 success=False,
+                duration_ms=duration_ms,
                 error_type=type(e).__name__,
             )
 

--- a/backend/utils/token_tracker.py
+++ b/backend/utils/token_tracker.py
@@ -5,11 +5,26 @@
 """
 
 import logging
+import os
 from contextvars import ContextVar
 from dataclasses import dataclass, field
 from typing import Any, List, Optional
 
 logger = logging.getLogger(__name__)
+
+_DEFAULT_CEREBRAS_INPUT_COST_PER_1K = 0.0
+_DEFAULT_CEREBRAS_OUTPUT_COST_PER_1K = 0.0
+
+
+def _env_float(name: str, default: float) -> float:
+    raw = os.getenv(name, "").strip()
+    if not raw:
+        return default
+    try:
+        return float(raw)
+    except ValueError:
+        logger.warning("Invalid %s=%r. Falling back to %.6f.", name, raw, default)
+        return default
 
 
 @dataclass
@@ -130,6 +145,19 @@ class TokenTracker:
                     input_cost = (prompt_tokens / 1000) * config.input_cost_per_1k
                     output_cost = (completion_tokens / 1000) * config.output_cost_per_1k
                     return input_cost + output_cost
+            cerebras_fast_model = os.getenv("CEREBRAS_FAST_MODEL", "gpt-oss-120b").strip()
+            if model == cerebras_fast_model or model.startswith("gpt-oss"):
+                input_cost_per_1k = _env_float(
+                    "CEREBRAS_INPUT_COST_PER_1K",
+                    _DEFAULT_CEREBRAS_INPUT_COST_PER_1K,
+                )
+                output_cost_per_1k = _env_float(
+                    "CEREBRAS_OUTPUT_COST_PER_1K",
+                    _DEFAULT_CEREBRAS_OUTPUT_COST_PER_1K,
+                )
+                input_cost = (prompt_tokens / 1000) * input_cost_per_1k
+                output_cost = (completion_tokens / 1000) * output_cost_per_1k
+                return input_cost + output_cost
             logger.warning("No cost data for model '%s'. Cost reported as $0.00.", model)
         except Exception as e:
             logger.debug("Cost estimation failed: %s", e)


### PR DESCRIPTION
## Summary

Implements the remaining Phase 2 readiness blockers from Epic #842 in one deployable backend PR.

- FU-01 / #843: propagate LLM provider/model/latency through explicit agent metadata using a `str`-compatible `LLMResponseText`, without changing existing `generate()` call signatures.
- FU-02 / #844: deploy Event KB sync as a Cloud Run Job + Cloud Scheduler job, bind `GOOGLE_CALENDAR_ICAL_URL`, and run the sync during backend deploy.
- FU-03 / #845 and FU-04 / #846: emit memory loader/promoter/extractor/candidate aggregate observability events and add a read-only memory loader benchmark script.
- FU-05 / #847: register `ContextSignals` with LangGraph checkpoint serde.
- FU-06 / #848: preserve cross-session recall path and add proof-oriented tests.
- Cerebras follow-up: remove the noisy unknown-cost warning for `gpt-oss` direct-hop models via env-configurable cost settings, and add a post-deploy live `/api/chat` Cloud Logging gate so provider/model/route/latency cannot regress to `unknown` unnoticed.

Refs #842, #843, #844, #845, #846, #847, #848.
These issues will be closed after merge, CI/CD deployment, and live Google Cloud verification.

## Verification

Local:
- `uv run pytest backend/tests/llm/test_openrouter.py backend/tests/utils/test_token_tracker.py backend/tests/agents/test_business_info_agent.py backend/tests/agents/test_event_agent.py backend/tests/agents/test_farewell_agent.py backend/tests/agents/test_slide_agent.py backend/tests/agents/test_facility_agent.py backend/tests/agents/test_general_knowledge_agent.py -q` -> 210 passed
- `uv run pytest backend/tests/utils/test_memory_helper_unit.py backend/tests/utils/test_memory_extractor.py backend/tests/services/test_memory_promoter.py backend/tests/utils/test_checkpointer.py -q` -> 223 passed
- `uv run pytest backend/tests/api/test_chat_api.py backend/tests/observability/test_structured_logger_tts.py -q` -> 11 passed
- `uv run pytest backend/tests/services/test_event_kb_sync.py -q` -> 5 passed
- `uv run pytest backend/tests -m "not ragas and not slow and not e2e" --tb=short -q` -> 3611 passed, 43 skipped, 245 deselected
- `source backend/.env && uv run pytest backend/tests/e2e/test_cross_session_memory_e2e.py --run-e2e -q -rs` -> 5 passed
- `uv run ruff check ...` -> passed
- `uv run black --check ...` -> passed
- `.github/workflows/ci.yml` parsed with `yaml.safe_load`

Live prep already completed before this PR:
- Cloud Scheduler API enabled in project `aipartner-426616`.
- `GOOGLE_CALENDAR_ICAL_URL` promoted from local env to Google Secret Manager.
- `engineer-cafe-navigator@aipartner-426616.iam.gserviceaccount.com` granted `roles/secretmanager.secretAccessor` for Event KB job runtime.
- Event KB job `event-kb-sync` executed once successfully and wrote 279 `knowledge_base` rows with `category='event'` and `source like 'event_bridge:%'`.
- Scheduler `event-kb-sync-daily` is enabled for `0 9 * * *` Asia/Tokyo with URI `https://run.googleapis.com/v2/projects/aipartner-426616/locations/asia-northeast1/jobs/event-kb-sync:run`.
