### PR TITLE
docs(adr): record Wave 2 live closeout evidence

### DIFF
--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -1,8 +1,57 @@
 # 現在の状態
 
-Last updated: 2026-05-05（git 同期メモ。**ライブの run / revision は 2026-05-03 のまま**で、再 dispatch していないため数値は更新していません）。
+Last updated: 2026-05-18（Wave 2 closeout。PR #852 / #874 / #875 merge 後、Cloud Run revision / live API / CI/CD / Vercel Preview を実測更新）。
 
 > **2026-05-05 git 同期メモ**: ルート README / `docs/README.md` / `docs/architecture/SYSTEM-ARCHITECTURE.md` / `docs/SECURITY.md` / `docs/DEPLOYMENT.md` / `docs/DEVELOPER-GUIDE.md` / `docs/api/API.md` / `frontend/README.md` / `backend/README.md` をスタブ化・索引化し、`docs/adr/README.md` と `docs/plans/comprehensive-refactoring-plan-2026-05-05.md` を新規追加しました（コード・運用ゲートには変更なし）。alpha NO-GO 判定は本ページの 2026-05-03 Reset Snapshot を引き続き正本とします。次に live workflow を再実行したタイミングで、本ページの run ID / revision を更新してください。
+
+## 2026-05-18 Wave 2 Closeout Snapshot
+
+Wave 2 の Date / Audio / Calendar critical UX fixes は、PR #852 で本体実装を merge し、PR #874 / #875 で live E2E follow-up と CI 到達性を修復した。最終的に develop CI/CD、Cloud Run deploy、live API verification まで完了した。
+
+確認元:
+
+- PR #852 `fix(wave2): implement date audio calendar reliability`
+- PR #874 `fix(wave2): close live E2E follow-up gaps`
+- PR #875 `fix(ci): skip direct DB E2E when Postgres is unreachable`
+- Final merge commit `eee8c0b19f459dcd25ccc5aad211895b037514c6`
+- PR #874 CI run `26001835735`, conclusion `success`
+- post-#874 develop CI run `26002065329`, conclusion `success`
+- PR #875 CI run `26002651705`, conclusion `success`
+- post-#875 develop CI run `26002826450`, conclusion `success`
+- Frontend Production Smoke run `25995874988`, conclusion `success`
+- Cloud Run revision `engineer-cafe-backend-00218-8zv`, traffic 100%
+- `event-kb-sync` latest execution `event-kb-sync-92wns`, `EXECUTION_SUCCEEDED`
+- Vercel Preview redeploy `dpl_BaPptKnk1KgRWn6TDyXGj6vBBdcD`, status `Ready`
+- PR #874 Vercel Preview deployment `GGugatUfdthE34EsnzBedLDFeZ2Q`, status `Ready`
+
+実測結果:
+
+- `/health` は `status=ok`, `api=ok`, `supabase=ok`, `llm_provider=configured`
+- `/api/chat` に `今日は何月何日ですか？` を送ると `今日は2026年5月18日（月曜日）です。` と返り、`metadata.sources=["system_clock"]`, `provider_called=false`
+- `/api/chat` に `今週のエンジニアカフェのイベントを教えてください。` を送ると `metadata.sources=["spreadsheet", "google_calendar", "connpass"]` で、5/19, 5/20, 5/23 のイベントを含む回答を返す
+- post-#875 live API smoke は Cloud Run `engineer-cafe-backend-00218-8zv` に対して以下を 200 で確認:
+  - `メインホールはどこにありますか？` -> `facility-info`, `FacilityAgent`, 1階メインホール / コワーキング
+  - `営業時間とWi-Fiのパスワードを教えてください` -> `facility-info`, `FacilityAgent`, 9:00〜22:00 / `engnecf-guest-*` / `akarenga-112years`
+  - `3Dプリンターの使い方を教えてください` -> `facility-info`, `FacilityAgent`, MAKER'sスペース / 無料講習 / 前日予約
+  - `サイノカフェのランチは？` -> `saino-cafe`, `BusinessInfoAgent`, サンド / ワッフル / 価格
+  - `ハッカソンの開催予定は？` -> `event`, `EventAgent`, Connpass `https://engineercafe.connpass.com/`
+  - `コーヒーはいくらですか？` -> `saino-cafe`, `BusinessInfoAgent`, ブレンド380円 / シングルオリジン460円 ほか
+- `event-kb-sync` job は `python -m backend.scripts.sync_event_kb --include-spreadsheet` で deploy 済み
+- Scheduler `event-kb-sync-daily` は `0 9 * * *`, `Asia/Tokyo`, `ENABLED`
+- Vercel Preview は `NEXT_PUBLIC_SUPABASE_URL` / `NEXT_PUBLIC_SUPABASE_ANON_KEY` 欠落で失敗していたが、Preview 全体 / Development / GitHub Secrets / Google Secret Manager を同期後、同じ PR preview を再デプロイして `Ready` になった
+
+GitHub Issue 状態:
+
+- Closed by PR #852: #770, #851, #855, #856, #857, #858, #859, #860, #861, #862, #863, #864, #865, #866, #867, #868, #869, #870, #871
+- post-#875 の追加証跡は #855 / #857 / #770 にコメント追記済み
+
+残リスク:
+
+- GitHub runner から Supabase direct Postgres へ到達できない環境では、PR #875 により direct DB E2E は skip される。HTTP/Cloud Run live proof は通っているが、direct DB proof は到達可能 runner で別途確認する。
+- `VoiceInterface.tsx` の React hook dependency warning は既存 cleanup debt として残る。
+- iPad Safari 実機スピーカー証跡は次回 onsite window で取得する。今回の closeout は CI browser proof + production smoke + live backend proof。
+
+この snapshot の設計判断は [ADR-026](adr/026-wave2-kiosk-ux-reliability-baseline.md) を正本とする。
 
 ## 概要
 

