### PR TITLE
refactor: frontend-supabase-cleanup系の残タスクコメント消化

### DIFF
--- a/frontend/src/__tests__/query-classifier.test.ts
+++ b/frontend/src/__tests__/query-classifier.test.ts
@@ -1,0 +1,47 @@
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+
+import { QueryClassifier } from '@/lib/query-classifier';
+
+test('applies STT corrections before classifying Engineer Cafe queries', async () => {
+  const classifier = new QueryClassifier();
+
+  const result = await classifier.classifyWithDetails('エンジニア壁の営業時間は？');
+
+  assert.equal(result.category, 'facility-info');
+  assert.equal(result.confidence, 1.0);
+  assert.equal(result.debugInfo?.reason, 'Engineer Cafe specific');
+});
+
+test('applies STT corrections before classifying Saino Cafe queries', async () => {
+  const classifier = new QueryClassifier();
+
+  const result = await classifier.classifyWithDetails('才納カフェの営業時間を教えて');
+
+  assert.equal(result.category, 'saino-cafe');
+});
+
+test('uses corrected basement wording for facility classification', async () => {
+  const classifier = new QueryClassifier();
+
+  const result = await classifier.classifyWithDetails('階下のMTGスペースについて');
+
+  assert.equal(result.category, 'facility-info');
+});
+
+test('keeps ambiguous cafe queries ambiguous after correction pass', async () => {
+  const classifier = new QueryClassifier();
+
+  const result = await classifier.classifyWithDetails('カフェの営業時間について教えて');
+
+  assert.equal(result.category, 'cafe-clarification-needed');
+});
+
+test('handles blank input and leaves the caller string unchanged', async () => {
+  const classifier = new QueryClassifier();
+  const input = 'エンジニア壁の営業時間は？';
+
+  assert.equal(await classifier.classify('   '), 'general');
+  assert.equal(await classifier.classify(input), 'facility-info');
+  assert.equal(input, 'エンジニア壁の営業時間は？');
+});

--- a/frontend/src/lib/feature-flags.ts
+++ b/frontend/src/lib/feature-flags.ts
@@ -21,6 +21,25 @@ interface FeatureFlags {
   MIGRATION_USER_PERCENTAGE: number; // 0-100
 }
 
