### PR TITLE
ci: scale Cloud Run backend to cost-minimal test posture (min=0/max=2)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -638,6 +638,10 @@ jobs:
             echo "::warning::EVENT_SHEET_GAS_TOKEN latest secret version not available; spreadsheet event sync disabled"
           fi
 
+          # Scaling / cost posture (Phase 1 完了後の最小コスト・テスト体制):
+          #   min=0/max=2 = scale-to-zero。アイドル課金ゼロ、初回は ~40s cold start。
+          #   本番ウォームプールへ戻す場合は min=1〜5 / max=3〜15 に変更（docs/DEPLOYMENT.md「Scaling and Cost Posture」参照）。
+          #   ここは Cloud Run 構成の正本。手動 gcloud で変えてもこの deploy で上書きされる。
           gcloud run deploy engineer-cafe-backend \
             --image asia-northeast1-docker.pkg.dev/aipartner-426616/cloud-run-source-deploy/engineer-cafe-backend:${{ github.sha }} \
             --region asia-northeast1 \
@@ -647,8 +651,8 @@ jobs:
             --memory 8Gi \
             --cpu 4 \
             --concurrency 1 \
-            --min-instances 5 \
-            --max-instances 15 \
+            --min-instances 0 \
+            --max-instances 2 \
             --cpu-boost \
             --no-cpu-throttling \
             --update-env-vars "ENVIRONMENT=production,TZ=Asia/Tokyo,TTS_PROVIDER=piper,TTS_REQUIRE_PRIMARY_PROVIDER=true,TTS_PIPER_PRIMARY_TIMEOUT_SECONDS=20,PIPER_PLUS_API_URL=https://piper-plus-639959525777.asia-northeast1.run.app,VOICEVOX_API_URL=https://voicevox-proto-639959525777.asia-northeast2.run.app,STT_PROVIDER=qwen-primary,STT_QWEN_RUNTIME=torch,STT_LLM_POSTPROCESS=false,VOICE_STT_REQUEST_TIMEOUT_SECONDS=15,QWEN_STT_TIMEOUT=15,QWEN_STT_HEDGE_DELAY_SECONDS=1.5,QWEN_STT_HEDGE_GRACE_SECONDS=4,QWEN_STT_LATENCY_BUDGET_SECONDS=11.5,STT_PRELOAD_QWEN_PRIMARY=true,STT_PRELOAD_VOSK_FALLBACK=true,STT_LOG_TRANSCRIPT=true,ENABLE_AGENT_MEMORY_STM_WRITES=false,ALLOW_AGENT_MEMORY_STM_WRITE_DISABLE=true,ENABLE_MEMORY_CANDIDATES=true,ENABLE_MEMORY_PROMOTION=true,ENABLE_LONG_TERM_MEMORY_RERANK=true,SENSOR_TRIGGER_EVENT_TTL_SECONDS=60,HF_HOME=/app/.hf_cache,FRONTEND_PRODUCTION_ORIGIN=${FRONTEND_PRODUCTION_ORIGIN},ALLOWED_ORIGINS=${FRONTEND_PRODUCTION_ORIGIN},FAST_LLM_ENABLED=true,FAST_LLM_PRIMARY_PROVIDER=cerebras,FAST_LLM_PRIMARY_MODEL=google/gemini-3.1-flash-lite-preview,FAST_LLM_FALLBACK_PROVIDER=gemini,FAST_LLM_FALLBACK_MODEL=google/gemini-2.5-flash-lite,FAST_LLM_TERTIARY_PROVIDER=cerebras,CEREBRAS_ENABLED=true,CEREBRAS_FAST_MODEL=gpt-oss-120b,CEREBRAS_REASONING_EFFORT=low,DEEP_REASONING_MODEL=google/gemini-3.1-pro-preview,DEEP_REASONING_FALLBACK_MODEL=google/gemini-2.5-pro,LANGSMITH_PROJECT=engineer-cafe-navigator-production,LANGCHAIN_PROJECT=engineer-cafe-navigator-production" \

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -207,6 +207,65 @@ EVENT_SHEET_GAS_URL=EVENT_SHEET_GAS_URL:latest
 EVENT_SHEET_GAS_TOKEN=EVENT_SHEET_GAS_TOKEN:latest
 ```
 
+### Scaling and Cost Posture
+
+Cloud Run scaling is the dominant cost lever. Two postures are supported; switch
+between them depending on whether the system is in live production use or in a
+cost-minimal development/test phase.
+
+| Posture | When | backend | piper-plus | voicevox-proto |
+| --- | --- | --- | --- | --- |
+| **Cost-minimal (test)** | No live kiosk traffic; dev/test only | `min=0 / max=2` | `min=0 / max=2` | `min=0 / max=2` |
+| **Production (warm)** | Live event / kiosk in use | `min=5 / max=15` | `min=2 / max=10` | `min=0 / max=12` |
+
+Idle baseline (min instances running 24/7; estimate from config x public pricing,
+actual billing unverified): production posture ~$1,350/mo (backend ~$1,140 +
+piper ~$207); cost-minimal posture ~$0 idle (pay only per request).
+
+**Source of truth**: backend scaling values live in `.github/workflows/ci.yml`
+(the `engineer-cafe-backend` deploy step). Any manual `gcloud run services update`
+to the backend is **overwritten on the next `develop` backend deploy** — to make a
+backend scaling change durable, edit ci.yml. `piper-plus` and `voicevox-proto` are
+not deployed by any workflow, so manual updates to them persist until a manual
+redeploy.
+
+**Cold start**: with `min=0`, the first request after idle pays a cold start
+(~40s) because the backend preloads the Qwen STT model
+(`STT_PRELOAD_QWEN_PRIMARY=true`) during startup; subsequent requests are 2-5s.
+`--cpu-boost` is kept on to speed startup. This is expected in cost-minimal
+posture — do not "fix" it by raising `minScale` unless returning to production.
+
+**Constraints**: keep backend memory at `8Gi` (4Gi OOMs at ~4270 MiB during model
+load). Do not pin traffic to a specific revision; deploys route `--to-latest`.
+
+#### Switch to cost-minimal test posture
+
+Immediate (live, until next CI deploy):
+
+```bash
+gcloud run services update engineer-cafe-backend --region=asia-northeast1 --min-instances=0 --max-instances=2
+gcloud run services update piper-plus            --region=asia-northeast1 --min-instances=0 --max-instances=2
+gcloud run services update voicevox-proto        --region=asia-northeast2 --min-instances=0 --max-instances=2
+```
+
+Durable (backend): set `--min-instances 0 --max-instances 2` in the
+`engineer-cafe-backend` deploy step of `.github/workflows/ci.yml`.
+
+#### Revert to production warm posture
+
+```bash
+gcloud run services update engineer-cafe-backend --region=asia-northeast1 --min-instances=5 --max-instances=15
+gcloud run services update piper-plus            --region=asia-northeast1 --min-instances=2 --max-instances=10
+gcloud run services update voicevox-proto        --region=asia-northeast2 --max-instances=12
+```
+
+Then restore `--min-instances 5 --max-instances 15` in the backend deploy step of
+`.github/workflows/ci.yml` so the next deploy keeps the warm pool. (Optional: drive
+these from GitHub repo variables to switch postures without a code change.)
+
+> Current posture (2026-06-01): **cost-minimal test** (Phase 1 complete, no live
+> kiosk traffic). `ci.yml` is set to `min=0 / max=2`.
+
 ### GCP Secret Manager
 
 Create a secret container once, then add versions:

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -260,8 +260,11 @@ gcloud run services update voicevox-proto        --region=asia-northeast2 --max-
 ```
 
 Then restore `--min-instances 5 --max-instances 15` in the backend deploy step of
