### PR TITLE
docs(plans,adr): Wave 3 engineer master handoff + ADR-027/028 (Refs #877)

### DIFF
--- a/docs/adr/027-wave3-observability-and-refactor-foundation.md
+++ b/docs/adr/027-wave3-observability-and-refactor-foundation.md
@@ -1,0 +1,225 @@
+# ADR-027: Wave 3 — Observability & Refactor Foundation (Pre Phase 2)
+
+## Status
+
+Proposed (2026-05-18) — Wave 2 (ADR-026) 完了直後、Phase 2 (Semantic Router 三段カスケード) 着手前の foundation hardening として起草。
+
+## Context
+
+### 2026-05-18 監査で判明した運用面の課題
+
+Wave 2 完了直後 (PR #852/#873/#874/#875/#876 merged) に独立検証を実施した結果、以下が明らかになった:
+
+#### 1. Observability gap (運用上致命的)
+
+| 項目 | 実測値 |
+|------|--------|
+| Cloud Monitoring alert policies | **0** |
+| Cloud Monitoring notification channels | **0** |
+| Cloud Logging log-based metrics | **0** |
+| Dashboard | なし (raw log のみ) |
+
+→ **「定期的にログを見るだけで会話が期待通りか、音声 I/O が期待速度か、正しい agent にルーティングしているか」が判断できない**。
+→ 「一定の閾値を超えた agent の動きの問題」を **検知する仕組みが完全に欠落**。
+
+#### 2. STT/TTS event call site 不完全
+
+`backend/observability/structured_logger.py` には以下の event が定義されているが、live log で出現していないものがある:
+
+| Event | 定義 | live 出現 |
+|-------|------|---------|
+| `chat_response` | ✅ | ✅ (22 件 / 24h) |
+| `memory_store_message` | ✅ | ✅ (44 件) |
+| `ltm_promote` | ✅ | ✅ (44 件) |
+| `stt_qwen_complete` | ✅ | ❌ (0 件 — call site 不在 / レベル抑制) |
+| `stt_winner` | ✅ | ❌ |
+| `tts_cache` | ✅ | ❌ |
+| `agent_routing` | ❌ **未定義** | ❌ |
+| `voice_round_trip` | ❌ **未定義** | ❌ |
+
+→ STT/TTS と agent routing の構造化ログが **設計はあるが運用に乗っていない**。
+
+#### 3. Frontend audio telemetry 未連携
+
+Wave 2 で FU-17 として追加された `useVoiceSessionController.ts:73` の `console.debug` は **ブラウザ console にしか出ない**:
+
+```ts
+console.debug(`[VoiceSessionController] ${message}`, details);
+```
+
+Datadog / Sentry / Backend telemetry endpoint への送信は未配線。
+→ watchdog 発火率、fallback 発火率、user-interaction-gate timeout 率を **Backend からは見えない**。
+
+#### 4. Backend / Frontend に大ファイルが多数残存
+
+ルール: `ファイル 800 行未満` (`~/.claude/rules/coding-style.md`)
+
+**Backend** (17 ファイル超過):
+- 3,033 行: `backend/agents/stt_agent.py`
+- 2,588 行: `backend/workflows/main_workflow.py`
+- 2,071 行: `backend/agents/facility_agent.py`
+- 1,984 行: `backend/main.py`
+- 1,731 行: `backend/tools/enhanced_rag.py`
+- 1,635 行: `backend/agents/business_info_agent.py`
+- 1,610 行: `backend/agents/voice_agent.py`
+- … 計 17 ファイル
+
+**Frontend** (6 ファイル超過):
+- 1,959 行: `frontend/src/app/components/VoiceInterface.tsx`
+- 1,555 行: `frontend/src/app/components/CharacterAvatar.tsx`
+- 1,304 行: `frontend/src/app/components/ReceptionPdfGuide.tsx`
+- 962 行: `frontend/src/lib/vrm-utils.ts`
+- 840 行: `frontend/src/app/page.tsx`
+- 824 行: `frontend/src/lib/voice-recorder.ts`
+
+#### 5. docs/plans に 21 件の plan が累積、archive ルール無し
+
+ステータス (completed / superseded / active) の表示なし。古いものと新しいものの区別がつかず、新規メンバーが古い計画を SoT と誤認するリスク。
+
+#### 6. ルートドキュメントが Wave 2 後の状態に追随していない
+
+- `docs/STT-Implementation-Trace.md`: 2026-04-12 最終更新 (Wave 2 で日付処理周辺の prompt 変更があったが反映なし)
+- `docs/observability-runbook.md`: Issue #513 ベース、Wave 2 の event 整備や次の Cloud Monitoring alert に未対応
+
+## Decision
+
+Wave 3 を **2 テーマ並列** で実施する:
+
+### Theme A: Observability & Alerting (FU-21〜25)
+
+定期的にログを見れば運用状態が分かり、閾値を超えれば自動で `company@cor-jp.com` に alert が飛ぶ体制を整備する。
+
+#### D1: Backend 構造化ログの call site を完成させる
+- `STT_LOGGER_NAME` で `stt_qwen_complete` / `stt_qwen_hedge_start` / `stt_vosk_complete` / `stt_winner` を **全 STT 呼び出しパス** で発火
+- `TTS_LOGGER_NAME` で `tts_synthesis_start` / `tts_synthesis_complete` / `tts_cache_hit` / `tts_cache_miss` を発火
+- 既存 `chat_response` event に `agent_route` / `intent` / `confidence` を必須 field として追加
+- 新規 `agent_routing` event を OrchestratorAgent の全 routing 決定で発火 (routed_to, reason, confidence)
+- 新規 `voice_round_trip` event を `/api/voice` のフル round-trip で発火 (stt_ms, chat_ms, tts_ms, total_ms)
+
+#### D2: Frontend telemetry を Backend に送信
+- `useVoiceSessionController.ts:73` の `console.debug` を **並列で** `/api/telemetry/voice` に POST
+- 送信 event: `voice_state_transition`, `thinking_watchdog_expire`, `fallback_tts_triggered`, `user_interaction_gate_timeout`, `audio_playback_failed`
+- Backend が受信 → 既存 `structured_logger` 経由で Cloud Logging に書き出し → Cloud Logging metric にも乗る
+
+#### D3: Cloud Logging log-based metrics
+以下を Cloud Logging のカスタムメトリクスとして登録 (gcloud / Terraform):
+
+| Metric 名 | 説明 | type |
+|----------|------|------|
+| `voice_round_trip_latency_ms` | `/api/voice` round-trip 全 quantile | distribution |
+| `chat_response_latency_ms` | chat_response.latency_ms quantile | distribution |
+| `stt_latency_ms` | stt_qwen_complete.latency_ms quantile | distribution |
+| `tts_latency_ms` | tts_synthesis_complete.latency_ms quantile | distribution |
+| `agent_route_distribution` | agent_routing.routed_to value count | counter |
+| `stt_winner_ratio` | stt_winner.provider value count (qwen vs vosk) | counter |
+| `error_rate_5m` | severity>=ERROR 件数 / 5min | counter |
+| `frontend_audio_watchdog_rate` | thinking_watchdog_expire 件数 | counter |
+| `frontend_fallback_rate` | fallback_tts_triggered 件数 | counter |
+
+#### D4: Cloud Monitoring alert policies + 通知
+- Notification channel: **`company@cor-jp.com` (Email)** を新規作成
+- Alert policy (初期は **WARN しきい値**で過剰アラートを避ける):
+
+| Alert 名 | 条件 | しきい値 | severity |
+|---------|------|---------|---------|
+| `voice-round-trip-p95-slow` | voice_round_trip_latency_ms p95 > 8s for 10 min | warn | P2 |
+| `chat-response-p95-slow` | chat_response_latency_ms p95 > 6s for 10 min | warn | P2 |
+| `stt-latency-degradation` | stt_latency_ms p95 > 5s for 15 min | warn | P2 |
+| `backend-error-burst` | error_rate_5m > 20 (件 / 5min) for 10 min | error | P1 |
+| `agent-routing-skew` | agent_route_distribution `fallback_general` ratio > 30% for 30 min | warn | P3 |
+| `frontend-audio-watchdog-spike` | frontend_audio_watchdog_rate > 10 (件 / 15min) | warn | P2 |
+| `cloud-run-traffic-zero` | Cloud Run request count = 0 for 30 min (営業時間 12-20 JST) | info | P3 |
+
+→ alert は `company@cor-jp.com` に email、subject prefix `[Engineer Cafe Navigator]`、本文に Cloud Logging 直リンク。
+
+#### D5: Cloud Monitoring dashboard
+- 単一 dashboard `Engineer Cafe Navigator — Production` を新設
+- パネル: latency p50/p95 (voice/chat/stt/tts), error rate, agent route distribution, traffic count
+- terraform/cloud-monitoring/ 配下に IaC 化 (review/plan/apply 手動)
+
+### Theme B: Refactoring & Documentation (FU-26〜30)
+
+Wave 2 で大量追加したコード・ドキュメントを Phase 2 着手前に整理する。
+
+#### D6: Dead code 削除
+- Frontend: `npx knip` + `npx ts-prune` 実行 → unused export を削除
+- Backend: `ruff check --select F401,F811` + `vulture backend/ --min-confidence=80` → unused import / dead function 削除
+- 検出 → 削除 → unit test 全 PASS が条件
+
+#### D7: Backend 大ファイル分割 (最優先 top 6)
+
+| 対象 | 現行行数 | 分割方針 |
+|------|---------|---------|
+| `backend/agents/stt_agent.py` | 3,033 | Qwen / Vosk / hedge / postprocess を別 module に分離 |
+| `backend/workflows/main_workflow.py` | 2,588 | subgraph 別 + helper 関数を分離 |
+| `backend/agents/facility_agent.py` | 2,071 | facility category 別 (hall / reception / wifi / amenity) に分離 |
+| `backend/main.py` | 1,984 | route 別 module (api/voice / api/chat / api/calendar / api/admin) に分離 |
+| `backend/tools/enhanced_rag.py` | 1,731 | RAG pipeline stage (retrieve / rerank / filter / format) ごとに分離 |
+| `backend/agents/business_info_agent.py` | 1,635 | category 別 (saino_cafe / hours / pricing) に分離 |
+
+各分割: 既存テスト全 PASS + behaviorally equivalent (= 出力 1:1 一致) が必須。
+
+#### D8: Frontend 大ファイル分割
+
+| 対象 | 現行行数 | 分割方針 |
+|------|---------|---------|
+| `frontend/src/app/components/VoiceInterface.tsx` | 1,959 | hooks 抽出 (use*) + sub-component (PlaybackController, FallbackUI 等) に分離 |
+| `frontend/src/app/components/CharacterAvatar.tsx` | 1,555 | VRM lifecycle / 表情 / lipsync を hooks に分離 |
+| `frontend/src/app/components/ReceptionPdfGuide.tsx` | 1,304 | PDF render / navigation / UI を分離 |
+
+#### D9: docs/plans archive 整理 + ルートドキュメント更新
+- `docs/plans/archive/` を新設、completed / superseded plan を移動
+- 各 plan に冒頭 `> Status: completed (YYYY-MM-DD) / superseded by ...` を明記
+- `docs/STT-Implementation-Trace.md` を Wave 2 後の状態に最新化 (TZ=Asia/Tokyo + date-only fast path 追記)
+- `docs/observability-runbook.md` に Wave 3 で追加した metric / alert を追記
+- `docs/CODEMAPS/` を新設、`/update-codemaps` skill で `backend.md`, `frontend.md`, `architecture.md` を自動生成
+
+#### D10: 4-point data flow audit
+CLAUDE.md ルール「endpoint 修正時、client → API route → backend → response の 4 点一致を確認」を Wave 2 で変更された全エンドポイントに対して実施:
+
+- `/api/voice/*` (frontend → /api/voice → backend → response)
+- `/api/chat` (同上)
+- `/api/calendar` (同上)
+- `/api/reception/*` (Wave 7 で導入の subgraph)
+- (NEW) GAS Web App → `EVENT_SHEET_GAS_URL` → `SheetsEventSource` → KB
+
+各 endpoint について audit report markdown (1 ページ / endpoint) を `docs/data-flow/` 配下に保存。
+
+## Consequences
+
+### Positive
+- 運用が「raw log 目視」から「dashboard + alert」に進化
+- Wave 2 で導入した audio reliability が **数値で計測可能**になる
+- 大ファイルが分割され Phase 2 (Semantic Router) の差分が読みやすくなる
+- 古い plan が archive されることで新規メンバーの混乱が減る
+
+### Negative
+- alert policy が過敏すぎると alert fatigue → 初期は warn しきい値、運用 1 ヶ月で再調整
+- 大ファイル分割は import path 変更が広範に発生 → CI で全 unit/integration test 必須
+- terraform/cloud-monitoring/ を導入する場合、Cloud Build 経由の plan/apply フローを整備する必要
+
+### Out of Scope (Wave 3 では実装しない)
+- Phase 2 Semantic Router cascade (ADR-023)
+- Memory hierarchy 再設計 (ADR-024)
+- 新規エージェント追加
+- VRM / animation の本格リファクタ (D8 の component 分割のみ)
+
+## Follow-up
+
+- **Wave 3 完了後**: 1 週間運用ログ蓄積 → alert しきい値再調整 → Wave 4 (Phase 2 着手判断)
+- iPad kiosk 実機での audio reliability proof (ADR-026 Follow-up 継続)
+- BigQuery export sink を Wave 4 で検討 (ad-hoc 分析用)
+
+## Approvals
+
+- Proposed: Claude (2026-05-18) — Wave 2 後の独立検証を踏まえた Wave 3 設計
+- 承認待ち: Terada Kousuke (terisuke)
+
+## References
+
+- [ADR-026 Wave 2 Kiosk UX Reliability Baseline](./026-wave2-kiosk-ux-reliability-baseline.md)
+- [ADR-024 Memory & Reception Modernization](./024-memory-and-reception-modernization.md)
+- [ADR-023 Routing Modernization (Semantic Router)](./023-routing-modernization.md)
+- `backend/observability/structured_logger.py` (既存 logger 基盤)
+- `docs/observability-runbook.md` (Issue #513 ベース、Wave 3 で拡張)
+- [Wave 3 Handoff Doc](../plans/wave3-observability-refactor-handoff-2026-05-18.md)

--- a/docs/adr/028-oss-portable-observability-and-infrastructure.md
+++ b/docs/adr/028-oss-portable-observability-and-infrastructure.md
@@ -1,0 +1,137 @@
+# ADR-028: OSS-Portable Observability & Infrastructure
+
+## Status
+
+Proposed (2026-05-18) — OSS Portability Audit (`docs/plans/oss-portability-audit-2026-05-18.md`) を受けて、ADR-027 の Theme A (D4/D5) を OSS-friendly に置き換える追加 ADR。
+
+## Context
+
+### Engineer Cafe Navigator は OSS (ISC license) として公開されている
+- ルート `LICENSE` = ISC License、`README.md` で明示
+- `docs/OSS-LICENSE-POSTURE.md` で third-party dependency posture を整理
+
+### しかし infra/CI は GCP-locked
+2026-05-18 OSS Portability Audit で判明:
+- `infra/terraform/` 全 11 ファイル: provider = GCP only (`google_monitoring_*`, `google_logging_metric`, `google_secret_manager_secret`)
+- `.github/workflows/ci.yml`: gcloud 関連 26 hits (Cloud Run deploy, Secret Manager, Cloud Scheduler, Artifact Registry)
+- `scripts/*.sh` 13 本: `gcloud logging read`, `gcloud secrets versions access` 多用
+- `docs/DEPLOYMENT.md`: Cloud Run + Vercel + Supabase 前提のみ
+
+### Application code は実は portable
+- Backend Python: GCP SDK 直接 import は **2 ファイルのみ** (legacy `GoogleSTTClient`, `GoogleTTSClient`)
+- 現行 primary path (Qwen STT + Piper TTS + Cerebras LLM via OpenRouter) は完全 vendor-neutral
+- Frontend Next.js: GCP SDK 使用 **ゼロ**
+- 既存 `backend/observability/structured_logger.py` は stdout JSON 出力で **既に vendor-neutral**
+
+### OSS contributor が deploy できない問題
+- 「ISC license で OSS」と謳いながら `git clone` した OSS contributor は GCP project + Secret Manager + Cloud Run + Cloud Monitoring の設定無しでは Production Ready な observability/alert が組めない
+- これは OSS の趣旨に反する
+
+## Decision
+
+**Application layer は完全 vendor-neutral 化、Infrastructure layer は deployer choice にする**「ハイブリッド戦略」を採用。
+
+### D1: OpenTelemetry SDK を application 層の標準にする
+- Backend Python:
+  - 既存 `structured_logger.py` の API 互換性は保持
+  - 内部実装で `opentelemetry-sdk` + `opentelemetry-exporter-otlp` に置き換え
+  - 各 event を OpenTelemetry semantic convention (logs/metrics/traces) として emit
+- Frontend Next.js:
+  - `navigator.sendBeacon('/api/telemetry/voice', ...)` で Backend に委譲 (現行 Wave 3 FU-23 設計のまま)
+  - Backend が受信して OTel SDK に転送
+
+### D2: OpenTelemetry Collector が中継 hub
+- Cloud Run / Docker Compose の sidecar として OTel Collector を deploy
+- Exporter は config 駆動で選択:
+  - **GCP exporter** (`googlecloud`): Cloud Logging / Cloud Monitoring に送信 (terisuke 本番運用)
+  - **OTLP exporter**: OSS deployer の Grafana stack (Loki + Prometheus + Tempo) に送信
+  - **Prometheus exporter** (pull): OSS deployer が Prometheus 直接 scrape
+  - **stdout exporter**: ローカル開発・CI
+
+### D3: Alert rule は Prometheus rule YAML 形式で portable に定義
+- 単一 source `infra/observability/alerts.rules.yml` で全 alert 定義
+- GCP 運用時: 既存 `infra/terraform/alerts.tf` の Phase 1b 資産を保持 + 本 YAML から派生生成する converter を追加
+- OSS deployer: Alertmanager に直接 mount して使う
+- 通知 target = `company@cor-jp.com` (両環境で共通)
+
+### D4: Secret backend を抽象化
+- 新規 `backend/utils/secrets.py` で provider-agnostic SecretProvider interface 定義
+- Provider 実装 (env config で切替):
+  - `EnvSecretProvider` (default): `os.getenv(...)` (OSS deployer の最小構成)
+  - `SopsSecretProvider`: sops-encrypted YAML を起動時に decrypt (OSS deployer 推奨)
+  - `GcpSecretProvider`: 既存 `gcloud secrets versions access` 経路 (terisuke 本番運用)
+  - `VaultSecretProvider`: HashiCorp Vault (enterprise OSS deployer)
+- Application code は `secrets.get("EVENT_SHEET_GAS_TOKEN")` で透過呼び出し
+
+### D5: Cron backend を抽象化
+- 現行 `backend/scripts/sync_event_kb.py` をそのまま使う
+- 起動 trigger:
+  - GCP 運用: Cloud Scheduler → Cloud Run Job (現行のまま)
+  - OSS deployer: GitHub Actions cron / systemd timer / `apscheduler` in-process (例 documentation 提供)
+- script 側は trigger に依存しない CLI として実装維持
+
+### D6: Container hosting を deployer choice にする
+- Backend `Dockerfile` は既に `python:3.11-slim` ベース、portable
+- Frontend `Dockerfile` も同様 (next.js standalone build 対応)
+- 新規 `docker-compose.yml` を repo root に追加 (OSS deployer がローカルで全 stack を起動可能):
+  - services: backend, frontend, supabase (or postgres + pgvector), loki, prometheus, grafana, alertmanager, otel-collector
+- 既存 Cloud Run deploy path (`.github/workflows/ci.yml`) は保持
+
+### D7: Legacy Google STT/TTS client を削除
+- `backend/agents/stt_agent.py` の `GoogleSTTClient` クラス削除
+- `backend/agents/voice_agent.py` の `GoogleTTSClient` クラス削除
+- 影響: 現在も production primary 路線 (Qwen / Piper) は無傷
+- これで Application code から GCP SDK 完全除去
+
+### D8: DEPLOYMENT.md を 2 deployment path 構造に
+- 「Path A: GCP Production (Cloud Run + Vercel + Supabase)」 — 現状 terisuke が運用中
+- 「Path B: OSS Self-Hosted (docker-compose)」 — OSS deployer 向け
+- 両 path で共通: env vars, secrets schema, OTel Collector config
+
+## Consequences
+
+### Positive
+- **OSS contributor が GCP account なしで full stack を self-host できる**
+- Application code から GCP SDK 完全除去 → 移植性 100%
+- Observability backend を deployer が選択可能 (Cloud Monitoring / Grafana / Datadog / 他)
+- Alert rule が単一 YAML source、両環境で共通
+- 既存 GCP 運用 (terisuke 本番) は **無傷で継続**
+- Wave 3 既存設計 (ADR-027) の Theme A も OSS-friendly に進化
+
+### Negative
+- Wave 3 工数増加 (約 +8 日 = Theme C 5d + Theme A 改修 3d)
+- OpenTelemetry SDK の学習コスト (Python / TS 双方)
+- 2 つの infra config (GCP exporter / OTLP) を維持するオーバーヘッド
+- OSS deployer の SMTP server 確保が前提 (docker-compose に mailhog 同梱で開発時は OK)
+
+### Out of scope (本 ADR では実装しない)
+- BigQuery export sink (将来検討)
+- Kubernetes Helm chart (Wave 4+ 検討)
+- Multi-cloud abstraction (AWS / Azure adapter) — 本 ADR は OSS portability に focus、multi-cloud 商用化は別判断
+- Frontend Vercel 脱却 (Next.js standalone は対応するが、Cloudflare Pages / Netlify 等 migration は Wave 4+)
+
+## Follow-up
+
+- Wave 3 完了後 1 ヶ月: OSS deployer の docker-compose path で実際に self-host 検証してくれる external contributor を募集
+- Wave 4 検討: Helm chart, Kubernetes manifest example, Terraform module for AWS/Azure (商用 multi-cloud に進化判断したら)
+- ADR-027 の Decision D4 / D5 (Cloud Logging metrics / GCP-only alerts) は **本 ADR で superseded**
+
+## Approvals
+
+- Proposed: Claude (2026-05-18) — OSS portability audit 後の追加 ADR
+- 承認待ち: Terada Kousuke (terisuke)
+
+## References
+
+- [ADR-027 Wave 3 Observability & Refactor Foundation](./027-wave3-observability-and-refactor-foundation.md)
+- [OSS Portability Audit (2026-05-18)](../plans/oss-portability-audit-2026-05-18.md)
+- [ADR-026 Wave 2 Kiosk UX Reliability Baseline](./026-wave2-kiosk-ux-reliability-baseline.md)
+- [README OSS License declaration](../../README.md)
+- [LICENSE](../../LICENSE) (ISC)
+- [docs/OSS-LICENSE-POSTURE.md](../OSS-LICENSE-POSTURE.md)
+- OpenTelemetry Python SDK: https://opentelemetry.io/docs/instrumentation/python/
+- OpenTelemetry Collector: https://opentelemetry.io/docs/collector/
+- Grafana Loki: https://grafana.com/oss/loki/
+- Prometheus Alertmanager: https://prometheus.io/docs/alerting/latest/alertmanager/
+- HashiCorp Vault: https://www.vaultproject.io/
+- sops (Mozilla): https://github.com/getsops/sops

--- a/docs/plans/oss-portability-audit-2026-05-18.md
+++ b/docs/plans/oss-portability-audit-2026-05-18.md
@@ -1,0 +1,259 @@
+# OSS Portability Audit (2026-05-18)
+
+> **対象**: terisuke + Backend / Frontend / Infra 全担当
+> **作成**: 2026-05-18, Claude Code session
+> **目的**: OSS として公開している (ISC license) Engineer Cafe Navigator の GCP プラットフォーム依存度を実測し、Wave 3 で OSS-portable 基盤への移行計画を策定するための監査レポート
+> **トリガー**: terisuke 指摘 (Cloud Monitoring/Alert がプラットフォーム依存なので OSS deployer が使えない)
+
+---
+
+## 0. Executive Summary
+
+| 領域 | GCP 依存度 | OSS deployer 影響 | 移行難度 |
+|------|-----------|-----------------|---------|
+| **Application code (backend)** | **低** (2 ファイル、legacy fallback のみ) | 小 | ⭐ 容易 |
+| **Application code (frontend)** | **ゼロ** | なし | — |
+| **Observability (logs / metrics / alerts)** | **高** (infra/terraform/ 全 GCP-locked) | 大 (OSS だと観測不能) | ⭐⭐⭐ 中-高 |
+| **Secret management** | **高** (Secret Manager 専用) | 中 (env 直書き fallback あり) | ⭐⭐ 中 |
+| **Cron / scheduled jobs** | **高** (Cloud Scheduler) | 中 (GitHub Actions cron で代替可) | ⭐⭐ 中 |
+| **Compute / hosting** | **高** (Cloud Run) | 中 (Dockerfile 既存、k8s/Compose 可) | ⭐⭐ 中 |
+| **CI/CD** | **高** (gcloud 26 hits) | 中 (GHCR + 他 host で可) | ⭐⭐ 中 |
+| **Database** | **ゼロ** (Supabase = self-hostable) | なし | — |
+| **LLM provider** | **ゼロ** (OpenRouter = vendor-neutral) | なし | — |
+
+### 結論
+**コードは既に 95% OSS-portable、infra (terraform/CI/scripts) が GCP-locked**。Wave 3 で OSS-friendly な observability/secrets/cron 基盤を追加 (既存 GCP は GCP exporter として保持) すれば、両方の deployer (terisuke の本番運用 + OSS contributor) が共存できる。
+
+---
+
+## 1. 詳細監査結果
+
+### 1.1 Application code (Backend Python)
+
+**Backend Python の google-* import 実測 (`git ls-tree origin/develop` + grep)**:
+
+| File | line | import | 用途 |
+|------|------|--------|------|
+| `backend/agents/stt_agent.py` | 1491 | `from google.cloud import speech` | **GoogleSTTClient** (legacy fallback、現行は Qwen primary) |
+| `backend/agents/voice_agent.py` | 444 | `from google.oauth2 import service_account` | **GoogleTTSClient** (legacy Wavenet TTS、現行は Piper primary) |
+| `backend/agents/voice_agent.py` | 471 | `from google.auth.transport.requests` | 上記 access token refresh |
+
+**Backend dependencies**:
+- `requirements.txt`: `google-auth>=2.0.0` (transitive、access token refresh 用)
+- `google-cloud-speech` は実は requirements.txt に **書かれていない** (Cloud Run image でのみ available) → already abstracted as optional
+
+**結論**: Application code の GCP 結合は **legacy fallback path 2 箇所のみ**。primary path (Qwen + Piper) は完全 vendor-neutral。
+
+### 1.2 Application code (Frontend)
+
+**Frontend `@google-cloud/*` direct import grep 結果: ZERO**
+
+`@opentelemetry/api` が `frontend/package-lock.json` に transitive dep で出現するが、direct import なし。
+→ Frontend は **完全 OSS-portable**。
+
+### 1.3 Infrastructure (infra/terraform/)
+
+**全 11 ファイル、全 GCP-locked**:
+
+| File | 内容 | GCP resource |
+|------|------|------------|
+| `providers.tf` | provider 宣言 | `google` only |
+| `variables.tf` | GCP project_id / region default | `aipartner-426616` / `asia-northeast1` |
+| `secrets.tf` | Secret Manager 管理 | `google_secret_manager_secret` |
+| `log_metrics.tf` | log-based metrics (chat_response_count 等) | `google_logging_metric` |
+| `alerts.tf` | SLO burn rate alert (chat fallback 等) | `google_monitoring_alert_policy` |
+| `dashboard.tf` | STT latency dashboard | `google_monitoring_dashboard` |
+| `outputs.tf` | output 定義 | GCP resource id 系 |
+| `locals.tf` | local 変数 (metric.type 等) | GCP-specific naming |
+
+**既存 alerts.tf の中身** (重要):
+- `Engineer Cafe chat fallback burn rate` (1h / 6h burn rate, SLO 98%) — Issue #513 Phase 1b で land 済
+- `notification_channels = var.notification_channel_ids` (デフォ `[]`、apply 前に手動セット)
+- → **既に GCP-locked な alert は存在するが、notification channel が未設定 (default empty)**
+
+### 1.4 CI / CD (.github/workflows/ci.yml)
+
+**gcloud 関連の hits: 26** (主要):
+
+| ライン | 操作 | GCP service |
+|-------|------|------------|
+| 531 | `google-github-actions/auth@v3` | Workload Identity Federation |
+| 539 | `gcloud auth configure-docker` | Artifact Registry |
+| 545-551 | `docker build/push asia-northeast1-docker.pkg.dev/...` | Artifact Registry |
+| 565-570 | `gcloud secrets create / versions add` | Secret Manager (CI 経由で API key sync) |
+| 604-624 | `gcloud secrets versions access` | Secret Manager 読み (5 secrets) |
+| 630 | `gcloud run deploy` | Cloud Run service deploy |
+| 654 | `gcloud run services update-traffic` | Cloud Run traffic split |
+| 672 | `gcloud services enable cloudscheduler.googleapis.com run.googleapis.com` | API enable |
+| 683 | `gcloud run jobs deploy` | Cloud Run Job (cron) |
+| 699-716 | `gcloud scheduler jobs create/update http` | Cloud Scheduler |
+| 731 | `gcloud run jobs execute` | Cron 実行 |
+| 829 | `gcloud secrets versions access --secret=API_SECRET_KEY` | Smoke test 用 |
+
+**他の workflow**:
+- `alpha-live-verification.yml`: 5 hits (Cloud Run revision 確認)
+- `terraform-plan.yml`: 1 hit (terraform PR validation)
+- `voice-e2e-nightly.yml`: 1 hit (API key 取得)
+
+**Scripts**:
+- `cloud-logging-verify.sh`: 5 hits (`gcloud logging read`)
+- `onsite-voice-live-proof.sh`: 5 hits (Secret Manager + gcloud)
+- `stt-postdeploy-logging-check.sh`: 3 hits
+- 他 10 script 程度
+
+### 1.5 Cloud Run hosting
+
+- backend, piper-plus, voicevox-proto の 3 service が Cloud Run で稼働
+- Dockerfile は `python:3.11-slim` ベース、portable
+- env vars / secrets が GCP Secret Manager bind
+- Workload Identity Federation で SA 認証
+
+### 1.6 OSS / LICENSE 宣言
+
+- ルート `LICENSE` = **ISC License** (very permissive)
+- `docs/OSS-LICENSE-POSTURE.md` で third-party dependency posture を整理
+- `README.md` で「**OSS / ライセンス: LICENSE (ISC)**」を明示
+- 一方で `DEPLOYMENT.md` は Cloud Run + Vercel 前提のみ記述 ← **OSS contributor が deploy できない**
+
+---
+
+## 2. OSS Portable Alternative マッピング
+
+| 領域 | 現状 GCP | OSS / Portable 代替 | 移行コスト | 既存資産活用 |
+|------|---------|------------------|----------|------------|
+| **構造化ログ** | Cloud Logging (stdout 経由) | stdout JSON (既に出力済) → Grafana Loki / Vector / journald | **ゼロ** (既に portable) | structured_logger.py そのまま使える |
+| **Metrics** | Cloud Logging log-based metrics | OpenTelemetry SDK → Prometheus / VictoriaMetrics | ⭐⭐ | terraform spec を OTel semantic convention に翻訳 |
+| **Alerts** | google_monitoring_alert_policy (Terraform) | Prometheus Alertmanager (rule YAML) | ⭐⭐ | alerts.tf の condition を YAML alert rule に変換 |
+| **通知 (email)** | google_monitoring_notification_channel | Alertmanager SMTP receiver | ⭐ (SMTP server 必要) | 同 `company@cor-jp.com` を target |
+| **Dashboard** | google_monitoring_dashboard | Grafana dashboard JSON | ⭐⭐ | dashboard.tf の widget spec を Grafana JSON に翻訳 |
+| **Secrets** | Secret Manager + Workload Identity | (a) `.env` + sops-encrypted, (b) HashiCorp Vault, (c) Doppler | ⭐⭐ | env vars 経由のため app code は変更不要 |
+| **Cron** | Cloud Scheduler → Cloud Run Job | (a) GitHub Actions cron, (b) systemd timer, (c) APScheduler in-process | ⭐ | sync_event_kb.py を Python script として直接呼べる |
+| **Compute** | Cloud Run | docker-compose / Kubernetes / Fly.io / Railway / VPS | ⭐ | Dockerfile 既存、追加 compose.yaml だけ |
+| **Container Registry** | Artifact Registry | GHCR (GitHub Container Registry) / Docker Hub | ⭐ | CI 設定変更のみ |
+| **Frontend hosting** | Vercel | Cloudflare Pages / Netlify / Docker self-host (Next.js standalone) | ⭐ | Vercel 専用 API 未使用 |
+
+### 重要: ハイブリッド戦略 (推奨)
+
+「**Application は vendor-neutral、infra は deployer choice**」を実現:
+
+```
+              ┌─ Backend (Python, ZERO GCP coupling in primary path)
+              │   ├─ logs.info(extra={"event":..., ...}) → stdout JSON
+              │   └─ otel.metric.record(...)              → OTel SDK
+              │
+              ├─ Frontend (Next.js, ZERO GCP coupling)
+              │   └─ navigator.sendBeacon('/api/telemetry/voice', ...)
+              │
+              v
+       ┌──────────────────────────┐
+       │ OpenTelemetry Collector  │  ← sidecar or external
+       └──────────────────────────┘
+              │
+   ┌──────────┼──────────────────────────────┐
+   v          v                              v
+[GCP exporter]   [OTLP/Prometheus exporter]   [stdout exporter (dev)]
+   │                  │                          │
+   v                  v                          v
+Cloud Logging   Loki/Prometheus/Grafana   docker logs
++ Monitoring    + Alertmanager (OSS)      (local dev)
+(現行)          (OSS contributor)         (CI)
+```
+
+**メリット**:
+- Application code から GCP SDK を **完全除去**できる
+- terisuke は GCP exporter で Cloud Monitoring 経由運用継続
+- OSS contributor は docker-compose で Grafana stack を立てて使える
+- 同じ alert rule YAML を双方で使える (Prometheus rule format → GCP に変換できる converter あり)
+
+---
+
+## 3. 現在 Wave 3 ADR-027 / Issue 群との衝突点
+
+### 3.1 ADR-027 の問題点
+- **GCP-specific な alert/metric を「全部新規作成」前提**で書いてある
+- 既存 `infra/terraform/alerts.tf` の Phase 1b 資産を考慮していない
+- OSS portability の視点が完全に欠如
+
+### 3.2 Issue の修正必要箇所
+- **#883 FU-24** "Cloud Logging log-based metrics 9 個作成" → OpenTelemetry semantic convention で metric 定義に変更
+- **#884 FU-25** "Notification channel + Alert policies" → Prometheus alert YAML + Alertmanager (GCP は exporter として保持)
+- 新規 **Theme C** 追加: OSS Portability (FU-31〜35)
+
+### 3.3 PR #890 への対応
+- そのまま merge OK (ADR-027 として "Proposed" 状態)
+- merge 後に **ADR-028 (OSS Portability)** を追加で起票し、ADR-027 の D4/D5 を OSS-friendly に置き換える形で superseded
+- または PR #890 を update して ADR-027 と ADR-028 を同 PR に統合
+
+---
+
+## 4. 推奨アクション (3 段階)
+
+### 段階 1: 即時 (本セッション)
+- [ ] 本 audit doc を `feat/wave3-design` branch に追加
+- [ ] **ADR-028: OSS-Portable Observability & Infrastructure** を起草
+- [ ] Wave 3 Epic #877 に Theme C 追加コメント
+- [ ] FU-24 #883 / FU-25 #884 を「OSS-friendly に改定 (Theme C 待ち)」とコメント
+- [ ] 新 Theme C sub-issues (FU-31〜35) を起票
+
+### 段階 2: Wave 3 実装中 (1〜2 週間)
+- [ ] FU-31: Legacy GoogleSTTClient + GoogleTTSClient を削除 (Qwen + Piper のみに統一)
+- [ ] FU-32: docker-compose.yaml (backend + frontend + Loki + Prometheus + Grafana + Alertmanager + SMTP) 追加
+- [ ] FU-33: Secret backend 抽象化 (`backend/utils/secrets.py` で env / sops / Vault を pluggable)
+- [ ] FU-34: Cron backend 抽象化 (Cloud Scheduler / GitHub Actions cron / APScheduler の例 documentation)
+- [ ] FU-35: `docs/DEPLOYMENT.md` 改訂 — Cloud Run path + OSS Docker Compose path の 2 つを記述
+
+### 段階 3: Wave 4+ (1〜2 月)
+- OpenTelemetry SDK 全面導入 (Backend Python + Frontend TS)
+- terraform/cloud-monitoring/ の GCP 専用 resource を、OpenTelemetry 経由の汎用定義 + GCP exporter config に置き換え
+- `infra/k8s/` 新設 (OSS deployer 向けの Kubernetes manifest example)
+
+---
+
+## 5. 工数見積 (Wave 3 拡張版)
+
+| Theme | 既存工数 | OSS 化追加 | 合計 |
+|-------|---------|----------|------|
+| Theme A (Observability) | 7.5d | +3d (OTel SDK 導入) | 10.5d |
+| Theme B (Refactor) | 9d | 変更なし | 9d |
+| **Theme C (OSS Portability)** | — | **+5d (新規)** | 5d |
+| 合計 | 16.5d | +8d | **24.5d** |
+
+人員: Backend 2-3 名 + Frontend 1-2 名 + Infra 1 名 並列で **約 10〜14 営業日** (Theme C を Theme A/B と並列実施)
+
+---
+
+## 6. リスク & トレードオフ
+
+| Risk | 影響 | 緩和策 |
+|------|------|--------|
+| Wave 3 工数増 (16.5d → 24.5d) | リリース遅延 1 週間 | Theme C は P1 として後回し可、Theme A/B 優先で alpha closer 維持 |
+| OpenTelemetry 学習コスト | engineer 慣れ要 | Python OTel SDK は標準 API、Datadog/Sentry 経験者は流用可 |
+| 2 つの infra config 維持コスト | infra engineer 工数 | OTel Collector config 1 本で両方カバー、terraform は GCP exporter config のみ |
+| OSS deployer の SMTP server 確保 | external dependency | docker-compose に `mailhog` (開発用) + production は OS 提供 SMTP に委譲 |
+| GCP-only feature (Workload Identity Federation) 失う | CI セキュリティ低下 | OSS deployer は env-based secret 経由、CI も別 path |
+
+---
+
+## 7. 結論
+
+terisuke 指摘は **的確かつ実現可能**:
+
+1. ✅ **Application code は既に 95% portable** (Backend 2 ファイル + 全 Frontend が GCP-free)
+2. ✅ **既存 structured_logger.py は stdout JSON 出力で既に vendor-neutral**
+3. ⚠️ **infra/terraform/, CI workflow, scripts は GCP-locked** だが、これらは OSS deployer 視点では再生成可能
+4. ⭐ **OpenTelemetry + Grafana stack + docker-compose の追加で OSS deployer が完全に self-host 可能になる**
+5. 🔄 **既存 GCP 資産 (infra/terraform/alerts.tf 等) は GCP exporter として保持**、Wave 3 で削除しない
+
+→ **Wave 3 に Theme C (OSS Portability) を追加** し、Application は完全 vendor-neutral、infra は deployer choice の構造に進化させるのが最適解。
+
+---
+
+## 8. Reference
+
+- ADR-027 (Wave 3 設計、本 audit で改定提案): `docs/adr/027-wave3-observability-and-refactor-foundation.md`
+- ADR-028 (OSS Portability、本 audit から起草予定): `docs/adr/028-oss-portable-observability-and-infrastructure.md`
+- 既存 GCP infra: `infra/terraform/`
+- OSS license posture: `docs/OSS-LICENSE-POSTURE.md`
+- README ISC license 宣言: `README.md`
+- Wave 3 Epic: #877
+- Wave 3 PR (本 audit と合流): #890

--- a/docs/plans/wave3-engineer-handoff-master-2026-05-18.md
+++ b/docs/plans/wave3-engineer-handoff-master-2026-05-18.md
@@ -1,0 +1,1123 @@
+# 🛠️ Wave 3 Engineer Handoff (Master) — Pre Phase 2 Foundation Hardening
+
+> **対象**: Wave 3 を実装する Backend / Frontend / Infra エンジニア全員
+> **作成**: 2026-05-18, Claude Code session (terisuke 指示)
+> **目的**: Phase 2 (ADR-023 Semantic Router 三段カスケード) 着手前に「ログ・観測性・コード/ドキュメント整理・OSS portability」を完成させ、Phase 2 実装をスムーズにする
+> **このドキュメント 1 ファイルで作業着手可能** (他 doc は参照用、必須ではない)
+
+---
+
+## 📑 目次
+
+- [§0 これは何 / 必読 1 分要約](#0-これは何--必読-1-分要約)
+- [§1 背景: なぜ Wave 3 が必要か](#1-背景-なぜ-wave-3-が必要か)
+- [§2 ゴール / 非ゴール](#2-ゴール--非ゴール)
+- [§3 監査で確定した事実 (実測 evidence)](#3-監査で確定した事実-実測-evidence)
+- [§4 3 テーマ全体像](#4-3-テーマ全体像)
+- [§5 アーキテクチャ決定 (ADR-027 + ADR-028 要約)](#5-アーキテクチャ決定-adr-027--adr-028-要約)
+- [§6 全 15 sub-issues 詳細仕様](#6-全-15-sub-issues-詳細仕様)
+- [§7 PR 分割・依存関係・並列性](#7-pr-分割依存関係並列性)
+- [§8 10〜14 営業日 Daily Schedule](#8-10-14-営業日-daily-schedule)
+- [§9 担当別 First-Day Checklist](#9-担当別-first-day-checklist)
+- [§10 Exit Criteria (Wave 3 完了条件)](#10-exit-criteria-wave-3-完了条件)
+- [§11 Risk Register & Mitigation](#11-risk-register--mitigation)
+- [§12 コーディング規約 (再確認)](#12-コーディング規約-再確認)
+- [§13 検証 / Live smoke / regression 確認手順](#13-検証--live-smoke--regression-確認手順)
+- [§14 Reference: ADR / Issue / 関連 PR](#14-reference-adr--issue--関連-pr)
+
+---
+
+## §0 これは何 / 必読 1 分要約
+
+**Wave 3** は Pre Phase 2 Foundation Hardening:
+
+1. **Observability** — 定期ログ確認で会話・音声 I/O・agent routing が期待通りか分かる。閾値超過で `company@cor-jp.com` に自動 email alert
+2. **Refactoring** — Wave 2 で肥大化した Backend 17 file / Frontend 6 file (≥800 行) の分割、dead code 削除、docs 整理
+3. **OSS Portability** — ISC license で OSS 公開しているが infra/CI が GCP-locked → OpenTelemetry + Grafana stack + docker-compose で OSS deployer も self-host 可能に
+
+**実装単位**: 1 Epic + 3 Theme + 15 sub-issues + 約 18 PR、**並列実行で 10〜14 営業日**
+**人員想定**: Backend 2〜3 + Frontend 1〜2 + Infra 1
+**着手前提**: 本 PR (#890) が develop に merged されること
+**ゴール**: Phase 2 (Semantic Router cascade) 着手時に observability + clean codebase が揃っている状態
+
+---
+
+## §1 背景: なぜ Wave 3 が必要か
+
+### 1.1 Wave 2 完了直後の独立検証で 3 つの critical gap が判明
+
+| Gap | 実態 | 影響 |
+|-----|------|------|
+| **Observability 未整備** | Cloud Monitoring alert **0** / notification channel **0** / log-based metric **0** | 運用が「raw log 目視」のみ、agent 異常を検知できない |
+| **コード肥大化** | Backend ≥800 行 file **17 個**、Frontend **6 個** (top: stt_agent.py 3,033 行, VoiceInterface.tsx 1,959 行) | Phase 2 で差分が読めない、Wave 2 で追加した 3,229 行が消化されていない |
+| **OSS 公開なのに GCP-locked** | infra/terraform/ 全 11 ファイル GCP only、ci.yml gcloud 26 hits、scripts/ 13 本 gcloud 使用 | ISC license で OSS と謳いながら、外部 contributor は `git clone` しても deploy 不能 |
+
+### 1.2 terisuke からの 3 つの指示
+
+1. > ログの整備。定期的にログを見るだけで会話が期待通りに進んでいるか、音声入出力が期待通りのスピードが出ているか、正しいエージェントにルーティングしているかをわかるようにしてほしい。一定の域を超えたエージェントの動きの問題などがあれば、クラウドログのアラートを使って **company@cor-jp.com** という管理者のアドレスに送るようにしてほしい。
+2. > フロントエンドとバックエンド、全体的なリファクタリング。これだけ大規模な改修を行ったので、ドキュメントはもちろんのこと、コード自体にも無駄な部分があったりするはずなので、フェーズ 2 に入る前に、コードとドキュメントの全体整理をしておきたい。
+3. > Cloud Monitoring/Alert は GCP というプラットフォームに依存している部分があるので、できればプラットフォームに依存しない logging/alert システムを実装したい。
+
+→ 3 指示が **3 つの Theme** に 1 対 1 対応する。
+
+---
+
+## §2 ゴール / 非ゴール
+
+### Goals (Wave 3 完了時に満たすべきこと)
+
+#### Observability
+- ✅ `gcloud logging read jsonPayload.event="stt_qwen_complete"` で live STT 実 latency / confidence が取れる
+- ✅ `gcloud logging read jsonPayload.event="agent_routing"` で全 routing 決定が追える
+- ✅ `voice_round_trip` event で STT / chat / TTS の breakdown latency が見える
+- ✅ Frontend `thinking_watchdog_expire` 等の audio reliability event が Backend log に出る
+- ✅ Cloud Monitoring (GCP path) **and** Prometheus/Grafana (OSS path) **の両方**で同じ alert rule が動く
+- ✅ `company@cor-jp.com` に test alert が **両 path 両方から** 到達確認
+
+#### Refactoring
+- ✅ Backend `find backend -name '*.py' -not -path '*/tests/*' -exec wc -l {} + | awk '$1 >= 800'` → **0 行**
+- ✅ Frontend `find frontend/src -name '*.tsx' -o -name '*.ts' | grep -v test | xargs wc -l | awk '$1 >= 800'` → **0 行**
+- ✅ `npx knip` 結果 0
+- ✅ `vulture backend/ --min-confidence=80` 結果 0
+- ✅ `docs/plans/archive/` に 16 件移動、各 plan に status 明記
+- ✅ `docs/CODEMAPS/` に backend.md / frontend.md / architecture.md
+- ✅ `docs/data-flow/` に 5 endpoint audit report
+
+#### OSS Portability
+- ✅ `grep -rE "from google\.(cloud|oauth2|auth)" backend/ --include='*.py'` → **0 件** (Application 層 GCP SDK ゼロ)
+- ✅ `docker compose up` で OSS deployer が 9 service 起動成功
+- ✅ OSS deployer が docker-compose で `curl /api/chat` smoke 6 件 200
+- ✅ DEPLOYMENT.md に Path A (GCP) + Path B (OSS docker-compose) の 2 path 完全記述
+
+### Non-Goals (Wave 3 では実装しない、Wave 4+ 候補)
+
+- ❌ Phase 2 Semantic Router cascade (ADR-023) — Wave 3 完了後の次フェーズ
+- ❌ Memory hierarchy 再設計 (ADR-024) — 同上
+- ❌ 新規エージェント追加
+- ❌ Helm chart / Kubernetes manifest example
+- ❌ Multi-cloud abstraction (AWS / Azure adapter)
+- ❌ Frontend Vercel 脱却 (Next.js standalone は対応するが migration は別 Wave)
+- ❌ BigQuery export sink
+- ❌ Backend ≥800 行 file の **top 6 以外** (残 11 file は P2 で Wave 3.5 候補)
+- ❌ Frontend ≥800 行 file の **top 3 以外** (残 3 file は P2 で Wave 3.5 候補)
+
+---
+
+## §3 監査で確定した事実 (実測 evidence)
+
+### 3.1 Cloud Monitoring 現状 (2026-05-18 `gcloud` 実測)
+
+```bash
+$ gcloud alpha monitoring policies list --project=aipartner-426616
+(空) ← 0 件
+
+$ gcloud alpha monitoring channels list --project=aipartner-426616
+(空) ← 0 件、company@cor-jp.com 未登録
+
+$ gcloud logging metrics list --project=aipartner-426616
+(空) ← 0 件
+```
+
+### 3.2 既存 observability 資産
+
+| 種別 | 既存箇所 | 状態 |
+|------|---------|------|
+| structured logger | `backend/observability/structured_logger.py` | ✅ 既存、chat_response / memory_* 動作中 |
+| GCP terraform | `infra/terraform/{alerts,dashboard,log_metrics,secrets}.tf` | ✅ Issue #513 Phase 1b で land 済、notification_channel 未設定 |
+| Alpha live proof | `scripts/onsite-voice-live-proof.sh` | ✅ 既存、Wave 3 で改修不要 |
+| Observability runbook | `docs/observability-runbook.md` | △ Wave 3 alert を追記する FU-29 で対応 |
+
+### 3.3 Backend 構造化ログ live 出現状況 (24h)
+
+| Event | 定義 | live 出現 | Wave 3 対応 |
+|-------|------|---------|------------|
+| `chat_response` | ✅ | 22/日 | FU-22 で field 追加 |
+| `memory_*` (5 種) | ✅ | 44/日 (各) | 既に OK |
+| `stt_qwen_complete` | ✅ 定義のみ | 0/日 | FU-21 で call site 実装 |
+| `stt_winner` | ✅ 定義のみ | 0/日 | FU-21 |
+| `tts_synthesis_*` | ❌ 未定義 | 0/日 | FU-21 で定義 + call site |
+| `agent_routing` | ❌ 未定義 | 0/日 | FU-22 で新設 |
+| `voice_round_trip` | ❌ 未定義 | 0/日 | FU-22 で新設 |
+
+### 3.4 大ファイル一覧 (実測 `git ls-tree origin/develop` + `wc -l`)
+
+#### Backend ≥800 行 (17 file)
+
+| Rank | File | 行数 | Wave 3 対応 (FU-27 top 6) |
+|------|------|-----:|--------------------------|
+| 1 | `backend/agents/stt_agent.py` | 3,033 | ✅ 分割対象 |
+| 2 | `backend/workflows/main_workflow.py` | 2,588 | ✅ 分割対象 |
+| 3 | `backend/agents/facility_agent.py` | 2,071 | ✅ 分割対象 |
+| 4 | `backend/main.py` | 1,984 | ✅ 分割対象 |
+| 5 | `backend/tools/enhanced_rag.py` | 1,731 | ✅ 分割対象 |
+| 6 | `backend/evaluation/run_live_api_eval.py` | 1,729 | ❌ Wave 3.5 (eval 系) |
+| 7 | `backend/agents/business_info_agent.py` | 1,635 | ✅ 分割対象 |
+| 8 | `backend/agents/voice_agent.py` | 1,610 | ❌ Wave 3.5 (FU-31 で legacy 削除後再評価) |
+| 9-17 | (他 9 file 1,084〜1,360 行) | — | ❌ Wave 3.5 |
+
+#### Frontend ≥800 行 (6 file)
+
+| Rank | File | 行数 | Wave 3 対応 (FU-28 top 3) |
+|------|------|-----:|--------------------------|
+| 1 | `frontend/src/app/components/VoiceInterface.tsx` | 1,959 | ✅ 分割対象 |
+| 2 | `frontend/src/app/components/CharacterAvatar.tsx` | 1,555 | ✅ 分割対象 |
+| 3 | `frontend/src/app/components/ReceptionPdfGuide.tsx` | 1,304 | ✅ 分割対象 |
+| 4 | `frontend/src/lib/vrm-utils.ts` | 962 | ❌ Wave 3.5 |
+| 5 | `frontend/src/app/page.tsx` | 840 | ❌ Wave 3.5 |
+| 6 | `frontend/src/lib/voice-recorder.ts` | 824 | ❌ Wave 3.5 |
+
+### 3.5 GCP SDK 直接 import 実測
+
+```bash
+$ grep -rnE "^(from|import) (google\.cloud|google\.oauth2|google\.auth|googleapiclient)" backend/ --include='*.py' | grep -v tests/
+backend/agents/stt_agent.py:1491:        from google.cloud import speech       # ← GoogleSTTClient (legacy fallback)
+backend/agents/voice_agent.py:444:        from google.oauth2 import service_account  # ← GoogleTTSClient (legacy)
+backend/agents/voice_agent.py:471:        from google.auth.transport.requests import Request as GoogleAuthRequest
+```
+
+**Frontend** (`grep -rE "@google-cloud|googleapis|gcloud" frontend/src/` ): **0 件**
+
+→ Application 層は **2 ファイルの legacy fallback** 以外完全 portable。FU-31 で削除すると application 層 GCP SDK ゼロ。
+
+### 3.6 docs/plans 累積状況
+
+```bash
+$ git ls-tree -r origin/develop docs/plans/ | wc -l
+21
+```
+
+archive 規則なし、status (completed/active) 表示なし。FU-29 で `docs/plans/archive/` 新設 + 16 件移動。
+
+---
+
+## §4 3 テーマ全体像
+
+```
+#877 [Epic][Wave 3] Pre Phase 2 Foundation Hardening
+│
+├── #878 [Theme A] Observability & Alerting              ── 10.5 day (Backend + Infra)
+│   │   定期ログで状態が分かる + 閾値超過で company@cor-jp.com に alert
+│   │
+│   ├── #880 FU-21 STT/TTS structured log call site       (1.5d, Backend)
+│   ├── #881 FU-22 agent_routing + voice_round_trip event (1.5d, Backend)
+│   ├── #882 FU-23 Frontend telemetry → Backend POST      (2.0d, FE+BE)
+│   ├── #883 FU-24 log-based metrics (OTel に改定)         (1.5d, Infra)
+│   └── #884 FU-25 alert + dashboard (両 path)             (2.0d, Infra)
+│       *#883/#884 は ADR-028 で OSS-friendly 設計に置き換え*
+│
+├── #879 [Theme B] Refactoring & Documentation           ── 9.0 day (Backend + Frontend)
+│   │   コード/ドキュメント整理、Phase 2 差分を読みやすく
+│   │
+│   ├── #885 FU-26 Dead code 削除                          (1.5d, BE+FE)
+│   ├── #886 FU-27 Backend 大ファイル分割 top 6           (3.0d, Backend, 6 PR)
+│   ├── #887 FU-28 Frontend 大ファイル分割 top 3          (2.5d, Frontend, 3 PR)
+│   ├── #888 FU-29 docs archive + CODEMAPS                (1.0d, 誰でも)
+│   └── #889 FU-30 4-point data flow audit                (1.0d, Backend)
+│
+└── #891 [Theme C] OSS Portability                       ── 5.0 day (BE+FE+Infra)
+    │   GCP 依存から application 層を切り離し、OSS deployer が self-host 可
+    │
+    ├── #892 FU-31 Legacy GoogleSTTClient/TTSClient 削除  (0.5d, Backend)
+    ├── #893 FU-32 docker-compose + Grafana stack         (1.5d, Infra)
+    ├── #894 FU-33 Secret backend 抽象化                  (1.0d, Backend)
+    ├── #895 FU-34 Cron backend 抽象化 + docs             (0.5d, Infra)
+    └── #896 FU-35 DEPLOYMENT.md 2-path 改訂              (1.0d, 誰でも)
+```
+
+**並列性**:
+- Theme A / Theme B / Theme C は **完全並列可能** (依存なし)
+- Theme A 内: FU-21 / FU-22 並列、FU-23 は両者完了後、FU-24 は FU-21/22/23 完了後、FU-25 は FU-24 完了後
+- Theme B 内: FU-26 / FU-27 / FU-28 / FU-29 / FU-30 全て並列可
+- Theme C 内: FU-31 / FU-32 / FU-33 / FU-34 / FU-35 全て並列可、ただし FU-32 と Theme A FU-23 は OTel Collector 設定で coordinate 要
+
+---
+
+## §5 アーキテクチャ決定 (ADR-027 + ADR-028 要約)
+
+### ADR-027 (Wave 3 Foundation Hardening) 10 Decisions
+
+| ID | 決定 | 担当 Theme |
+|----|------|----------|
+| D1 | Backend 構造化ログの call site 完成 (STT/TTS/agent_routing/voice_round_trip) | A |
+| D2 | Frontend telemetry を Backend に送信 (`/api/telemetry/voice`) | A |
+| D3 | Cloud Logging log-based metrics 9 個 (**ADR-028 で OTel semantic convention に改定**) | A |
+| D4 | Cloud Monitoring alert + notification channel (**ADR-028 で portable に改定**) | A |
+| D5 | Cloud Monitoring dashboard (**ADR-028 で Grafana JSON に改定**) | A |
+| D6 | Dead code 削除 (knip + ts-prune + vulture) | B |
+| D7 | Backend 大ファイル分割 top 6 | B |
+| D8 | Frontend 大ファイル分割 top 3 | B |
+| D9 | docs/plans archive + ルート docs 更新 + CODEMAPS | B |
+| D10 | 4-point data flow audit | B |
+
+### ADR-028 (OSS Portability) 8 Decisions
+
+| ID | 決定 | 担当 Theme |
+|----|------|----------|
+| D1 | OpenTelemetry SDK を application 層の標準に | A + C |
+| D2 | OTel Collector を中継 hub に (GCP / OTLP / Prometheus / stdout exporter 切替) | C |
+| D3 | Alert rule を Prometheus rule YAML で portable 定義 | A + C |
+| D4 | Secret backend 抽象化 (`SecretProvider` interface, Env/Sops/GCP/Vault) | C |
+| D5 | Cron backend 抽象化 (CLI script trigger 化) | C |
+| D6 | Container hosting を deployer choice (docker-compose 追加) | C |
+| D7 | Legacy GoogleSTTClient + GoogleTTSClient 削除 | C |
+| D8 | DEPLOYMENT.md を 2-path (Path A GCP / Path B OSS) | C |
+
+### 重要なアーキテクチャ画
+
+```
+┌────────────────────────────────────────────────────────────┐
+│ Application Layer (vendor-neutral)                         │
+│                                                            │
+│ Backend (Python):                                          │
+│   structured_logger (wrapped) → OpenTelemetry SDK          │
+│   - log.info(extra={"event":"chat_response", ...})         │
+│   - meter.create_histogram(...).record(...)                │
+│                                                            │
+│ Frontend (Next.js):                                        │
+│   navigator.sendBeacon('/api/telemetry/voice', payload)    │
+│        ↓                                                   │
+│   Backend /api/telemetry/voice → OTel SDK                  │
+└────────────────────────┬───────────────────────────────────┘
+                         ↓
+         ┌───────────────────────────────────────┐
+         │ OpenTelemetry Collector (sidecar)     │
+         │ - receivers: otlp                     │
+         │ - exporters: (config-driven)          │
+         │   * googlecloud (terisuke production) │
+         │   * prometheus + loki (OSS deployer)  │
+         │   * stdout (dev / CI)                 │
+         └───┬───────────────────────────────┬───┘
+             ↓                               ↓
+   ┌─────────────────────┐         ┌──────────────────────────┐
+   │ Path A: GCP         │         │ Path B: OSS Self-Hosted  │
+   │ Cloud Logging       │         │ Loki (logs)              │
+   │ Cloud Monitoring    │         │ Prometheus (metrics)     │
+   │ Notification → Email│         │ Alertmanager → SMTP      │
+   │   company@cor-jp.com│         │   company@cor-jp.com     │
+   │ (既存 terraform)    │         │ (docker-compose + YAML)  │
+   └─────────────────────┘         └──────────────────────────┘
+                                              ↑
+                                   ┌──────────┴───────┐
+                                   │ Grafana          │
+                                   │ - dashboard JSON │
+                                   │ - alert UI       │
+                                   └──────────────────┘
+```
+
+→ **同一 YAML alert rule で両 path 同じ通知**、deployer は env config で path 選択。
+
+---
+
+## §6 全 15 sub-issues 詳細仕様
+
+> **Note**: 各 issue の問題定義 / 修正方針 / Verification は GitHub Issue 本文に詳細記載。本セクションは **着手順に並べた要約 + file:line 引用 + 受入条件** のみ記載。
+
+### Theme A: Observability & Alerting (FU-21〜25)
+
+#### 🔧 FU-21 [P0] Backend STT/TTS structured log call site (#880, 1.5d)
+
+**問題**: `backend/observability/structured_logger.py` に `stt_qwen_complete` / `stt_winner` / `tts_cache` event が定義済だが live で 0/日 (call site 不在)。
+
+**実装**:
+- 対象 file: `backend/agents/stt_agent.py`, `backend/clients/qwen_stt_client.py`, `backend/clients/piper_plus_client.py`, `backend/services/tts_*.py`
+- 全 STT/TTS path に `STT_LOGGER` / `TTS_LOGGER` 呼出を追加
+- `chat_response` event に `agent_route` / `intent` / `confidence` field 追加
+
+**ペイロード schema**:
+```json
+{
+  "event": "stt_qwen_complete",
+  "provider": "qwen-primary",
+  "language": "ja",
+  "audio_duration_ms": 2340,
+  "latency_ms": 1820,
+  "confidence": 0.94,
+  "transcript_length": 18,
+  "winner": true,
+  "session_id": "...",
+  "request_id": "..."
+}
+```
+
+**受入条件**:
+- [ ] `pytest backend/tests/observability/test_stt_tts_events.py` 全 PASS
+- [ ] live: `gcloud logging read 'jsonPayload.event="stt_qwen_complete"' --limit 5 --freshness=1h` で実 record
+- [ ] `chat_response` event に新 field 確認
+
+---
+
+#### 🔧 FU-22 [P0] agent_routing + voice_round_trip event (#881, 1.5d)
+
+**問題**: agent routing 決定がログから追えない。voice round-trip 全体時間が分からない。
+
+**実装**:
+- 対象 file: `backend/agents/orchestrator_agent.py`, `backend/api/voice.py`, `backend/api/chat.py`
+- 新 event `agent_routing`: `{routed_to, intent, confidence, fallback_used, alternatives: [(name, score)], latency_ms}`
+- 新 event `voice_round_trip`: `{stt_ms, chat_ms, tts_ms, total_ms, success, error_type, session_id, request_id}`
+
+**受入条件**:
+- [ ] `pytest backend/tests/agents/test_orchestrator_routing_events.py` PASS
+- [ ] live: `/api/voice` 1 セッション後に `agent_routing` + `voice_round_trip` + `chat_response` 3 種類 event が出る
+
+---
+
+#### 🔧 FU-23 [P0] Frontend telemetry → Backend POST (#882, 2.0d)
+
+**問題**: Wave 2 FU-17 で追加した `useVoiceSessionController.ts:73` の `console.debug` はブラウザ側のみで Backend に来ない → watchdog 発火率 / fallback 発火率 / gate timeout 率が観測不能。
+
+**実装**:
+- Backend: 新 endpoint `POST /api/telemetry/voice` (auth required) → 受信して `structured_logger` 経由で Cloud Logging に転送
+- Frontend: `useVoiceSessionController.ts` の state transition + watchdog expire を `navigator.sendBeacon()` で送信
+- 送信 event: `voice_state_transition`, `thinking_watchdog_expire`, `fallback_tts_triggered`, `user_interaction_gate_timeout`, `audio_playback_failed`
+- 既存 `console.debug` は残す (開発用)
+
+**受入条件**:
+- [ ] kiosk で連続 3 発話 → 全 transition event が backend log に出る
+- [ ] Safari iOS 旧 version で `sendBeacon` failover 動作
+
+---
+
+#### 🔧 FU-24 [P0] Log-based metrics (ADR-028 で OTel に改定) (#883, 1.5d)
+
+**問題**: Cloud Logging に raw log は出るが、percentile / count / distribution の集計 metric が無い。Cloud Monitoring dashboard も alert も組めない。
+
+**実装** (ADR-028 改定後):
+- OpenTelemetry semantic convention で 9 metric 定義 (vendor-neutral)
+  ```python
+  # backend/observability/otel_meter.py (新設)
+  voice_round_trip_ms = meter.create_histogram("voice_round_trip_ms", unit="ms")
+  chat_response_ms = meter.create_histogram("chat_response_ms", unit="ms")
+  stt_latency_ms = meter.create_histogram("stt_latency_ms", unit="ms")
+  tts_latency_ms = meter.create_histogram("tts_latency_ms", unit="ms")
+  agent_route_count = meter.create_counter("agent_route_count")
+  stt_winner_count = meter.create_counter("stt_winner_count")
+  error_count = meter.create_counter("error_count")
+  frontend_audio_watchdog_count = meter.create_counter("frontend_audio_watchdog_count")
+  frontend_fallback_count = meter.create_counter("frontend_fallback_count")
+  ```
+- OTel Collector config (`infra/observability/otel-collector-config.yaml`) で:
+  - GCP path: `exporters: googlecloud` (既存 terraform/log_metrics.tf と並走、徐々に置き換え)
+  - OSS path: `exporters: prometheus` (FU-32 docker-compose で起動)
+
+**Dependency**: FU-21 + FU-22 + FU-23 完了
+
+**受入条件**:
+- [ ] `pytest backend/tests/observability/test_otel_meter.py` PASS
+- [ ] live: OTel Collector 経由で Cloud Monitoring に metric 流入 (GCP path)
+- [ ] OSS path: docker-compose で Prometheus に同 metric 流入 (FU-32 と同 PR で確認)
+
+---
+
+#### 🔧 FU-25 [P0] Alert + Notification + Dashboard (両 path) (#884, 2.0d)
+
+**問題**: Cloud Monitoring alert policy 0 + notification channel 0、 OSS path も無し。
+
+**実装** (ADR-028 改定後):
+- 単一 source `infra/observability/alerts.rules.yml` に Prometheus rule YAML で 7 alert 定義:
+
+| Alert | Condition | Severity |
+|-------|-----------|---------|
+| `voice_round_trip_p95_slow` | `histogram_quantile(0.95, voice_round_trip_ms) > 8000` for 10min | P2 |
+| `chat_response_p95_slow` | `histogram_quantile(0.95, chat_response_ms) > 6000` for 10min | P2 |
+| `stt_latency_degradation` | `histogram_quantile(0.95, stt_latency_ms) > 5000` for 15min | P2 |
+| `backend_error_burst` | `rate(error_count[5m]) > 4` for 10min | P1 |
+| `agent_routing_skew` | `rate(agent_route_count{routed_to="fallback_general"}[30m]) / rate(agent_route_count[30m]) > 0.3` | P3 |
+| `frontend_audio_watchdog_spike` | `rate(frontend_audio_watchdog_count[15m]) > 0.011` (10/15min) | P2 |
+| `cloud_run_traffic_zero` | `absent(rate(chat_response_ms_count[30m]))` (12-20 JST) | P3 |
+
+- GCP path: Python converter (`scripts/sync_alerts_to_gcp.py`) で `alerts.rules.yml` → `infra/terraform/alerts_generated.tf` 生成 (notification_channel_id 注入)
+- OSS path: `infra/observability/alertmanager.yml` で SMTP receiver → `company@cor-jp.com`
+- Dashboard: Grafana JSON `infra/observability/grafana/dashboards/engineer-cafe-navigator.json` (両 path 共通)
+
+**Dependency**: FU-24 完了
+
+**受入条件**:
+- [ ] GCP path: `gcloud alpha monitoring policies list` で 7 policy 表示、test alert を fire させて company@cor-jp.com に email 到達
+- [ ] OSS path: docker-compose の Alertmanager + mailhog で test alert 受信
+- [ ] Dashboard 全パネル data 表示 (両 path)
+
+---
+
+### Theme B: Refactoring & Documentation (FU-26〜30)
+
+#### 🧹 FU-26 [P0] Dead code 削除 (#885, 1.5d)
+
+**実装**:
+```bash
+# Frontend
+cd frontend
+npx knip --reporter json > /tmp/knip.json
+npx ts-prune > /tmp/ts-prune.txt
+# Backend
+cd backend
+ruff check --select F401,F811 .
+vulture backend/ --min-confidence=80 > /tmp/vulture.txt
+```
+
+検出された unused export / import / function を **テストが落ちないことを確認しながら** 削除。
+
+**受入条件**:
+- [ ] knip / ts-prune / vulture / ruff F401/F811 結果ゼロ
+- [ ] カバレッジ ≥80% 維持
+- [ ] `pnpm lint && pnpm typecheck && pnpm build` + `ruff check . && black --check . && pytest -m "not slow and not ragas"` 全 PASS
+
+---
+
+#### 🪓 FU-27 [P0] Backend 大ファイル分割 top 6 (#886, 3.0d, 6 PR)
+
+**分割計画**:
+
+| 対象 | 現行 | 分割方針 |
+|------|------|---------|
+| `backend/main.py` (1,984) | → | `backend/api/__init__.py` + `voice.py` + `chat.py` + `calendar.py` + `admin.py` |
+| `backend/agents/stt_agent.py` (3,033) | → | `stt_agent.py` (公開 IF) + `stt/qwen_handler.py` + `stt/vosk_handler.py` + `stt/hedge.py` + `stt/postprocess.py` |
+| `backend/workflows/main_workflow.py` (2,588) | → | subgraph 別 + helper module |
+| `backend/agents/facility_agent.py` (2,071) | → | category 別 (hall / reception / wifi / amenity) |
+| `backend/agents/business_info_agent.py` (1,635) | → | category 別 (saino_cafe / hours / pricing) |
+| `backend/tools/enhanced_rag.py` (1,731) | → | pipeline stage 別 (retrieve / rerank / filter / format) |
+
+**完了条件 (per PR)**:
+- [ ] 分割後の全 file < 800 行
+- [ ] 既存 unit / integration test 全 PASS
+- [ ] live smoke 6 query 全 200、レスポンス文字列が分割前と 1:1 一致 (behaviorally equivalent)
+
+---
+
+#### 🪓 FU-28 [P0] Frontend 大ファイル分割 top 3 (#887, 2.5d, 3 PR)
+
+**分割計画**:
+
+| 対象 | 現行 | 分割方針 |
+|------|------|---------|
+| `VoiceInterface.tsx` (1,959) | → | container + `hooks/useVoicePlayback.ts` + `hooks/useFallbackTTS.ts` + `components/PlaybackController.tsx` + `components/FallbackUI.tsx` |
+| `CharacterAvatar.tsx` (1,555) | → | container + `hooks/useVRMLifecycle.ts` + `hooks/useExpression.ts` + `hooks/useLipsync.ts` |
+| `ReceptionPdfGuide.tsx` (1,304) | → | component 別 (render / navigation / UI) |
+
+**完了条件 (per PR)**:
+- [ ] 分割後の全 file < 800 行
+- [ ] `pnpm lint && pnpm typecheck && pnpm build` PASS
+- [ ] Playwright e2e PASS (特に `theme-b-audio-reliability.spec.ts`)
+- [ ] VRM 表示 + lipsync 視覚的回帰なし (手動確認)
+
+---
+
+#### 📚 FU-29 [P1] docs archive + CODEMAPS (#888, 1.0d)
+
+**実装**:
+1. `docs/plans/archive/` 新設、以下 16 件を移動 + 各 plan 冒頭に `> Status: completed (YYYY-MM-DD) / superseded by ...` 追記:
+   - production-hardening-session-2026-03-14
+   - deployment-readiness-2026-03-15
+   - production-integration-2026-03-16
+   - qwen-cloud-run-validation-2026-04-11
+   - alpha-trial-p1-remediation-2026-04-13
+   - production-readiness-followup-2026-04-19
+   - alpha-fast-response-implementation-2026-04-30
+   - alpha-parallel-blocker-plan-2026-04-30
+   - alpha-remediation-plan-2026-05-02
+   - alpha-reset-plan-2026-05-03
+   - comprehensive-refactoring-plan-2026-05-05
+   - post-alpha-voice-rag-frontend-scope-2026-05-09
+   - voice-speed-issue-closure-2026-05-16
+   - reception-quality-issues-2026-05-16
+   - frontend-api-separation-closure-2026-05-16
+   - alpha-ui-e2e-hardening-2026-04-12
+2. アクティブ残: wave2 / event-source-spreadsheet / event-spreadsheet-engineer-handoff / post-adr023-investigation / semantic-router-self-eval / **wave3 系 (本 master を含む)**
+3. ルート docs 更新: `docs/STT-Implementation-Trace.md` を Wave 2 後の状態に最新化、`docs/observability-runbook.md` に Wave 3 alert 追記
+4. `docs/CODEMAPS/` 新設、`/update-codemaps` skill で `backend.md`, `frontend.md`, `architecture.md` 自動生成
+
+**受入条件**:
+- [ ] `ls docs/plans/archive/` で 16 件
+- [ ] STT-Implementation-Trace.md に "Wave 2" mention
+- [ ] observability-runbook.md に Wave 3 metric 名 mention
+- [ ] `docs/CODEMAPS/{backend,frontend,architecture}.md` 全存在
+
+---
+
+#### 📚 FU-30 [P1] 4-point data flow audit (#889, 1.0d)
+
+**対象 endpoint** (Wave 2 で変更):
+- `/api/voice/*` (STT + TTS proxy)
+- `/api/chat` (LangGraph 全 agent)
+- `/api/calendar` (Google Calendar ICS)
+- `/api/reception/*` (Wave 7 subgraph)
+- **NEW**: GAS Web App → `EVENT_SHEET_GAS_URL` → `SheetsEventSource` → KB
+
+各 endpoint について `docs/data-flow/<endpoint>.md` 作成、`Client → API route → Backend → Response` の 4 セクションを **file:line 引用付き** で記録。
+
+**受入条件**:
+- [ ] `docs/data-flow/` に 5 file
+- [ ] 各 file に 4 セクション存在
+- [ ] file:line 引用が valid (develop branch リンク)
+
+---
+
+### Theme C: OSS Portability (FU-31〜35)
+
+#### 🌱 FU-31 [P1] Legacy GoogleSTTClient/TTSClient 削除 (#892, 0.5d)
+
+**対象 file:line**:
+- `backend/agents/stt_agent.py:1491` `from google.cloud import speech` (GoogleSTTClient class)
+- `backend/agents/voice_agent.py:444` `from google.oauth2 import service_account` (GoogleTTSClient class)
+- `backend/agents/voice_agent.py:471` `from google.auth.transport.requests import Request as GoogleAuthRequest`
+
+**実装**:
+1. `GoogleSTTClient` クラスとその参照を削除
+2. `GoogleTTSClient` クラスとその参照を削除
+3. `STT_PROVIDER=google` / `TTS_PROVIDER=google` の dispatch 条件削除、env var 許容値から `google` 除外
+4. `backend/requirements.txt` から `google-auth` を削除 (transitive 確認)
+5. 関連 unit test 削除
+
+**受入条件**:
+- [ ] `grep -rE "from google\.(cloud|oauth2|auth)" backend/ --include='*.py'` → **0 件**
+- [ ] `pytest -m "not slow"` 全 PASS
+- [ ] live: `STT_PROVIDER=qwen-primary` + `TTS_PROVIDER=piper` で Wave 2 smoke 6 query regression なし
+
+---
+
+#### 🌱 FU-32 [P1] docker-compose.yml + Grafana stack (#893, 1.5d)
+
+**追加 file**:
+- `docker-compose.yml` (repo root)
+- `infra/observability/otel-collector-config.yaml`
+- `infra/observability/prometheus.yml`
+- `infra/observability/loki-config.yaml`
+- `infra/observability/alertmanager.yml` (SMTP receiver, target=company@cor-jp.com)
+- `infra/observability/grafana/dashboards/engineer-cafe-navigator.json`
+
+**docker-compose services** (9 個):
+| Service | Image | Port |
+|---------|-------|-----:|
+| backend | (local Dockerfile.backend) | 8000 |
+| frontend | (local Dockerfile.frontend) | 3000 |
+| postgres | pgvector/pgvector:pg16 | 5432 |
+| otel-collector | otel/opentelemetry-collector-contrib | 4317, 4318 |
+| loki | grafana/loki | 3100 |
+| prometheus | prom/prometheus | 9090 |
+| grafana | grafana/grafana | 3001 |
+| alertmanager | prom/alertmanager | 9093 |
+| mailhog | mailhog/mailhog | 1025, 8025 |
+
+**受入条件**:
+- [ ] `docker compose up -d` で 9 service 全起動
+- [ ] `curl http://localhost:8000/health` → 200
+- [ ] `curl http://localhost:3000` → frontend OK
+- [ ] Grafana UI (`:3001`) でログ + metrics dashboard 表示
+- [ ] mailhog UI (`:8025`) で test alert mail 受信
+
+---
+
+#### 🌱 FU-33 [P1] Secret backend 抽象化 (#894, 1.0d)
+
+**新規 file**: `backend/utils/secrets.py`
+
+```python
+from typing import Protocol
+import os
+
+class SecretProvider(Protocol):
+    def get(self, key: str, default: str | None = None) -> str | None: ...
+
+class EnvSecretProvider:
+    def get(self, key, default=None): return os.getenv(key, default)
+
+class SopsSecretProvider:
+    def __init__(self, sops_file): ...
+    def get(self, key, default=None): ...
+
+class GcpSecretProvider:
+    # Cloud Run の env bind を活用、internal は env 経由
+    def get(self, key, default=None): return os.getenv(key, default)
+
+class VaultSecretProvider:
+    def __init__(self, vault_addr, token): ...
+    def get(self, key, default=None): ...
+
+def get_secret_provider() -> SecretProvider:
+    backend = os.getenv("SECRET_BACKEND", "env")
+    return {"env": EnvSecretProvider, "sops": SopsSecretProvider,
+            "gcp": GcpSecretProvider, "vault": VaultSecretProvider}[backend]()
+```
+
+主要呼出箇所 (`SheetsEventSource`, OpenRouter client, Cerebras client, Tavily client) を `secrets.get(...)` に置き換え。
+
+**受入条件**:
+- [ ] `pytest backend/tests/utils/test_secrets.py` で 4 provider mock test PASS
+- [ ] live: SECRET_BACKEND=env で Cloud Run regression なし
+- [ ] `docs/deployment/secrets-sops.md` で sops 実例
+
+---
+
+#### 🌱 FU-34 [P1] Cron backend 抽象化 + docs (#895, 0.5d)
+
+**実装**:
+1. `backend/scripts/sync_event_kb.py` の CLI 性確認 (entry point + idempotency)
+2. 新規 `docs/deployment/cron-options.md` で 4 trigger 例:
+   - GCP Cloud Scheduler → Cloud Run Job (現行 production)
+   - GitHub Actions cron (`.github/workflows/event-kb-sync.example.yml`)
+   - systemd timer (`infra/systemd/event-kb-sync.timer.example`)
+   - In-process APScheduler
+
+**受入条件**:
+- [ ] `python -m backend.scripts.sync_event_kb --help` で CLI 動作
+- [ ] documentation の 4 例が copy-paste 実行可能
+
+---
+
+#### 🌱 FU-35 [P1] DEPLOYMENT.md 2-path 改訂 (#896, 1.0d)
+
+**実装**: `docs/DEPLOYMENT.md` を Path A (GCP) + Path B (OSS docker-compose) の 2-path 構造に改訂。
+
+**受入条件**:
+- [ ] 新人が GCP account 無しで Path B を docker-compose で 30 分以内に起動
+- [ ] terisuke が Path A セクションで現行運用が再現
+- [ ] 両 path で smoke test 6 query が pass
+
+---
+
+## §7 PR 分割・依存関係・並列性
+
+### 推奨 PR 一覧 (合計 約 18 PR)
+
+#### Theme A (5 PR)
+- PR-W3A-1: FU-21 STT/TTS events
+- PR-W3A-2: FU-22 routing + roundtrip
+- PR-W3A-3: FU-23 frontend telemetry + Backend `/api/telemetry/voice`
+- PR-W3A-4: FU-24 OTel meter + Collector config
+- PR-W3A-5: FU-25 alerts.rules.yml + Alertmanager config + GCP converter + Grafana JSON
+
+#### Theme B (約 12 PR)
+- PR-W3B-1: FU-26 dead code 削除
+- PR-W3B-2a〜f: FU-27 backend split (6 PR、1 file/PR)
+- PR-W3B-3a〜c: FU-28 frontend split (3 PR、1 file/PR)
+- PR-W3B-4: FU-29 docs archive + CODEMAPS
+- PR-W3B-5: FU-30 data flow audit
+
+#### Theme C (5 PR)
+- PR-W3C-1: FU-31 legacy GCP client 削除
+- PR-W3C-2: FU-32 docker-compose + Grafana stack
+- PR-W3C-3: FU-33 secrets abstraction
+- PR-W3C-4: FU-34 cron abstraction docs
+- PR-W3C-5: FU-35 DEPLOYMENT.md
+
+### 依存グラフ
+
+```mermaid
+graph LR
+  Wave3Doc[PR #890 merge] --> All
+
+  subgraph ThemeA[Theme A]
+    A1[PR-W3A-1 FU-21] --> A4[PR-W3A-4 FU-24]
+    A2[PR-W3A-2 FU-22] --> A4
+    A3[PR-W3A-3 FU-23] --> A4
+    A4 --> A5[PR-W3A-5 FU-25]
+  end
+
+  subgraph ThemeB[Theme B]
+    B1[PR-W3B-1 FU-26]
+    B2[PR-W3B-2a..f FU-27]
+    B3[PR-W3B-3a..c FU-28]
+    B4[PR-W3B-4 FU-29]
+    B5[PR-W3B-5 FU-30]
+  end
+
+  subgraph ThemeC[Theme C]
+    C1[PR-W3C-1 FU-31]
+    C2[PR-W3C-2 FU-32] -.coordinate.-> A4
+    C3[PR-W3C-3 FU-33]
+    C4[PR-W3C-4 FU-34]
+    C5[PR-W3C-5 FU-35] --> C2
+  end
+
+  All --> ThemeA
+  All --> ThemeB
+  All --> ThemeC
+```
+
+**並列実行可能**:
+- 起動時: PR-W3A-1, PR-W3A-2, PR-W3A-3, PR-W3B-1, PR-W3B-2a, PR-W3B-3a, PR-W3B-4, PR-W3B-5, PR-W3C-1, PR-W3C-3, PR-W3C-4 が同時着手可能 (= 最大 **11 PR 並列**)
+- FU-32 (docker-compose) と FU-24 (OTel) は config 整合性のため coordinate 必要 (同じ engineer か密 sync)
+
+---
+
+## §8 10〜14 営業日 Daily Schedule
+
+```
+Day 1
+  BE-A: PR-W3A-1 (FU-21 STT/TTS events) 着手
+  BE-B: PR-W3A-2 (FU-22 routing + roundtrip) 着手
+  FE:   PR-W3A-3 (FU-23 frontend telemetry) 着手
+  Infra: PR-W3C-2 (FU-32 docker-compose) 着手
+  All:  PR-W3B-1 (FU-26 dead code) 着手
+
+Day 2-3
+  BE-A: PR-W3A-1 merge → PR-W3B-2a (FU-27 main.py split) 着手
+  BE-B: PR-W3A-2 merge → PR-W3B-2b (FU-27 stt_agent.py split) 着手
+  FE:   PR-W3A-3 merge → PR-W3B-3a (FU-28 VoiceInterface.tsx split) 着手
+  Infra: PR-W3C-2 進行 + PR-W3A-4 (FU-24 OTel) coordinate
+  BE-C: PR-W3C-3 (FU-33 secrets) + PR-W3C-1 (FU-31 legacy GCP 削除)
+
+Day 4-5
+  BE-A/B: PR-W3B-2 continue (workflow / facility split)
+  FE:   PR-W3B-3b (FU-28 CharacterAvatar split)
+  Infra: PR-W3A-4 merge → PR-W3A-5 (FU-25 alerts) 着手 + PR-W3C-4 (FU-34)
+  Docs: PR-W3B-4 (FU-29 archive) 着手
+
+Day 6-7
+  BE-A/B: PR-W3B-2 final (business_info / enhanced_rag)
+  FE:   PR-W3B-3c (FU-28 ReceptionPdfGuide split)
+  Infra: PR-W3A-5 + PR-W3C-2 統合検証 (両 path で alert 動作)
+  Docs: PR-W3B-5 (FU-30 data flow) + PR-W3C-5 (FU-35 DEPLOYMENT.md)
+
+Day 8-9
+  全 PR review + green merge
+  live smoke 6 query 全 200 確認
+  両 path で test alert 到達確認 (GCP / OSS)
+
+Day 10-12 (buffer)
+  regression 修正、Phase 2 readiness 最終確認
+
+Day 13-14 (optional, 運用観察 buffer)
+  metric / alert 閾値再調整、Phase 2 着手前の最終 dry-run
+```
+
+---
+
+## §9 担当別 First-Day Checklist
+
+### Backend Engineer (A: STT/TTS 系)
+```bash
+# Day 1 朝
+git fetch origin develop
+git checkout -b feat/wave3-stt-tts-events origin/develop
+
+# 既存 structured_logger.py を読んで API 把握
+git show origin/develop:backend/observability/structured_logger.py | less
+
+# call site 候補をリストアップ
+grep -rn "QwenSTTClient\|PiperPlus\|transcribe\|synthesize" backend/agents/ backend/clients/ backend/services/
+
+# 既存 chat_response event 周辺を確認
+grep -rn "chat_response\|CHAT_RESPONSE_EVENT" backend/
+
+# FU-21 unit test 用 fixture 確認
+ls backend/tests/observability/ || mkdir -p backend/tests/observability/
+
+# 実装開始 → PR-W3A-1
+```
+
+### Backend Engineer (B: workflow + agent_routing 系)
+```bash
+git checkout -b feat/wave3-routing-events origin/develop
+
+# orchestrator の routing 決定点をリストアップ
+grep -rnE "def.*route|return.*agent|self\.agents\[" backend/agents/orchestrator_agent.py
+
+# /api/voice の round-trip を握る箇所
+grep -rn "speech_to_text\|text_to_speech\|api/voice" backend/api/
+
+# 実装開始 → PR-W3A-2
+```
+
+### Frontend Engineer
+```bash
+git checkout -b feat/wave3-frontend-telemetry origin/develop
+
+# Wave 2 で追加した useVoiceSessionController.ts:73 周辺を確認
+git show origin/develop:frontend/src/app/hooks/useVoiceSessionController.ts | sed -n '60,120p'
+
+# state transition + watchdog 発火点を握る
+grep -nE "console\.debug|watchdog|fallback|gate.*timeout" frontend/src/app/hooks/useVoiceSessionController.ts frontend/src/lib/audio/audio-user-interaction-gate.ts
+
+# 新 Backend endpoint の Backend 担当と調整 (FU-23 は coordinated implementation)
+
+# 実装開始 → PR-W3A-3
+```
+
+### Infra Engineer
+```bash
+# Day 1 朝
+git checkout -b feat/wave3-otel-collector origin/develop
+
+# 既存 GCP terraform を読む
+ls infra/terraform/
+cat infra/terraform/log_metrics.tf
+cat infra/terraform/alerts.tf
+cat infra/terraform/dashboard.tf
+
+# Cloud Monitoring 現状確認
+gcloud alpha monitoring policies list --project=aipartner-426616
+gcloud alpha monitoring channels list --project=aipartner-426616
+
+# OTel Collector の Docker image 動作確認
+docker run --rm otel/opentelemetry-collector-contrib:latest --help
+
+# docker-compose に必要な service の port を整理
+# 実装開始 → PR-W3C-2 (docker-compose) → PR-W3A-4 (OTel meter)
+```
+
+### Doc Engineer (誰でも可)
+```bash
+git checkout -b docs/wave3-archive-and-codemaps origin/develop
+
+# 移動対象 16 件を確認
+ls docs/plans/
+
+# `/update-codemaps` skill で初版生成 (Claude Code skill)
+# 実装開始 → PR-W3B-4
+```
+
+---
+
+## §10 Exit Criteria (Wave 3 完了条件)
+
+### Theme A
+- [ ] Cloud Logging に `stt_qwen_complete` / `tts_synthesis_complete` / `agent_routing` / `voice_round_trip` event が live 発火
+- [ ] Frontend `thinking_watchdog_expire` / `fallback_tts_triggered` event が Cloud Logging に出る
+- [ ] **GCP path**: `gcloud alpha monitoring policies list` で 7 policy 表示、test alert が `company@cor-jp.com` に届く
+- [ ] **OSS path**: docker-compose の Alertmanager + mailhog で同じ alert が test fire 確認
+- [ ] Dashboard で latency / agent route 等のチャート可視化
+
+### Theme B
+- [ ] `find backend -name '*.py' -not -path '*/tests/*' -exec wc -l {} + | awk '$1 >= 800'` → 0 行
+- [ ] `find frontend/src -name '*.tsx' -o -name '*.ts' | grep -v test | xargs wc -l | awk '$1 >= 800'` → 0 行
+- [ ] `npx knip` / `vulture` / `ruff F401/F811` 結果ゼロ
+- [ ] `docs/plans/archive/` に 16 件、ルート docs 最新化、CODEMAPS 3 file 生成
+- [ ] `docs/data-flow/` に 5 endpoint audit report
+
+### Theme C
+- [ ] `grep -rE "from google\.(cloud|oauth2|auth)" backend/ --include='*.py'` → 0 件
+- [ ] `docker compose up` で 9 service 全起動
+- [ ] OSS deployer が docker-compose で smoke 6 query 200
+- [ ] DEPLOYMENT.md に 2 path 完全記述
+
+### 統合
+- [ ] CI all green
+- [ ] live regression なし (Wave 2 smoke 6 query 全成功維持)
+- [ ] terisuke 本番 (rev 00218 系) で latency / error rate 悪化なし
+
+---
+
+## §11 Risk Register & Mitigation
+
+| # | Risk | 影響 | Mitigation | Owner |
+|---|------|------|-----------|-------|
+| R1 | OpenTelemetry SDK 学習コスト | Day 1-2 で進捗遅延 | Python OTel SDK 公式 docs (https://opentelemetry.io/docs/instrumentation/python/) を Day 0 で読む。Datadog/Sentry 経験者を assign | Backend Lead |
+| R2 | 大ファイル分割で import path 大量変更 → CI 緑化に時間 | 各 PR で半日ロス | 各分割 PR を 1 file ずつに限定、CI が落ちたら即 revert | Backend |
+| R3 | Cloud Monitoring 月額コスト増 (metric ingestion + alert eval) | $20-50/月 (推定) | Day 0 で見積、$100/月 超えそうなら閾値再調整 | Infra |
+| R4 | alert 閾値が初期過敏 → alert fatigue | 運用負荷 | 初期は **warn** 閾値のみ、運用 1 週間後に re-evaluate | Infra |
+| R5 | docker-compose で Supabase 互換性問題 (pgvector 等) | OSS deployer が起動失敗 | `pgvector/pgvector:pg16` 公式 image 採用、init.sql で extension 自動有効化 | Infra |
+| R6 | Frontend 分割で VRM lifecycle (CharacterAvatar) 壊す | UX regression | Playwright e2e 必須、特に lipsync 視覚的確認 | Frontend |
+| R7 | terraform/cloud-monitoring と OTel Collector の二重管理 | infra 工数増 | converter (`scripts/sync_alerts_to_gcp.py`) で alerts.rules.yml を SoT 化、terraform は generated 化 | Infra |
+| R8 | iPad Safari 旧 version で `navigator.sendBeacon` 不在 | telemetry 欠損 | `'sendBeacon' in navigator` 判定 + `fetch keepalive` failover | Frontend |
+| R9 | Backend FU-31 で legacy GCP client 削除すると STT_PROVIDER=google が動かなくなる | env config の breaking change | env var 許容値から `google` 除外、CHANGELOG.md に明記、terisuke 本番は qwen-primary なので影響なし | Backend |
+| R10 | OSS deployer の SMTP server 確保 | external dependency | docker-compose に mailhog 同梱 (開発)、production は SendGrid/Mailgun 例 documentation | Infra |
+| R11 | Wave 3 工数 24.5d が想定超過 | リリース遅延 | Theme C は P1 として後回し可、Theme A/B 優先で 16.5d 達成を最低条件 | PM |
+| R12 | Phase 2 着手前に Wave 3 が終わらない | Phase 2 が混沌に | Theme C が間に合わなくても Theme A/B 完了で Phase 2 着手 OK (OSS portability は Wave 3.5 に分離) | PM |
+
+---
+
+## §12 コーディング規約 (再確認)
+
+(`~/.claude/rules/coding-style.md` 抜粋)
+
+- イミュータブル: `return { ...user, name }` (ミューテーション禁止)
+- 高凝集・低結合、機能/ドメイン別整理
+- **関数 50 行未満、ファイル 800 行未満、ネスト 4 レベル未満**
+- Zod で入力バリデーション、パラメータ化クエリ (SQL injection 防止)
+- console.log 禁止、ハードコード禁止、秘密情報は環境変数 (or `secrets.get()`)
+
+(`CLAUDE.md` 抜粋)
+
+- Frontend: `cd frontend && pnpm lint && pnpm typecheck && pnpm build`
+- Backend: `cd backend && ruff check . && black --check . && pytest -m "not slow and not ragas"`
+- Docker on Apple Silicon: Use `--platform linux/amd64` when building for Cloud Run
+- Cloud Run env vars: `--update-env-vars` (NOT `--set-env-vars`)
+- `/api/marp` (FE) ≠ `/api/slides` (BE) — different purposes
+- ALWAYS trace full data flow: client → API route → backend → response
+
+---
+
+## §13 検証 / Live smoke / regression 確認手順
+
+### Standard live smoke (Wave 2 から継承)
+
+```bash
+PROJECT=aipartner-426616
+API_KEY=$(gcloud secrets versions access latest --secret=API_SECRET_KEY --project=${PROJECT})
+URL="https://engineer-cafe-backend-639959525777.asia-northeast1.run.app"
+
+run_chat() {
+  curl -sSL -X POST "$URL/api/chat" \
+    -H "Content-Type: application/json" \
+    -H "X-API-Key: $API_KEY" \
+    -d "{\"query\":\"$1\",\"session_id\":\"smoke-$(date +%s%N)\",\"language\":\"ja\"}" \
+    --max-time 60 | jq -r '.metadata.agent + " | " + .answer[0:100]'
+}
+
+run_chat "今日は何月何日ですか"          # GeneralKnowledgeAgent / system_clock
+run_chat "今週開催されるイベントを全部教えて"  # EventAgent / spreadsheet+connpass+calendar
+run_chat "ハッカソンの予定はありますか？"  # EventAgent / connpass
+run_chat "Engineer Cafe のメインホールの広さは？"  # FacilityAgent / enhanced_rag
+run_chat "営業時間とWi-Fiについて教えて"  # FacilityAgent / enhanced_rag
+run_chat "サイノカフェのランチメニュー"  # BusinessInfoAgent / enhanced_rag
+
+# 期待: 6/6 200 OK、agent / sources 正確
+```
+
+### Theme A 検証
+
+```bash
+# 1. STT event 確認 (FU-21 完了後)
+gcloud logging read 'jsonPayload.event="stt_qwen_complete"' \
+  --project=${PROJECT} --limit=5 --freshness=1h \
+  --format='value(jsonPayload.latency_ms,jsonPayload.confidence,jsonPayload.provider)'
+
+# 2. agent_routing event (FU-22)
+gcloud logging read 'jsonPayload.event="agent_routing"' \
+  --project=${PROJECT} --limit=5 --freshness=1h
+
+# 3. voice_round_trip event (FU-22)
+gcloud logging read 'jsonPayload.event="voice_round_trip"' \
+  --project=${PROJECT} --limit=5 --freshness=1h \
+  --format='value(jsonPayload.stt_ms,jsonPayload.chat_ms,jsonPayload.tts_ms,jsonPayload.total_ms)'
+
+# 4. Frontend telemetry (FU-23)
+gcloud logging read 'jsonPayload.event="thinking_watchdog_expire"' \
+  --project=${PROJECT} --limit=5
+
+# 5. Cloud Monitoring metric (FU-24)
+gcloud logging metrics list --project=${PROJECT}
+# expect: voice_round_trip_ms, chat_response_ms, stt_latency_ms, tts_latency_ms,
+#         agent_route_count, stt_winner_count, error_count,
+#         frontend_audio_watchdog_count, frontend_fallback_count
+
+# 6. Alert policy (FU-25)
+gcloud alpha monitoring policies list --project=${PROJECT} \
+  --format='value(displayName,enabled)'
+# expect: 7 policy, enabled=True
+
+# 7. Notification channel
+gcloud alpha monitoring channels list --project=${PROJECT}
+# expect: company@cor-jp.com email channel
+
+# 8. Test alert fire (OSS path)
+docker compose -f docker-compose.yml up -d
+# 意図的に latency > 8s の event を inject
+# mailhog UI で alert 受信確認
+```
+
+### Theme B 検証
+
+```bash
+# File size 確認
+find backend -name '*.py' -not -path '*/tests/*' -exec wc -l {} + | awk '$1 >= 800 {print}'
+# expect: 空
+
+find frontend/src -name '*.tsx' -o -name '*.ts' | grep -v test \
+  | xargs wc -l | awk '$1 >= 800 {print}'
+# expect: 空
+
+# Dead code
+cd frontend && npx knip && npx ts-prune
+cd backend && ruff check --select F401,F811 . && vulture . --min-confidence=80
+
+# docs
+ls docs/plans/archive/ | wc -l  # expect: 16
+ls docs/CODEMAPS/                # expect: backend.md, frontend.md, architecture.md
+ls docs/data-flow/               # expect: 5 file
+```
+
+### Theme C 検証
+
+```bash
+# GCP SDK 完全除去
+grep -rE "from google\.(cloud|oauth2|auth)" backend/ --include='*.py' | grep -v tests/
+# expect: 空
+
+# docker-compose 起動
+docker compose up -d
+sleep 30
+docker compose ps
+# expect: 9 service all "Up"
+
+# Smoke (OSS path)
+curl -sSL http://localhost:8000/health         # expect: 200
+curl -sSL http://localhost:3000                # expect: 200
+curl -sSL http://localhost:3001                # expect: Grafana login
+curl -sSL http://localhost:9090/-/healthy      # expect: Prometheus OK
+curl -sSL http://localhost:9093/-/healthy      # expect: Alertmanager OK
+curl -sSL http://localhost:8025                # expect: Mailhog UI
+
+# OSS smoke の 6 query (上記 run_chat と同じ、URL を http://localhost:8000 に変更)
+```
+
+---
+
+## §14 Reference: ADR / Issue / 関連 PR
+
+### ADR
+- [ADR-027 Wave 3 Foundation Hardening](../adr/027-wave3-observability-and-refactor-foundation.md) — 全体設計、10 Decision
+- [ADR-028 OSS-Portable Observability](../adr/028-oss-portable-observability-and-infrastructure.md) — OSS portability、8 Decision、ADR-027 D4/D5 を supersede
+- [ADR-026 Wave 2 Kiosk UX Reliability](../adr/026-wave2-kiosk-ux-reliability-baseline.md) — 前 Wave、Wave 3 のトリガー
+- [ADR-024 Memory & Reception Modernization](../adr/024-memory-and-reception-modernization.md) — Phase 2 関連
+- [ADR-023 Routing Modernization (Semantic Router)](../adr/023-routing-modernization.md) — Phase 2 本体
+
+### 関連 doc
+- [`docs/plans/oss-portability-audit-2026-05-18.md`](./oss-portability-audit-2026-05-18.md) — GCP 依存度 全範囲監査 (本 doc の根拠)
+- [`docs/plans/wave3-observability-refactor-handoff-2026-05-18.md`](./wave3-observability-refactor-handoff-2026-05-18.md) — Theme A/B 初版 handoff (本 master の前身)
+- [`docs/plans/wave2-date-audio-calendar-handoff-2026-05-17.md`](./wave2-date-audio-calendar-handoff-2026-05-17.md) — Wave 2 (closed) handoff
+- [`docs/observability-runbook.md`](../observability-runbook.md) — 既存 observability runbook (Wave 3 で更新)
+- [`backend/observability/structured_logger.py`](../../backend/observability/structured_logger.py) — 既存 structured logger
+- [`infra/terraform/`](../../infra/terraform/) — 既存 GCP terraform (Wave 3 で活用)
+
+### GitHub Issues
+
+| ID | # | Title | Theme | Priority |
+|----|---|-------|-------|----------|
+| Epic | #877 | [Wave 3] Pre Phase 2 Foundation Hardening | — | P0 |
+| Theme A | #878 | Observability & Alerting | A | P0 |
+| Theme B | #879 | Refactoring & Documentation | B | P0 |
+| Theme C | #891 | OSS Portability | C | P1 |
+| FU-21 | #880 | STT/TTS structured log call site | A | P0 |
+| FU-22 | #881 | agent_routing + voice_round_trip event | A | P0 |
+| FU-23 | #882 | Frontend telemetry → Backend POST | A | P0 |
+| FU-24 | #883 | log-based metrics (OTel に改定) | A | P0 |
+| FU-25 | #884 | alert + dashboard (両 path) | A | P0 |
+| FU-26 | #885 | Dead code 削除 | B | P0 |
+| FU-27 | #886 | Backend 大ファイル分割 top 6 | B | P0 |
+| FU-28 | #887 | Frontend 大ファイル分割 top 3 | B | P0 |
+| FU-29 | #888 | docs/plans archive + CODEMAPS | B | P1 |
+| FU-30 | #889 | 4-point data flow audit | B | P1 |
+| FU-31 | #892 | Legacy GoogleSTTClient/TTSClient 削除 | C | P1 |
+| FU-32 | #893 | docker-compose + Grafana stack | C | P1 |
+| FU-33 | #894 | Secret backend 抽象化 | C | P1 |
+| FU-34 | #895 | Cron backend 抽象化 + docs | C | P1 |
+| FU-35 | #896 | DEPLOYMENT.md 2-path 改訂 | C | P1 |
+
+### 関連 PR
+- PR #890 (本 doc を含む Wave 3 設計 PR、merge 後に各 Theme 着手) - `feat/wave3-design`
+- PR #876 (Wave 2 ADR-026 record, merged)
+- PR #875 (Wave 2 follow-up, merged)
+- PR #874 (Wave 2 follow-up, merged)
+- PR #873 (Wave 2 hardening, merged)
+- PR #852 (Wave 2 main implementation, merged)
+
+### Cloud Run (Wave 3 開始時の base 状態)
+- Service: `engineer-cafe-backend` @ `asia-northeast1` (project `aipartner-426616`)
+- Revision: `engineer-cafe-backend-00218-8zv` (100% traffic)
+- TZ: `Asia/Tokyo`
+- env: `EVENT_SHEET_GAS_URL` + `EVENT_SHEET_GAS_TOKEN` bound
+
+---
+
+## 🚀 着手の合図
+
+PR #890 が `develop` に merged された時点で、各エンジニアは **§9 の First-Day Checklist** に従って着手してください。
+
+質問・blocker が出た場合は GitHub Issue にコメント、または terisuke に Slack で連絡。
+
+**Phase 2 (Semantic Router cascade) は Wave 3 完了後に着手判断**。Wave 3 で整備した metric / alert / clean codebase が Phase 2 実装の土台になります。
+
+---
+
+**End of Wave 3 Engineer Handoff Master**

--- a/docs/plans/wave3-observability-refactor-handoff-2026-05-18.md
+++ b/docs/plans/wave3-observability-refactor-handoff-2026-05-18.md
@@ -1,0 +1,316 @@
+# Wave 3 Handoff: Observability & Refactor Foundation (Pre Phase 2)
+
+> **対象**: Backend / Frontend / Infra (terraform) 担当エンジニア
+> **作成**: 2026-05-18, Claude Code session (terisuke 指示)
+> **位置付け**: ADR-027 の実装ハンドオフ。Wave 2 (ADR-026) merge 後の運用 gap を埋める Pre Phase 2 foundation hardening
+> **想定工数**: 8〜12 営業日 (Theme A + B 並列、Backend 2〜3 名 + Frontend 1〜2 名)
+
+---
+
+## 0. Executive Summary
+
+terisuke 指示:
+> 一つ目は、ログの整備。定期的にログを見るだけで会話が期待通りに進んでいるか、音声入出力が期待通りのスピードが出ているか、正しいエージェントにルーティングしているかをわかるようにしてほしい。一定の域を超えたエージェントの動きの問題などがあれば、クラウドログのアラートを使って company@cor-jp.com という管理者のアドレスに送るようにしてほしい。
+> 二つ目に、フロントエンドとバックエンド、全体的なリファクタリング。これだけ大規模な改修を行ったので、おそらくドキュメントはもちろんのこと、コード自体にも無駄な部分があったりするはずなので、そこを詳細に調査した上で、フェーズ2に入る前に、コードとドキュメントの全体整理をしておきたい。
+
+→ **Theme A (Observability + Alert)** + **Theme B (Refactor + Docs)** の 2 テーマで Wave 3 を構成。
+
+---
+
+## 1. 現状調査結果 (2026-05-18 実測)
+
+### 1.1 Observability (Theme A 必要性)
+
+| 項目 | 実測 | 評価 |
+|------|------|------|
+| Cloud Monitoring alert policies | **0** | ❌ 完全未整備 |
+| Notification channels | **0** | ❌ company@cor-jp.com 未登録 |
+| Log-based metrics | **0** | ❌ percentile / count なし |
+| Backend structured_logger.py | ✅ 既存 | △ 一部 event は call site 不在 |
+| memory_* events | ✅ 44 件/日 発火 | OK |
+| chat_response event | ✅ 22 件/日 発火 | OK (ただし field 不足) |
+| stt_qwen_complete event | ❌ 0 件/日 | NG (定義あるが呼ばれていない) |
+| tts_* events | ❌ 0 件/日 | NG |
+| agent_routing event | ❌ 未定義 | NG |
+| Frontend audio telemetry | console.debug only | NG (Backend に来ない) |
+
+### 1.2 Refactor (Theme B 必要性)
+
+**Backend ≥800 行 ファイル: 17 個**
+
+| ファイル | 行数 | 優先度 |
+|---------|------|--------|
+| `backend/agents/stt_agent.py` | 3,033 | P0 (最大) |
+| `backend/workflows/main_workflow.py` | 2,588 | P0 |
+| `backend/agents/facility_agent.py` | 2,071 | P0 |
+| `backend/main.py` | 1,984 | P0 |
+| `backend/tools/enhanced_rag.py` | 1,731 | P1 |
+| `backend/evaluation/run_live_api_eval.py` | 1,729 | P2 (eval 系後回し) |
+| `backend/agents/business_info_agent.py` | 1,635 | P1 |
+| `backend/agents/voice_agent.py` | 1,610 | P1 |
+| `backend/scripts/seed_knowledge.py` | 1,360 | P2 |
+| `backend/evaluation/live_quality_gates.py` | 1,308 | P2 |
+| `backend/agents/character_control_agent.py` | 1,292 | P2 |
+| `backend/config/routing_constants.py` | 1,256 | P2 |
+| `backend/agents/general_knowledge_agent.py` | 1,222 | P2 |
+| `backend/utils/memory_helper.py` | 1,084 | P2 |
+| `backend/api/knowledge.py` | 1,041 | P2 |
+| `backend/utils/intent_classifier.py` | 899 | P3 |
+| `backend/agents/event_agent.py` | 891 | P3 |
+
+**Frontend ≥800 行 ファイル: 6 個**
+
+| ファイル | 行数 | 優先度 |
+|---------|------|--------|
+| `frontend/src/app/components/VoiceInterface.tsx` | 1,959 | P0 |
+| `frontend/src/app/components/CharacterAvatar.tsx` | 1,555 | P0 |
+| `frontend/src/app/components/ReceptionPdfGuide.tsx` | 1,304 | P1 |
+| `frontend/src/lib/vrm-utils.ts` | 962 | P1 |
+| `frontend/src/app/page.tsx` | 840 | P2 |
+| `frontend/src/lib/voice-recorder.ts` | 824 | P2 |
+
+**docs**:
+- `docs/plans/` に **21 ファイル**累積、status / archive 規則なし
+- `docs/STT-Implementation-Trace.md`: 2026-04-12 最終 (Wave 2 反映なし)
+- `docs/CODEMAPS/`: **存在しない**
+
+**Dead code**:
+- TODO / FIXME / HACK は backend 0 件 (= プラスの兆候)
+- knip / ts-prune / vulture 未実行 — Wave 3 で初実行
+
+---
+
+## 2. Theme A: Observability & Alerting (FU-21〜25)
+
+### FU-21 [P0] Backend STT/TTS 構造化ログ call site 完成
+- **対象**: `backend/agents/stt_agent.py`, `backend/clients/qwen_stt_client.py`, `backend/clients/piper_plus_client.py`, `backend/services/tts_*.py`
+- **発火 event**: `stt_qwen_complete`, `stt_qwen_hedge_start`, `stt_vosk_complete`, `stt_winner`, `tts_synthesis_start`, `tts_synthesis_complete`, `tts_cache_hit/miss`
+- **payload schema** (必須 fields):
+  ```json
+  {
+    "event": "stt_qwen_complete",
+    "provider": "qwen-primary",
+    "language": "ja",
+    "audio_duration_ms": 2340,
+    "latency_ms": 1820,
+    "confidence": 0.94,
+    "transcript_length": 18,
+    "winner": true,
+    "session_id": "...",
+    "request_id": "..."
+  }
+  ```
+- **Verification**: `pytest backend/tests/observability/test_stt_tts_events.py` 全 PASS + live で `gcloud logging read 'jsonPayload.event="stt_qwen_complete"' --limit 5` で実 record 確認
+- **工数**: 1.5 日
+
+### FU-22 [P0] agent_routing + voice_round_trip event 新設
+- **対象**: `backend/agents/orchestrator_agent.py`, `backend/api/voice.py`, `backend/api/chat.py`
+- **新 event**:
+  - `agent_routing`: `{routed_to, intent, confidence, fallback_used, alternatives, latency_ms}`
+  - `voice_round_trip`: `{stt_ms, chat_ms, tts_ms, total_ms, success, error_type}`
+- **既存 chat_response 拡張**: `agent_route`, `intent`, `confidence`, `tools_used[]` を必須化
+- **Verification**: live `/api/voice` 1 セッション後に 3 event 種類すべてが Cloud Logging に出ること
+- **工数**: 1.5 日
+
+### FU-23 [P0] Frontend telemetry → Backend POST
+- **対象**: `frontend/src/app/hooks/useVoiceSessionController.ts`, `frontend/src/lib/audio/audio-user-interaction-gate.ts`
+- **新 endpoint**: `POST /api/telemetry/voice` (Backend 新設)
+  - payload: `{event, payload, session_id, browser_info, timestamp}`
+  - Backend 側で structured_logger 経由で Cloud Logging に書き出し
+- **送信 event**: `voice_state_transition`, `thinking_watchdog_expire`, `fallback_tts_triggered`, `user_interaction_gate_timeout`, `audio_playback_failed`
+- **送信方式**: `navigator.sendBeacon()` で非同期 fire-and-forget (UX に影響しない)
+- **既存 console.debug は残す** (開発用)
+- **Verification**: kiosk で連続 3 発話 → 全 transition event が backend log に出る
+- **工数**: 2 日
+
+### FU-24 [P0] Cloud Logging log-based metrics
+- **対象**: `terraform/cloud-monitoring/metrics.tf` 新設 (または gcloud script)
+- **作成する metric (9 個)**:
+
+| Metric 名 | type | filter |
+|----------|------|--------|
+| `voice_round_trip_latency_ms` | distribution | `jsonPayload.event="voice_round_trip" → total_ms` |
+| `chat_response_latency_ms` | distribution | `jsonPayload.event="chat_response" → latency_ms` |
+| `stt_latency_ms` | distribution | `jsonPayload.event="stt_qwen_complete" → latency_ms` |
+| `tts_latency_ms` | distribution | `jsonPayload.event="tts_synthesis_complete" → latency_ms` |
+| `agent_route_distribution` | counter | `jsonPayload.event="agent_routing" group_by routed_to` |
+| `stt_winner_ratio` | counter | `jsonPayload.event="stt_winner" group_by provider` |
+| `error_rate_5m` | counter | `severity>=ERROR` |
+| `frontend_audio_watchdog_rate` | counter | `jsonPayload.event="thinking_watchdog_expire"` |
+| `frontend_fallback_rate` | counter | `jsonPayload.event="fallback_tts_triggered"` |
+
+- **Verification**: `gcloud logging metrics list` で 9 metric 全表示 + Cloud Monitoring UI で data 流入確認
+- **工数**: 1 日
+
+### FU-25 [P0] Notification channel + Alert policies
+- **対象**: `terraform/cloud-monitoring/alerts.tf` 新設
+- **Notification channel**: Email = `company@cor-jp.com`
+- **Alert policies** (7 件、初期は warn しきい値):
+
+| Alert | Condition | Severity |
+|-------|-----------|---------|
+| voice-round-trip-p95-slow | voice_round_trip_latency_ms p95 > 8s for 10min | P2 |
+| chat-response-p95-slow | chat_response_latency_ms p95 > 6s for 10min | P2 |
+| stt-latency-degradation | stt_latency_ms p95 > 5s for 15min | P2 |
+| backend-error-burst | error_rate_5m > 20/5min for 10min | P1 |
+| agent-routing-skew | `fallback_general` ratio > 30% for 30min | P3 |
+| frontend-audio-watchdog-spike | frontend_audio_watchdog_rate > 10/15min | P2 |
+| cloud-run-traffic-zero | request count = 0 for 30min (12-20 JST) | P3 |
+
+- **Alert email**: subject prefix `[Engineer Cafe Navigator]`, 本文に Cloud Logging URL
+- **Dashboard**: `Engineer Cafe Navigator — Production` 新設、上記 metric を panel 化
+- **Verification**: test alert を意図的に fire させて company@cor-jp.com に届くこと
+- **工数**: 1.5 日
+
+### Theme A 合計工数: **約 7.5 日** (Backend 2 名並列で 4 日)
+
+---
+
+## 3. Theme B: Refactoring & Documentation (FU-26〜30)
+
+### FU-26 [P0] Dead code 削除
+- **対象**: 全 frontend + 全 backend
+- **手順**:
+  1. Frontend: `cd frontend && npx knip --reporter json > /tmp/knip.json` + `npx ts-prune > /tmp/ts-prune.txt`
+  2. Backend: `cd backend && ruff check --select F401,F811 .` + `vulture backend/ --min-confidence=80 > /tmp/vulture.txt`
+  3. 検出された unused export / import / function を **テストが落ちないことを確認しながら** 削除
+  4. 削除前後でカバレッジ ≥80% 維持
+- **Verification**: `pnpm lint && pnpm typecheck && pnpm build`, `ruff check . && black --check . && pytest -m "not slow and not ragas"` 全 PASS
+- **工数**: 1.5 日
+
+### FU-27 [P0] Backend 大ファイル分割 (top 6)
+- **対象** (順番):
+  1. `backend/main.py` (1,984) → `backend/api/__init__.py` + `backend/api/voice.py` + `backend/api/chat.py` + `backend/api/calendar.py` + `backend/api/admin.py`
+  2. `backend/agents/stt_agent.py` (3,033) → `stt_agent.py` (公開 IF) + `stt/qwen_handler.py` + `stt/vosk_handler.py` + `stt/hedge.py` + `stt/postprocess.py`
+  3. `backend/workflows/main_workflow.py` (2,588) → subgraph 別 + helper module 分離
+  4. `backend/agents/facility_agent.py` (2,071) → category 別
+  5. `backend/agents/business_info_agent.py` (1,635) → category 別
+  6. `backend/tools/enhanced_rag.py` (1,731) → pipeline stage 別
+- **完了条件**: 分割後の各 file < 800 行、既存 unit/integration test 全 PASS、live behavior 1:1 一致 (live smoke)
+- **PR 分割**: 各 file 分割を 1 PR (= 6 PR)
+- **工数**: 3 日 (Backend engineer 2 名並列で 1.5 日)
+
+### FU-28 [P0] Frontend 大ファイル分割 (top 3)
+- **対象**:
+  1. `VoiceInterface.tsx` (1,959) → `VoiceInterface.tsx` (container) + `hooks/useVoicePlayback.ts` + `hooks/useFallbackTTS.ts` + `components/PlaybackController.tsx` + `components/FallbackUI.tsx`
+  2. `CharacterAvatar.tsx` (1,555) → `CharacterAvatar.tsx` (container) + `hooks/useVRMLifecycle.ts` + `hooks/useExpression.ts` + `hooks/useLipsync.ts`
+  3. `ReceptionPdfGuide.tsx` (1,304) → component 分離
+- **完了条件**: 分割後の各 file < 800 行、Playwright e2e PASS (theme-b-audio-reliability.spec.ts 含む)
+- **PR 分割**: 各 file 分割を 1 PR (= 3 PR)
+- **工数**: 2.5 日 (Frontend engineer 1 名で)
+
+### FU-29 [P1] docs 整理 + CODEMAPS 整備
+- **手順**:
+  1. `docs/plans/archive/` 新設、completed plan を移動 (各 plan 冒頭に `> Status: completed YYYY-MM-DD` 追記)
+  2. 移動対象 (推奨, 16 件): production-hardening-2026-03-14, deployment-readiness-2026-03-15, production-integration-2026-03-16, qwen-cloud-run-validation-2026-04-11, alpha-trial-p1-remediation-2026-04-13, production-readiness-followup-2026-04-19, alpha-fast-response-2026-04-30, alpha-parallel-blocker-2026-04-30, alpha-remediation-2026-05-02, alpha-reset-2026-05-03, comprehensive-refactoring-2026-05-05, post-alpha-voice-rag-frontend-2026-05-09, voice-speed-issue-closure-2026-05-16, reception-quality-issues-2026-05-16, frontend-api-separation-closure-2026-05-16, alpha-ui-e2e-hardening-2026-04-12
+  3. アクティブ残す (推奨, 5 件): wave2-date-audio-calendar-handoff, event-source-spreadsheet-integration, event-spreadsheet-engineer-handoff, post-adr023-investigation, semantic-router-self-eval, **+ 本 wave3-observability-refactor-handoff**
+  4. `docs/STT-Implementation-Trace.md` を Wave 2 後の状態に最新化 (TZ=Asia/Tokyo + date-only fast path 追記)
+  5. `docs/observability-runbook.md` に Wave 3 で追加した metric / alert を追記
+  6. `docs/CODEMAPS/` 新設、`/update-codemaps` skill で `backend.md`, `frontend.md`, `architecture.md` を自動生成
+- **完了条件**: docs/plans/archive 移動完了、ルート 4 docs 最新化、CODEMAPS 3 file 生成
+- **工数**: 1 日
+
+### FU-30 [P1] 4-point data flow audit
+- **対象 endpoint** (Wave 2 で変更されたもの):
+  - `/api/voice/*` (STT + TTS)
+  - `/api/chat` (LangGraph 全 agent)
+  - `/api/calendar` (Google Calendar ICS)
+  - `/api/reception/*` (Wave 7 subgraph)
+  - GAS Web App → `EVENT_SHEET_GAS_URL` → `SheetsEventSource` → KB (新 flow)
+- **手順**: 各 endpoint について `docs/data-flow/<endpoint>.md` を作成、`Client → API route → Backend → Response` の 4 点を file:line 引用付きで記録
+- **完了条件**: 5 endpoint 全て markdown 作成、CLAUDE.md ルール satisfied
+- **工数**: 1 日
+
+### Theme B 合計工数: **約 9 日** (Backend 2 名 + Frontend 1 名並列で 5 日)
+
+---
+
+## 4. 全体スケジュール案 (8〜12 営業日)
+
+```mermaid
+graph TD
+  D1[Day 1-2: FU-21 STT/TTS event + FU-26 dead code] --> D3[Day 3-4: FU-22 routing + FU-27 backend split 1-2]
+  D3 --> D5[Day 5-6: FU-23 frontend telemetry + FU-28 frontend split]
+  D5 --> D7[Day 7-8: FU-24 metrics + FU-27 backend split 3-6]
+  D7 --> D9[Day 9: FU-25 alert + dashboard]
+  D9 --> D10[Day 10: FU-29 docs + FU-30 data flow audit]
+  D10 --> D11[Day 11-12: 統合検証 + 1 週間運用バッファ]
+```
+
+### 推奨 PR 分割
+
+| PR | Branch | Scope | 担当 |
+|----|--------|-------|------|
+| PR-W3A-1 | `feat/wave3-stt-tts-events` | FU-21 (STT/TTS structured log call site) | Backend |
+| PR-W3A-2 | `feat/wave3-routing-roundtrip-events` | FU-22 (agent_routing + voice_round_trip) | Backend |
+| PR-W3A-3 | `feat/wave3-frontend-telemetry` | FU-23 (frontend → backend telemetry) | Frontend + Backend |
+| PR-W3A-4 | `feat/wave3-cloud-metrics-alerts` | FU-24 + FU-25 (terraform) | Infra |
+| PR-W3B-1 | `refactor/wave3-dead-code-removal` | FU-26 | Backend + Frontend |
+| PR-W3B-2a..f | `refactor/wave3-backend-split-<file>` | FU-27 (各 file ごと 1 PR) | Backend |
+| PR-W3B-3a..c | `refactor/wave3-frontend-split-<file>` | FU-28 (各 file ごと 1 PR) | Frontend |
+| PR-W3B-4 | `docs/wave3-archive-and-codemaps` | FU-29 | 誰でも |
+| PR-W3B-5 | `docs/wave3-data-flow-audit` | FU-30 | Backend |
+
+合計 PR 数: **約 13 PR**。並列マージ可能 (各 PR は独立)。
+
+---
+
+## 5. GitHub Issue 構成案
+
+### Epic
+- **`[Epic][Wave 3] Pre Phase 2 Foundation Hardening (Observability + Refactor)`**
+  - Labels: `epic`, `wave-3`, `P0`, `pre-phase-2`
+
+### Theme Sub-Epics (2)
+- **`[Theme A][Wave 3] Observability & Alerting (FU-21〜25)`**
+  - Labels: `wave-3`, `theme-a`, `P0`, `backend`, `infrastructure`
+- **`[Theme B][Wave 3] Refactoring & Documentation (FU-26〜30)`**
+  - Labels: `wave-3`, `theme-b`, `P0`, `backend`, `frontend`, `documentation`
+
+### Sub-Issues (10)
+- FU-21 〜 FU-30 (本 doc §2 + §3 参照)
+
+---
+
+## 6. 完了条件 (全 Wave 3 GO)
+
+- [ ] Cloud Monitoring: 9 metric + 7 alert policy + 1 notification channel (`company@cor-jp.com`) deployed
+- [ ] Backend log: `agent_routing` / `voice_round_trip` / `stt_*` / `tts_*` event が live で発火
+- [ ] Frontend telemetry: `thinking_watchdog_expire` 等の 5 event が Cloud Logging に出る
+- [ ] Backend ファイル: 全 ≥800 行 file が < 800 行 に分割
+- [ ] Frontend ファイル: 全 ≥800 行 file が < 800 行 に分割
+- [ ] Dead code: knip / ts-prune / vulture 結果ゼロ
+- [ ] docs/plans/archive: 16 件移動完了、status 明記
+- [ ] docs/STT-Implementation-Trace.md / observability-runbook.md 最新化
+- [ ] docs/CODEMAPS/ 3 file 生成
+- [ ] docs/data-flow/ 5 endpoint 監査完了
+- [ ] CI: lint / typecheck / build / test 全 PASS
+- [ ] live smoke: Wave 2 と同じ 6 query で regression なし
+- [ ] alert dry-run: company@cor-jp.com に test mail 到達確認
+
+---
+
+## 7. Open Questions / Risks
+
+| # | Question / Risk | Owner | 期限 |
+|---|----------------|-------|------|
+| Q1 | terraform/cloud-monitoring を新規導入するか、gcloud script で済ますか | Infra | Day 0 |
+| Q2 | Backend api 分割で main.py の app instance を誰が hold するか (FastAPI mount pattern) | Backend | Day 1 |
+| Q3 | Frontend telemetry の `navigator.sendBeacon` failover (Safari iOS 旧 version) | Frontend | Day 5 |
+| Q4 | Alert しきい値 (p95 8s 等) が初期過敏ではないか | Backend / 運用 | Day 9 |
+| R1 | 大ファイル分割で import path 大量変更 → CI 緑化に時間 | Backend | 各 PR で個別対応 |
+| R2 | Cloud Monitoring 月額コスト増 (metric ingestion + alert eval) | Infra | Day 0 概算 |
+| R3 | 既存 plan を archive する際、現在進行中のものを誤って archive する | doc owner | §3 FU-29 リスト参照 |
+| R4 | terraform 導入で手動 plan/apply ルール (observability-runbook.md) との二重管理 | Infra | Day 0 |
+| R5 | Frontend 分割で VRM lifecycle (CharacterAvatar) を壊す | Frontend | Playwright e2e 必須 |
+
+---
+
+## 8. Reference
+
+- ADR-027 (本 Wave の根拠): `docs/adr/027-wave3-observability-and-refactor-foundation.md`
+- ADR-026 (Wave 2): `docs/adr/026-wave2-kiosk-ux-reliability-baseline.md`
+- 既存 observability runbook: `docs/observability-runbook.md`
+- 既存 structured logger: `backend/observability/structured_logger.py`
+- Cloud Run service: `engineer-cafe-backend` @ `asia-northeast1` (project `aipartner-426616`)
+- Notification target: `company@cor-jp.com`


### PR DESCRIPTION
Refs #877

## 🎯 これは何

Wave 3 (Pre Phase 2 Foundation Hardening) **の設計 + エンジニアハンドオフドキュメント** を land する PR です。実装コード変更ゼロ。

terisuke が **engineers にそのまま渡せる単一ハンドオフ**として `docs/plans/wave3-engineer-handoff-master-2026-05-18.md` (1,123 行) を新設しました。エンジニアは **この 1 ファイルを読むだけで Wave 3 全 15 sub-issues に着手できる** よう設計されています (他 doc は参照用)。

## 📦 Land する 5 ドキュメント (1,937 行)

| # | ファイル | 行 | 役割 |
|---|---------|---:|------|
| 1 | **`docs/plans/wave3-engineer-handoff-master-2026-05-18.md`** | **1,123** | ⭐ **engineers がまず読む master handoff (本 PR の中心)** |
| 2 | `docs/adr/027-wave3-observability-and-refactor-foundation.md` | 225 | ADR-027 — Wave 3 全体設計、10 Decision |
| 3 | `docs/adr/028-oss-portable-observability-and-infrastructure.md` | 137 | ADR-028 — OSS portability、8 Decision (ADR-027 D4/D5 を supersede) |
| 4 | `docs/plans/wave3-observability-refactor-handoff-2026-05-18.md` | 316 | Theme A/B 初版 handoff (master の前身) |
| 5 | `docs/plans/oss-portability-audit-2026-05-18.md` | 259 | GCP 依存 全範囲監査 |

## 🎯 Why

Wave 2 後の独立検証で 3 つの致命 gap を発見:

| Gap | 実測 | 対応 Theme |
|-----|------|----------|
| Observability 未整備 | Cloud Monitoring alert **0** / channel **0** / metric **0** | A |
| Code/Docs 肥大化 | Backend ≥800行 **17** / Frontend **6** / docs/plans **21** | B |
| OSS 公開なのに GCP-locked | infra/terraform 全 11 GCP / ci.yml gcloud **26 hits** | C |

terisuke 3 指示 → Theme A (ログ + email alert to `company@cor-jp.com`) + Theme B (refactor) + Theme C (OSS portability) に 1:1 対応。

## 📐 Wave 3 構成 (1 Epic + 3 Theme + 15 sub-issues)

```
#877 [Epic][Wave 3] Pre Phase 2 Foundation Hardening
├── #878 [Theme A] Observability & Alerting (FU-21~25)         10.5d
│   ├── #880 FU-21 STT/TTS structured log call site
│   ├── #881 FU-22 agent_routing + voice_round_trip event
│   ├── #882 FU-23 Frontend telemetry → Backend POST
│   ├── #883 FU-24 metrics (ADR-028 で OTel に改定)
│   └── #884 FU-25 alert + dashboard (両 path)
├── #879 [Theme B] Refactoring & Documentation (FU-26~30)      9.0d
│   ├── #885 FU-26 Dead code 削除
│   ├── #886 FU-27 Backend 大ファイル分割 top 6 (6 PR)
│   ├── #887 FU-28 Frontend 大ファイル分割 top 3 (3 PR)
│   ├── #888 FU-29 docs archive + CODEMAPS
│   └── #889 FU-30 4-point data flow audit
└── #891 [Theme C] OSS Portability (FU-31~35)                  5.0d
    ├── #892 FU-31 Legacy GoogleSTTClient/TTSClient 削除
    ├── #893 FU-32 docker-compose + Grafana stack
    ├── #894 FU-33 Secret backend 抽象化 (Env/Sops/GCP/Vault)
    ├── #895 FU-34 Cron backend 抽象化 + docs
    └── #896 FU-35 DEPLOYMENT.md 2-path 改訂
```

工数: **約 24.5d**、並列実行で **10〜14 営業日**

## 🛠️ Master Handoff Doc の構造

`wave3-engineer-handoff-master-2026-05-18.md` の目次:

- §0 必読 1 分要約
- §1 背景 (3 gap + terisuke 3 指示)
- §2 ゴール / 非ゴール
- §3 監査で確定した事実 (実測 evidence、コード:行引用)
- §4 3 テーマ全体像 (ASCII tree)
- §5 アーキテクチャ決定 (ADR-027 D1〜D10 + ADR-028 D1〜D8 統合 + 図)
- §6 全 15 sub-issues 詳細仕様 (payload schema、受入条件)
- §7 PR 分割 + mermaid 依存グラフ (18 PR 想定、最大 11 PR 並列)
- §8 Daily Schedule (14 営業日、role 別 task 配分)
- §9 担当別 First-Day Checklist (Backend A/B、Frontend、Infra、Doc の copy-paste shell コマンド)
- §10 Exit Criteria (Theme 別 + 統合)
- §11 Risk Register (12 件 + mitigation + owner)
- §12 コーディング規約 (再確認)
- §13 検証 / Live smoke / regression 確認手順 (両 path で curl 例)
- §14 Reference (ADR / Issue / 関連 PR / Cloud Run base 状態)

## ✅ Verification (本 PR factcheck)

- `gcloud alpha monitoring policies/channels list` → 0 件 (ADR-027 根拠)
- `gcloud logging metrics list` → 0 件
- Backend google-cloud SDK 直 import 2 ファイル (`stt_agent.py:1491`, `voice_agent.py:444,471`)
- `infra/terraform/` 11 ファイル 全 GCP-locked (`providers.tf` = google only)
- CI workflow gcloud hits **26** (`ci.yml`)
- Backend ≥800行 **17** + Frontend ≥800行 **6** (`git ls-tree origin/develop` + `wc -l` 実測)
- README で ISC license 明示済

## 📋 Reviewer Focus

1. **Master handoff §6 (15 sub-issues 仕様)** が GitHub Issue 本文と整合しているか
2. **§5 architecture 図** で OTel Collector の exporter 切替が正しく描けているか
3. **§8 Daily Schedule** の並列性 (Day 1 で 11 PR 同時着手) が現実的か
4. **§9 First-Day Checklist** の shell コマンドが copy-paste で動くか
5. **§11 Risk Register** の R3/R7 (terraform 二重管理) と R12 (Theme C 後回し fallback) の判断
6. ADR-028 が ADR-027 D4/D5 を superseded する整理が明確か

## 🚀 Merge 後の流れ

1. terisuke が **`docs/plans/wave3-engineer-handoff-master-2026-05-18.md` をエンジニアに共有**
2. 各エンジニアが §9 の First-Day Checklist に従って Day 1 着手
3. Theme A/B/C 並列で 18 PR を 10〜14 日かけて merge
4. Wave 3 完了 → Phase 2 (Semantic Router cascade, ADR-023) 着手判断

## Out of scope

- Theme A/B/C 各 FU の実装本体 (本 PR merge 後の個別 PR)
- terraform/cloud-monitoring 追加実装
- 大ファイル分割の実コミット
- docker-compose.yml 実体追加
- OpenTelemetry SDK 導入

## Related

- Wave 2 (closed): #855 / ADR-026
- Wave 3 Epic: #877 (implementation closure remains tracked separately)
- 既存 GCP terraform (Issue #513 Phase 1b): `infra/terraform/alerts.tf` (ADR-028 で活用)

🤖 Generated with Claude Code

