### PR TITLE
fix(ci): skip direct DB E2E when Postgres is unreachable

### DIFF
--- a/backend/tests/e2e/conftest.py
+++ b/backend/tests/e2e/conftest.py
@@ -12,6 +12,7 @@ import re
 import uuid
 from pathlib import Path
 
+import psycopg
 import pytest
 import pytest_asyncio
 
@@ -47,6 +48,27 @@ def _is_real_url(value: str) -> bool:
     return not any(lower.startswith(p) for p in _PLACEHOLDER_URLS)
 
 
+def _is_real_db_uri(value: str) -> bool:
+    """DB URI がテスト用プレースホルダーでないことを確認"""
+    if not value:
+        return False
+    lower = value.lower()
+    return (
+        lower.startswith(("postgresql://", "postgres://"))
+        and not lower.startswith(_PLACEHOLDER_PREFIXES)
+        and "localhost:0" not in lower
+    )
+
+
+def _is_postgres_connectable(db_uri: str, timeout: int = 5) -> bool:
+    """Return True when this runner can open a PostgreSQL connection."""
+    try:
+        with psycopg.connect(db_uri, connect_timeout=timeout):
+            return True
+    except Exception:
+        return False
+
+
 # ---------------------------------------------------------------------------
 # Session-scoped fixtures
 # ---------------------------------------------------------------------------
@@ -68,6 +90,17 @@ def _check_e2e_env():
             "SUPABASE_URL / SUPABASE_KEY is missing or is a placeholder. "
             "Set real values to run E2E tests."
         )
+
+
+@pytest.fixture(scope="session")
+def reachable_supabase_db_uri(_check_e2e_env) -> str:
+    """SUPABASE_DB_URI を使う E2E 用に runner からの DB 到達性を確認する。"""
+    db_uri = os.getenv("SUPABASE_DB_URI", "")
+    if not _is_real_db_uri(db_uri):
+        pytest.skip("SUPABASE_DB_URI not configured for direct PostgreSQL E2E tests")
+    if not _is_postgres_connectable(db_uri):
+        pytest.skip("SUPABASE_DB_URI PostgreSQL endpoint is not reachable from this runner")
+    return db_uri
 
 
 async def _close_shared_llm_provider() -> None:

--- a/backend/tests/e2e/test_cross_session_memory_e2e.py
+++ b/backend/tests/e2e/test_cross_session_memory_e2e.py
@@ -16,7 +16,6 @@ store フィクスチャは sync にして AsyncPostgresStore の CM を返す�
 """
 
 import asyncio
-import os
 import uuid
 
 import pytest
@@ -29,17 +28,14 @@ from langgraph.store.postgres.aio import AsyncPostgresStore
 
 
 @pytest.fixture
-def store_cm(_check_e2e_env):
+def store_cm(reachable_supabase_db_uri):
     """AsyncPostgresStore コンテキストマネージャーを返す（sync fixture）。
 
     sync fixture なので event loop に依存しない。
     テスト関数内で ``async with store_cm as store`` するため、
     store の接続はテスト自身の event loop で確立される。
     """
-    db_uri = os.getenv("SUPABASE_DB_URI")
-    if not db_uri:
-        pytest.skip("SUPABASE_DB_URI not set")
-    return AsyncPostgresStore.from_conn_string(db_uri)
+    return AsyncPostgresStore.from_conn_string(reachable_supabase_db_uri)
 
 
 @pytest.fixture

--- a/backend/tests/e2e/test_memory_promotion_store_e2e.py
+++ b/backend/tests/e2e/test_memory_promotion_store_e2e.py
@@ -1,6 +1,5 @@
 """E2E tests for memory promotion using a real AsyncPostgresStore."""
 
-import os
 import uuid
 
 import pytest
@@ -12,16 +11,14 @@ from backend.services.memory_promoter import MemoryPromoter
 
 @pytest.mark.e2e
 class TestMemoryPromotionStoreE2E:
-    async def test_promotes_repeated_candidates_to_long_term_memory(self):
-        db_uri = os.getenv("SUPABASE_DB_URI")
-        if not db_uri:
-            pytest.skip("SUPABASE_DB_URI not set")
-
+    async def test_promotes_repeated_candidates_to_long_term_memory(
+        self, reachable_supabase_db_uri
+    ):
         user_id = f"promoter-e2e-{uuid.uuid4().hex[:8]}"
         candidate_ns = ("visitor_memory_candidates", user_id)
         long_term_ns = ("visitor_memories", user_id)
 
-        async with AsyncPostgresStore.from_conn_string(db_uri) as store:
+        async with AsyncPostgresStore.from_conn_string(reachable_supabase_db_uri) as store:
             await store.setup()
             promoter = MemoryPromoter()
 


### PR DESCRIPTION
## Summary
- add a shared E2E fixture that validates SUPABASE_DB_URI and direct PostgreSQL reachability before running direct Store tests
- use it for cross-session memory and memory promotion Store E2E tests
- prevents GitHub-hosted runners without IPv6/direct DB reachability from failing optional backend E2E after the required live API checks have run

## Verification
- ruff check backend/tests/e2e/conftest.py backend/tests/e2e/test_cross_session_memory_e2e.py backend/tests/e2e/test_memory_promotion_store_e2e.py
- black --check backend/tests/e2e/conftest.py backend/tests/e2e/test_cross_session_memory_e2e.py backend/tests/e2e/test_memory_promotion_store_e2e.py
- SUPABASE_DB_URI=postgresql://postgres:postgres@localhost:0/postgres OPENROUTER_API_KEY=test-key-not-real SUPABASE_URL=http://test.invalid SUPABASE_KEY=test-key-not-real python -m pytest backend/tests/e2e/test_cross_session_memory_e2e.py backend/tests/e2e/test_memory_promotion_store_e2e.py --run-e2e -q -> 6 skipped

Refs #855 #857 #770