-`.github/workflows/ci.yml` so the next deploy keeps the warm pool. (Optional: drive
-these from GitHub repo variables to switch postures without a code change.)
+`.github/workflows/ci.yml` so the next deploy keeps the warm pool, **and** restore
+the matching `minScale`/`maxScale` in `scripts/validate-p0-cloudrun-vercel-timeouts.mjs`
+(the P0 guard tracks the intended posture; it fails CI if ci.yml and the guard
+disagree). (Optional: drive these from GitHub repo variables to switch postures
+without a code change.)
 
 > Current posture (2026-06-01): **cost-minimal test** (Phase 1 complete, no live
 > kiosk traffic). `ci.yml` is set to `min=0 / max=2`.

--- a/scripts/validate-p0-cloudrun-vercel-timeouts.mjs
+++ b/scripts/validate-p0-cloudrun-vercel-timeouts.mjs
@@ -61,11 +61,15 @@ for (let index = 0; index < args.length; index += 1) {
   }
 }
 
+// Scaling posture tracks the current intended Cloud Run cost posture.
+// 2026-06-01: cost-minimal test posture (Phase 1 complete) = min 0 / max 2.
+// To revert to the production warm pool, set minScale/maxScale back to 5 / 15
+// here AND in .github/workflows/ci.yml. See docs/DEPLOYMENT.md "Scaling and Cost Posture".
 const expected = {
   service: process.env.CLOUD_RUN_SERVICE || 'engineer-cafe-backend',
   region: process.env.CLOUD_RUN_REGION || 'asia-northeast1',
-  minScale: 5,
-  maxScale: 15,
+  minScale: 0,
+  maxScale: 2,
   containerConcurrency: 1,
   timeoutSeconds: 300,
   startupCpuBoost: true,
@@ -77,8 +81,8 @@ const expected = {
 const expectedPiperPlus = {
   service: process.env.PIPER_PLUS_SERVICE || 'piper-plus',
   region: process.env.PIPER_PLUS_REGION || 'asia-northeast1',
-  minScale: 2,
-  maxScale: 10,
+  minScale: 0,
+  maxScale: 2,
   containerConcurrency: 4,
   timeoutSeconds: 300,
   startupCpuBoost: true,
@@ -109,8 +113,8 @@ if (!proxySource.includes('BACKEND_PROXY_TIMEOUT_MS = 110_000')) {
 
 const workflowSource = readFileSync(workflowPath, 'utf8');
 for (const requiredDeployFlag of [
-  '--min-instances 5',
-  '--max-instances 15',
+  '--min-instances 0',
+  '--max-instances 2',
   '--cpu-boost',
   '--no-cpu-throttling',
 ]) {


### PR DESCRIPTION
## 目的

Phase 1 完了に伴い、エンジニアカフェナビゲーターの Cloud Run を**最小コストのテスト体制**へ恒久化する。常時ウォームプール（backend min=5）は live kiosk 運用が無い現フェーズでは不要。

## 背景（重要な発見）

- backend の live 構成は `min=5/max=15`・4CPU/8Gi・CPU常時割当で、**アイドルだけで月 ~$1,140 試算**（piper 常時2台 ~$207 含め ~$1,350/月、構成×公開単価。実請求は未検証）。
- **`.github/workflows/ci.yml` が `--min-instances 5 --max-instances 15` をハードコード**しており、手動 `gcloud` 変更は **develop への backend deploy ごとに上書き**される（＝手動変更は揮発性）。恒久化には ci.yml の修正が必須。

## 変更内容

| ファイル | 変更 |
|---|---|
| `.github/workflows/ci.yml` | backend deploy: `--min-instances 5→0` / `--max-instances 15→2`。8Gi/4cpu/concurrency=1/`--cpu-boost`/`--no-cpu-throttling` は維持。revert 用コメント追記 |
| `docs/DEPLOYMENT.md` | `### Scaling and Cost Posture` 追加。test/production 両posture表・ci.yml が正本である注意・即時(gcloud)+恒久(ci.yml)の切替/revert 手順・cold start/8Gi 制約 |

## 既に適用済みの live 変更（このPRとは別の即時オペ）

3サービスとも `gcloud run services update` で `min=0/max=2` 反映済み:
- `engineer-cafe-backend` (an1) → rev `00226-x92`
- `piper-plus` (an1) → rev `00008-bc5`
- `voicevox-proto` (an2) → rev `00015-4h9`

piper/voicevox はどの workflow もデプロイしないため手動変更が恒久。backend のみ ci.yml が正本なので本PRで揃える。検証: backend `/health` → 200 (api/supabase ok, llm configured)。

## 効果（試算・実請求未検証）

アイドル月額 **~$1,350 → ほぼ $0**（テストで叩いた分だけ従量）。

## トレードオフ

- `min=0` のため backend 初回リクエストは **~40s のコールドスタート**（Qwen STT preload）。2回目以降 2-5s。`--cpu-boost` は維持。
- 本番イベント時は DEPLOYMENT.md の "Revert to production warm posture" 手順で `min=5/max=15` に戻す（gcloud 即時 + ci.yml 恒久）。

## レビュー観点

- CI/config + docs のみ（アプリコード変更なし）
- ci.yml の min/max 以外（8Gi/cpu/boost/throttling/env/secrets）が無変更であること
- YAML 構文 OK（`yaml.safe_load` 検証済み）

🤖 Generated with [Claude Code](https://claude.com/claude-code)