### PR TITLE
[P0] Restore deterministic JST time answers

### DIFF
--- a/backend/agents/general_knowledge/responses.py
+++ b/backend/agents/general_knowledge/responses.py
@@ -88,6 +88,14 @@ class GeneralKnowledgeResponseMixin:
     def _is_date_only_query(query: str) -> bool:
         return QueryClassifier._is_date_only_query(query)
 
+    @staticmethod
+    def _is_current_time_query(query: str) -> bool:
+        classifier = QueryClassifier()
+        normalized = classifier._normalize_query(query)
+        if QueryClassifier._is_date_only_query(normalized):
+            return False
+        return classifier._is_current_time_query(normalized)
+
     def _current_date_response(self, query: str, language: SupportedLanguage) -> Dict[str, Any]:
         compact = self._compact_query(query)
         from backend.agents import general_knowledge_agent as agent_module
@@ -199,6 +207,54 @@ class GeneralKnowledgeResponseMixin:
                 "rag_used": False,
                 "provider_called": False,
                 "timezone": "Asia/Tokyo",
+            },
+        }
+
+    def _current_time_response(self, query: str, language: SupportedLanguage) -> Dict[str, Any]:
+        from backend.agents import general_knowledge_agent as agent_module
+
+        now = agent_module.get_now_jst()
+        weekdays_ja = ("月", "火", "水", "木", "金", "土", "日")
+        weekdays_zh = ("星期一", "星期二", "星期三", "星期四", "星期五", "星期六", "星期日")
+        weekdays_ko = ("월요일", "화요일", "수요일", "목요일", "금요일", "토요일", "일요일")
+
+        if language == "en":
+            answer = (
+                f"[helpful]The current Japan Standard Time is "
+                f"{now.strftime('%H:%M')} on {now.strftime('%A, %B %-d, %Y')}."
+            )
+        elif language == "zh":
+            answer = (
+                f"[helpful]现在的日本标准时间是{now.year}年{now.month}月{now.day}日"
+                f"（{weekdays_zh[now.weekday()]}）{now.hour}点{now.minute:02d}分。"
+            )
+        elif language == "ko":
+            answer = (
+                f"[helpful]현재 일본 표준시는 {now.year}년 {now.month}월 {now.day}일"
+                f"({weekdays_ko[now.weekday()]}) {now.hour}시 {now.minute:02d}분입니다."
+            )
+        else:
+            answer = (
+                f"[helpful]今の日本標準時は{now.year}年{now.month}月{now.day}日"
+                f"（{weekdays_ja[now.weekday()]}曜日）{now.hour}時{now.minute:02d}分です。"
+            )
+
+        return {
+            "answer": answer,
+            "emotion": "helpful",
+            "metadata": {
+                "agent": self.name,
+                "status": "success",
+                "category": "general_knowledge",
+                "request_type": "current-time",
+                "route": "general_knowledge",
+                "query_type": "current-time",
+                "sources": ["system_clock"],
+                "web_search_used": False,
+                "rag_used": False,
+                "provider_called": False,
+                "timezone": "Asia/Tokyo",
+                "current_time_jst": now.isoformat(),
             },
         }
 

