### PR TITLE
ci: fix live observability smoke prompt

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -755,11 +755,12 @@ jobs:
 
           REQUEST_ID="ci-llm-observability-${GITHUB_SHA:0:12}-$(date +%s)"
           SESSION_ID="${REQUEST_ID}"
+          VISITOR_NAME="CI検証太郎${GITHUB_SHA:0:6}"
           API_KEY="$(gcloud secrets versions access latest --secret=API_SECRET_KEY)"
           CHAT_BODY=$(mktemp)
           cat > "$CHAT_BODY" <<JSON
           {
-            "query": "覚えて、私はCIテストユーザーです。量子コンピュータを初心者向けに一文で説明してください",
+            "query": "私の名前は${VISITOR_NAME}です。量子コンピュータを初心者向けに一文で説明してください",
             "session_id": "${SESSION_ID}",
             "language": "ja",
             "visitor_id": "${SESSION_ID}"


### PR DESCRIPTION
## Summary
- change the develop deploy smoke prompt so it exercises both Cerebras LLM metadata and memory candidate aggregation
- avoid the explicit `覚えて` phrasing that routes to memory-write ack and intentionally skips the LLM

## Live proof before PR
- revision: `engineer-cafe-backend-00211-wdf`
- request_id: `codex-probe-name-llm-1778991121`
- `/api/chat` metadata: provider=`cerebras`, model=`gpt-oss-120b`, route=`general_knowledge`
- Cloud Logging events present for same request_id: `chat_response`, `memory_loader_get_recent_messages_duration_ms`, `memory_extractor_run`, `memory_promote_run`, `memory_candidate_aggregate`

## Verification
- workflow smoke query guard passed
- workflow yaml parse passed

Refs #842 #843 #845 #846 #847 #848