+type RAGExperimentOptions = Readonly<{
+  category?: string;
+  language?: string;
+}>;
+
+interface RAGExperimentSearchResult {
+  readonly similarity?: number;
+  readonly [key: string]: unknown;
+}
+
+interface RAGExperimentLogResult {
+  readonly userId: string;
+  readonly variant: 'control' | 'treatment';
+  readonly query: string;
+  readonly responseTime: number;
+  readonly resultCount: number;
+  readonly avgSimilarity: number;
+}
+
 class FeatureFlagManager {
   private static instance: FeatureFlagManager;
   private flags: FeatureFlags;
@@ -173,13 +192,10 @@ export class RAGExperiment {
   static async runExperiment(
     userId: string,
     query: string,
-    options?: {
-      category?: string;
-      language?: string;
-    }
+    options?: RAGExperimentOptions
   ): Promise<{
     variant: 'control' | 'treatment';
-    results: any[];
+    results: RAGExperimentSearchResult[];
     metrics: {
       responseTime: number;
       resultCount: number;
@@ -190,7 +206,7 @@ export class RAGExperiment {
     const variant = useNewImplementation ? 'treatment' : 'control';
     
     const startTime = Date.now();
-    let results: any[];
+    let results: RAGExperimentSearchResult[];
     
     if (variant === 'treatment') {
       // New implementation (would be implemented later)
@@ -202,7 +218,7 @@ export class RAGExperiment {
     
     const responseTime = Date.now() - startTime;
     const avgSimilarity = results.length > 0
-      ? results.reduce((sum, r) => sum + (r.similarity || 0), 0) / results.length
+      ? results.reduce((sum, result) => sum + (result.similarity || 0), 0) / results.length
       : 0;
     
     // Log experiment results if enabled
@@ -233,10 +249,10 @@ export class RAGExperiment {
    */
   static async runParallelComparison(
     query: string,
-    options?: any
+    options?: RAGExperimentOptions
   ): Promise<{
-    control: any;
-    treatment: any;
+    control: Awaited<ReturnType<typeof RAGExperiment.runExperiment>>;
+    treatment: Awaited<ReturnType<typeof RAGExperiment.runExperiment>>;
     comparison: {
       responseTimeDiff: number;
       resultCountDiff: number;
@@ -259,20 +275,26 @@ export class RAGExperiment {
     };
   }
   
-  private static async searchWithCurrentImplementation(query: string, options?: any): Promise<any[]> {
-    // TODO: Implement after backend migration is complete
-    console.warn('[RAGExperiment] Current implementation disabled during migration');
+  private static async searchWithCurrentImplementation(
+    query: string,
+    options?: RAGExperimentOptions
+  ): Promise<RAGExperimentSearchResult[]> {
+    // Backend owns active RAG search through EnhancedRAGSearch behind /api/chat.
+    // There is no frontend/backend experiment search contract yet, so the legacy
+    // A/B helper stays inert until ADR-025 Phase B0/B2 defines that API surface.
     void query;
     void options;
-    return []; // Return empty array during migration
+    return [];
   }
   
-  private static async searchWithNewEmbeddings(query: string, options?: any): Promise<any[]> {
-    // Placeholder for new implementation
+  private static async searchWithNewEmbeddings(
+    query: string,
+    options?: RAGExperimentOptions
+  ): Promise<RAGExperimentSearchResult[]> {
     return this.searchWithCurrentImplementation(query, options);
   }
   
-  private static async logExperimentResult(result: any): Promise<void> {
-    // Log to analytics system
+  private static async logExperimentResult(result: RAGExperimentLogResult): Promise<void> {
+    void result;
   }
 }

--- a/frontend/src/lib/knowledge-base-utils.ts
+++ b/frontend/src/lib/knowledge-base-utils.ts
@@ -3,9 +3,10 @@ import { supabaseAdmin } from './supabase';
 import { SupportedLanguage } from '@/lib/types';
 
 /**
- * TODO(frontend-supabase-cleanup): This server-only helper still uses direct
- * Supabase access because active admin knowledge routes and cron jobs depend on
- * it. Remove it after those paths proxy through the backend.
+ * Frontend migration note: admin knowledge CRUD/upload now proxy to backend
+ * /api/knowledge, but /api/health/knowledge and legacy seed/import scripts
+ * still call this helper. Keep it server-only until those remaining paths move
+ * to backend or are deleted.
  */
 export interface KnowledgeBaseEntry {
   content: string;

--- a/frontend/src/lib/monitoring/rag-metrics.ts
+++ b/frontend/src/lib/monitoring/rag-metrics.ts
@@ -4,8 +4,9 @@ import { supabaseAdmin } from '../supabase';
 /**
  * RAG Metrics for monitoring search performance and external API usage
  *
- * TODO(frontend-supabase-cleanup): Keep this server-only until monitoring and
- * cron flows are fully handled by the backend.
+ * Frontend migration note: /api/cron/update-knowledge-base records batch-import
+ * metrics here. Backend owns active RAG search, but the cron metrics write path
+ * has not moved behind backend yet, so this remains server-only.
  */
 export class RAGMetrics {
   private static instance: RAGMetrics;

--- a/frontend/src/lib/query-classifier.ts
+++ b/frontend/src/lib/query-classifier.ts
@@ -3,7 +3,7 @@
  * EnhancedQAAgentから分離して、テスト可能でメンテナンスしやすい構造にする
  */
 
-import { SupportedLanguage } from '@/lib/types';
+import { STTCorrection } from '@/lib/stt-correction';
 
 export interface QueryClassificationResult {
   category: string;
@@ -36,8 +36,7 @@ export class QueryClassifier {
    * STT補正を適用（既存のロジックを維持）
    */
   private applySttCorrections(query: string): string {
-    // TODO: applySttCorrectionsを適切にインポートまたは実装
-    return query;
+    return STTCorrection.correct(query);
   }
 
   /**
@@ -47,8 +46,8 @@ export class QueryClassifier {
     question: string,
     conversationContext?: any
   ): Promise<QueryClassificationResult> {
-    const normalizedQuestion = this.normalizeQuery(question);
-    const lowerQuestion = normalizedQuestion.toLowerCase();
+    const correctedQuestion = this.applySttCorrections(question);
+    const normalizedQuestion = this.normalizeQuery(correctedQuestion);
     
     // 現在時刻のチェック（最優先）
     if (this.isCurrentTimeQuery(normalizedQuestion)) {

--- a/frontend/src/lib/rollback-manager.ts
+++ b/frontend/src/lib/rollback-manager.ts
@@ -5,9 +5,10 @@ import { supabaseAdmin } from './supabase';
 /**
  * Rollback manager for safe production deployments
  *
- * TODO(frontend-supabase-cleanup): Alerts still invoke this from a frontend
- * route handler. Move the workflow behind the backend before removing direct
- * Supabase access from frontend runtime code.
+ * Frontend migration note: /api/alerts/webhook still invokes snapshot and
+ * emergency-shutdown actions from a Next route. backend/api/alerts.py only logs
+ * alert rows today, so keep this server-only Supabase path until backend owns
+ * the automated rollback workflow.
  */
 export class RollbackManager {
   private static instance: RollbackManager;

--- a/frontend/src/lib/types.ts
+++ b/frontend/src/lib/types.ts
@@ -1,14 +1,9 @@
 /**
- * Shared frontend type definitions
- * TODO: These should eventually be imported from backend API types
+ * Shared frontend language definitions.
+ *
+ * backend/api/knowledge_models.py currently validates knowledge mutations as
+ * ja/en. Keep this local union narrow until generated backend API types are
+ * available to the frontend build.
  */
 
 export type SupportedLanguage = 'ja' | 'en';
-
-export interface KnowledgeSearchResult {
-  id: string;
-  content: string;
-  metadata: Record<string, any>;
-  similarity?: number;
-  category?: string;
-}


### PR DESCRIPTION
Closes #922

## 概要
Developer フォルダリファクタリング計画 Phase 4-3 対応。frontend/src/lib 配下の frontend-supabase-cleanup 系の残タスクコメント6件を消化。

## 各項目の処置
| ファイル | 処置 | 理由 |
|---|---|---|
| query-classifier.ts | **実装** | STTCorrection.correct() を import し分類前に適用。テスト追加(5件) |
| feature-flags.ts | 移行待ちコメント化 + console.warn 削除 | backend に実験用 search API 契約が無く不活性 path のため明示 |
| rollback-manager.ts | 証跡付きコメント更新 | /api/alerts/webhook が rollback を直呼び、backend alerts は記録のみ |
| types.ts | 未使用 KnowledgeSearchResult 削除 | 参照なし。SupportedLanguage は維持 |
| knowledge-base-utils.ts | 証跡付きコメント更新 | admin CRUD は proxy 済みだが health route / legacy scripts が依存 |
| monitoring/rag-metrics.ts | 証跡付きコメント更新 | frontend cron が metrics を直書き、backend 移行未完了 |

## 検証
- `pnpm lint` / `pnpm typecheck` / `pnpm build`: pass(CI ゲート相当)
- node テスト 161件 + 新規 query-classifier.test.ts 5件: pass
- full `pnpm test` の Integrated suite(localhost:3000 要起動) / Router suite(`@/mastra/agents/router-agent` 欠損)の失敗は develop 由来の既存事象(本PRと無関係、develop で grep 裏取り済み)

## レビュー
- code-reviewer: Approve(CRITICAL/HIGH ゼロ)
- Codex CLI 経路A: PASS(指摘ゼロ)

## 制約遵守
- Tailwind v3.4.17 維持、.github/workflows/voice-e2e-nightly.yml 未変更、console.log 追加なし

🤖 Generated with [Claude Code](https://claude.com/claude-code)