--- a/backend/agents/general_knowledge_agent.py
+++ b/backend/agents/general_knowledge_agent.py
@@ -141,6 +141,8 @@ class GeneralKnowledgeAgent(GeneralKnowledgeMemoryMixin, GeneralKnowledgeRespons
         try:
             if self._is_date_only_query(query):
                 return self._current_date_response(query, language)
+            if query_type == "current-time" or self._is_current_time_query(query):
+                return self._current_time_response(query, language)
 
             mode = self._resolve_general_mode(query, query_type)
             if mode == "assistant_profile":

--- a/backend/config/business_hours.py
+++ b/backend/config/business_hours.py
@@ -11,8 +11,8 @@
 BUSINESS_HOURS: dict[str, dict[str, str] | None] = {
     "weekday": {"open": "09:00", "close": "22:00"},
     "saturday": {"open": "09:00", "close": "22:00"},
-    "sunday": None,
-    "holiday": None,
+    "sunday": {"open": "09:00", "close": "22:00"},
+    "holiday": {"open": "09:00", "close": "22:00"},
 }
 
 # 閉館警告を表示する閉館前の分数

--- a/backend/config/routing_constants.py
+++ b/backend/config/routing_constants.py
@@ -258,6 +258,7 @@ REQUEST_TYPE_TO_AGENT_MAP: dict[str, AgentNodeName] = {
     "assistant_profile": "general_knowledge",
     "daily_conversation": "general_knowledge",
     "current_info": "general_knowledge",
+    "current-time": "general_knowledge",
 }
 
 AgentResolutionSource: TypeAlias = Literal["request_type", "category", "agent", "alias", "fallback"]

--- a/backend/tests/agents/test_general_knowledge_agent.py
+++ b/backend/tests/agents/test_general_knowledge_agent.py
@@ -566,6 +566,49 @@ class TestGeneralKnowledgeAgentIntegration:
         self.mock_provider.generate.assert_not_called()
 
     @pytest.mark.asyncio
+    async def test_answer_query_current_time_uses_system_clock_without_search(self):
+        fixed_now = datetime(2026, 5, 24, 21, 40, 11, tzinfo=ZoneInfo("Asia/Tokyo"))
+
+        with patch("backend.agents.general_knowledge_agent.get_now_jst", return_value=fixed_now):
+            result = await self.agent.answer_query(
+                query="今何時ですか?",
+                language="ja",
+                session_id="test_session",
+                query_type="current-time",
+            )
+
+        assert "2026年5月24日" in result["answer"]
+        assert "21時40分" in result["answer"]
+        assert result["metadata"]["query_type"] == "current-time"
+        assert result["metadata"]["sources"] == ["system_clock"]
+        assert result["metadata"]["web_search_used"] is False
+        assert result["metadata"]["rag_used"] is False
+        assert result["metadata"]["provider_called"] is False
+        assert result["metadata"]["timezone"] == "Asia/Tokyo"
+        self.mock_web_search.search.assert_not_called()
+        self.mock_provider.generate.assert_not_called()
+        self.mock_rag_search.search.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_answer_query_current_time_natural_english_uses_system_clock(self):
+        fixed_now = datetime(2026, 5, 24, 21, 40, 11, tzinfo=ZoneInfo("Asia/Tokyo"))
+
+        with patch("backend.agents.general_knowledge_agent.get_now_jst", return_value=fixed_now):
+            result = await self.agent.answer_query(
+                query="What time is it now?",
+                language="en",
+                session_id="test_session",
+                query_type="general",
+            )
+
+        assert "21:40" in result["answer"]
+        assert "Japan Standard Time" in result["answer"]
+        assert result["metadata"]["query_type"] == "current-time"
+        self.mock_web_search.search.assert_not_called()
+        self.mock_provider.generate.assert_not_called()
+        self.mock_rag_search.search.assert_not_called()
+
+    @pytest.mark.asyncio
     @pytest.mark.parametrize("language,query,expected_fragment", DATE_ONLY_AGENT_CASES)
     async def test_multilingual_date_only_queries_use_system_clock_without_external_calls(
         self, language, query, expected_fragment

--- a/backend/tests/agents/test_orchestrator_fast_routing.py
+++ b/backend/tests/agents/test_orchestrator_fast_routing.py
@@ -588,6 +588,22 @@ class TestOrchestratorFastRouting:
     @pytest.mark.parametrize(
         "query",
         [
+            "今何時ですか?",
+            "今の時間教えてください",
+            "What time is it now?",
+        ],
+    )
+    def test_current_time_routes_to_current_time_fast_path(self, orchestrator, query):
+        result = orchestrator._try_fast_routing(query)
+
+        assert result is not None
+        assert result["agent"] == "general_knowledge"
+        assert result["category"] == "current-time"
+        assert result["request_type"] == "current-time"
+
+    @pytest.mark.parametrize(
+        "query",
+        [
             "今天是几月几号？",
             "本周是哪几天？",
             "오늘 날짜 알려줘",

--- a/backend/tests/utils/test_query_classifier.py
+++ b/backend/tests/utils/test_query_classifier.py
@@ -81,10 +81,17 @@ class TestQueryClassifier:
     @pytest.mark.asyncio
     async def test_current_time_query_english(self):
         """現在時刻クエリの分類（英語）"""
-        result = await self.classifier.classify_with_details("whattimeisitnow")
+        result = await self.classifier.classify_with_details("What time is it now?")
 
         assert result.category == "current-time"
         assert result.confidence == 1.0
+
+    @pytest.mark.asyncio
+    async def test_current_time_query_does_not_catch_business_hours(self):
+        """営業時間質問を現在時刻として誤分類しない。"""
+        result = await self.classifier.classify_with_details("What time do you close?")
+
+        assert result.category != "current-time"
 
     @pytest.mark.asyncio
     async def test_calendar_query(self):

--- a/backend/tests/utils/test_time_utils.py
+++ b/backend/tests/utils/test_time_utils.py
@@ -10,10 +10,12 @@ import pytest
 
 from backend.utils.time_utils import (
     JST,
+    get_business_hours_for_date,
     get_current_time_period,
     get_minutes_until_closing,
     get_now_jst,
     get_today_business_hours,
+    is_engineer_cafe_closed_date,
     is_closing_soon,
 )
 
@@ -199,10 +201,34 @@ class TestGetTodayBusinessHours:
         assert open_time == time(9, 0)
         assert close_time == time(22, 0)
 
-    def test_sunday_closed(self) -> None:
-        """日曜日（weekday=6）は休館日（None）を検証する。"""
+    def test_sunday(self) -> None:
+        """日曜日（weekday=6）の営業時間を検証する。"""
         result = get_today_business_hours(6)
-        assert result is None
+        assert result is not None
+        open_time, close_time = result
+        assert open_time == time(9, 0)
+        assert close_time == time(22, 0)
+
+    def test_regular_closed_day_last_monday(self) -> None:
+        """毎月最終月曜日は休館日として扱う。"""
+        target = datetime(2026, 3, 30, 21, 30, tzinfo=JST).date()
+
+        assert is_engineer_cafe_closed_date(target) is True
+        assert get_business_hours_for_date(target) is None
+
+    def test_regular_open_day_sunday(self) -> None:
+        """最終月曜・年末年始以外の日曜は9:00-22:00で扱う。"""
+        target = datetime(2026, 3, 8, 21, 30, tzinfo=JST)
+
+        assert is_engineer_cafe_closed_date(target.date()) is False
+        assert get_business_hours_for_date(target) == (time(9, 0), time(22, 0))
+
+    def test_year_end_closed_day(self) -> None:
+        """年末年始は休館日として扱う。"""
+        target = datetime(2026, 12, 30, 12, 0, tzinfo=JST).date()
+
+        assert is_engineer_cafe_closed_date(target) is True
+        assert get_business_hours_for_date(target) is None
 
     def test_custom_config(self) -> None:
         """カスタム設定での営業時間取得を検証する。"""

--- a/backend/tests/workflows/test_main_workflow.py
+++ b/backend/tests/workflows/test_main_workflow.py
@@ -1769,6 +1769,35 @@ class TestOrchestratorIntegration:
 
     @pytest.mark.asyncio
     @patch("backend.workflows.main_workflow.OrchestratorAgent")
+    async def test_keyword_router_fast_routes_current_time(self, mock_orchestrator_class):
+        from backend.workflows.main_workflow import MainWorkflow
+
+        mock_orchestrator_class.return_value = _StubOrchestrator()
+
+        with patch("backend.utils.memory_helper.get_memory_helper") as mock_get_helper:
+            mock_helper = AsyncMock()
+            mock_helper.store_message = AsyncMock()
+            mock_get_helper.return_value = mock_helper
+
+            workflow = MainWorkflow()
+            result = await workflow._keyword_router_node(
+                {
+                    "query": "今何時ですか?",
+                    "session_id": "time-session",
+                    "language": "ja",
+                    "routing": {},
+                }
+            )
+
+        assert result["routing"]["pre_memory_fast_path_agent"] == "general_knowledge"
+        assert result["routing"]["category"] == "current-time"
+        assert result["routing"]["request_type"] == "current-time"
+        assert workflow._keyword_router_decision({"routing": result["routing"]}) == (
+            "general_knowledge"
+        )
+
+    @pytest.mark.asyncio
+    @patch("backend.workflows.main_workflow.OrchestratorAgent")
     async def test_keyword_router_keeps_anaphora_on_normal_path(self, mock_orchestrator_class):
         from backend.workflows.main_workflow import MainWorkflow
 

--- a/backend/tests/workflows/test_time_greeting.py
+++ b/backend/tests/workflows/test_time_greeting.py
@@ -168,8 +168,8 @@ class TestFormatResponseClosingWarning:
     @pytest.mark.asyncio
     async def test_no_warning_on_closed_day(self, workflow: MainWorkflow) -> None:
         """休館日には閉館警告が出ないことを検証する。"""
-        # 2026-03-08 は日曜日 (weekday=6)
-        mock_now = datetime(2026, 3, 8, 21, 35, 0, tzinfo=JST)
+        # 2026-03-30 は毎月最終月曜日
+        mock_now = datetime(2026, 3, 30, 21, 35, 0, tzinfo=JST)
         state = _make_state()
         runtime = _make_runtime()
 
@@ -183,3 +183,23 @@ class TestFormatResponseClosingWarning:
 
         closing = result["metadata"]["closing_warning"]
         assert closing["is_closing_soon"] is False
+
+    @pytest.mark.asyncio
+    async def test_closing_warning_on_sunday(self, workflow: MainWorkflow) -> None:
+        """日曜日も通常開館日として閉館警告を出す。"""
+        mock_now = datetime(2026, 3, 8, 21, 40, 0, tzinfo=JST)
+        state = _make_state(answer="元の回答です。", language="ja")
+        runtime = _make_runtime()
+
+        with (
+            patch("backend.utils.time_utils.get_now_jst", return_value=mock_now),
+            patch.object(workflow, "_character_control_agent", None),
+            patch("backend.utils.memory_helper.get_memory_helper") as mock_memory,
+        ):
+            mock_memory.return_value.store_message = AsyncMock()
+            result = await workflow._format_response_node(state, runtime)
+
+        closing = result["metadata"]["closing_warning"]
+        assert closing["is_closing_soon"] is True
+        assert closing["minutes_remaining"] == 20
+        assert "閉館まであと約20分" in result["messages"][-1].content

--- a/backend/utils/intent_classifier.py
+++ b/backend/utils/intent_classifier.py
@@ -203,6 +203,15 @@ def is_current_info_request(lower_query: str) -> bool:
     return any(marker in lower_query for marker in current_markers)
 
 
+def is_current_time_request(lower_query: str) -> bool:
+    """Detect exact current-time questions that should use the system clock."""
+    classifier = QueryClassifier()
+    normalized = classifier._normalize_query(lower_query)
+    if QueryClassifier._is_date_only_query(normalized):
+        return False
+    return classifier._is_current_time_query(normalized)
+
+
 def classify_fast_intent(query: str) -> Optional[FastIntent]:
     """Return the same fast keyword route used by the orchestrator."""
     lower_query = query.lower()
@@ -283,6 +292,14 @@ def classify_fast_intent(query: str) -> Optional[FastIntent]:
                 "greeting",
                 f"Greeting keyword detected: {stripped[:30]}",
             )
+
+    if is_current_time_request(lower_query):
+        return FastIntent(
+            "general_knowledge",
+            "current-time",
+            "current-time",
+            "Current time request detected",
+        )
 
     cafe_entity = resolve_cafe_entity(query)
     if cafe_entity == "saino":

--- a/backend/utils/query_classifier.py
+++ b/backend/utils/query_classifier.py
@@ -193,6 +193,28 @@ class QueryClassifier:
         if self._is_date_only_query(normalized_question):
             return True
 
+        compact_question = re.sub(r"[\s　]+", "", normalized_question.lower()).strip("!?？。、.,")
+        time_scope_exclusions = [
+            "営業時間",
+            "最終受付",
+            "受付時間",
+            "何時まで",
+            "何時から",
+            "開店",
+            "閉店",
+            "開館",
+            "閉館",
+            "openinghours",
+            "businesshours",
+            "lastreception",
+            "whendoyouopen",
+            "whendoyouclose",
+            "whattimedoyouopen",
+            "whattimedoyouclose",
+        ]
+        if any(exc in compact_question for exc in time_scope_exclusions):
+            return False
+
         time_keywords = [
             "現在時刻",
             "現在の時刻",
@@ -200,7 +222,10 @@ class QueryClassifier:
             "今何時",
             "currenttime",
             "whattime",
+            "what time is it",
             "timenow",
+            "time now",
+            "current time",
             "今時刻",
             "時刻を教えて",
             "whattimeisitnow",
@@ -213,7 +238,10 @@ class QueryClassifier:
                 if "今" in normalized_question or "現在" in normalized_question:
                     return True
 
-        return any(keyword in normalized_question for keyword in time_keywords)
+        return any(
+            keyword in normalized_question.lower() or keyword.replace(" ", "") in compact_question
+            for keyword in time_keywords
+        )
 
     @staticmethod
     def _is_date_only_query(normalized_question: str) -> bool:

--- a/backend/utils/time_utils.py
+++ b/backend/utils/time_utils.py
@@ -5,7 +5,8 @@
 営業時間取得などの機能を提供する。
 """
 
-from datetime import datetime, time
+import calendar
+from datetime import date, datetime, time
 from zoneinfo import ZoneInfo
 
 from backend.config.business_hours import BUSINESS_HOURS, CLOSING_WARNING_MINUTES, TIMEZONE
@@ -125,6 +126,29 @@ def get_today_business_hours(
     close_time = time(int(close_parts[0]), int(close_parts[1]))
 
     return (open_time, close_time)
+
+
+def is_engineer_cafe_closed_date(target_date: date) -> bool:
+    """エンジニアカフェの定期休館日に該当するかを返す。"""
+    if (target_date.month, target_date.day) >= (12, 29) or (target_date.month, target_date.day) <= (
+        1,
+        3,
+    ):
+        return True
+
+    if target_date.weekday() != 0:
+        return False
+
+    last_day = calendar.monthrange(target_date.year, target_date.month)[1]
+    return target_date.day + 7 > last_day
+
+
+def get_business_hours_for_date(target: date | datetime) -> tuple[time, time] | None:
+    """日付を考慮したエンジニアカフェの営業時間を返す。"""
+    target_date = target.date() if isinstance(target, datetime) else target
+    if is_engineer_cafe_closed_date(target_date):
+        return None
+    return get_today_business_hours(target_date.weekday())
 
 
 def get_now_jst() -> datetime:

--- a/backend/utils/topic_guard.py
+++ b/backend/utils/topic_guard.py
@@ -22,6 +22,7 @@ ON_TOPIC_CATEGORIES: set[str] = {
     "daily_conversation",
     "general_light",
     "current_info",
+    "current-time",
     "consultation",
     "community",
     "career",

--- a/backend/workflows/main/response.py
+++ b/backend/workflows/main/response.py
@@ -313,9 +313,9 @@ class ResponseWorkflowMixin:
             from backend.config.routing_constants import CLOSING_WARNING_TEMPLATES
             from backend.utils.time_utils import (
                 get_current_time_period,
+                get_business_hours_for_date,
                 get_minutes_until_closing,
                 get_now_jst,
-                get_today_business_hours,
                 is_closing_soon,
             )
 
@@ -323,7 +323,7 @@ class ResponseWorkflowMixin:
             time_period = get_current_time_period(now.hour)
             metadata["time_period"] = time_period
 
-            business_hours = get_today_business_hours(now.weekday())
+            business_hours = get_business_hours_for_date(now)
             closing_warning: dict[str, object] = {"is_closing_soon": False}
 
             if business_hours is not None:


### PR DESCRIPTION
## Summary
- Fixes #917.
- Restores deterministic current-time answers for `今何時?`, `今の時間教えて`, `What time is it now?`, etc. using the backend Asia/Tokyo system clock.
- Keeps current-time requests on `general_knowledge` with `request_type=query_type=current-time`, without LLM, RAG, or web-search calls.
- Updates closing-warning date handling so regular Sundays use 9:00-22:00 and true regular closed days are last Monday / year-end New Year.

## Root Cause
Cloud Run logs showed the affected turns were transcribed correctly and entered `GeneralKnowledgeAgent`, with no 5xx/ERROR. The query classifier could recognize current-time questions, but the fast routing layer did not preserve `current-time`, and `GeneralKnowledgeAgent` only had a deterministic system-clock path for date-only queries. As a result, `今何時` fell through to LLM generation and could produce guessed or refusal answers.

## Validation
- `backend/.venv/bin/python -m pytest backend/tests/agents/test_general_knowledge_agent.py backend/tests/agents/test_orchestrator_fast_routing.py backend/tests/utils/test_query_classifier.py backend/tests/utils/test_time_utils.py backend/tests/workflows/test_time_greeting.py backend/tests/workflows/test_main_workflow.py::TestOrchestratorIntegration::test_keyword_router_fast_routes_current_time backend/tests/workflows/test_main_workflow.py::TestOrchestratorIntegration::test_keyword_router_fast_routes_current_weather -q` -> 340 passed
- `backend/.venv/bin/python -m pytest backend/tests/api/test_chat_api.py backend/tests/test_main_endpoints.py -q` -> 46 passed
- `backend/.venv/bin/python -m pytest backend/tests/workflows/test_main_workflow.py -q` -> 67 passed
- `backend/.venv/bin/python -m ruff check ...` -> passed
- `backend/.venv/bin/python -m black --check ...` -> passed
- `python3 scripts/check-large-files.py` -> passed
- `git diff --check` -> passed