--- a/docs/adr/026-wave2-kiosk-ux-reliability-baseline.md
+++ b/docs/adr/026-wave2-kiosk-ux-reliability-baseline.md
@@ -1,0 +1,228 @@
+# ADR-026: Wave 2 Kiosk UX Reliability Baseline
+
+## Status
+
+Accepted (2026-05-18) — PR #852 / #874 / #875 で実装・follow-up・CI reachability を完了し、develop CI/CD と Cloud Run live verification 済み。
+
+## Context
+
+2026-05-17 の Wave 2 では、受付 kiosk の実地 UX に直結する 3 系統の P0/P1 問題を同時に閉じた。PR #852 で本体を実装し、その後 PR #874 で live E2E follow-up gap、PR #875 で GitHub runner から direct Postgres に到達できない CI 環境差を修復した。
+
+1. Date determinism: 「今日は何月何日ですか」のような日付確認が calendar / web search / LLM に流れ、現在日時の回答が不安定になる。
+2. Audio playback reliability: iPad / mobile Safari を含むブラウザ音声再生で、再生終了の二重発火、ユーザー操作 gate 停止、thinking 状態滞留、失敗時の無音が起きる。
+3. Calendar modernization: Google Calendar だけでは Engineer Cafe curated event の source of truth として弱く、キャンセル・過去日・曖昧な範囲解釈が混入する。
+
+また PR #852 以降の Vercel Preview deploy が失敗しており、原因は repository code ではなく Vercel project の Preview 全体に `NEXT_PUBLIC_SUPABASE_URL` と `NEXT_PUBLIC_SUPABASE_ANON_KEY` が存在しないことだった。Production には存在していたため production smoke は通ったが、PR Preview の信頼性としては不健全だった。
+
+## Decision
+
+### D1: Date-only questions bypass LLM and search
+
+日付だけを尋ねる query は deterministic system-clock path に固定する。
+
+- `query_classifier` は date-only phrase を `general_knowledge` / current-time fast path に分類する。
+- `web_search` は bare `今日`, `明日`, `昨日`, `今週` を検索 trigger として扱わない。
+- `GeneralKnowledgeAgent` は JST system clock で回答し、metadata に `sources=["system_clock"]`, `provider_called=false` を残す。
+- 天気、ニュース、latest、search、trend など現在情報が必要な query は従来どおり current-info path に流す。
+
+### D2: Cloud Run and scheduled jobs use JST explicitly
+
+Cloud Run service と `event-kb-sync` Cloud Run Job は `TZ=Asia/Tokyo` を持つ。Docker image も `tzdata` を含める。
+
+### D3: Event source priority is spreadsheet > connpass > Google Calendar
+
+Engineer Cafe curated events は、GAS Web App 経由の spreadsheet source を最優先にする。
+
+- `SheetsEventSource` は `EVENT_SHEET_GAS_URL` と `EVENT_SHEET_GAS_TOKEN` を Secret Manager から読む。
+- Apps Script の 302 redirect を前提に `follow_redirects=True` を使う。
+- spreadsheet response は allowlist された公開項目だけを取り込み、PII columns は backend に流さない。
+- EventAgent は spreadsheet / Google Calendar / Connpass を並列取得し、重複を正規化 title + date で dedupe する。
+- Google Calendar は cancelled / noise prefix / 過去日を除外する。
+
+### D4: Voice state machine must fail back to audible or idle
+
+ブラウザ音声再生は、失敗時に無音で止まらないことを baseline とする。
+
+- audio queue は playback settlement を一度だけ発火させる。
+- user interaction gate は timeout と `sessionStorage` bypass persistence を持つ。
+- voice controller は processing / thinking が watchdog window を超えた場合に idle へ戻す。
+- 音声再生失敗時は session 内で回数制限つきの browser fallback speech を出す。
+- state transition telemetry を送る。
+
+### D5: Preview deploy env must be unified across Vercel, GitHub Secrets, and Secret Manager
+
+Public Supabase env は secret value を出力せずに以下へ揃える。
+
+- local `frontend/.env.local`
+- GitHub Actions repository secrets
+- Google Secret Manager
+- Vercel Production
+- Vercel Preview (all branches)
+- Vercel Development
+
+Production だけに env がある状態は、PR Preview の deploy gate を壊すため不可とする。
+
+## Verification
+
+### Implementation PRs
+
+- PR: [#852](https://github.com/EngineerCafeJP/engineercafe-navigator/pull/852) — Wave 2 Date / Audio / Calendar implementation
+- Merge commit: `2866921b06dd705c8b39dcf0ae6e2c8e97a3abd4`
+- Merged: 2026-05-17 16:07:00 UTC
+- develop CI: `25995874994`, conclusion `success`
+- Frontend Production Smoke: `25995874988`, conclusion `success`
+- PR: [#874](https://github.com/EngineerCafeJP/engineercafe-navigator/pull/874) — live E2E follow-up gaps
+- Merge commit: `f7582f1a5e99360b86d57735fa4fcb6a8d9736cf`
+- Merged: 2026-05-17 20:37:37 UTC
+- PR CI: `26001835735`, conclusion `success`
+- post-merge develop CI: `26002065329`, conclusion `success`
+- PR: [#875](https://github.com/EngineerCafeJP/engineercafe-navigator/pull/875) — direct DB E2E reachability guard
+- Merge commit: `eee8c0b19f459dcd25ccc5aad211895b037514c6`
+- Merged: 2026-05-17 21:11:05 UTC
+- PR CI: `26002651705`, conclusion `success`
+- post-merge develop CI: `26002826450`, conclusion `success`
+
+### Cloud Run
+
+- Service: `engineer-cafe-backend`
+- Region: `asia-northeast1`
+- Revision: `engineer-cafe-backend-00218-8zv`
+- Traffic: latest revision 100%
+- Secret bindings verified: `API_SECRET_KEY`, `GOOGLE_CALENDAR_ICAL_URL`, `EVENT_SHEET_GAS_URL`, `EVENT_SHEET_GAS_TOKEN`, `LANGSMITH_API_KEY`, `CEREBRAS_API_KEY`
+
+### Event KB sync
+
+- Job: `event-kb-sync`
+- Args: `python -m backend.scripts.sync_event_kb --include-spreadsheet`
+- Image: same merge SHA image as Cloud Run service
+- Latest execution: `event-kb-sync-92wns`
+- Completion: `EXECUTION_SUCCEEDED`
+- Completed at: 2026-05-17 16:29:36 UTC
+- Scheduler: `event-kb-sync-daily`, `0 9 * * *`, `Asia/Tokyo`, `ENABLED`
+
+### Live API
+
+Health check:
+
+```text
+GET /health -> 200
+status=ok
+checks: api=ok, supabase=ok, llm_provider=configured
+```
+
+Date deterministic check:
+
+```text
+POST /api/chat "今日は何月何日ですか？" -> 200
+answer: 今日は2026年5月18日（月曜日）です。
+metadata.sources: ["system_clock"]
+metadata.provider_called: false
+metadata.route: general_knowledge
+```
+
+Weekly event source check:
+
+```text
+POST /api/chat "今週のエンジニアカフェのイベントを教えてください。" -> 200
+metadata.route: event
+metadata.sources: ["spreadsheet", "google_calendar", "connpass"]
+answer includes 2026-05-19, 2026-05-20, and 2026-05-23 events.
+```
+
+Post-#875 live route smoke against `engineer-cafe-backend-00218-8zv`:
+
+```text
+POST /api/chat "メインホールはどこにありますか？" -> 200
+route=facility-info, agent=FacilityAgent
+answer mentions 1階メインホール, event-priority coworking, Wi-Fi, power.
+
+POST /api/chat "営業時間とWi-Fiのパスワードを教えてください" -> 200
+route=facility-info, agent=FacilityAgent
+answer mentions 9:00〜22:00, engnecf-guest-2.4GHz/5GHz, akarenga-112years.
+
+POST /api/chat "3Dプリンターの使い方を教えてください" -> 200
+route=facility-info, agent=FacilityAgent
+answer mentions MAKER'sスペース, free training, web reservation by previous day.
+
+POST /api/chat "サイノカフェのランチは？" -> 200
+route=saino-cafe, agent=BusinessInfoAgent
+answer mentions sandwiches, waffles, prices, and drink-set discount.
+
+POST /api/chat "ハッカソンの開催予定は？" -> 200
+route=event, agent=EventAgent
+answer mentions Connpass and https://engineercafe.connpass.com/.
+
+POST /api/chat "コーヒーはいくらですか？" -> 200
+route=saino-cafe, agent=BusinessInfoAgent
+answer mentions blend coffee 380円 and single origin 460円.
+```
+
+### Vercel Preview
+
+Original PR #852 preview deployment failed:
+
+```text
+[env-check] Missing required env var(s): NEXT_PUBLIC_SUPABASE_URL, NEXT_PUBLIC_SUPABASE_ANON_KEY
+```
+
+After syncing Preview / Development envs, redeploying the same PR preview succeeded:
+
+```text
+Deployment: dpl_BaPptKnk1KgRWn6TDyXGj6vBBdcD
+Target: preview
+Status: Ready
+[env-check] Vercel production env check passed (4 required vars checked).
+Build Completed in /vercel/output
+Deployment completed
+```
+
+Production frontend smoke also returned HTTP 200 at `https://frontend-delta-six-20.vercel.app`.
+
+PR #874 Vercel Preview also completed successfully after env parity was repaired:
+
+```text
+Deployment: GGugatUfdthE34EsnzBedLDFeZ2Q
+Target: preview
+Status: Ready
+```
+
+## Consequences
+
+### Positive
+
+- Date-only questions are deterministic and cheap.
+- EventAgent now uses the Cafe-maintained spreadsheet as the curated source without requiring staff workflow changes.
+- Google Calendar is still used, but it is no longer the only or highest-priority source.
+- Audio failure modes now have bounded state recovery instead of indefinite thinking / silence.
+- Preview deploys no longer fail just because a branch does not have branch-scoped public Supabase env.
+
+### Negative
+
+- `SheetsEventSource` depends on the GAS Web App availability and token binding.
+- Browser fallback speech is less natural than primary TTS, so it is a reliability fallback, not a UX target.
+- Direct DB E2E depends on runner network reachability to Supabase Postgres. PR #875 skips those tests when the runner cannot reach Postgres directly, while HTTP/Cloud Run live proof remains mandatory.
+- Existing React hook dependency warnings remain in `VoiceInterface.tsx`; they are not introduced by this ADR but remain cleanup debt.
+
+## Follow-up
+
+- Keep Vercel Preview env in sync when adding any production-required frontend env.
+- Add a scheduled env parity check if more Preview-only failures appear.
+- Use a network-reachable runner or Cloud SQL/Auth Proxy style path before requiring direct DB E2E as a hard gate.
+- Capture iPad Safari audio proof when the next onsite device window is available; CI proves browser flow, not physical speaker behavior.
+
+## Approvals
+
+- Proposed: Codex (2026-05-18) — Wave 2 implementation and live verification closeout.
+- Accepted: Terada Kousuke (terisuke, 2026-05-18) — requested PR → merge → CI/CD → Google Cloud verification → issue close → ADR/docs closeout.
+
+## References
+
+- [PR #852](https://github.com/EngineerCafeJP/engineercafe-navigator/pull/852)
+- [PR #874](https://github.com/EngineerCafeJP/engineercafe-navigator/pull/874)
+- [PR #875](https://github.com/EngineerCafeJP/engineercafe-navigator/pull/875)
+- [Issue #855](https://github.com/EngineerCafeJP/engineercafe-navigator/issues/855)
+- [Issue #856](https://github.com/EngineerCafeJP/engineercafe-navigator/issues/856)
+- [Issue #857](https://github.com/EngineerCafeJP/engineercafe-navigator/issues/857)
+- [Issue #858](https://github.com/EngineerCafeJP/engineercafe-navigator/issues/858)
+- [Issue #770](https://github.com/EngineerCafeJP/engineercafe-navigator/issues/770)
+- [Issue #851](https://github.com/EngineerCafeJP/engineercafe-navigator/issues/851)

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -15,6 +15,7 @@
 | [020 — Knowledge ingestion mutation contract](020-knowledge-ingestion-mutation-contract.md)                         | RAG 投入・変更・preview の契約                           |
 | [021 — Frontend/backend separation before React/Vite migration](021-frontend-backend-separation-before-react-vite.md) | Next API proxy 廃止を React/Vite 移行より先に行う判断           |
 | [022 — Reception slide static assets](022-reception-slide-static-assets.md)                                         | 受付PDF/音声を frontend static asset として扱う判断             |
+| [026 — Wave 2 kiosk UX reliability baseline](026-wave2-kiosk-ux-reliability-baseline.md)                            | 日付 deterministic / 音声復帰 / event spreadsheet / Vercel Preview env 統一 |
 
 
 ## ワークフロー・音声・観測
@@ -31,6 +32,7 @@
 | [023 — Semantic Router + runtime self-evaluation](023-semantic-router-and-runtime-self-evaluation.md) | ルーティング再設計（三段カスケード）と LangGraph critic_node 自己評価 |
 | [024 — Memory & Reception modernization](024-memory-and-reception-modernization.md) | STM/LTM 観測性ゼロ・O(N)スキャン・受付 dead code を Phase A0–A4 で整理 |
 | [025 — Frontend proxy deletion → Vite migration](025-frontend-proxy-deletion-and-vite-migration.md) | ADR-021 を Phase B0–B3 に分解、ADR-024 と並列実行 |
+| [026 — Wave 2 kiosk UX reliability baseline](026-wave2-kiosk-ux-reliability-baseline.md) | Wave 2 の日付・音声・カレンダー信頼性 baseline と live verification |
 
 
 ## キャラ・長期記憶・インフラ観測
@@ -52,5 +54,5 @@
 
 ## メモ
 
-- ADR 番号は 005 以降を運用しており、**015 は欠番**です（採番のみ存在し、文書化に至らなかったため）。新しい ADR を起票する際は 026 から付番してください（023–025 は本リスト追加済）。
+- ADR 番号は 005 以降を運用しており、**015 は欠番**です（採番のみ存在し、文書化に至らなかったため）。新しい ADR を起票する際は 027 から付番してください（023–026 は本リスト追加済）。
 - 001–004 についても、本リポジトリでは初期から ADR 005 以降のみを保守しています。


### PR DESCRIPTION
## Summary

- Add ADR-026 for the Wave 2 kiosk UX reliability baseline.
- Update docs/STATUS.md with PR #852 / #874 / #875, CI run IDs, Cloud Run `engineer-cafe-backend-00218-8zv`, Vercel Preview recovery, and live API smoke evidence.
- Register ADR-026 in the ADR index.

## Verification

- `git diff --check origin/develop...HEAD`
- Evidence already commented on #855, #857, and #770.

Refs #855
Refs #857
Refs #770
Refs #852
Refs #874
Refs #875