### PR TITLE
[codex] Stabilize kiosk OCR camera retries

### DIFF
--- a/frontend/e2e/reception-flow.spec.ts
+++ b/frontend/e2e/reception-flow.spec.ts
@@ -89,6 +89,98 @@ async function keepOcrCameraPending(page: import('@playwright/test').Page) {
   });
 }
 
+async function recordPendingVideoMediaRequests(page: import('@playwright/test').Page) {
+  await page.addInitScript(() => {
+    const mediaWindow = window as Window & {
+      __PLAYWRIGHT_GET_USER_MEDIA_CALLS__?: Array<Record<string, unknown> | null>;
+    };
+    mediaWindow.__PLAYWRIGHT_GET_USER_MEDIA_CALLS__ = [];
+
+    const existingMediaDevices = navigator.mediaDevices ?? {};
+    const pendingVideoStream = new Promise<MediaStream>(() => {
+      // Keep the OCR camera startup request pending after it has been observed.
+    });
+
+    Object.defineProperty(navigator, 'mediaDevices', {
+      configurable: true,
+      value: {
+        ...existingMediaDevices,
+        getUserMedia: async (constraints?: MediaStreamConstraints) => {
+          const snapshot = constraints
+            ? (JSON.parse(JSON.stringify(constraints)) as Record<string, unknown>)
+            : null;
+          mediaWindow.__PLAYWRIGHT_GET_USER_MEDIA_CALLS__?.push(snapshot);
+
+          if (constraints?.video) {
+            return pendingVideoStream;
+          }
+
+          return new MediaStream();
+        },
+      },
+    });
+  });
+}
+
+async function readRecordedGetUserMediaCalls(page: import('@playwright/test').Page) {
+  return page.evaluate(() => {
+    const mediaWindow = window as Window & {
+      __PLAYWRIGHT_GET_USER_MEDIA_CALLS__?: Array<Record<string, unknown> | null>;
+    };
+    return mediaWindow.__PLAYWRIGHT_GET_USER_MEDIA_CALLS__ ?? [];
+  });
+}
+
+async function recordStaleSavedCameraThenFallback(
+  page: import('@playwright/test').Page,
+  staleDeviceId = 'stale-camera-id',
+) {
+  await page.addInitScript(({ deviceId }) => {
+    window.localStorage.setItem('kiosk-camera-device-id', deviceId);
+    const mediaWindow = window as Window & {
+      __PLAYWRIGHT_GET_USER_MEDIA_CALLS__?: Array<Record<string, unknown> | null>;
+    };
+    mediaWindow.__PLAYWRIGHT_GET_USER_MEDIA_CALLS__ = [];
+
+    const existingMediaDevices = navigator.mediaDevices ?? {};
+    const pendingVideoStream = new Promise<MediaStream>(() => {
+      // Keep the fallback camera startup request pending after it has been observed.
+    });
+
+    Object.defineProperty(navigator, 'mediaDevices', {
+      configurable: true,
+      value: {
+        ...existingMediaDevices,
+        getUserMedia: async (constraints?: MediaStreamConstraints) => {
+          const snapshot = constraints
+            ? (JSON.parse(JSON.stringify(constraints)) as Record<string, unknown>)
+            : null;
+          mediaWindow.__PLAYWRIGHT_GET_USER_MEDIA_CALLS__?.push(snapshot);
+
+          const videoConstraints =
+            constraints && typeof constraints.video === 'object' ? constraints.video : null;
+          const deviceIdConstraint =
+            videoConstraints && 'deviceId' in videoConstraints
+              ? (videoConstraints.deviceId as { exact?: string } | string)
+              : null;
+          if (
+            typeof deviceIdConstraint === 'object' &&
+            deviceIdConstraint?.exact === deviceId
+          ) {
+            throw new DOMException('Requested camera is no longer available', 'OverconstrainedError');
+          }
+
+          if (constraints?.video) {
+            return pendingVideoStream;
+          }
+
+          return new MediaStream();
+        },
+      },
+    });
+  }, { deviceId: staleDeviceId });
+}
+
 async function provideReadableOcrCamera(page: import('@playwright/test').Page) {
   await page.addInitScript(() => {
     const existingMediaDevices = navigator.mediaDevices ?? {};
@@ -349,7 +441,7 @@ test.describe('Reception flow — device mode button routes', () => {
   });
 
   test('button_pressed with member_card mode opens the kiosk OCR overlay', async ({ page }) => {
-    await keepOcrCameraPending(page);
+    await recordPendingVideoMediaRequests(page);
     await page.goto('/', { waitUntil: 'domcontentloaded' });
     await dismissInitialModal(page);
 
@@ -365,6 +457,54 @@ test.describe('Reception flow — device mode button routes', () => {
       /会員証|Member card/,
     );
     await expect(page.getByTestId('kiosk-welcome-ocr-overlay')).toBeHidden({ timeout: 5_000 });
+
+    await expect
+      .poll(
+        async () => {
+          const calls = await readRecordedGetUserMediaCalls(page);
+          return calls.filter((call) => Boolean(call?.video)).length;
+        },
+        { timeout: 5_000 },
+      )
+      .toBeGreaterThanOrEqual(1);
+
+    const videoCalls = (await readRecordedGetUserMediaCalls(page)).filter((call) =>
+      Boolean(call?.video),
+    );
+    expect(videoCalls[0]).toMatchObject({
+      audio: false,
+    });
+  });
+
+  test('button_pressed member_card falls back when the saved camera id is stale', async ({
+    page,
+  }) => {
+    await recordStaleSavedCameraThenFallback(page);
+    await page.goto('/', { waitUntil: 'domcontentloaded' });
+    await dismissInitialModal(page);
+
+    await dispatchDeviceDetection(page, {
+      type: 'button_pressed',
+      device_id: 'e2e-device-mode',
+      timestamp: new Date().toISOString(),
+      data: { mode: 'member_card' },
+    });
+
+    await expect
+      .poll(
+        async () => {
+          const calls = await readRecordedGetUserMediaCalls(page);
+          return calls.filter((call) => Boolean(call?.video)).length;
+        },
+        { timeout: 5_000 },
+      )
+      .toBeGreaterThanOrEqual(2);
+
+    const savedCameraId = await page.evaluate(() =>
+      window.localStorage.getItem('kiosk-camera-device-id'),
+    );
+    expect(savedCameraId).toBeNull();
+    await expect(page.getByTestId('kiosk-ocr-overlay')).toBeVisible({ timeout: 5_000 });
   });
 
   test('button_pressed with handwriting mode sends OCR text to the voice conversation', async ({
@@ -625,6 +765,68 @@ test.describe('Reception flow — member card OCR success', () => {
       { timeout: 8_000 },
     );
     await expect(page.getByTestId('response-text')).toContainText('フェーズ2以降');
+  });
+
+  test('member card OCR retries automatic capture after a high-confidence no-number response', async ({
+    page,
+  }) => {
+    const ocrRequests: Array<Record<string, unknown>> = [];
+
+    await page.route('**/api/ocr', async (route) => {
+      ocrRequests.push(route.request().postDataJSON() as Record<string, unknown>);
+
+      const isFirstAttempt = ocrRequests.length === 1;
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify(
+          isFirstAttempt
+            ? {
+                success: true,
+                mode: 'member_card',
+                member_number: null,
+                recognized_text: 'Engineer Cafe member card text without an ID',
+                confidence: 0.93,
+                language: null,
+                expression: null,
+                processing_time_ms: 98,
+                visitor_identity: null,
+                error: null,
+              }
+            : {
+                success: true,
+                mode: 'member_card',
+                member_number: 24680,
+                recognized_text: null,
+                confidence: 0.96,
+                language: null,
+                expression: null,
+                processing_time_ms: 119,
+                visitor_identity: null,
+                error: null,
+              },
+        ),
+      });
+    });
+
+    await mockReceptionStart(page, '会員証を確認しました。ご用件をお聞かせください。');
+
+    await page.goto('/', { waitUntil: 'domcontentloaded' });
+    await dismissInitialModal(page);
+
+    await page.getByRole('button', { name: /会員証|Member card/ }).click();
+
+    await expect.poll(() => ocrRequests.length, { timeout: 12_000 }).toBe(2);
+    expect(ocrRequests[0]).toMatchObject({ mode: 'member_card' });
+    expect(ocrRequests[1]).toMatchObject({ mode: 'member_card' });
+    expect(typeof ocrRequests[0].image_data).toBe('string');
+    expect(typeof ocrRequests[1].image_data).toBe('string');
+
+    await expect(page.getByTestId('kiosk-ocr-overlay')).toBeHidden({ timeout: 5_000 });
+    await expect(page.getByTestId('response-text')).toContainText(
+      '会員番号 24680 を読み取りました',
+      { timeout: 8_000 },
+    );
   });
 });
 

--- a/frontend/src/components/reception/OcrCameraView.tsx
+++ b/frontend/src/components/reception/OcrCameraView.tsx
@@ -93,6 +93,9 @@ export function OcrCameraView({
     }
     autoStartedRef.current = true;
     void startCamera();
+    return () => {
+      autoStartedRef.current = false;
+    };
   }, [autoStart, startCamera]);
 
   const cameraErrorNotifiedRef = useRef(false);

--- a/frontend/src/hooks/useOcrCamera.ts
+++ b/frontend/src/hooks/useOcrCamera.ts
@@ -51,6 +51,67 @@ const DEFAULT_CONFIDENCE_THRESHOLD_MEMBER = 0.8;
 const DEFAULT_CONFIDENCE_THRESHOLD_HANDWRITING = 0.7;
 const SCAN_LOOP_INTERVAL_MS = 200;
 const SELECTED_CAMERA_DEVICE_ID_STORAGE_KEY = 'kiosk-camera-device-id';
+const IDEAL_CAMERA_SIZE = { width: { ideal: 1280 }, height: { ideal: 720 } } as const;
+
+function isRecoverableCameraConstraintError(error: unknown): boolean {
+  if (!(error instanceof DOMException)) return false;
+  return error.name === 'OverconstrainedError' || error.name === 'NotFoundError';
+}
+
+function getCameraConstraints(selectedDeviceId: string | null): MediaStreamConstraints[] {
+  const fallbackConstraints: MediaStreamConstraints[] = [
+    {
+      video: { facingMode: { ideal: 'environment' }, ...IDEAL_CAMERA_SIZE },
+      audio: false,
+    },
+    {
+      video: IDEAL_CAMERA_SIZE,
+      audio: false,
+    },
+    {
+      video: true,
+      audio: false,
+    },
+  ];
+
+  if (!selectedDeviceId || selectedDeviceId === 'default') {
+    return fallbackConstraints;
+  }
+
+  return [
+    {
+      video: {
+        deviceId: { exact: selectedDeviceId },
+        ...IDEAL_CAMERA_SIZE,
+      },
+      audio: false,
+    },
+    {
+      video: {
+        deviceId: { ideal: selectedDeviceId },
+        ...IDEAL_CAMERA_SIZE,
+      },
+      audio: false,
+    },
+    ...fallbackConstraints,
+  ];
+}
+
+function isTerminalOcrSuccess(
+  result: OcrResponse,
+  mode: OcrMode,
+  confidenceThreshold: number,
+): boolean {
+  if (!result.success || result.confidence < confidenceThreshold) {
+    return false;
+  }
+
+  if (mode === 'member_card') {
+    return typeof result.member_number === 'number';
+  }
+
+  return Boolean(result.recognized_text?.trim());
+}
 
 export function useOcrCamera(options: UseOcrCameraOptions): UseOcrCameraReturn {
   const {
@@ -79,7 +140,9 @@ export function useOcrCamera(options: UseOcrCameraOptions): UseOcrCameraReturn {
   const scanLoopTimerRef = useRef<ReturnType<typeof setInterval> | null>(null);
   const lastSubmitTimeRef = useRef<number>(0);
   const isSubmittingRef = useRef(false);
+  const submittingRunIdRef = useRef<number | null>(null);
   const attemptsRef = useRef(0);
+  const scanRunIdRef = useRef(0);
 
   // Stable refs for callbacks to avoid stale closures (HIGH-1 fix)
   const onSuccessRef = useRef(options.onSuccess);
@@ -94,11 +157,29 @@ export function useOcrCamera(options: UseOcrCameraOptions): UseOcrCameraReturn {
   // Reuse a single offscreen canvas to avoid GC pressure (HIGH-4 fix)
   const qualityCanvasRef = useRef<HTMLCanvasElement | null>(null);
 
+  const isCurrentScanRun = useCallback((runId: number) => {
+    return scanRunIdRef.current === runId && streamRef.current !== null;
+  }, []);
+
+  const resumeScanning = useCallback((runId: number) => {
+    if (isCurrentScanRun(runId)) {
+      setState('scanning');
+    }
+  }, [isCurrentScanRun]);
+
   // Cleanup
   const stopCamera = useCallback(() => {
+    scanRunIdRef.current += 1;
+    isSubmittingRef.current = false;
+    submittingRunIdRef.current = null;
+
     if (scanLoopTimerRef.current) {
       clearInterval(scanLoopTimerRef.current);
       scanLoopTimerRef.current = null;
+    }
+    if (videoRef.current) {
+      videoRef.current.pause();
+      videoRef.current.srcObject = null;
     }
     if (streamRef.current) {
       streamRef.current.getTracks().forEach((t) => t.stop());
@@ -107,7 +188,8 @@ export function useOcrCamera(options: UseOcrCameraOptions): UseOcrCameraReturn {
   }, []);
 
   // Submit a quality-passing frame
-  const submitFrame = useCallback(async () => {
+  const submitFrame = useCallback(async (runId: number) => {
+    if (!isCurrentScanRun(runId)) return;
     if (isSubmittingRef.current) return;
     if (attemptsRef.current >= maxAttempts) return;
 
@@ -126,17 +208,27 @@ export function useOcrCamera(options: UseOcrCameraOptions): UseOcrCameraReturn {
       brightness: quality.brightness,
     });
 
-    if (!quality.passed) return;
+    if (!quality.passed) {
+      resumeScanning(runId);
+      return;
+    }
 
     // Submit cooldown: only send API request every 2 seconds
     const now = Date.now();
-    if (now - lastSubmitTimeRef.current < submitIntervalMs) return;
+    if (now - lastSubmitTimeRef.current < submitIntervalMs) {
+      resumeScanning(runId);
+      return;
+    }
 
     // Capture frame
     const frameData = captureFrame(video);
-    if (!frameData) return;
+    if (!frameData) {
+      resumeScanning(runId);
+      return;
+    }
 
     isSubmittingRef.current = true;
+    submittingRunIdRef.current = runId;
     lastSubmitTimeRef.current = now;
     setState('submitting');
     const currentAttempt = attemptsRef.current + 1;
@@ -149,9 +241,11 @@ export function useOcrCamera(options: UseOcrCameraOptions): UseOcrCameraReturn {
         mode,
         session_id: sessionId,
       });
+      if (!isCurrentScanRun(runId)) return;
+
       setLastResult(result);
 
-      const isSuccess = result.success && result.confidence >= confidenceThreshold;
+      const isSuccess = isTerminalOcrSuccess(result, mode, confidenceThreshold);
 
       if (isSuccess) {
         setState('success');
@@ -162,62 +256,111 @@ export function useOcrCamera(options: UseOcrCameraOptions): UseOcrCameraReturn {
         stopCamera();
         onFallbackRef.current?.();
       } else {
-        setState('scanning');
+        resumeScanning(runId);
       }
     } catch {
+      if (!isCurrentScanRun(runId)) return;
+
       if (currentAttempt >= maxAttempts) {
         setState('fallback');
         stopCamera();
         onFallbackRef.current?.();
       } else {
-        setState('scanning');
+        resumeScanning(runId);
       }
     } finally {
-      isSubmittingRef.current = false;
+      if (submittingRunIdRef.current === runId) {
+        isSubmittingRef.current = false;
+        submittingRunIdRef.current = null;
+      }
     }
-  }, [mode, sessionId, maxAttempts, submitIntervalMs, confidenceThreshold, stopCamera]);
+  }, [
+    mode,
+    sessionId,
+    maxAttempts,
+    submitIntervalMs,
+    confidenceThreshold,
+    stopCamera,
+    isCurrentScanRun,
+    resumeScanning,
+  ]);
 
   // Start camera
   const startCamera = useCallback(async () => {
+    stopCamera();
+    const runId = scanRunIdRef.current;
     setState('starting');
     attemptsRef.current = 0;
+    isSubmittingRef.current = false;
+    submittingRunIdRef.current = null;
+    lastSubmitTimeRef.current = 0;
     setAttempts(0);
     setLastResult(null);
+    setQualityInfo(null);
 
     try {
+      if (!navigator.mediaDevices?.getUserMedia) {
+        throw new DOMException('getUserMedia is not available', 'NotSupportedError');
+      }
       const selectedDeviceId =
         typeof window !== 'undefined'
           ? window.localStorage.getItem(SELECTED_CAMERA_DEVICE_ID_STORAGE_KEY)
           : null;
-      const video =
-        selectedDeviceId && selectedDeviceId !== 'default'
-          ? {
-              deviceId: { exact: selectedDeviceId },
-              width: { ideal: 1280 },
-              height: { ideal: 720 },
-            }
-          : { facingMode: 'environment', width: { ideal: 1280 }, height: { ideal: 720 } };
-      const stream = await navigator.mediaDevices.getUserMedia({
-        video,
-        audio: false,
-      });
+      let stream: MediaStream | null = null;
+      let lastError: unknown = null;
+      const constraintsList = getCameraConstraints(selectedDeviceId);
+
+      for (let i = 0; i < constraintsList.length; i += 1) {
+        try {
+          stream = await navigator.mediaDevices.getUserMedia(constraintsList[i]);
+          break;
+        } catch (error) {
+          lastError = error;
+          const canRetry = isRecoverableCameraConstraintError(error);
+          if (i === 0 && selectedDeviceId && canRetry) {
+            window.localStorage.removeItem(SELECTED_CAMERA_DEVICE_ID_STORAGE_KEY);
+          }
+          if (!canRetry) {
+            break;
+          }
+        }
+      }
+
+      if (!stream) {
+        throw lastError ?? new DOMException('Camera stream unavailable', 'NotFoundError');
+      }
+      if (scanRunIdRef.current !== runId) {
+        stream.getTracks().forEach((t) => t.stop());
+        return;
+      }
       streamRef.current = stream;
 
       if (videoRef.current) {
         videoRef.current.srcObject = stream;
-        await videoRef.current.play();
+        void videoRef.current.play().catch(() => undefined);
+      }
+
+      if (scanRunIdRef.current !== runId) {
+        stream.getTracks().forEach((t) => t.stop());
+        if (streamRef.current === stream) {
+          streamRef.current = null;
+        }
+        return;
       }
 
       setState('scanning');
 
       // Start scan loop (quality check + submit)
       scanLoopTimerRef.current = setInterval(() => {
-        void submitFrame();
+        void submitFrame(runId);
       }, SCAN_LOOP_INTERVAL_MS);
     } catch {
+      if (scanRunIdRef.current !== runId) return;
+
+      stopCamera();
       setState('error');
     }
-  }, [submitFrame]);
+  }, [stopCamera, submitFrame]);
 
   // Skip button
   const skip = useCallback(() => {


### PR DESCRIPTION
## Summary

Closes #915.

Fixes the kiosk OCR camera lifecycle regressions observed on 2026-05-24 JST:

- device-mode member-card OCR could enter the OCR screen but fail to start the camera when the saved camera `deviceId` was stale;
- member-card OCR could stop after a high-confidence OCR response that did not actually include a `member_number`;
- in dev/Strict effects, the auto-started OCR camera could remain stuck at "カメラ起動中..." after the first in-flight start was invalidated.

## Root Cause

The last 5 hours of Cloud Run logs showed OCR backend completions, no backend errors, and all recent member-card OCR completions had `member=None`. That points away from a backend 5xx and toward frontend camera/retry state.

Implementation findings:

- `useOcrCamera` used `deviceId: { exact: savedId }` and moved to `error` immediately if `getUserMedia()` rejected. iOS/browser device IDs can become stale across permission/session changes.
- OCR terminal success was based on `result.success && confidence >= threshold`, so member-card mode could stop scanning even when `member_number` was still `null`.
- stale in-flight camera/OCR work could still race against retry/cleanup, and React dev Strict effects exposed the OCR auto-start suppression path.

## Changes

- Add camera constraint fallback order: saved exact device, saved ideal device, environment camera, ideal video size, then `video: true`.
- Remove stale saved camera ID after recoverable constraint errors.
- Treat member-card OCR as terminal success only when a numeric `member_number` exists.
- Treat handwriting OCR as terminal success only when recognized text is non-empty.
- Keep scan state active after quality rejects, submit cooldown, or frame-capture misses.
- Add scan-run IDs so stale in-flight OCR/start results cannot overwrite state after retry/skip/unmount.
- Make OCR auto-start restartable under React Strict effects.
- Strengthen Playwright coverage for camera startup, stale saved camera fallback, and second automatic OCR POST after a high-confidence no-number response.

## Validation

- `pnpm --dir frontend typecheck`
- `pnpm --dir frontend test:node`
- `pnpm --dir frontend lint`
- `python3 scripts/check-large-files.py`
- `git diff --check`
- `PLAYWRIGHT_BASE_URL=http://127.0.0.1:3001 pnpm --dir frontend exec playwright test --config=playwright.config.ts e2e/reception-flow.spec.ts --project=chromium --workers=1`

## Notes

No backend request/response shape changes. Existing unrelated local changes under `docs/development/AGENTS.md` and `.claude/worktrees/` were not staged.
